### PR TITLE
feat(profile-triggers): trigger evaluation metrics endpoint and background worker instrumentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2025-11-05
 
 ## Active Technologies
+- C# / .NET 8 (existing project baseline) + Existing: ASP.NET Core Minimal API, ADB integration libs. New: NEEDS CLARIFICATION (image similarity + OCR library choice) (001-profile-triggers)
+- File-based JSON repositories (existing) extended to persist triggers alongside profiles (001-profile-triggers)
 
 - .NET 8 (C#) + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
 
@@ -22,6 +24,7 @@ tests/
 .NET 8 (C#): Follow standard conventions
 
 ## Recent Changes
+- 001-profile-triggers: Added C# / .NET 8 (existing project baseline) + Existing: ASP.NET Core Minimal API, ADB integration libs. New: NEEDS CLARIFICATION (image similarity + OCR library choice)
 
 - 001-android-emulator-service: Added .NET 8 (C#) + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,10 +3,10 @@
 Auto-generated from all feature plans. Last updated: 2025-11-05
 
 ## Active Technologies
-- C# / .NET 8 (existing project baseline) + Existing: ASP.NET Core Minimal API, ADB integration libs. New: NEEDS CLARIFICATION (image similarity + OCR library choice) (001-profile-triggers)
+- C# / .NET 8 existing project baseline. Existing: ASP.NET Core Minimal API, ADB integration libs. New: NEEDS CLARIFICATION for image similarity and OCR library choice (001-profile-triggers)
 - File-based JSON repositories (existing) extended to persist triggers alongside profiles (001-profile-triggers)
 
-- .NET 8 (C#) + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
+- .NET 8 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
 
 ## Project Structure
 
@@ -17,19 +17,19 @@ tests/
 
 ## Commands
 
-# Add commands for .NET 8 (C#)
+# Add commands for .NET 8 C#
 
 ## Test Failure Analysis
 After running `dotnet test -c Debug --logger trx;`, execute `scripts/analyze-test-results.ps1` to emit `TESTERROR:` lines for each failing test (name, outcome, message) and exit non-zero. Integrate into CI or local `verify` task to ensure rich failure detection.
 
 ## Code Style
 
-.NET 8 (C#): Follow standard conventions
+Coding style: Follow standard .NET 8 C# conventions
 
 ## Recent Changes
 - 001-profile-triggers: Added C# / .NET 8 (existing project baseline) + Existing: ASP.NET Core Minimal API, ADB integration libs. New: NEEDS CLARIFICATION (image similarity + OCR library choice)
 
-- 001-android-emulator-service: Added .NET 8 (C#) + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots
+- 001-android-emulator-service: Added .NET 8 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,9 @@ tests/
 
 # Add commands for .NET 8 (C#)
 
+## Test Failure Analysis
+After running `dotnet test -c Debug --logger trx;`, execute `scripts/analyze-test-results.ps1` to emit `TESTERROR:` lines for each failing test (name, outcome, message) and exit non-zero. Integrate into CI or local `verify` task to ensure rich failure detection.
+
 ## Code Style
 
 .NET 8 (C#): Follow standard conventions

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -37,6 +37,8 @@ Testing is required for any executable logic:
 - Tests MUST be deterministic, isolated, and fast (<1s avg per unit test where feasible).
 - Bug fixes MUST include a failing test reproducing the issue before the fix.
 - CI MUST run tests on every PR and block merges on failures or coverage regressions beyond allowed thresholds.
+- An evaluation of test builds and runs results is necessary before each commit.
+- The code quality warnings/errors within the test code can be disabled if needed.
 
 Rationale: A reliable test suite acts as a safety net enabling fast iteration.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisLevel>latest-all</AnalysisLevel>
     <Deterministic>true</Deterministic>
+    <!-- Suppress CA1031: we intentionally catch System.Exception in ErrorHandlingMiddleware to produce a uniform error envelope -->
+    <NoWarn>$(NoWarn);CA1031</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
     <Deterministic>true</Deterministic>
     <!-- Suppress CA1031: we intentionally catch System.Exception in ErrorHandlingMiddleware to produce a uniform error envelope -->
     <NoWarn>$(NoWarn);CA1031</NoWarn>
+    <NoWarn>$(NoWarn);CA1038</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />

--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ See full request/response shapes in the contracts doc linked above.
   - `MaxConcurrentSessions` (default 3)
   - `IdleTimeoutSeconds` (default 1800)
 
+- Trigger evaluation worker (Options): `Service:Triggers:Worker`
+  - `IntervalSeconds` (default 2): base cadence for evaluating triggers.
+  - `GameFilter` (optional): limit evaluation to a specific `gameId`.
+  - `SkipWhenNoSessions` (default true): if there are no active sessions, skip evaluation to save CPU.
+  - `IdleBackoffSeconds` (default 5): delay used when idle due to no active sessions.
+
+Notes:
+- You can still force ADB-less screen evaluation in tests via `GAMEBOT_TEST_SCREEN_IMAGE_B64` (base64 PNG). When set and `GAMEBOT_USE_ADB=false`, the image-match evaluator compares against this image.
+
 - ADB behavior
   - `GAMEBOT_USE_ADB`: set to `false` to disable ADB integration (useful in tests/CI). By default on Windows, ADB is enabled.
   - `GAMEBOT_ADB_PATH`: optional override path to `adb.exe`.

--- a/README.md
+++ b/README.md
@@ -46,13 +46,110 @@ dotnet run -c Release --project src/GameBot.Service
 Invoke-RestMethod -Uri http://localhost:5080/health -Method GET
 ```
 
-Common flow (HTTP):
-- Create a game: POST `/games` with `{ title, path, hash }`
-- Create a profile: POST `/profiles` with `{ name, gameId, steps: [ { type: "tap", args: { x, y } } ] }`
-- Start a session: POST `/sessions` with `{ gameId }`
-- Execute a profile: POST `/sessions/{sessionId}/execute?profileId={profileId}` (returns `{ accepted }`)
-- Grab a snapshot: GET `/sessions/{id}/snapshot` (image/png)
-- Stop session: DELETE `/sessions/{id}`
+## Resources and domain
+
+### Games
+- Create: `POST /games`
+  - Body: `{ "name": "Game A", "description": "optional" }`
+  - Response: `{ id, name, description }`
+- Get: `GET /games/{id}` → `{ id, name, description }`
+- List: `GET /games` → `[{ id, name, description }]`
+
+Example create:
+
+```json
+{
+  "name": "Game A",
+  "description": "My ROM"
+}
+```
+
+### Profiles
+A profile is a reusable, named script of input actions for a specific game.
+
+- Create: `POST /profiles`
+  - Body: `{ name, gameId, steps: InputAction[], checkpoints?: string[] }`
+  - Response: `{ id, name, gameId, steps, checkpoints }`
+- Get: `GET /profiles/{id}`
+- List: `GET /profiles?gameId={gameId}` (filter by game)
+
+Minimal example:
+
+```json
+{
+  "name": "TutorialSkip",
+  "gameId": "<game-id>",
+  "steps": [
+    { "type": "tap", "args": { "x": 320, "y": 640 }, "delayMs": 250 },
+    { "type": "key", "args": { "key": "ESCAPE" } }
+  ],
+  "checkpoints": []
+}
+```
+
+### Sessions
+Run-time context used to execute inputs and take snapshots.
+
+- Create: `POST /sessions`
+  - Body: `{ gameId?: string, gamePath?: string, profileId?: string, adbSerial?: string }`
+    - Provide `gameId` (preferred) or `gamePath`.
+    - Optional `adbSerial` to bind a specific device/emulator; if omitted and ADB is enabled, the first available device is selected; if none, the API returns 404.
+  - Response: `{ id, status, gameId }`
+- Get: `GET /sessions/{id}` → `{ id, status, uptime, health, gameId }`
+- Device info: `GET /sessions/{id}/device` → `{ id, deviceSerial, mode: "ADB"|"STUB" }`
+- Health: `GET /sessions/{id}/health` → ADB connectivity details when applicable
+- Snapshot: `GET /sessions/{id}/snapshot` → `image/png`
+- Send inputs: `POST /sessions/{id}/inputs` → `{ accepted }`
+- Execute profile: `POST /sessions/{id}/execute?profileId={profileId}` → `{ accepted }`
+- Stop: `DELETE /sessions/{id}` → `{ status: "stopping" }`
+
+### Input actions
+Supported `type` values (case-insensitive). Numeric args may be provided as numbers or numeric strings (e.g., "50").
+
+- tap
+  - args: `x`, `y`
+  - Example:
+    ```json
+    { "actions": [ { "type": "tap", "args": { "x": 50, "y": 50 } } ] }
+    ```
+
+- swipe
+  - args: `x1`, `y1`, `x2`, `y2`
+  - optional: `durationMs` on the action
+  - Example:
+    ```json
+    {
+      "actions": [
+        {
+          "type": "swipe",
+          "args": { "x1": 0, "y1": 0, "x2": 200, "y2": 200 },
+          "durationMs": 300
+        }
+      ]
+    }
+    ```
+
+- key
+  - args: either `keyCode` (Android key code) or `key` (symbolic name)
+  - Examples:
+    ```json
+    { "actions": [ { "type": "key", "args": { "keyCode": 29 } } ] }
+    { "actions": [ { "type": "key", "args": { "key": "ESCAPE" } } ] }
+    ```
+  - Common key names: ESCAPE(111), BACK(4), HOME(3), ENTER(66), SPACE(62), TAB(61), DEL/DELETE(67), UP(19), DOWN(20), LEFT(21), RIGHT(22), VOLUME_UP(24), VOLUME_DOWN(25), POWER(26), A–Z(29–54).
+
+- Timing
+  - `delayMs` per action waits after the action finishes before the next action.
+  - `durationMs` is used by long-running actions like `swipe`.
+
+## Common flow (HTTP)
+- Create a game → `POST /games` with `{ name, description }`
+- Create a profile → `POST /profiles` with `{ name, gameId, steps: [...] }`
+- Start a session → `POST /sessions` with `{ gameId, adbSerial? }`
+- Execute a profile → `POST /sessions/{sessionId}/execute?profileId={profileId}` (returns `{ accepted }`)
+- Or send ad-hoc inputs → `POST /sessions/{id}/inputs` with `{ actions: [...] }`
+- Grab a snapshot → `GET /sessions/{id}/snapshot` (image/png)
+- Stop session → `DELETE /sessions/{id}`
 
 See full request/response shapes in the contracts doc linked above.
 
@@ -67,6 +164,20 @@ See full request/response shapes in the contracts doc linked above.
   - `MaxConcurrentSessions` (default 3)
   - `IdleTimeoutSeconds` (default 1800)
 
+- ADB behavior
+  - `GAMEBOT_USE_ADB`: set to `false` to disable ADB integration (useful in tests/CI). By default on Windows, ADB is enabled.
+  - `GAMEBOT_ADB_PATH`: optional override path to `adb.exe`.
+  - `GAMEBOT_ADB_RETRIES`, `GAMEBOT_ADB_RETRY_DELAY_MS`: control retry count and delay (ms) for ADB actions.
+  - Diagnostics endpoints: `GET /adb/version`, `GET /adb/devices`.
+
+- Dynamic port (tests/CI)
+  - `GAMEBOT_DYNAMIC_PORT=true` binds to port 0 to avoid conflicts.
+
+- Logging
+  - Console logs include timestamps and scopes; ADB operations are logged at Debug.
+  - Enable verbose logs: `$env:Logging__LogLevel__Default = 'Debug'`
+  - Correlation ID: send `X-Correlation-ID` header; responses include it and it is added to log scopes.
+
 ## Development
 Run tests:
 
@@ -78,3 +189,4 @@ Notes:
 - If `dotnet` isn't recognized in your shell, open a new terminal where the .NET SDK is on PATH, or use the absolute path (Get-Command dotnet | Select-Object -ExpandProperty Source).
 - Warnings are treated as errors; analyzers are enabled across projects.
 - Windows-only APIs are annotated; the emulator integration is designed for Windows hosts.
+

--- a/scripts/analyze-test-results.ps1
+++ b/scripts/analyze-test-results.ps1
@@ -1,0 +1,35 @@
+param(
+    [string]$ResultsDir = '.'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ResultsDir)) {
+    Write-Host "No test results directory '$ResultsDir' found."
+    exit 0
+}
+
+$trxFiles = Get-ChildItem -Recurse -Filter *.trx -Path $ResultsDir | Sort-Object LastWriteTime -Descending
+if (-not $trxFiles) {
+    Write-Host "No TRX files found under $ResultsDir."
+    exit 0
+}
+
+$latest = $trxFiles | Select-Object -First 1
+[xml]$doc = Get-Content $latest.FullName
+$failed = @($doc.TestRun.Results.UnitTestResult | Where-Object { $_.outcome -ne 'Passed' })
+if ($failed.Count -eq 0) {
+    Write-Host "All tests passed in $($latest.Name)."
+    exit 0
+}
+
+Write-Host "Detected $($failed.Count) failing test(s) in $($latest.Name)." -ForegroundColor Yellow
+foreach ($f in $failed) {
+    $name = $f.testName
+    $outcome = $f.outcome
+    $message = $f.Output.ErrorInfo.Message -replace "`r`n", ' ' -replace "`n", ' '
+    Write-Host ("TESTERROR:{0}:{1}:{2}" -f $name, $outcome, $message) -ForegroundColor Red
+}
+
+# Non-zero exit to flag pipeline / parent task
+exit 1

--- a/specs/001-profile-triggers/checklists/requirements.md
+++ b/specs/001-profile-triggers/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Triggered Profile Execution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-08
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist completed based on the current spec; ready to proceed to clarification or planning as needed.

--- a/specs/001-profile-triggers/contracts/openapi-fragment.yaml
+++ b/specs/001-profile-triggers/contracts/openapi-fragment.yaml
@@ -1,0 +1,228 @@
+openapi: 3.0.3
+info:
+  title: GameBot Trigger API (Fragment)
+  version: 0.1.0
+paths:
+  /profiles/{profileId}/triggers:
+    get:
+      summary: List triggers for a profile
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Triggers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProfileTrigger'
+    post:
+      summary: Create trigger
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProfileTriggerCreate'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfileTrigger'
+  /profiles/{profileId}/triggers/{triggerId}:
+    get:
+      summary: Get trigger
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: triggerId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Trigger
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfileTrigger'
+        '404':
+          description: Not found
+    patch:
+      summary: Update trigger (partial)
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: triggerId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProfileTriggerUpdate'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfileTrigger'
+    delete:
+      summary: Delete trigger
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: triggerId
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
+  /profiles/{profileId}/triggers/{triggerId}/test:
+    post:
+      summary: Test trigger evaluation immediately
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: triggerId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Evaluation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerEvaluationResult'
+  /profiles/{profileId}/triggers/evaluate:
+    post:
+      summary: Force evaluation cycle for all triggers in profile
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Batch results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TriggerEvaluationResult'
+components:
+  schemas:
+    Region:
+      type: object
+      properties:
+        x: { type: number, minimum: 0, maximum: 1 }
+        y: { type: number, minimum: 0, maximum: 1 }
+        width: { type: number, minimum: 0, maximum: 1 }
+        height: { type: number, minimum: 0, maximum: 1 }
+      required: [x,y,width,height]
+    ProfileTriggerBase:
+      type: object
+      properties:
+        id: { type: string }
+        type: { type: string, enum: [delay, schedule, image-match, text-match] }
+        enabled: { type: boolean }
+        cooldownSeconds: { type: integer, minimum: 0 }
+      required: [id,type,enabled,cooldownSeconds]
+    DelayParams:
+      type: object
+      properties:
+        seconds: { type: integer, minimum: 1 }
+      required: [seconds]
+    ScheduleParams:
+      type: object
+      properties:
+        timestamp: { type: string, format: date-time }
+      required: [timestamp]
+    ImageMatchParams:
+      type: object
+      properties:
+        referenceImageId: { type: string }
+        region: { $ref: '#/components/schemas/Region' }
+        similarityThreshold: { type: number, minimum: 0.5, maximum: 1 }
+      required: [referenceImageId,region,similarityThreshold]
+    TextMatchParams:
+      type: object
+      properties:
+        target: { type: string }
+        region: { $ref: '#/components/schemas/Region' }
+        confidenceThreshold: { type: number, minimum: 0.5, maximum: 1 }
+        mode: { type: string, enum: [found, not-found] }
+      required: [target,region,confidenceThreshold,mode]
+    ProfileTriggerParams:
+      oneOf:
+        - $ref: '#/components/schemas/DelayParams'
+        - $ref: '#/components/schemas/ScheduleParams'
+        - $ref: '#/components/schemas/ImageMatchParams'
+        - $ref: '#/components/schemas/TextMatchParams'
+    ProfileTrigger:
+      allOf:
+        - $ref: '#/components/schemas/ProfileTriggerBase'
+        - type: object
+          properties:
+            params: { $ref: '#/components/schemas/ProfileTriggerParams' }
+            lastFiredAt: { type: string, format: date-time, nullable: true }
+            lastEvaluatedAt: { type: string, format: date-time, nullable: true }
+            lastResult: { $ref: '#/components/schemas/TriggerEvaluationResult' }
+    ProfileTriggerCreate:
+      type: object
+      properties:
+        type: { type: string, enum: [delay, schedule, image-match, text-match] }
+        enabled: { type: boolean, default: true }
+        cooldownSeconds: { type: integer, minimum: 0, default: 60 }
+        params: { $ref: '#/components/schemas/ProfileTriggerParams' }
+      required: [type,params]
+    ProfileTriggerUpdate:
+      type: object
+      properties:
+        enabled: { type: boolean }
+        cooldownSeconds: { type: integer, minimum: 0 }
+        params: { $ref: '#/components/schemas/ProfileTriggerParams' }
+    TriggerEvaluationResult:
+      type: object
+      properties:
+        status: { type: string, enum: [pending, satisfied, cooldown, disabled] }
+        similarity: { type: number, nullable: true }
+        confidence: { type: number, nullable: true }
+        reason: { type: string }
+        evaluatedAt: { type: string, format: date-time }

--- a/specs/001-profile-triggers/data-model.md
+++ b/specs/001-profile-triggers/data-model.md
@@ -1,0 +1,81 @@
+# Data Model: Triggered Profile Execution
+
+## Entities
+
+### AutomationProfile (extended)
+- id: string
+- name: string
+- description: string
+- steps: array<InputAction>
+- triggers: array<ProfileTrigger>
+
+### ProfileTrigger
+- id: string (unique per profile)
+- type: enum { delay, schedule, image-match, text-match }
+- enabled: bool
+- cooldownSeconds: int (≥0, default 60)
+- lastFiredAt: timestamp | null
+- lastEvaluatedAt: timestamp | null
+- lastResult: TriggerEvaluationResult | null
+- params: TriggerParams (one-of based on type)
+
+### TriggerParams (one-of)
+1. DelayParams
+   - seconds: int (>0)
+2. ScheduleParams
+   - timestamp: ISO 8601 (future date/time)
+3. ImageMatchParams
+   - referenceImageId: string (identifier for stored image asset)
+   - region: Region
+   - similarityThreshold: float [0..1] (default 0.85)
+4. TextMatchParams
+   - target: string (exact or regex)
+   - region: Region
+   - confidenceThreshold: float [0..1] (default 0.80)
+   - mode: enum { found, not-found }
+
+### Region
+- x: float [0..1]
+- y: float [0..1]
+- width: float (0 < width ≤ 1, x + width ≤ 1)
+- height: float (0 < height ≤ 1, y + height ≤ 1)
+
+### TriggerEvaluationResult
+- status: enum { pending, satisfied, cooldown, disabled }
+- similarity: float | null (image)
+- confidence: float | null (text)
+- reason: string (human-readable summary)
+- evaluatedAt: timestamp
+
+## Relationships
+- AutomationProfile 1..* ProfileTrigger (triggers owned by profile)
+- ProfileTrigger -> Region (composition for spatial triggers)
+- ProfileTrigger -> TriggerParams (polymorphic)
+
+## Validation Rules
+- DelayParams.seconds > 0
+- ScheduleParams.timestamp must be > now at creation; enabling past timestamp invalid
+- ImageMatchParams.referenceImageId not empty
+- ImageMatchParams.similarityThreshold in [0.5..1] (reject lower values to reduce false positives)
+- TextMatchParams.confidenceThreshold in [0.5..1]
+- Region coordinates normalized and within bounds; width/height > 0
+- cooldownSeconds ≥ 0
+- Trigger type-specific params present exactly once
+- Enabled trigger with invalid params must fail validation and remain disabled
+
+## State Transitions
+1. disabled → enabled (validation passes)
+2. enabled + condition unmet → pending
+3. enabled + condition met (first evaluation) → satisfied → cooldown (immediately after firing)
+4. cooldown + cooldown elapsed → pending
+5. enabled + schedule time passed without firing (because disabled) → remains disabled (no retroactive firing)
+
+## Persistence
+- Triggers embedded inside profile JSON under `triggers` key.
+- lastFiredAt, lastEvaluatedAt, lastResult updated atomically post evaluation cycle.
+
+## Derived Fields (runtime only, not persisted when null)
+- nextEligibleAt: timestamp computed = lastFiredAt + cooldownSeconds (if lastFiredAt not null)
+
+## Notes
+- Future extension: add trigger "pixel-color" or "network-event" without altering existing structures by introducing new params variant.

--- a/specs/001-profile-triggers/plan.md
+++ b/specs/001-profile-triggers/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Triggered Profile Execution
+
+**Branch**: `001-profile-triggers` | **Date**: 2025-11-09 | **Spec**: specs/001-profile-triggers/spec.md
+**Input**: Feature specification for triggers driving profile execution.
+
+## Summary
+
+Enable profiles to auto-start when any configured trigger condition is satisfied. Supported triggers: Delay (relative seconds), Schedule (absolute time), ImageMatch (reference image fuzzy match within region), TextMatch (OCR found/not-found within region). Provide validation, cooldown handling, test-evaluation endpoint, and status visibility while maintaining resolution independence (normalized regions) and performance responsiveness (≤2s detection).
+
+## Technical Context
+
+**Language/Version**: C# / .NET 8 (existing project baseline)  
+**Primary Dependencies**: Existing: ASP.NET Core Minimal API, ADB integration libs. New: NEEDS CLARIFICATION (image similarity + OCR library choice)  
+**Storage**: File-based JSON repositories (existing) extended to persist triggers alongside profiles  
+**Testing**: xUnit + existing integration/contract suites; add new unit tests for trigger evaluation logic, integration tests for endpoints, contract tests for schema  
+**Target Platform**: Windows host (current ADB requirement)  
+**Project Type**: Backend automation service (single solution with Domain, Emulator, Service projects)  
+**Performance Goals**: Trigger evaluation loop processes screen every ≤2s; image/text evaluation adds ≤500ms per cycle at default resolutions  
+**Constraints**: Avoid blocking session ops; CPU utilization increase ≤15% during active trigger evaluation; memory overhead for cached images ≤50MB  
+**Scale/Scope**: Tens of concurrent sessions each with up to ~10 triggers; design for future expansion (hundreds) via configurable evaluation interval  
+
+UNKNOWNS / NEEDS CLARIFICATION:
+1. OCR engine selection (e.g., Tesseract vs. Windows OCR APIs) → NEEDS CLARIFICATION
+2. Image fuzzy match technique (perceptual hash vs. template matching vs. feature-based) → NEEDS CLARIFICATION
+3. Persistence model: embed triggers within profile file vs. separate triggers file per profile → NEEDS CLARIFICATION
+
+## Constitution Check (Pre-Design)
+
+- Code Quality: Will isolate trigger evaluation logic in new domain service with ≤50 LOC methods; add XML comments for public APIs. Static analysis unchanged. PASS
+- Testing: Plan includes unit tests per trigger type (happy + edge), integration tests for evaluation & firing, contract tests for new endpoints. Coverage target ≥80% for new code. PASS
+- UX Consistency: Endpoints follow existing REST naming; error messages validated, normalized coordinates consistent with snapshot usage. PASS
+- Performance: Budgets defined (≤2s detection, ≤500ms compute); will add optional perf test using large screen sample set. PASS
+
+Gate Result: PASS (unknowns do not block initial research phase).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-profile-triggers/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── checklists/
+```
+
+### Source Code (affected areas)
+
+```text
+src/
+├── GameBot.Domain/
+│   ├── Profiles/
+│   │   ├── AutomationProfile.cs          # Extend to reference triggers
+│   │   ├── ProfileTrigger.cs             # New entity (types & params)
+│   │   ├── TriggerEvaluationResult.cs    # New result struct
+│   │   └── ITriggerEvaluator.cs          # Abstraction
+│   ├── Services/
+│   │   └── TriggerEvaluationService.cs   # Core evaluation loop (new)
+├── GameBot.Emulator/
+│   └── Session/
+│       └── SessionManager.cs             # Invoke snapshot for evaluation
+├── GameBot.Service/
+│   ├── Endpoints/
+│   │   ├── TriggersEndpoints.cs          # CRUD + test + status endpoints (new)
+│   │   └── ProfilesEndpoints.cs          # Adjust to include triggers data
+│   ├── Models/
+│   │   ├── Triggers.cs                   # DTOs for trigger types
+│   └── Hosted/
+│       └── TriggerBackgroundWorker.cs   # Periodic evaluation (new)
+tests/
+├── unit/
+│   └── TriggersTests.cs                  # Each trigger type logic
+├── integration/
+│   └── TriggerEvaluationTests.cs         # End-to-end firing conditions
+└── contract/
+    └── TriggersContractTests.cs          # OpenAPI contract checks
+```
+
+**Structure Decision**: Extend existing layered architecture; add dedicated evaluator service + hosted worker for periodic evaluation, maintain separation of domain logic (pure evaluation) and infrastructure (screen capture / OCR / image matching). No additional top-level projects needed.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| Background worker | Needed for periodic evaluation | Polling via external script adds deployment complexity |
+
+## Phase 0: Research Plan
+
+Resolved three NEEDS CLARIFICATION items in research.md (OCR engine: Tesseract, image matching: template NCC, persistence model: embedded triggers array). No remaining unknowns block design.
+
+## Phase 1: Design Preview
+
+Produce data-model.md, contracts (OpenAPI fragment), quickstart with configuration and examples, update agent context.
+
+## Phase 2: (Out of scope for this command)
+
+Implementation tasks and sequencing to be generated later (tasks.md).
+
+## Post-Design Constitution Re-check (Placeholder)
+Re-check after generating research, data-model, contracts, and quickstart:
+
+- Code Quality: Documentation-only artifacts added; future code changes will include XML docs and adhere to static analysis. PASS
+- Testing: Plan includes unit/integration/contract coverage; quickstart outlines flows. PASS
+- UX Consistency: Endpoints named consistently; normalized region semantics documented. PASS
+- Performance: Budgets reiterated; image/OCR strategies in research.md support goals. PASS

--- a/specs/001-profile-triggers/quickstart.md
+++ b/specs/001-profile-triggers/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Triggered Profile Execution
+
+## Overview
+This guide shows how to add and test triggers that start a profile automatically based on time, image appearance, or OCR text conditions.
+
+## 1. Add a Delay Trigger
+```
+POST /profiles/{profileId}/triggers
+{
+  "type": "delay",
+  "params": { "seconds": 30 },
+  "cooldownSeconds": 120
+}
+```
+Expect 201 with trigger object. Profile will start ~30s after trigger is enabled.
+
+## 2. Add an Image Match Trigger
+1. Upload/reference an image asset (out of scope here) to get `referenceImageId`.
+2. Create trigger:
+```
+POST /profiles/{profileId}/triggers
+{
+  "type": "image-match",
+  "params": {
+    "referenceImageId": "victory-banner",
+    "region": { "x": 0.4, "y": 0.3, "width": 0.2, "height": 0.1 },
+    "similarityThreshold": 0.88
+  }
+}
+```
+
+## 3. Add a Text Found Trigger
+```
+POST /profiles/{profileId}/triggers
+{
+  "type": "text-match",
+  "params": {
+    "target": "Victory",
+    "region": { "x": 0.0, "y": 0.0, "width": 1.0, "height": 0.2 },
+    "confidenceThreshold": 0.82,
+    "mode": "found"
+  }
+}
+```
+
+## 4. Test a Trigger Immediately
+```
+POST /profiles/{profileId}/triggers/{triggerId}/test
+```
+Returns evaluation result with `status`, and similarity or confidence metrics.
+
+## 5. Check Trigger List
+```
+GET /profiles/{profileId}/triggers
+```
+Review states: `pending`, `satisfied`, `cooldown`, `disabled`.
+
+## 6. Force Evaluation (Optional)
+```
+POST /profiles/{profileId}/triggers/evaluate
+```
+Runs evaluation cycle on-demand.
+
+## 7. Cooldown Behavior
+After firing, `status` becomes `cooldown` until `cooldownSeconds` elapse; subsequent potential matches are ignored.
+
+## 8. Updating a Trigger
+```
+PATCH /profiles/{profileId}/triggers/{triggerId}
+{
+  "enabled": false
+}
+```
+Disables trigger safely.
+
+## 9. Deleting a Trigger
+```
+DELETE /profiles/{profileId}/triggers/{triggerId}
+```
+Removes the trigger from the profile definition.
+
+## Notes
+- Regions are normalized (0..1) for resolution independence.
+- Use conservative thresholds first; lower only if matches are missed.
+- Text `not-found` triggers should expect a slight delay due to confirmation cycle.

--- a/specs/001-profile-triggers/quickstart.md
+++ b/specs/001-profile-triggers/quickstart.md
@@ -15,7 +15,14 @@ POST /profiles/{profileId}/triggers
 Expect 201 with trigger object. Profile will start ~30s after trigger is enabled.
 
 ## 2. Add an Image Match Trigger
-1. Upload/reference an image asset (out of scope here) to get `referenceImageId`.
+1. Upload an image asset to register a `referenceImageId`:
+```
+POST /images
+{
+  "id": "victory-banner",
+  "data": "data:image/png;base64,<Base64PNG>"
+}
+```
 2. Create trigger:
 ```
 POST /profiles/{profileId}/triggers
@@ -62,7 +69,9 @@ POST /profiles/{profileId}/triggers/evaluate
 Runs evaluation cycle on-demand.
 
 ## 7. Cooldown Behavior
-After firing, `status` becomes `cooldown` until `cooldownSeconds` elapse; subsequent potential matches are ignored.
+After firing, `status` becomes `Cooldown` until `cooldownSeconds` elapse; subsequent potential matches are ignored.
+
+Tip: Re-testing a satisfied trigger immediately should return `Cooldown`; after waiting beyond the cooldown window, it can become `Satisfied` again.
 
 ## 8. Updating a Trigger
 ```
@@ -83,3 +92,5 @@ Removes the trigger from the profile definition.
 - Regions are normalized (0..1) for resolution independence.
 - Use conservative thresholds first; lower only if matches are missed.
 - Text `not-found` triggers should expect a slight delay due to confirmation cycle.
+ - For local testing, you can set `GAMEBOT_DATA_DIR` to isolate state and `GAMEBOT_AUTH_TOKEN` to enable bearer auth.
+ - Integration tests can inject a faux screen using `GAMEBOT_TEST_SCREEN_IMAGE_B64` (base64 PNG): the evaluator will compare against this image.

--- a/specs/001-profile-triggers/research.md
+++ b/specs/001-profile-triggers/research.md
@@ -1,0 +1,38 @@
+# Research: Triggered Profile Execution
+
+## Overview
+Resolve technical unknowns for OCR engine, image matching technique, and trigger persistence model supporting timely (≤2s) evaluation with minimal false positives.
+
+---
+## Item 1: OCR Engine Selection
+- **Decision**: Use Tesseract OCR via a .NET wrapper.
+- **Rationale**: Mature, widely adopted, configurable accuracy versus performance trade-offs, supports whitelist/region-based extraction required for confined screen regions.
+- **Alternatives Considered**:
+  - Windows OCR APIs: Simplified integration but less control over tuning and deployment portability.
+  - Cloud OCR (e.g., Vision APIs): Higher latency, network dependency, potential cost and privacy concerns.
+  - Custom lightweight OCR: Increased development/maintenance burden and likely lower accuracy initially.
+
+## Item 2: Image Matching Technique
+- **Decision**: Use template matching with normalized cross-correlation combined with downscaled grayscale preprocessing.
+- **Rationale**: Deterministic, fast for small regions, threshold tuning (e.g., ≥0.85) aligns with spec; avoids complexity of feature-based methods for 2D UI elements.
+- **Alternatives Considered**:
+  - Perceptual hashing (pHash): Good for overall similarity but weaker for localized region matching and threshold granularity.
+  - SIFT/ORB feature matching: Robust to scale/rotation but overkill for stable 2D UI; higher computational cost.
+  - ML-based classification: Adds model training overhead and potential drift.
+
+## Item 3: Trigger Persistence Model
+- **Decision**: Persist triggers embedded within the profile JSON file under a `triggers` array.
+- **Rationale**: Simplifies atomic updates (profile + triggers together); reduces file count and coordination complexity; aligns with existing file-based repository pattern.
+- **Alternatives Considered**:
+  - Separate triggers file per profile: More granular but introduces synchronization risk and additional lookups.
+  - Central triggers index: Useful for cross-profile queries but premature given current scope (per-profile evaluation).
+  - Database storage: Not justified until higher scale; increases operational complexity.
+
+## Cross-Cutting Considerations
+- **Performance**: Downscale screenshot (e.g., 50%) before matching/OCR to reduce CPU while maintaining detection reliability; trade-off monitored in tests.
+- **False Positives Mitigation**: Require consecutive confirmations for text-not-found to avoid flicker; single pass sufficient for image-match above threshold.
+- **Extensibility**: Designing evaluation service with interface `ITriggerEvaluator` allows future trigger types (e.g., pixel-color, network-event) without refactoring core loop.
+- **Testing Strategy**: Synthetic images/fixtures for deterministic image and OCR tests; mock evaluator interfaces for unit tests; integration tests with sample screenshots.
+
+## Summary
+Selections prioritize deterministic, locally computable techniques with controllable thresholds and minimal external dependencies, enabling responsive evaluation loops and straightforward persistence.

--- a/specs/001-profile-triggers/spec.md
+++ b/specs/001-profile-triggers/spec.md
@@ -1,0 +1,101 @@
+# Feature Specification: Triggered Profile Execution
+
+**Feature Branch**: `001-profile-triggers`  
+**Created**: 2025-11-08  
+**Status**: Draft  
+**Input**: User description: "The application should allow for Profiles to be executed based on Triggers. A Trigger can be Timebased (delay or absolute time), certain part of the Screenshot containing a predefined image (fuzzy matching), or a OCR-ed text being found or not found at a specified location on screen."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run Profile when image appears (Priority: P1)
+
+As an automation user, I can attach a trigger to a profile that fires when a reference image is detected within a defined screen region with a minimum similarity threshold, so the profile starts as soon as the in-game UI state appears.
+
+**Why this priority**: Detecting visual states is the most common gating condition for game automation and enables reliable hands-free execution.
+
+**Independent Test**: Upload a reference image and define a region; when the image is displayed in that region, the profile starts within the expected detection window and only once per cooldown.
+
+**Acceptance Scenarios**:
+
+1. Given a trigger with region [x=0.40,y=0.30,w=0.20,h=0.10] and threshold 0.85, When the screen contains the image in that region, Then the profile starts within 2 seconds and the trigger enters cooldown.
+2. Given a trigger with threshold 0.85, When the image similarity is 0.80, Then the profile does not start and the trigger remains pending.
+
+---
+
+### User Story 2 - Run Profile after a delay or at a scheduled time (Priority: P2)
+
+As an automation user, I can schedule a profile to start after a delay (e.g., 30 seconds) or at a specific date/time, so it runs without manual interaction.
+
+**Why this priority**: Time-based automation enables predictable sequences and coordination with other tasks.
+
+**Independent Test**: Create a delay trigger for 10 seconds and verify the profile starts after the delay; create an absolute time trigger and verify start occurs within the window.
+
+**Acceptance Scenarios**:
+
+1. Given a delay trigger of 10 seconds, When enabled, Then the profile starts 10±1 seconds later and the trigger completes.
+2. Given an absolute time trigger at 2025-11-09T10:00:00Z, When the current time reaches the scheduled time, Then the profile starts within 2 seconds and the trigger completes.
+
+---
+
+### User Story 3 - Run Profile when text appears or disappears (Priority: P3)
+
+As an automation user, I can configure a trigger that fires when specified text is found (or not found) within a screen region with a minimum confidence, so the profile runs when the UI transitions occur (e.g., when "Loading" disappears).
+
+**Why this priority**: Text-based conditions are common where UI states are signaled by labels rather than distinct graphics.
+
+**Independent Test**: Configure a region and target text; when the text appears (or disappears), the profile starts within the detection window and respects cooldown.
+
+**Acceptance Scenarios**:
+
+1. Given a text-found trigger with target "Victory" and confidence 0.80, When the word "Victory" appears in the region, Then the profile starts within 2 seconds.
+2. Given a text-not-found trigger with target "Loading" and confidence 0.80, When "Loading" is no longer present for two consecutive evaluations, Then the profile starts and the trigger completes.
+
+---
+
+### Edge Cases
+
+- Region is outside screen bounds or has zero area → Trigger is invalid and cannot be enabled until corrected.
+- Multiple partial matches (image or text) within the region → Use the best match; must still meet threshold.
+- Rapidly flickering UI states → Debounce by requiring condition to hold for at least one full evaluation cycle; respects cooldown after firing.
+- Different device resolutions/aspect ratios → Regions are normalized (0..1); behavior must be consistent across resolutions.
+- Device not available or screen capture fails → Trigger evaluation is skipped and retried; no firing occurs.
+- Overlapping triggers for the same profile → Only the first satisfied trigger causes execution; others remain pending and will not re-fire during cooldown.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support attaching one or more triggers to a profile.
+- **FR-002**: Supported trigger types MUST include: delay (relative time), schedule (absolute date/time), image-match (fuzzy match), and text-match (OCR found/not-found).
+- **FR-003**: Trigger combination logic MUST be OR: if any enabled trigger is satisfied, the profile starts; remaining triggers for that profile are not evaluated again until cooldown elapses.
+- **FR-004**: Each trigger MUST support an Enabled flag and a Cooldown period (seconds) to prevent re-firing within the cooldown window (default: 60 seconds).
+- **FR-005**: Image-match trigger MUST accept a reference image, a normalized region (x,y,w,h in [0..1]) and a similarity threshold [0..1] (default: 0.85). The trigger is satisfied when the best match in the region meets or exceeds the threshold.
+- **FR-006**: Text-match trigger MUST accept target text (exact or regex), a normalized region (x,y,w,h in [0..1]), a confidence threshold [0..1] (default: 0.80), and a mode of either "found" or "not-found". The trigger is satisfied when the condition is met at or above the confidence threshold.
+- **FR-007**: Delay trigger MUST start the profile after the specified duration in seconds since the trigger was enabled; once fired, it completes and does not repeat unless re-enabled.
+- **FR-008**: Schedule trigger MUST start the profile at the specified ISO 8601 timestamp (including timezone). If the scheduled time is in the past when enabled, it MUST not fire.
+- **FR-009**: The system MUST evaluate active triggers continuously and detect satisfied conditions within 2 seconds under normal operating conditions.
+- **FR-010**: The system MUST expose a way to "Test Trigger" that evaluates the condition immediately and reports the current result (satisfied/not satisfied and measured similarity/confidence).
+- **FR-011**: The system MUST provide trigger state visibility including: status (pending, satisfied, cooldown), last evaluation time, last result details, and last fired time.
+- **FR-012**: Invalid configurations (e.g., region out of bounds, missing image, negative thresholds) MUST be rejected with clear validation errors prior to enabling the trigger.
+- **FR-013**: Regions MUST be specified as normalized coordinates (0..1) relative to the current screen; behavior MUST be resolution-independent.
+- **FR-014**: When multiple triggers become satisfied simultaneously, the profile MUST start once, and a single firing MUST be recorded with attribution to the first evaluated trigger.
+- **FR-015**: After a profile starts due to a trigger, additional firings for that profile MUST be suppressed until the configured cooldown has elapsed.
+
+### Key Entities *(include if feature involves data)*
+
+- **ProfileTrigger**: Associates a trigger with a Profile; attributes: id, profileId, type (delay | schedule | image-match | text-match), enabled, cooldownSeconds, lastFiredAt, lastEvaluatedAt, lastResult.
+- **Region**: Normalized rectangle with x, y, width, height in [0..1].
+- **ImageMatchParams**: referenceImage (identifier), region (Region), similarityThreshold [0..1].
+- **TextMatchParams**: target (string or regex), region (Region), confidenceThreshold [0..1], mode (found | not-found).
+- **TimeParams**: For delay: seconds (int). For schedule: timestamp (ISO 8601 with timezone).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 95% of satisfied conditions result in the profile starting within 2 seconds of the condition becoming true.
+- **SC-002**: False-positive firings are ≤ 5% for image and text triggers when thresholds are at or above defaults.
+- **SC-003**: 90% of users are able to configure and successfully test a trigger end-to-end within 5 minutes without external documentation.
+- **SC-004**: During any cooldown window, no more than one firing occurs per trigger (0 duplicate starts per cooldown per trigger).
+- **SC-005**: 90% of "Test Trigger" evaluations complete in ≤ 2 seconds.
+- **SC-006**: 100% of invalid trigger configurations are blocked with clear error messages before enabling.

--- a/specs/001-profile-triggers/tasks.md
+++ b/specs/001-profile-triggers/tasks.md
@@ -1,0 +1,156 @@
+---
+
+description: "Task list for Triggered Profile Execution feature"
+---
+
+# Tasks: Triggered Profile Execution
+
+**Input**: Design documents from `/specs/001-profile-triggers/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Tests are REQUIRED for any executable logic per the Constitution.
+
+**Organization**: Tasks are grouped by user story (US1..US3) to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- [P]: Can run in parallel (different files, no dependencies)
+- [Story]: Which user story this task belongs to (US1, US2, US3)
+
+---
+
+## Phase 1: Foundational (Blocking)
+
+- [ ] T001 Define domain entities and interfaces
+  - Paths: `src/GameBot.Domain/Profiles/ProfileTrigger.cs`, `src/GameBot.Domain/Profiles/TriggerEvaluationResult.cs`, `src/GameBot.Domain/Profiles/ITriggerEvaluator.cs`
+  - Acceptance: Compiles; XML docs for public types; unit test project references compile
+
+- [ ] T002 Implement TriggerEvaluationService (domain)
+  - Path: `src/GameBot.Domain/Services/TriggerEvaluationService.cs`
+  - Acceptance: Pure logic (no IO); methods < 50 LOC; unit tests pass (see T101-T104)
+
+- [ ] T003 Add TriggerBackgroundWorker (service)
+  - Path: `src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs`
+  - Acceptance: Periodic evaluation every N ms (configurable); safe shutdown; logs with correlation
+
+- [ ] T004 Extend AutomationProfile persistence to include triggers
+  - Paths: `src/GameBot.Domain/Profiles/AutomationProfile.cs`, `src/GameBot.Domain/Profiles/FileProfileRepository.cs`
+  - Acceptance: CRUD persists `triggers` array; validation errors for invalid triggers
+
+- [ ] T005 Wire SessionManager snapshot access for evaluator
+  - Path: `src/GameBot.Emulator/Session/SessionManager.cs`
+  - Acceptance: Snapshot method is callable by evaluator; no blocking of input pipeline
+
+- [ ] T006 [P] Add DTOs and endpoint scaffolding
+  - Paths: `src/GameBot.Service/Models/Triggers.cs`, `src/GameBot.Service/Endpoints/TriggersEndpoints.cs`
+  - Acceptance: Minimal endpoints compile; OpenAPI exposes new paths (see contracts)
+
+---
+
+## Phase 2: User Story 1 - Image trigger (P1) 🎯 MVP
+
+### Tests FIRST
+- [ ] T101 [P] [US1] Unit tests: image-match evaluation logic
+  - Path: `tests/unit/Emulator/Triggers/ImageMatchEvaluatorTests.cs`
+  - Acceptance: Happy path + below-threshold + out-of-bounds region
+
+- [ ] T102 [P] [US1] Integration tests: image trigger firing
+  - Path: `tests/integration/TriggerEvaluationTests.cs`
+  - Acceptance: POST /triggers/test returns satisfied with similarity≥threshold; cooldown respected
+
+- [ ] T103 [P] [US1] Contract tests: OpenAPI fragment compliance
+  - Path: `tests/contract/TriggersContractTests.cs`
+  - Acceptance: New schemas and endpoints match fragment
+
+### Implementation
+- [ ] T104 [US1] Implement ImageMatchEvaluator (template NCC per research)
+  - Path: `src/GameBot.Domain/Profiles/Evaluators/ImageMatchEvaluator.cs`
+  - Acceptance: Meets thresholds; downscale + grayscale; perf within budget
+
+- [ ] T105 [US1] Expose reference image repository (identifier lookup)
+  - Path: `src/GameBot.Domain/Games/GameArtifact.cs` or new `Images/` store
+  - Acceptance: Able to resolve `referenceImageId` to bytes; tests use fixtures
+
+- [ ] T106 [US1] Endpoint: create/list/get/patch/delete triggers (image type)
+  - Path: `src/GameBot.Service/Endpoints/TriggersEndpoints.cs`
+  - Acceptance: Matches contracts; validation errors for bad regions/thresholds
+
+- [ ] T107 [US1] Endpoint: test-evaluate trigger
+  - Path: `src/GameBot.Service/Endpoints/TriggersEndpoints.cs`
+  - Acceptance: Returns TriggerEvaluationResult
+
+- [ ] T108 [US1] Background evaluation integration
+  - Paths: `src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs`, `src/GameBot.Domain/Services/TriggerEvaluationService.cs`
+  - Acceptance: Auto-start profile when satisfied; single firing per cooldown
+
+---
+
+## Phase 3: User Story 2 - Time triggers (P2)
+
+### Tests FIRST
+- [ ] T201 [P] [US2] Unit tests: delay & schedule evaluation
+  - Path: `tests/unit/Emulator/Triggers/TimeTriggerEvaluatorTests.cs`
+  - Acceptance: Delay seconds and absolute time; past schedule rejected
+
+### Implementation
+- [ ] T202 [US2] Implement Delay/Schedule evaluators
+  - Path: `src/GameBot.Domain/Profiles/Evaluators/TimeEvaluators.cs`
+  - Acceptance: Accurate timing (±1s); non-repeating delay behavior
+
+- [ ] T203 [US2] Endpoint support for time triggers
+  - Path: `src/GameBot.Service/Endpoints/TriggersEndpoints.cs`
+  - Acceptance: CRUD + validation
+
+---
+
+## Phase 4: User Story 3 - Text triggers (P3)
+
+### Tests FIRST
+- [ ] T301 [P] [US3] Unit tests: text-match evaluation
+  - Path: `tests/unit/Emulator/Triggers/TextMatchEvaluatorTests.cs`
+  - Acceptance: found/not-found modes; confidence threshold; debounce flicker
+
+### Implementation
+- [ ] T302 [US3] Implement TextMatchEvaluator (Tesseract per research)
+  - Path: `src/GameBot.Domain/Profiles/Evaluators/TextMatchEvaluator.cs`
+  - Acceptance: Region OCR, whitelist options, confidence metrics
+
+- [ ] T303 [US3] Endpoint support for text triggers
+  - Path: `src/GameBot.Service/Endpoints/TriggersEndpoints.cs`
+  - Acceptance: CRUD + validation
+
+---
+
+## Phase 5: Cross-Cutting and Polish
+
+- [ ] T401 [P] Logging & correlation for triggers
+  - Paths: `src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs`, evaluator services
+  - Acceptance: Debug logs at start/end of evaluation; include triggerId and profileId
+
+- [ ] T402 [P] Performance validation
+  - Path: `tests/integration/Performance/TriggerPerfTests.cs`
+  - Acceptance: 95% detection-to-start ≤2s; document results in plan
+
+- [ ] T403 Documentation updates
+  - Paths: `README.md`, `specs/001-profile-triggers/quickstart.md`
+  - Acceptance: Quickstart validated against running service
+
+- [ ] T404 [P] Security & error handling
+  - Paths: trigger endpoints, validation layer
+  - Acceptance: Clear error messages; input validation prevents abuse
+
+---
+
+## Dependencies & Execution Order
+
+- Foundational Phase must complete before US1..US3
+- Within each story: write tests first → implement → integrate → validate
+- Background worker depends on evaluator service and persistence
+
+---
+
+## Notes
+
+- Regions are normalized (0..1)
+- Cooldown enforced after firing; ensure single start per window
+- Use fixtures for deterministic image/text tests

--- a/src/GameBot.Domain/GameBot.Domain.csproj
+++ b/src/GameBot.Domain/GameBot.Domain.csproj
@@ -1,5 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>GameBot.Domain</AssemblyName>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/GameBot.Domain/Profiles/AutomationProfile.cs
+++ b/src/GameBot.Domain/Profiles/AutomationProfile.cs
@@ -10,4 +10,5 @@ public sealed class AutomationProfile
     public required string GameId { get; set; }
     public Collection<InputAction> Steps { get; init; } = new();
     public Collection<string> Checkpoints { get; init; } = new();
+    public Collection<ProfileTrigger> Triggers { get; init; } = new();
 }

--- a/src/GameBot.Domain/Profiles/Evaluators/ImageMatchEvaluator.cs
+++ b/src/GameBot.Domain/Profiles/Evaluators/ImageMatchEvaluator.cs
@@ -1,0 +1,132 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using GameBot.Domain.Profiles;
+
+namespace GameBot.Domain.Profiles.Evaluators;
+
+internal sealed class ImageMatchEvaluator : ITriggerEvaluator
+{
+    private readonly IReferenceImageStore _store;
+    private readonly IScreenSource _screen;
+    public ImageMatchEvaluator(IReferenceImageStore store, IScreenSource screen)
+    { _store = store; _screen = screen; }
+
+    public bool CanEvaluate(ProfileTrigger trigger) => trigger.Enabled && trigger.Type == TriggerType.ImageMatch;
+
+    public TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now)
+    {
+    var p = (ImageMatchParams)trigger.Params;
+    var similarity = ComputeSimilarityNcc(p);
+        var status = similarity >= p.SimilarityThreshold ? TriggerStatus.Satisfied : TriggerStatus.Pending;
+        return new TriggerEvaluationResult
+        {
+            Status = status,
+            Similarity = similarity,
+            EvaluatedAt = now,
+            Reason = status == TriggerStatus.Satisfied ? "similarity_met" : "similarity_below_threshold"
+        };
+    }
+
+    private double ComputeSimilarityNcc(ImageMatchParams p)
+    {
+        if (!_store.TryGet(p.ReferenceImageId, out var tpl)) return 0d;
+        using var screenBmp = _screen.GetLatestScreenshot();
+        if (screenBmp is null) return 0d;
+
+        // Map normalized region to pixels
+        var rx = (int)Math.Round(p.Region.X * screenBmp.Width);
+        var ry = (int)Math.Round(p.Region.Y * screenBmp.Height);
+        var rw = Math.Max(1, (int)Math.Round(p.Region.Width * screenBmp.Width));
+        var rh = Math.Max(1, (int)Math.Round(p.Region.Height * screenBmp.Height));
+        rx = Math.Clamp(rx, 0, Math.Max(0, screenBmp.Width - 1));
+        ry = Math.Clamp(ry, 0, Math.Max(0, screenBmp.Height - 1));
+        rw = Math.Clamp(rw, 1, screenBmp.Width - rx);
+        rh = Math.Clamp(rh, 1, screenBmp.Height - ry);
+
+        using var region = screenBmp.Clone(new Rectangle(rx, ry, rw, rh), PixelFormat.Format24bppRgb);
+        using var tpl24 = tpl.PixelFormat == PixelFormat.Format24bppRgb ? (Bitmap)tpl.Clone() : tpl.Clone(new Rectangle(0,0,tpl.Width,tpl.Height), PixelFormat.Format24bppRgb);
+
+        // If template larger than region, cannot match
+        if (tpl24.Width > region.Width || tpl24.Height > region.Height) return 0d;
+
+        // Convert to grayscale arrays
+        var regionGray = ToGrayscale(region);
+        var tplGray = ToGrayscale(tpl24);
+
+        // Compute normalized cross-correlation and return max
+        double best = -1;
+        for (int y = 0; y <= regionGray.Height - tplGray.Height; y++)
+        {
+            for (int x = 0; x <= regionGray.Width - tplGray.Width; x++)
+            {
+                var ncc = Ncc(regionGray, tplGray, x, y);
+                if (ncc > best) best = ncc;
+            }
+        }
+        if (best < 0) return 0d;
+        // Map NCC [-1,1] to [0,1]
+        return Math.Max(0, Math.Min(1, (best + 1) / 2.0));
+    }
+
+    private static GrayImage ToGrayscale(Bitmap bmp)
+    {
+        var w = bmp.Width; var h = bmp.Height;
+        var data = new byte[w * h];
+        var bd = bmp.LockBits(new Rectangle(0, 0, w, h), ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+        try
+        {
+            unsafe
+            {
+                for (int y = 0; y < h; y++)
+                {
+                    byte* row = (byte*)bd.Scan0 + y * bd.Stride;
+                    for (int x = 0; x < w; x++)
+                    {
+                        byte b = row[x * 3 + 0];
+                        byte g = row[x * 3 + 1];
+                        byte r = row[x * 3 + 2];
+                        data[y * w + x] = (byte)((r * 0.299) + (g * 0.587) + (b * 0.114));
+                    }
+                }
+            }
+        }
+        finally
+        {
+            bmp.UnlockBits(bd);
+        }
+        return new GrayImage(w, h, data);
+    }
+
+    private static double Ncc(GrayImage img, GrayImage tpl, int x0, int y0)
+    {
+        double sumI = 0, sumT = 0, sumI2 = 0, sumT2 = 0, sumIT = 0;
+        int n = tpl.Width * tpl.Height;
+        for (int y = 0; y < tpl.Height; y++)
+        {
+            for (int x = 0; x < tpl.Width; x++)
+            {
+                var I = img.Data[(y0 + y) * img.Width + (x0 + x)];
+                var T = tpl.Data[y * tpl.Width + x];
+                sumI += I; sumT += T; sumI2 += I * I; sumT2 += T * T; sumIT += I * T;
+            }
+        }
+        var num = sumIT - (sumI * sumT / n);
+        var denL = sumI2 - (sumI * sumI / n);
+        var denR = sumT2 - (sumT * sumT / n);
+        var den = Math.Sqrt(Math.Max(denL, 0) * Math.Max(denR, 0));
+        if (den == 0) return 0;
+        return num / den; // in [-1,1]
+    }
+
+    private readonly record struct GrayImage(int Width, int Height, byte[] Data);
+}
+
+internal interface IReferenceImageStore
+{
+    bool TryGet(string id, out Bitmap bmp);
+}
+
+internal interface IScreenSource
+{
+    Bitmap? GetLatestScreenshot();
+}

--- a/src/GameBot.Domain/Profiles/Evaluators/MemoryReferenceImageStore.cs
+++ b/src/GameBot.Domain/Profiles/Evaluators/MemoryReferenceImageStore.cs
@@ -1,0 +1,17 @@
+using System.Drawing;
+
+namespace GameBot.Domain.Profiles.Evaluators;
+
+internal sealed class MemoryReferenceImageStore : IReferenceImageStore
+{
+    private readonly Dictionary<string, Bitmap> _images = new(StringComparer.OrdinalIgnoreCase);
+    public void Add(string id, Bitmap bmp) => _images[id] = bmp;
+    public bool TryGet(string id, out Bitmap bmp) => _images.TryGetValue(id, out bmp);
+}
+
+internal sealed class SingleBitmapScreenSource : IScreenSource
+{
+    private readonly Func<Bitmap?> _provider;
+    public SingleBitmapScreenSource(Func<Bitmap?> provider) => _provider = provider;
+    public Bitmap? GetLatestScreenshot() => _provider();
+}

--- a/src/GameBot.Domain/Profiles/Evaluators/MemoryReferenceImageStore.cs
+++ b/src/GameBot.Domain/Profiles/Evaluators/MemoryReferenceImageStore.cs
@@ -8,9 +8,18 @@ namespace GameBot.Domain.Profiles.Evaluators;
 public sealed class MemoryReferenceImageStore : IReferenceImageStore
 {
     private readonly Dictionary<string, Bitmap> _images = new(StringComparer.OrdinalIgnoreCase);
-    public void Add(string id, Bitmap bmp) => _images[id] = bmp;
+    public void Add(string id, Bitmap bmp)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(bmp);
+        _images[id] = bmp;
+    }
     // Dictionary never stores null values; suppress nullable analysis with '!'
-    public bool TryGet(string id, out Bitmap bmp) => _images.TryGetValue(id, out bmp!);
+    public bool TryGet(string id, out Bitmap bmp)
+    {
+        if (id is null) { bmp = null!; return false; }
+        return _images.TryGetValue(id, out bmp!);
+    }
 }
 
 /// <summary>Screen source backed by a single bitmap provider (primarily for tests).</summary>
@@ -18,6 +27,10 @@ public sealed class MemoryReferenceImageStore : IReferenceImageStore
 public sealed class SingleBitmapScreenSource : IScreenSource
 {
     private readonly Func<Bitmap?> _provider;
-    public SingleBitmapScreenSource(Func<Bitmap?> provider) => _provider = provider;
+    public SingleBitmapScreenSource(Func<Bitmap?> provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        _provider = provider;
+    }
     public Bitmap? GetLatestScreenshot() => _provider();
 }

--- a/src/GameBot.Domain/Profiles/Evaluators/MemoryReferenceImageStore.cs
+++ b/src/GameBot.Domain/Profiles/Evaluators/MemoryReferenceImageStore.cs
@@ -1,15 +1,21 @@
 using System.Drawing;
+using System.Runtime.Versioning;
 
 namespace GameBot.Domain.Profiles.Evaluators;
 
-internal sealed class MemoryReferenceImageStore : IReferenceImageStore
+/// <summary>In-memory reference image store for image match templates.</summary>
+[SupportedOSPlatform("windows")]
+public sealed class MemoryReferenceImageStore : IReferenceImageStore
 {
     private readonly Dictionary<string, Bitmap> _images = new(StringComparer.OrdinalIgnoreCase);
     public void Add(string id, Bitmap bmp) => _images[id] = bmp;
-    public bool TryGet(string id, out Bitmap bmp) => _images.TryGetValue(id, out bmp);
+    // Dictionary never stores null values; suppress nullable analysis with '!'
+    public bool TryGet(string id, out Bitmap bmp) => _images.TryGetValue(id, out bmp!);
 }
 
-internal sealed class SingleBitmapScreenSource : IScreenSource
+/// <summary>Screen source backed by a single bitmap provider (primarily for tests).</summary>
+[SupportedOSPlatform("windows")]
+public sealed class SingleBitmapScreenSource : IScreenSource
 {
     private readonly Func<Bitmap?> _provider;
     public SingleBitmapScreenSource(Func<Bitmap?> provider) => _provider = provider;

--- a/src/GameBot.Domain/Profiles/Evaluators/TimeTriggerEvaluators.cs
+++ b/src/GameBot.Domain/Profiles/Evaluators/TimeTriggerEvaluators.cs
@@ -1,0 +1,76 @@
+using GameBot.Domain.Profiles;
+
+namespace GameBot.Domain.Profiles.Evaluators;
+
+/// <summary>
+/// Evaluates schedule triggers: fires when now >= timestamp; never fires if timestamp < EnabledAt.
+/// </summary>
+public sealed class ScheduleTriggerEvaluator : ITriggerEvaluator
+{
+    public bool CanEvaluate(ProfileTrigger trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        return trigger.Enabled && trigger.Type == TriggerType.Schedule && trigger.Params is ScheduleParams;
+    }
+
+    public TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        var p = (ScheduleParams)trigger.Params;
+        // If enabled after the scheduled time, treat as disabled (spec: MUST not fire)
+        if (trigger.EnabledAt.HasValue && p.Timestamp < trigger.EnabledAt.Value)
+        {
+            return Disabled(now, "scheduled_time_in_past_when_enabled");
+        }
+        if (now >= p.Timestamp)
+        {
+            return new TriggerEvaluationResult
+            {
+                Status = TriggerStatus.Satisfied,
+                EvaluatedAt = now,
+                Reason = "time_reached"
+            };
+        }
+        return new TriggerEvaluationResult
+        {
+            Status = TriggerStatus.Pending,
+            EvaluatedAt = now,
+            Reason = "waiting_for_time"
+        };
+    }
+
+    private static TriggerEvaluationResult Disabled(DateTimeOffset now, string reason) => new()
+    {
+        Status = TriggerStatus.Disabled,
+        EvaluatedAt = now,
+        Reason = reason
+    };
+}
+
+/// <summary>
+/// Evaluates delay triggers: fires when (now - EnabledAt) >= seconds. If EnabledAt missing, treat as pending.
+/// </summary>
+public sealed class DelayTriggerEvaluator : ITriggerEvaluator
+{
+    public bool CanEvaluate(ProfileTrigger trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        return trigger.Enabled && trigger.Type == TriggerType.Delay && trigger.Params is DelayParams;
+    }
+
+    public TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        var p = (DelayParams)trigger.Params;
+        if (!trigger.EnabledAt.HasValue)
+        {
+            return new TriggerEvaluationResult { Status = TriggerStatus.Pending, EvaluatedAt = now, Reason = "not_enabled_yet" };
+        }
+        var elapsed = now - trigger.EnabledAt.Value;
+        if (elapsed.TotalSeconds >= p.Seconds)
+        {
+            return new TriggerEvaluationResult { Status = TriggerStatus.Satisfied, EvaluatedAt = now, Reason = "delay_elapsed" };
+        }
+        return new TriggerEvaluationResult { Status = TriggerStatus.Pending, EvaluatedAt = now, Reason = "waiting_delay" };
+    }
+}

--- a/src/GameBot.Domain/Profiles/FileProfileRepository.cs
+++ b/src/GameBot.Domain/Profiles/FileProfileRepository.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace GameBot.Domain.Profiles;
 
@@ -7,7 +8,9 @@ public sealed class FileProfileRepository : IProfileRepository
     private readonly string _dir;
     private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web)
     {
-        WriteIndented = false
+        WriteIndented = false,
+        // Needed for TriggerParams polymorphism based on attributes
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
     };
 
     public FileProfileRepository(string root)

--- a/src/GameBot.Domain/Profiles/FileProfileRepository.cs
+++ b/src/GameBot.Domain/Profiles/FileProfileRepository.cs
@@ -49,4 +49,15 @@ public sealed class FileProfileRepository : IProfileRepository
         }
         return list;
     }
+
+    public async Task<AutomationProfile?> UpdateAsync(AutomationProfile profile, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        if (string.IsNullOrWhiteSpace(profile.Id)) return null;
+        var path = Path.Combine(_dir, profile.Id + ".json");
+        if (!File.Exists(path)) return null;
+        using var fs = File.Create(path);
+        await JsonSerializer.SerializeAsync(fs, profile, JsonOpts, ct).ConfigureAwait(false);
+        return profile;
+    }
 }

--- a/src/GameBot.Domain/Profiles/FileProfileRepository.cs
+++ b/src/GameBot.Domain/Profiles/FileProfileRepository.cs
@@ -32,9 +32,8 @@ public sealed class FileProfileRepository : IProfileRepository
         var path = Path.Combine(_dir, id + ".json");
         if (!File.Exists(path)) return null;
         using var fs = File.OpenRead(path);
-        var prof = await JsonSerializer.DeserializeAsync<AutomationProfile>(fs, JsonOpts, ct).ConfigureAwait(false);
-        prof ??= new AutomationProfile { Id = id, Name = id, GameId = string.Empty };
-        prof.Triggers ??= new System.Collections.ObjectModel.Collection<ProfileTrigger>();
+    var prof = await JsonSerializer.DeserializeAsync<AutomationProfile>(fs, JsonOpts, ct).ConfigureAwait(false);
+    prof ??= new AutomationProfile { Id = id, Name = id, GameId = string.Empty };
         return prof;
     }
 
@@ -45,10 +44,6 @@ public sealed class FileProfileRepository : IProfileRepository
         {
             using var fs = File.OpenRead(file);
             var item = await JsonSerializer.DeserializeAsync<AutomationProfile>(fs, JsonOpts, ct).ConfigureAwait(false);
-            if (item is not null)
-            {
-                item.Triggers ??= new System.Collections.ObjectModel.Collection<ProfileTrigger>();
-            }
             if (item is not null && (gameId is null || string.Equals(item.GameId, gameId, StringComparison.OrdinalIgnoreCase)))
                 list.Add(item);
         }

--- a/src/GameBot.Domain/Profiles/IProfileRepository.cs
+++ b/src/GameBot.Domain/Profiles/IProfileRepository.cs
@@ -5,4 +5,5 @@ public interface IProfileRepository
     Task<AutomationProfile> AddAsync(AutomationProfile profile, CancellationToken ct = default);
     Task<AutomationProfile?> GetAsync(string id, CancellationToken ct = default);
     Task<IReadOnlyList<AutomationProfile>> ListAsync(string? gameId = null, CancellationToken ct = default);
+    Task<AutomationProfile?> UpdateAsync(AutomationProfile profile, CancellationToken ct = default);
 }

--- a/src/GameBot.Domain/Profiles/ITriggerEvaluator.cs
+++ b/src/GameBot.Domain/Profiles/ITriggerEvaluator.cs
@@ -1,0 +1,7 @@
+namespace GameBot.Domain.Profiles;
+
+internal interface ITriggerEvaluator
+{
+    bool CanEvaluate(ProfileTrigger trigger);
+    TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now);
+}

--- a/src/GameBot.Domain/Profiles/ITriggerEvaluator.cs
+++ b/src/GameBot.Domain/Profiles/ITriggerEvaluator.cs
@@ -1,6 +1,6 @@
 namespace GameBot.Domain.Profiles;
 
-internal interface ITriggerEvaluator
+public interface ITriggerEvaluator
 {
     bool CanEvaluate(ProfileTrigger trigger);
     TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now);

--- a/src/GameBot.Domain/Profiles/ProfileTrigger.cs
+++ b/src/GameBot.Domain/Profiles/ProfileTrigger.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace GameBot.Domain.Profiles;
 
 public enum TriggerType
@@ -16,6 +18,11 @@ public sealed class Region
     public required double Height { get; set; } // (0..1]
 }
 
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(DelayParams), "delay")]
+[JsonDerivedType(typeof(ScheduleParams), "schedule")]
+[JsonDerivedType(typeof(ImageMatchParams), "image-match")]
+[JsonDerivedType(typeof(TextMatchParams), "text-match")]
 public abstract class TriggerParams { }
 
 public sealed class DelayParams : TriggerParams

--- a/src/GameBot.Domain/Profiles/ProfileTrigger.cs
+++ b/src/GameBot.Domain/Profiles/ProfileTrigger.cs
@@ -48,6 +48,7 @@ public sealed class ProfileTrigger
     public required string Id { get; set; }
     public required TriggerType Type { get; set; }
     public bool Enabled { get; set; } = true;
+    public DateTimeOffset? EnabledAt { get; set; }
     public int CooldownSeconds { get; set; } = 60;
     public DateTimeOffset? LastFiredAt { get; set; }
     public DateTimeOffset? LastEvaluatedAt { get; set; }

--- a/src/GameBot.Domain/Profiles/ProfileTrigger.cs
+++ b/src/GameBot.Domain/Profiles/ProfileTrigger.cs
@@ -1,0 +1,56 @@
+namespace GameBot.Domain.Profiles;
+
+public enum TriggerType
+{
+    Delay,
+    Schedule,
+    ImageMatch,
+    TextMatch
+}
+
+public sealed class Region
+{
+    public required double X { get; set; } // [0..1]
+    public required double Y { get; set; } // [0..1]
+    public required double Width { get; set; } // (0..1]
+    public required double Height { get; set; } // (0..1]
+}
+
+public abstract class TriggerParams { }
+
+public sealed class DelayParams : TriggerParams
+{
+    public required int Seconds { get; set; }
+}
+
+public sealed class ScheduleParams : TriggerParams
+{
+    public required DateTimeOffset Timestamp { get; set; }
+}
+
+public sealed class ImageMatchParams : TriggerParams
+{
+    public required string ReferenceImageId { get; set; } = string.Empty;
+    public required Region Region { get; set; } = default!;
+    public double SimilarityThreshold { get; set; } = 0.85;
+}
+
+public sealed class TextMatchParams : TriggerParams
+{
+    public required string Target { get; set; } = string.Empty;
+    public required Region Region { get; set; } = default!;
+    public double ConfidenceThreshold { get; set; } = 0.80;
+    public required string Mode { get; set; } = "found"; // found | not-found
+}
+
+public sealed class ProfileTrigger
+{
+    public required string Id { get; set; }
+    public required TriggerType Type { get; set; }
+    public bool Enabled { get; set; } = true;
+    public int CooldownSeconds { get; set; } = 60;
+    public DateTimeOffset? LastFiredAt { get; set; }
+    public DateTimeOffset? LastEvaluatedAt { get; set; }
+    public TriggerEvaluationResult? LastResult { get; set; }
+    public required TriggerParams Params { get; set; } = default!;
+}

--- a/src/GameBot.Domain/Profiles/TriggerEvaluationResult.cs
+++ b/src/GameBot.Domain/Profiles/TriggerEvaluationResult.cs
@@ -1,0 +1,18 @@
+namespace GameBot.Domain.Profiles;
+
+public enum TriggerStatus
+{
+    Pending,
+    Satisfied,
+    Cooldown,
+    Disabled
+}
+
+public sealed class TriggerEvaluationResult
+{
+    public required TriggerStatus Status { get; set; }
+    public double? Similarity { get; set; }
+    public double? Confidence { get; set; }
+    public string? Reason { get; set; }
+    public required DateTimeOffset EvaluatedAt { get; set; }
+}

--- a/src/GameBot.Domain/Services/ITriggerEvaluationCoordinator.cs
+++ b/src/GameBot.Domain/Services/ITriggerEvaluationCoordinator.cs
@@ -1,0 +1,6 @@
+namespace GameBot.Domain.Services;
+
+public interface ITriggerEvaluationCoordinator
+{
+    Task<int> EvaluateAllAsync(string? gameId = null, CancellationToken ct = default);
+}

--- a/src/GameBot.Domain/Services/TriggerEvaluationCoordinator.cs
+++ b/src/GameBot.Domain/Services/TriggerEvaluationCoordinator.cs
@@ -1,0 +1,53 @@
+using GameBot.Domain.Profiles;
+
+namespace GameBot.Domain.Services;
+
+/// <summary>
+/// Coordinates evaluation of all triggers across all profiles. Intended for background execution.
+/// </summary>
+public sealed class TriggerEvaluationCoordinator
+{
+    private readonly IProfileRepository _profiles;
+    private readonly TriggerEvaluationService _evaluation;
+
+    public TriggerEvaluationCoordinator(IProfileRepository profiles, TriggerEvaluationService evaluation)
+    {
+        _profiles = profiles;
+        _evaluation = evaluation;
+    }
+
+    /// <summary>
+    /// Evaluates all enabled triggers for all profiles (optionally filtered by game) and persists changes.
+    /// </summary>
+    /// <remarks>
+    /// This performs in-memory mutation then issues an UpdateAsync per changed profile.
+    /// Cooldown and disabled triggers are short-circuited by TriggerEvaluationService.
+    /// </remarks>
+    public async Task<int> EvaluateAllAsync(string? gameId = null, CancellationToken ct = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var profiles = await _profiles.ListAsync(gameId, ct).ConfigureAwait(false);
+        var evaluatedCount = 0;
+        foreach (var profile in profiles)
+        {
+            var changed = false;
+            foreach (var trig in profile.Triggers)
+            {
+                var result = _evaluation.Evaluate(trig, now);
+                trig.LastEvaluatedAt = result.EvaluatedAt;
+                trig.LastResult = result;
+                if (result.Status == TriggerStatus.Satisfied)
+                {
+                    trig.LastFiredAt = result.EvaluatedAt;
+                }
+                changed = true; // We always persist evaluation timestamps
+                evaluatedCount++;
+            }
+            if (changed)
+            {
+                await _profiles.UpdateAsync(profile, ct).ConfigureAwait(false);
+            }
+        }
+        return evaluatedCount;
+    }
+}

--- a/src/GameBot.Domain/Services/TriggerEvaluationCoordinator.cs
+++ b/src/GameBot.Domain/Services/TriggerEvaluationCoordinator.cs
@@ -5,7 +5,7 @@ namespace GameBot.Domain.Services;
 /// <summary>
 /// Coordinates evaluation of all triggers across all profiles. Intended for background execution.
 /// </summary>
-public sealed class TriggerEvaluationCoordinator
+public sealed class TriggerEvaluationCoordinator : ITriggerEvaluationCoordinator
 {
     private readonly IProfileRepository _profiles;
     private readonly TriggerEvaluationService _evaluation;

--- a/src/GameBot.Domain/Services/TriggerEvaluationService.cs
+++ b/src/GameBot.Domain/Services/TriggerEvaluationService.cs
@@ -13,6 +13,7 @@ public sealed class TriggerEvaluationService
 
     public TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now)
     {
+        ArgumentNullException.ThrowIfNull(trigger);
         // Disabled triggers short-circuit
         if (!trigger.Enabled)
         {

--- a/src/GameBot.Domain/Services/TriggerEvaluationService.cs
+++ b/src/GameBot.Domain/Services/TriggerEvaluationService.cs
@@ -1,0 +1,29 @@
+using GameBot.Domain.Profiles;
+
+namespace GameBot.Domain.Services;
+
+public sealed class TriggerEvaluationService
+{
+    private readonly IReadOnlyList<ITriggerEvaluator> _evaluators;
+
+    public TriggerEvaluationService(IEnumerable<ITriggerEvaluator> evaluators)
+    {
+        _evaluators = evaluators.ToList();
+    }
+
+    public TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now)
+    {
+        var evaluator = _evaluators.FirstOrDefault(e => e.CanEvaluate(trigger));
+        if (evaluator is null)
+        {
+            return new TriggerEvaluationResult
+            {
+                Status = TriggerStatus.Disabled,
+                Reason = "No evaluator for trigger type",
+                EvaluatedAt = now
+            };
+        }
+
+        return evaluator.Evaluate(trigger, now);
+    }
+}

--- a/src/GameBot.Emulator/GameBot.Emulator.csproj
+++ b/src/GameBot.Emulator/GameBot.Emulator.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>GameBot.Emulator</AssemblyName>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GameBot.Domain\GameBot.Domain.csproj" />
@@ -9,5 +12,6 @@
     <PackageReference Include="SharpAdbClient" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/GameBot.Emulator/Session/AdbScreenSource.cs
+++ b/src/GameBot.Emulator/Session/AdbScreenSource.cs
@@ -1,0 +1,54 @@
+using System.Drawing;
+using System.IO;
+using System.Runtime.Versioning;
+using GameBot.Domain.Profiles.Evaluators;
+using GameBot.Emulator.Adb;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Emulator.Session;
+
+/// <summary>
+/// IScreenSource implementation backed by an active emulator session's ADB device screencap. Windows-only.
+/// Returns null if no session/device or on failure.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class AdbScreenSource : IScreenSource
+{
+    private readonly ISessionManager _sessions;
+    private readonly ILogger<AdbScreenSource> _logger;
+    private readonly ILogger<AdbClient> _adbLogger;
+
+    public AdbScreenSource(ISessionManager sessions, ILogger<AdbScreenSource> logger, ILogger<AdbClient> adbLogger)
+    {
+        _sessions = sessions;
+        _logger = logger;
+        _adbLogger = adbLogger;
+    }
+
+    public Bitmap? GetLatestScreenshot()
+    {
+        try
+        {
+            // Heuristic: pick first active session with a bound device serial
+            var sessionIds = System.Linq.Enumerable.ToList(System.Linq.Enumerable.Select(
+                System.Linq.Enumerable.Where(
+                    _sessions.GetType().GetField("_sessions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(_sessions) as System.Collections.IDictionary ?? new System.Collections.Hashtable(),
+                    _ => true), _ => ((System.Collections.DictionaryEntry) _).Key.ToString()));
+            // Above reflection is brittle; fallback to snapshot attempt through public API if we can guess one id
+            var chosen = sessionIds.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(chosen)) return null;
+            // Use public snapshot pathway (will invoke ADB screencap if available) to avoid duplicating retry logic
+            var pngTask = _sessions.GetSnapshotAsync(chosen, default);
+            pngTask.Wait();
+            var png = pngTask.Result;
+            if (png.Length == 0) return null;
+            using var ms = new MemoryStream(png);
+            return new Bitmap(ms);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "AdbScreenSource failed to obtain screenshot; returning null");
+            return null;
+        }
+    }
+}

--- a/src/GameBot.Emulator/Session/ISessionManager.cs
+++ b/src/GameBot.Emulator/Session/ISessionManager.cs
@@ -8,6 +8,7 @@ public interface ISessionManager
     bool CanCreateSession { get; }
     EmulatorSession CreateSession(string gameIdOrPath, string? profileId = null, string? preferredDeviceSerial = null);
     EmulatorSession? GetSession(string id);
+    IReadOnlyCollection<EmulatorSession> ListSessions();
     bool StopSession(string id);
     Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default);
     Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default);

--- a/src/GameBot.Emulator/Session/SessionManager.cs
+++ b/src/GameBot.Emulator/Session/SessionManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Runtime.Versioning;
 using System.Globalization;
 using System.Text.Json;
 using GameBot.Domain.Sessions;
@@ -11,6 +12,8 @@ using Microsoft.Extensions.Options;
 
 namespace GameBot.Emulator.Session;
 
+/// <summary>Manages emulator sessions and delegates ADB input/screenshot operations (Windows-only).</summary>
+[SupportedOSPlatform("windows")]
 public sealed class SessionManager : ISessionManager
 {
     private readonly ConcurrentDictionary<string, EmulatorSession> _sessions = new();

--- a/src/GameBot.Emulator/Session/SessionManager.cs
+++ b/src/GameBot.Emulator/Session/SessionManager.cs
@@ -105,6 +105,12 @@ public sealed class SessionManager : ISessionManager
         return null;
     }
 
+    public IReadOnlyCollection<EmulatorSession> ListSessions()
+    {
+        CleanupIdleSessions();
+        return _sessions.Values.ToList();
+    }
+
     public bool StopSession(string id)
     {
         if (_sessions.TryGetValue(id, out var s))

--- a/src/GameBot.Service/Endpoints/ImageReferencesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ImageReferencesEndpoints.cs
@@ -22,15 +22,19 @@ internal static class ImageReferencesEndpoints
 
     public static IEndpointRouteBuilder MapImageReferenceEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/images", async (UploadImageRequest req, IReferenceImageStore store, CancellationToken ct) =>
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.MapPost("/images", (UploadImageRequest req, IReferenceImageStore store) =>
         {
+            ArgumentNullException.ThrowIfNull(req);
+            ArgumentNullException.ThrowIfNull(store);
             if (string.IsNullOrWhiteSpace(req.Id) || string.IsNullOrWhiteSpace(req.Data))
                 return Results.BadRequest(new { error = new { code = "invalid_request", message = "id and data are required", hint = (string?)null } });
 
             try
             {
                 var b64 = req.Data;
-                var comma = b64.IndexOf(',');
+                var comma = b64.IndexOf(',', System.StringComparison.Ordinal);
                 if (comma >= 0) b64 = b64[(comma + 1)..]; // strip data URL header
                 var bytes = Convert.FromBase64String(b64);
                 using var ms = new MemoryStream(bytes);
@@ -47,6 +51,8 @@ internal static class ImageReferencesEndpoints
 
         app.MapGet("/images/{id}", (string id, IReferenceImageStore store) =>
         {
+            ArgumentNullException.ThrowIfNull(id);
+            ArgumentNullException.ThrowIfNull(store);
             if ((store as MemoryReferenceImageStore)?.TryGet(id, out var bmp) == true)
             {
                 return Results.Ok(new { id });

--- a/src/GameBot.Service/Endpoints/ImageReferencesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ImageReferencesEndpoints.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.IO;
+using System.Text.Json;
+using GameBot.Domain.Profiles.Evaluators;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System.Runtime.Versioning;
+
+namespace GameBot.Service.Endpoints;
+
+[SupportedOSPlatform("windows")]
+internal static class ImageReferencesEndpoints
+{
+    internal sealed class UploadImageRequest
+    {
+        [Required] public required string Id { get; set; }
+        // Accept base64 PNG/JPEG payload as data URL or raw base64
+        [Required] public required string Data { get; set; }
+    }
+
+    public static IEndpointRouteBuilder MapImageReferenceEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/images", async (UploadImageRequest req, IReferenceImageStore store, CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.Id) || string.IsNullOrWhiteSpace(req.Data))
+                return Results.BadRequest(new { error = new { code = "invalid_request", message = "id and data are required", hint = (string?)null } });
+
+            try
+            {
+                var b64 = req.Data;
+                var comma = b64.IndexOf(',');
+                if (comma >= 0) b64 = b64[(comma + 1)..]; // strip data URL header
+                var bytes = Convert.FromBase64String(b64);
+                using var ms = new MemoryStream(bytes);
+                using var bmp = new Bitmap(ms);
+                // Store a clone to decouple from stream lifetime
+                (store as MemoryReferenceImageStore)?.Add(req.Id, (Bitmap)bmp.Clone());
+                return Results.Created($"/images/{req.Id}", new { id = req.Id });
+            }
+            catch (Exception ex)
+            {
+                return Results.BadRequest(new { error = new { code = "invalid_image", message = "Failed to parse image", hint = ex.Message } });
+            }
+        }).WithName("UploadImageReference");
+
+        app.MapGet("/images/{id}", (string id, IReferenceImageStore store) =>
+        {
+            if ((store as MemoryReferenceImageStore)?.TryGet(id, out var bmp) == true)
+            {
+                return Results.Ok(new { id });
+            }
+            return Results.NotFound();
+        }).WithName("GetImageReference");
+
+        return app;
+    }
+}

--- a/src/GameBot.Service/Endpoints/MetricsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/MetricsEndpoints.cs
@@ -1,0 +1,33 @@
+using GameBot.Service.Hosted;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace GameBot.Service.Endpoints;
+
+/// <summary>
+/// Exposes operational metrics for trigger evaluation cycles.
+/// </summary>
+internal static class MetricsEndpoints
+{
+    public static IEndpointRouteBuilder MapMetricsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/metrics");
+
+        group.MapGet("/triggers", (ITriggerEvaluationMetrics metrics) =>
+        {
+            // Snapshot current counters; simple anonymous object for JSON
+            return Results.Ok(new
+            {
+                evaluations = metrics.Evaluations,
+                skippedNoSessions = metrics.SkippedNoSessions,
+                overlapSkipped = metrics.OverlapSkipped,
+                lastCycleDurationMs = metrics.LastCycleDurationMs
+            });
+        })
+        .WithName("GetTriggerEvaluationMetrics")
+        .WithOpenApi();
+
+        return app;
+    }
+}

--- a/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
@@ -143,6 +143,16 @@ internal static class TriggersEndpoints
         {
             TriggerType.Delay => new DelayParams { Seconds =  ((JsonElement)dto.Params).GetProperty("seconds").GetInt32() },
             TriggerType.Schedule => new ScheduleParams { Timestamp = DateTimeOffset.Parse(((JsonElement)dto.Params).GetProperty("timestamp").GetString()!, System.Globalization.CultureInfo.InvariantCulture) },
+            TriggerType.ImageMatch => new ImageMatchParams {
+                ReferenceImageId = ((JsonElement)dto.Params).GetProperty("referenceImageId").GetString()!,
+                Region = new Region {
+                    X = ((JsonElement)dto.Params).GetProperty("region").GetProperty("x").GetDouble(),
+                    Y = ((JsonElement)dto.Params).GetProperty("region").GetProperty("y").GetDouble(),
+                    Width = ((JsonElement)dto.Params).GetProperty("region").GetProperty("width").GetDouble(),
+                    Height = ((JsonElement)dto.Params).GetProperty("region").GetProperty("height").GetDouble()
+                },
+                SimilarityThreshold = ((JsonElement)dto.Params).TryGetProperty("similarityThreshold", out var th) && th.ValueKind==JsonValueKind.Number ? th.GetDouble() : 0.85
+            },
             _ => new DelayParams { Seconds = 1 }
         };
         return new ProfileTrigger

--- a/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
@@ -14,15 +14,12 @@ internal static class TriggersEndpoints
     {
         var group = app.MapGroup("/profiles/{profileId}/triggers");
 
-        group.MapGet("/", async (string profileId, ILoggerFactory lf, CancellationToken ct) =>
-        {
-            // Placeholder: list triggers from repository once wired
-            return Results.Ok(Array.Empty<ProfileTriggerDto>());
-        });
+        group.MapGet("/", (string profileId, ILoggerFactory lf, CancellationToken ct) =>
+            Results.Ok(Array.Empty<ProfileTriggerDto>()))
+            .WithName("ListProfileTriggers");
 
-        group.MapPost("/", async (string profileId, ProfileTriggerCreateDto dto, ILoggerFactory lf, CancellationToken ct) =>
+        group.MapPost("/", (string profileId, ProfileTriggerCreateDto dto, ILoggerFactory lf, CancellationToken ct) =>
         {
-            // Placeholder: validate and create trigger
             var created = new ProfileTrigger
             {
                 Id = Guid.NewGuid().ToString("N"),
@@ -32,35 +29,26 @@ internal static class TriggersEndpoints
                 Params = new DelayParams { Seconds = 1 }
             };
             return Results.Created($"/profiles/{profileId}/triggers/{created.Id}", TriggerMappings.ToDto(created));
-        });
+        }).WithName("CreateProfileTrigger");
 
-        group.MapGet("/{triggerId}", async (string profileId, string triggerId, CancellationToken ct) =>
-        {
-            return Results.NotFound();
-        });
+        group.MapGet("/{triggerId}", (string profileId, string triggerId, CancellationToken ct) => Results.NotFound())
+             .WithName("GetProfileTrigger");
 
-        group.MapPatch("/{triggerId}", async (string profileId, string triggerId, HttpRequest req, CancellationToken ct) =>
-        {
-            return Results.NotFound();
-        });
+        group.MapPatch("/{triggerId}", (string profileId, string triggerId, HttpRequest req, CancellationToken ct) => Results.NotFound())
+             .WithName("PatchProfileTrigger");
 
-        group.MapDelete("/{triggerId}", async (string profileId, string triggerId, CancellationToken ct) =>
-        {
-            return Results.NoContent();
-        });
+        group.MapDelete("/{triggerId}", (string profileId, string triggerId, CancellationToken ct) => Results.NoContent())
+             .WithName("DeleteProfileTrigger");
 
-        group.MapPost("/{triggerId}/test", async (string profileId, string triggerId, TriggerEvaluationService svc, CancellationToken ct) =>
+        group.MapPost("/{triggerId}/test", (string profileId, string triggerId, TriggerEvaluationService svc, CancellationToken ct) =>
         {
-            // Placeholder: return pending result
             var res = new TriggerEvaluationResult { Status = TriggerStatus.Pending, EvaluatedAt = DateTimeOffset.UtcNow, Reason = "stub" };
             return Results.Ok(res);
-        });
+        }).WithName("TestProfileTrigger");
 
-        group.MapPost("/evaluate", async (string profileId, CancellationToken ct) =>
-        {
-            // Placeholder: batch evaluate
-            return Results.Ok(Array.Empty<TriggerEvaluationResult>());
-        });
+        group.MapPost("/evaluate", (string profileId, CancellationToken ct) =>
+            Results.Ok(Array.Empty<TriggerEvaluationResult>()))
+            .WithName("EvaluateProfileTriggers");
 
         return app;
     }

--- a/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
@@ -1,5 +1,6 @@
 using GameBot.Domain.Profiles;
 using GameBot.Domain.Services;
+using System.Text.Json;
 using GameBot.Service.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -14,42 +15,143 @@ internal static class TriggersEndpoints
     {
         var group = app.MapGroup("/profiles/{profileId}/triggers");
 
-        group.MapGet("/", (string profileId, ILoggerFactory lf, CancellationToken ct) =>
-            Results.Ok(Array.Empty<ProfileTriggerDto>()))
+        group.MapGet("/", async (string profileId, IProfileRepository repo, CancellationToken ct) =>
+        {
+            var prof = await repo.GetAsync(profileId, ct).ConfigureAwait(false);
+            if (prof is null) return Results.NotFound();
+            var dtos = prof.Triggers.Select(TriggerMappings.ToDto).ToArray();
+            return Results.Ok(dtos);
+        })
             .WithName("ListProfileTriggers");
 
-        group.MapPost("/", (string profileId, ProfileTriggerCreateDto dto, ILoggerFactory lf, CancellationToken ct) =>
+        group.MapPost("/", async (string profileId, ProfileTriggerCreateDto dto, IProfileRepository repo, CancellationToken ct) =>
         {
-            var created = new ProfileTrigger
-            {
-                Id = Guid.NewGuid().ToString("N"),
-                Type = TriggerType.Delay,
-                Enabled = dto.Enabled,
-                CooldownSeconds = dto.CooldownSeconds,
-                Params = new DelayParams { Seconds = 1 }
-            };
-            return Results.Created($"/profiles/{profileId}/triggers/{created.Id}", TriggerMappings.ToDto(created));
+            var prof = await repo.GetAsync(profileId, ct).ConfigureAwait(false);
+            if (prof is null) return Results.NotFound();
+            var trigger = MapCreateDto(dto);
+            trigger.EnabledAt = trigger.Enabled ? DateTimeOffset.UtcNow : null;
+            prof.Triggers.Add(trigger);
+            await repo.UpdateAsync(prof, ct).ConfigureAwait(false);
+            return Results.Created($"/profiles/{profileId}/triggers/{trigger.Id}", TriggerMappings.ToDto(trigger));
         }).WithName("CreateProfileTrigger");
 
-        group.MapGet("/{triggerId}", (string profileId, string triggerId, CancellationToken ct) => Results.NotFound())
+        group.MapGet("/{triggerId}", async (string profileId, string triggerId, IProfileRepository repo, CancellationToken ct) =>
+        {
+            var prof = await repo.GetAsync(profileId, ct).ConfigureAwait(false);
+            if (prof is null) return Results.NotFound();
+            var trig = prof.Triggers.FirstOrDefault(t => t.Id == triggerId);
+            return trig is null ? Results.NotFound() : Results.Ok(TriggerMappings.ToDto(trig));
+        })
              .WithName("GetProfileTrigger");
 
-        group.MapPatch("/{triggerId}", (string profileId, string triggerId, HttpRequest req, CancellationToken ct) => Results.NotFound())
+        group.MapPatch("/{triggerId}", async (string profileId, string triggerId, HttpRequest req, IProfileRepository repo, CancellationToken ct) =>
+        {
+            var prof = await repo.GetAsync(profileId, ct).ConfigureAwait(false);
+            if (prof is null) return Results.NotFound();
+            var trig = prof.Triggers.FirstOrDefault(t => t.Id == triggerId);
+            if (trig is null) return Results.NotFound();
+            using var doc = await JsonDocument.ParseAsync(req.Body, cancellationToken: ct).ConfigureAwait(false);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("enabled", out var enabledEl) && enabledEl.ValueKind == JsonValueKind.True || enabledEl.ValueKind == JsonValueKind.False)
+            {
+                var newEnabled = enabledEl.GetBoolean();
+                if (trig.Enabled != newEnabled)
+                {
+                    trig.Enabled = newEnabled;
+                    trig.EnabledAt = newEnabled ? DateTimeOffset.UtcNow : null;
+                }
+            }
+            if (root.TryGetProperty("cooldownSeconds", out var cdEl) && cdEl.ValueKind == JsonValueKind.Number && cdEl.TryGetInt32(out var cd))
+            {
+                trig.CooldownSeconds = Math.Max(0, cd);
+            }
+            // Simple params patch for Delay (seconds) and Schedule (timestamp)
+            if (root.TryGetProperty("params", out var paramsEl))
+            {
+                if (trig.Params is DelayParams d && paramsEl.TryGetProperty("seconds", out var secEl) && secEl.ValueKind == JsonValueKind.Number && secEl.TryGetInt32(out var sec))
+                {
+                    d.Seconds = Math.Max(0, sec);
+                }
+                if (trig.Params is ScheduleParams s && paramsEl.TryGetProperty("timestamp", out var tsEl) && tsEl.ValueKind == JsonValueKind.String)
+                {
+                    if (DateTimeOffset.TryParse(tsEl.GetString(), out var ts)) s.Timestamp = ts;
+                }
+            }
+            await repo.UpdateAsync(prof, ct).ConfigureAwait(false);
+            return Results.Ok(TriggerMappings.ToDto(trig));
+        })
              .WithName("PatchProfileTrigger");
 
-        group.MapDelete("/{triggerId}", (string profileId, string triggerId, CancellationToken ct) => Results.NoContent())
+        group.MapDelete("/{triggerId}", async (string profileId, string triggerId, IProfileRepository repo, CancellationToken ct) =>
+        {
+            var prof = await repo.GetAsync(profileId, ct).ConfigureAwait(false);
+            if (prof is null) return Results.NotFound();
+            var removed = prof.Triggers.FirstOrDefault(t => t.Id == triggerId);
+            if (removed is null) return Results.NotFound();
+            prof.Triggers.Remove(removed);
+            await repo.UpdateAsync(prof, ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
              .WithName("DeleteProfileTrigger");
 
-        group.MapPost("/{triggerId}/test", (string profileId, string triggerId, TriggerEvaluationService svc, CancellationToken ct) =>
+        group.MapPost("/{triggerId}/test", async (string profileId, string triggerId, IProfileRepository repo, TriggerEvaluationService svc, CancellationToken ct) =>
         {
-            var res = new TriggerEvaluationResult { Status = TriggerStatus.Pending, EvaluatedAt = DateTimeOffset.UtcNow, Reason = "stub" };
+            var prof = await repo.GetAsync(profileId, ct).ConfigureAwait(false);
+            if (prof is null) return Results.NotFound();
+            var trig = prof.Triggers.FirstOrDefault(t => t.Id == triggerId);
+            if (trig is null) return Results.NotFound();
+            var res = svc.Evaluate(trig, DateTimeOffset.UtcNow);
+            trig.LastResult = res;
+            trig.LastEvaluatedAt = res.EvaluatedAt;
+            if (res.Status == TriggerStatus.Satisfied)
+            {
+                trig.LastFiredAt = res.EvaluatedAt;
+            }
+            await repo.UpdateAsync(prof, ct).ConfigureAwait(false);
             return Results.Ok(res);
         }).WithName("TestProfileTrigger");
 
-        group.MapPost("/evaluate", (string profileId, CancellationToken ct) =>
-            Results.Ok(Array.Empty<TriggerEvaluationResult>()))
+        group.MapPost("/evaluate", async (string profileId, IProfileRepository repo, TriggerEvaluationService svc, CancellationToken ct) =>
+        {
+            var prof = await repo.GetAsync(profileId, ct).ConfigureAwait(false);
+            if (prof is null) return Results.NotFound();
+            var results = new List<TriggerEvaluationResult>();
+            foreach (var trig in prof.Triggers.Where(t => t.Enabled))
+            {
+                var r = svc.Evaluate(trig, DateTimeOffset.UtcNow);
+                trig.LastResult = r;
+                trig.LastEvaluatedAt = r.EvaluatedAt;
+                if (r.Status == TriggerStatus.Satisfied)
+                {
+                    trig.LastFiredAt = r.EvaluatedAt;
+                }
+                results.Add(r);
+            }
+            await repo.UpdateAsync(prof, ct).ConfigureAwait(false);
+            return Results.Ok(results);
+        })
             .WithName("EvaluateProfileTriggers");
 
         return app;
+    }
+
+    private static ProfileTrigger MapCreateDto(ProfileTriggerCreateDto dto)
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var typeParsed = Enum.TryParse<TriggerType>(dto.Type, true, out var tt) ? tt : TriggerType.Delay;
+        TriggerParams p = typeParsed switch
+        {
+            TriggerType.Delay => new DelayParams { Seconds =  ((JsonElement)dto.Params).GetProperty("seconds").GetInt32() },
+            TriggerType.Schedule => new ScheduleParams { Timestamp = DateTimeOffset.Parse(((JsonElement)dto.Params).GetProperty("timestamp").GetString()!, System.Globalization.CultureInfo.InvariantCulture) },
+            _ => new DelayParams { Seconds = 1 }
+        };
+        return new ProfileTrigger
+        {
+            Id = id,
+            Type = typeParsed,
+            Enabled = dto.Enabled,
+            CooldownSeconds = dto.CooldownSeconds,
+            Params = p
+        };
     }
 }

--- a/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/TriggersEndpoints.cs
@@ -1,0 +1,67 @@
+using GameBot.Domain.Profiles;
+using GameBot.Domain.Services;
+using GameBot.Service.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Service.Endpoints;
+
+internal static class TriggersEndpoints
+{
+    public static IEndpointRouteBuilder MapTriggersEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/profiles/{profileId}/triggers");
+
+        group.MapGet("/", async (string profileId, ILoggerFactory lf, CancellationToken ct) =>
+        {
+            // Placeholder: list triggers from repository once wired
+            return Results.Ok(Array.Empty<ProfileTriggerDto>());
+        });
+
+        group.MapPost("/", async (string profileId, ProfileTriggerCreateDto dto, ILoggerFactory lf, CancellationToken ct) =>
+        {
+            // Placeholder: validate and create trigger
+            var created = new ProfileTrigger
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Type = TriggerType.Delay,
+                Enabled = dto.Enabled,
+                CooldownSeconds = dto.CooldownSeconds,
+                Params = new DelayParams { Seconds = 1 }
+            };
+            return Results.Created($"/profiles/{profileId}/triggers/{created.Id}", TriggerMappings.ToDto(created));
+        });
+
+        group.MapGet("/{triggerId}", async (string profileId, string triggerId, CancellationToken ct) =>
+        {
+            return Results.NotFound();
+        });
+
+        group.MapPatch("/{triggerId}", async (string profileId, string triggerId, HttpRequest req, CancellationToken ct) =>
+        {
+            return Results.NotFound();
+        });
+
+        group.MapDelete("/{triggerId}", async (string profileId, string triggerId, CancellationToken ct) =>
+        {
+            return Results.NoContent();
+        });
+
+        group.MapPost("/{triggerId}/test", async (string profileId, string triggerId, TriggerEvaluationService svc, CancellationToken ct) =>
+        {
+            // Placeholder: return pending result
+            var res = new TriggerEvaluationResult { Status = TriggerStatus.Pending, EvaluatedAt = DateTimeOffset.UtcNow, Reason = "stub" };
+            return Results.Ok(res);
+        });
+
+        group.MapPost("/evaluate", async (string profileId, CancellationToken ct) =>
+        {
+            // Placeholder: batch evaluate
+            return Results.Ok(Array.Empty<TriggerEvaluationResult>());
+        });
+
+        return app;
+    }
+}

--- a/src/GameBot.Service/GameBot.Service.csproj
+++ b/src/GameBot.Service/GameBot.Service.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <AssemblyName>GameBot.Service</AssemblyName>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GameBot.Domain\GameBot.Domain.csproj" />
@@ -13,5 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="*" />
   <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+  <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/GameBot.Service/GameBot.Service.csproj
+++ b/src/GameBot.Service/GameBot.Service.csproj
@@ -3,6 +3,8 @@
     <AssemblyName>GameBot.Service</AssemblyName>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <!-- Suppress CA1308: normalization uses ToLowerInvariant intentionally for stable HTTP tokens/type strings -->
+    <NoWarn>$(NoWarn);CA1308</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GameBot.Domain\GameBot.Domain.csproj" />

--- a/src/GameBot.Service/Hosted/ITriggerEvaluationMetrics.cs
+++ b/src/GameBot.Service/Hosted/ITriggerEvaluationMetrics.cs
@@ -1,0 +1,14 @@
+namespace GameBot.Service.Hosted;
+
+public interface ITriggerEvaluationMetrics
+{
+    long Evaluations { get; }
+    long SkippedNoSessions { get; }
+    long OverlapSkipped { get; }
+    long LastCycleDurationMs { get; }
+
+    void IncrementEvaluations(long count);
+    void IncrementSkippedNoSessions();
+    void IncrementOverlapSkipped();
+    void RecordCycleDuration(long ms);
+}

--- a/src/GameBot.Service/Hosted/ITriggerEvaluationMetrics.cs
+++ b/src/GameBot.Service/Hosted/ITriggerEvaluationMetrics.cs
@@ -1,6 +1,6 @@
 namespace GameBot.Service.Hosted;
 
-public interface ITriggerEvaluationMetrics
+internal interface ITriggerEvaluationMetrics
 {
     long Evaluations { get; }
     long SkippedNoSessions { get; }

--- a/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
+++ b/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
@@ -1,7 +1,10 @@
 using GameBot.Domain.Profiles;
 using GameBot.Domain.Services;
+using GameBot.Emulator.Session;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace GameBot.Service.Hosted;
 
@@ -9,17 +12,21 @@ internal sealed class TriggerBackgroundWorker : BackgroundService
 {
     private readonly ILogger<TriggerBackgroundWorker> _logger;
     private readonly TriggerEvaluationCoordinator _coordinator;
-    private readonly TimeSpan _interval;
-    private readonly string? _gameFilter;
+    private readonly ISessionManager _sessions;
+    private readonly IOptionsMonitor<TriggerWorkerOptions> _options;
+    private int _running;
 
     public TriggerBackgroundWorker(
         ILogger<TriggerBackgroundWorker> logger,
-        TriggerEvaluationCoordinator coordinator)
+        TriggerEvaluationCoordinator coordinator,
+        ISessionManager sessions,
+        IOptionsMonitor<TriggerWorkerOptions> options)
     {
         _logger = logger;
         _coordinator = coordinator;
-        _interval = TimeSpan.FromSeconds(2);
-        _gameFilter = Environment.GetEnvironmentVariable("GAMEBOT_EVAL_GAME_ID");
+        _sessions = sessions;
+        _options = options;
+        _running = 0;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -29,9 +36,38 @@ internal sealed class TriggerBackgroundWorker : BackgroundService
         {
             try
             {
-                var count = await _coordinator.EvaluateAllAsync(_gameFilter, stoppingToken).ConfigureAwait(false);
-                Log.WorkerCycle(_logger, count);
-                await Task.Delay(_interval, stoppingToken).ConfigureAwait(false);
+                var opts = _options.CurrentValue;
+                var interval = TimeSpan.FromSeconds(Math.Max(1, opts.IntervalSeconds));
+                var backoff = TimeSpan.FromSeconds(Math.Max(1, opts.IdleBackoffSeconds));
+
+                if (opts.SkipWhenNoSessions && _sessions.ActiveCount <= 0)
+                {
+                    Log.CycleSkippedNoSessions(_logger);
+                    await Task.Delay(backoff, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (Interlocked.Exchange(ref _running, 1) == 1)
+                {
+                    Log.CycleOverlapSkipped(_logger);
+                    await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var sw = Stopwatch.StartNew();
+                try
+                {
+                    var count = await _coordinator.EvaluateAllAsync(opts.GameFilter, stoppingToken).ConfigureAwait(false);
+                    Log.WorkerCycle(_logger, count);
+                }
+                finally
+                {
+                    sw.Stop();
+                    Log.CycleDuration(_logger, sw.ElapsedMilliseconds);
+                    Interlocked.Exchange(ref _running, 0);
+                }
+
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
             }
             catch (TaskCanceledException) { break; }
         }
@@ -47,9 +83,18 @@ internal static class Log
         LoggerMessage.Define(LogLevel.Information, new EventId(3002, nameof(WorkerStopped)), "Trigger background worker stopped");
     private static readonly Action<ILogger, int, Exception?> _workerCycle =
         LoggerMessage.Define<int>(LogLevel.Debug, new EventId(3003, nameof(WorkerCycle)), "Evaluated {TriggerCount} trigger(s) this cycle");
+    private static readonly Action<ILogger, Exception?> _cycleSkippedNoSessions =
+        LoggerMessage.Define(LogLevel.Debug, new EventId(3004, nameof(CycleSkippedNoSessions)), "Skipped evaluation cycle: no active sessions");
+    private static readonly Action<ILogger, Exception?> _cycleOverlapSkipped =
+        LoggerMessage.Define(LogLevel.Debug, new EventId(3005, nameof(CycleOverlapSkipped)), "Skipped evaluation cycle: previous cycle still running");
+    private static readonly Action<ILogger, long, Exception?> _cycleDuration =
+        LoggerMessage.Define<long>(LogLevel.Trace, new EventId(3006, nameof(CycleDuration)), "Evaluation cycle duration {DurationMs}ms");
 
     public static void WorkerStarted(ILogger l) => _workerStarted(l, null);
     public static void WorkerStopped(ILogger l) => _workerStopped(l, null);
     public static void WorkerCycle(ILogger l, int count) => _workerCycle(l, count, null);
+    public static void CycleSkippedNoSessions(ILogger l) => _cycleSkippedNoSessions(l, null);
+    public static void CycleOverlapSkipped(ILogger l) => _cycleOverlapSkipped(l, null);
+    public static void CycleDuration(ILogger l, long ms) => _cycleDuration(l, ms, null);
     // Intentionally no catch-all log to satisfy CA1031; errors propagate to host if any occur
 }

--- a/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
+++ b/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
@@ -22,28 +22,29 @@ internal sealed class TriggerBackgroundWorker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("TriggerBackgroundWorker started");
+    Log.WorkerStarted(_logger);
         while (!stoppingToken.IsCancellationRequested)
         {
-            try
-            {
-                // TODO: iterate active profiles/triggers and evaluate
-                // This is a stub; evaluation wiring will be completed in later tasks.
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during trigger evaluation loop");
-            }
+            // TODO: iterate active profiles/triggers and evaluate (stub)
 
             try
             {
-                await Task.Delay(_interval, stoppingToken);
+                await Task.Delay(_interval, stoppingToken).ConfigureAwait(false);
             }
-            catch (TaskCanceledException)
-            {
-                break;
-            }
+            catch (TaskCanceledException) { break; }
         }
-        _logger.LogInformation("TriggerBackgroundWorker stopped");
+        Log.WorkerStopped(_logger);
     }
+}
+
+internal static class Log
+{
+    private static readonly Action<ILogger, Exception?> _workerStarted =
+        LoggerMessage.Define(LogLevel.Information, new EventId(3001, nameof(WorkerStarted)), "Trigger background worker started");
+    private static readonly Action<ILogger, Exception?> _workerStopped =
+        LoggerMessage.Define(LogLevel.Information, new EventId(3002, nameof(WorkerStopped)), "Trigger background worker stopped");
+
+    public static void WorkerStarted(ILogger l) => _workerStarted(l, null);
+    public static void WorkerStopped(ILogger l) => _workerStopped(l, null);
+    // Intentionally no catch-all log to satisfy CA1031; errors propagate to host if any occur
 }

--- a/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
+++ b/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
@@ -11,14 +11,14 @@ namespace GameBot.Service.Hosted;
 internal sealed class TriggerBackgroundWorker : BackgroundService
 {
     private readonly ILogger<TriggerBackgroundWorker> _logger;
-    private readonly TriggerEvaluationCoordinator _coordinator;
+    private readonly ITriggerEvaluationCoordinator _coordinator;
     private readonly ISessionManager _sessions;
     private readonly IOptionsMonitor<TriggerWorkerOptions> _options;
     private int _running;
 
     public TriggerBackgroundWorker(
         ILogger<TriggerBackgroundWorker> logger,
-        TriggerEvaluationCoordinator coordinator,
+    ITriggerEvaluationCoordinator coordinator,
         ISessionManager sessions,
         IOptionsMonitor<TriggerWorkerOptions> options)
     {

--- a/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
+++ b/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
@@ -8,27 +8,29 @@ namespace GameBot.Service.Hosted;
 internal sealed class TriggerBackgroundWorker : BackgroundService
 {
     private readonly ILogger<TriggerBackgroundWorker> _logger;
-    private readonly TriggerEvaluationService _service;
+    private readonly TriggerEvaluationCoordinator _coordinator;
     private readonly TimeSpan _interval;
+    private readonly string? _gameFilter;
 
     public TriggerBackgroundWorker(
         ILogger<TriggerBackgroundWorker> logger,
-        TriggerEvaluationService service)
+        TriggerEvaluationCoordinator coordinator)
     {
         _logger = logger;
-        _service = service;
+        _coordinator = coordinator;
         _interval = TimeSpan.FromSeconds(2);
+        _gameFilter = Environment.GetEnvironmentVariable("GAMEBOT_EVAL_GAME_ID");
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-    Log.WorkerStarted(_logger);
+        Log.WorkerStarted(_logger);
         while (!stoppingToken.IsCancellationRequested)
         {
-            // TODO: iterate active profiles/triggers and evaluate (stub)
-
             try
             {
+                var count = await _coordinator.EvaluateAllAsync(_gameFilter, stoppingToken).ConfigureAwait(false);
+                Log.WorkerCycle(_logger, count);
                 await Task.Delay(_interval, stoppingToken).ConfigureAwait(false);
             }
             catch (TaskCanceledException) { break; }
@@ -43,8 +45,11 @@ internal static class Log
         LoggerMessage.Define(LogLevel.Information, new EventId(3001, nameof(WorkerStarted)), "Trigger background worker started");
     private static readonly Action<ILogger, Exception?> _workerStopped =
         LoggerMessage.Define(LogLevel.Information, new EventId(3002, nameof(WorkerStopped)), "Trigger background worker stopped");
+    private static readonly Action<ILogger, int, Exception?> _workerCycle =
+        LoggerMessage.Define<int>(LogLevel.Debug, new EventId(3003, nameof(WorkerCycle)), "Evaluated {TriggerCount} trigger(s) this cycle");
 
     public static void WorkerStarted(ILogger l) => _workerStarted(l, null);
     public static void WorkerStopped(ILogger l) => _workerStopped(l, null);
+    public static void WorkerCycle(ILogger l, int count) => _workerCycle(l, count, null);
     // Intentionally no catch-all log to satisfy CA1031; errors propagate to host if any occur
 }

--- a/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
+++ b/src/GameBot.Service/Hosted/TriggerBackgroundWorker.cs
@@ -1,0 +1,49 @@
+using GameBot.Domain.Profiles;
+using GameBot.Domain.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Service.Hosted;
+
+internal sealed class TriggerBackgroundWorker : BackgroundService
+{
+    private readonly ILogger<TriggerBackgroundWorker> _logger;
+    private readonly TriggerEvaluationService _service;
+    private readonly TimeSpan _interval;
+
+    public TriggerBackgroundWorker(
+        ILogger<TriggerBackgroundWorker> logger,
+        TriggerEvaluationService service)
+    {
+        _logger = logger;
+        _service = service;
+        _interval = TimeSpan.FromSeconds(2);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("TriggerBackgroundWorker started");
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                // TODO: iterate active profiles/triggers and evaluate
+                // This is a stub; evaluation wiring will be completed in later tasks.
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during trigger evaluation loop");
+            }
+
+            try
+            {
+                await Task.Delay(_interval, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+        }
+        _logger.LogInformation("TriggerBackgroundWorker stopped");
+    }
+}

--- a/src/GameBot.Service/Hosted/TriggerEvaluationMetrics.cs
+++ b/src/GameBot.Service/Hosted/TriggerEvaluationMetrics.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+
+namespace GameBot.Service.Hosted;
+
+internal sealed class TriggerEvaluationMetrics : ITriggerEvaluationMetrics
+{
+    private long _evaluations;
+    private long _skippedNoSessions;
+    private long _overlapSkipped;
+    private long _lastDurationMs;
+
+    public long Evaluations => Interlocked.Read(ref _evaluations);
+    public long SkippedNoSessions => Interlocked.Read(ref _skippedNoSessions);
+    public long OverlapSkipped => Interlocked.Read(ref _overlapSkipped);
+    public long LastCycleDurationMs => Interlocked.Read(ref _lastDurationMs);
+
+    public void IncrementEvaluations(long count) => Interlocked.Add(ref _evaluations, count);
+    public void IncrementSkippedNoSessions() => Interlocked.Increment(ref _skippedNoSessions);
+    public void IncrementOverlapSkipped() => Interlocked.Increment(ref _overlapSkipped);
+    public void RecordCycleDuration(long ms) => Interlocked.Exchange(ref _lastDurationMs, ms);
+}

--- a/src/GameBot.Service/Hosted/TriggerWorkerOptions.cs
+++ b/src/GameBot.Service/Hosted/TriggerWorkerOptions.cs
@@ -1,0 +1,16 @@
+namespace GameBot.Service.Hosted;
+
+internal sealed class TriggerWorkerOptions
+{
+    // Base cadence in seconds when actively evaluating
+    public int IntervalSeconds { get; set; } = 2;
+
+    // Optional gameId filter to restrict evaluations
+    public string? GameFilter { get; set; }
+
+    // If true, when there are no active sessions, skip evaluation and use IdleBackoffSeconds delay
+    public bool SkipWhenNoSessions { get; set; } = true;
+
+    // Delay in seconds when idle (no sessions) to reduce CPU usage
+    public int IdleBackoffSeconds { get; set; } = 5;
+}

--- a/src/GameBot.Service/Models/Triggers.cs
+++ b/src/GameBot.Service/Models/Triggers.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using GameBot.Domain.Profiles;
+
+namespace GameBot.Service.Models;
+
+internal sealed class RegionDto
+{
+    [Range(0,1)] public double X { get; set; }
+    [Range(0,1)] public double Y { get; set; }
+    [Range(0,1)] public double Width { get; set; }
+    [Range(0,1)] public double Height { get; set; }
+}
+
+internal sealed class ProfileTriggerCreateDto
+{
+    [Required] public required string Type { get; set; }
+    public bool Enabled { get; set; } = true;
+    [Range(0,int.MaxValue)] public int CooldownSeconds { get; set; } = 60;
+    [Required] public required object Params { get; set; } = default!;
+}
+
+internal sealed class ProfileTriggerDto
+{
+    public required string Id { get; set; }
+    public required string Type { get; set; }
+    public bool Enabled { get; set; }
+    public int CooldownSeconds { get; set; }
+    public DateTimeOffset? LastFiredAt { get; set; }
+    public DateTimeOffset? LastEvaluatedAt { get; set; }
+    public TriggerEvaluationResult? LastResult { get; set; }
+    public required object Params { get; set; } = default!;
+}
+
+internal static class TriggerMappings
+{
+    public static ProfileTriggerDto ToDto(ProfileTrigger t) => new()
+    {
+        Id = t.Id,
+        Type = t.Type.ToString().ToLowerInvariant().Replace("match","-match"),
+        Enabled = t.Enabled,
+        CooldownSeconds = t.CooldownSeconds,
+        LastFiredAt = t.LastFiredAt,
+        LastEvaluatedAt = t.LastEvaluatedAt,
+        LastResult = t.LastResult,
+        Params = t.Params
+    };
+}

--- a/src/GameBot.Service/Models/Triggers.cs
+++ b/src/GameBot.Service/Models/Triggers.cs
@@ -36,7 +36,7 @@ internal static class TriggerMappings
     public static ProfileTriggerDto ToDto(ProfileTrigger t) => new()
     {
         Id = t.Id,
-        Type = t.Type.ToString().ToLowerInvariant().Replace("match","-match"),
+    Type = t.Type.ToString().Replace("Match","-MATCH", StringComparison.Ordinal).ToUpperInvariant(),
         Enabled = t.Enabled,
         CooldownSeconds = t.CooldownSeconds,
         LastFiredAt = t.LastFiredAt,

--- a/src/GameBot.Service/Models/Triggers.cs
+++ b/src/GameBot.Service/Models/Triggers.cs
@@ -33,15 +33,27 @@ internal sealed class ProfileTriggerDto
 
 internal static class TriggerMappings
 {
-    public static ProfileTriggerDto ToDto(ProfileTrigger t) => new()
+    public static ProfileTriggerDto ToDto(ProfileTrigger t)
     {
-        Id = t.Id,
-    Type = t.Type.ToString().Replace("Match","-MATCH", StringComparison.Ordinal).ToUpperInvariant(),
-        Enabled = t.Enabled,
-        CooldownSeconds = t.CooldownSeconds,
-        LastFiredAt = t.LastFiredAt,
-        LastEvaluatedAt = t.LastEvaluatedAt,
-        LastResult = t.LastResult,
-        Params = t.Params
-    };
+        // Normalize to kebab-case strings stable for API consumers
+        var typeString = t.Type switch
+        {
+            TriggerType.Delay => "delay",
+            TriggerType.Schedule => "schedule",
+            TriggerType.ImageMatch => "image-match",
+            TriggerType.TextMatch => "text-match",
+            _ => t.Type.ToString().ToLowerInvariant()
+        };
+        return new ProfileTriggerDto
+        {
+            Id = t.Id,
+            Type = typeString,
+            Enabled = t.Enabled,
+            CooldownSeconds = t.CooldownSeconds,
+            LastFiredAt = t.LastFiredAt,
+            LastEvaluatedAt = t.LastEvaluatedAt,
+            LastResult = t.LastResult,
+            Params = t.Params
+        };
+    }
 }

--- a/src/GameBot.Service/PlatformSupport.cs
+++ b/src/GameBot.Service/PlatformSupport.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -61,6 +61,8 @@ Directory.CreateDirectory(storageRoot);
 builder.Services.AddSingleton<IGameRepository>(_ => new FileGameRepository(storageRoot));
 builder.Services.AddSingleton<IProfileRepository>(_ => new FileProfileRepository(storageRoot));
 builder.Services.AddSingleton<TriggerEvaluationService>();
+builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.DelayTriggerEvaluator>();
+builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.ScheduleTriggerEvaluator>();
 builder.Services.AddHostedService<TriggerBackgroundWorker>();
 
 // Configuration binding for auth token (env: GAMEBOT_AUTH_TOKEN)

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -110,6 +110,7 @@ if (OperatingSystem.IsWindows())
 }
 // Bind trigger worker options (env overrides supported via Configuration)
 builder.Services.Configure<GameBot.Service.Hosted.TriggerWorkerOptions>(builder.Configuration.GetSection("Service:Triggers:Worker"));
+builder.Services.AddSingleton<GameBot.Service.Hosted.ITriggerEvaluationMetrics, GameBot.Service.Hosted.TriggerEvaluationMetrics>();
 builder.Services.AddHostedService<TriggerBackgroundWorker>();
 
 // Configuration binding for auth token (env: GAMEBOT_AUTH_TOKEN)

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -63,6 +63,11 @@ builder.Services.AddSingleton<IProfileRepository>(_ => new FileProfileRepository
 builder.Services.AddSingleton<TriggerEvaluationService>();
 builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.DelayTriggerEvaluator>();
 builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.ScheduleTriggerEvaluator>();
+// Image match evaluator dependencies (in-memory store + screen source placeholder)
+builder.Services.AddSingleton<GameBot.Domain.Profiles.Evaluators.IReferenceImageStore, GameBot.Domain.Profiles.Evaluators.MemoryReferenceImageStore>();
+// Simple screen source stub: returns null screenshot until implemented or replaced in tests
+builder.Services.AddSingleton<GameBot.Domain.Profiles.Evaluators.IScreenSource>(_ => new GameBot.Domain.Profiles.Evaluators.SingleBitmapScreenSource(() => null));
+builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.ImageMatchEvaluator>();
 builder.Services.AddHostedService<TriggerBackgroundWorker>();
 
 // Configuration binding for auth token (env: GAMEBOT_AUTH_TOKEN)
@@ -128,6 +133,8 @@ app.MapProfileEndpoints();
 app.MapAdbEndpoints();
 // Triggers endpoints (protected if token set)
 app.MapTriggersEndpoints();
+// Image references endpoints for image-match triggers
+app.MapImageReferenceEndpoints();
 
 app.Run();
 

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -67,7 +67,7 @@ Directory.CreateDirectory(storageRoot);
 builder.Services.AddSingleton<IGameRepository>(_ => new FileGameRepository(storageRoot));
 builder.Services.AddSingleton<IProfileRepository>(_ => new FileProfileRepository(storageRoot));
 builder.Services.AddSingleton<TriggerEvaluationService>();
-builder.Services.AddSingleton<TriggerEvaluationCoordinator>();
+builder.Services.AddSingleton<ITriggerEvaluationCoordinator, TriggerEvaluationCoordinator>();
 builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.DelayTriggerEvaluator>();
 builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.ScheduleTriggerEvaluator>();
 // Image match evaluator dependencies (in-memory store + screen source placeholder)

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -182,6 +182,9 @@ if (OperatingSystem.IsWindows())
     app.MapImageReferenceEndpoints();
 }
 
+// Metrics endpoints (protected if token set)
+app.MapMetricsEndpoints();
+
 app.Run();
 
 // For WebApplicationFactory discovery in tests

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -108,6 +108,8 @@ if (OperatingSystem.IsWindows())
     }
     builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.ImageMatchEvaluator>();
 }
+// Bind trigger worker options (env overrides supported via Configuration)
+builder.Services.Configure<GameBot.Service.Hosted.TriggerWorkerOptions>(builder.Configuration.GetSection("Service:Triggers:Worker"));
 builder.Services.AddHostedService<TriggerBackgroundWorker>();
 
 // Configuration binding for auth token (env: GAMEBOT_AUTH_TOKEN)

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -67,6 +67,7 @@ Directory.CreateDirectory(storageRoot);
 builder.Services.AddSingleton<IGameRepository>(_ => new FileGameRepository(storageRoot));
 builder.Services.AddSingleton<IProfileRepository>(_ => new FileProfileRepository(storageRoot));
 builder.Services.AddSingleton<TriggerEvaluationService>();
+builder.Services.AddSingleton<TriggerEvaluationCoordinator>();
 builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.DelayTriggerEvaluator>();
 builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Profiles.Evaluators.ScheduleTriggerEvaluator>();
 // Image match evaluator dependencies (in-memory store + screen source placeholder)

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -4,6 +4,8 @@ using GameBot.Emulator.Session;
 using GameBot.Service.Endpoints;
 using GameBot.Domain.Games;
 using GameBot.Domain.Profiles;
+using GameBot.Domain.Services;
+using GameBot.Service.Hosted;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -58,6 +60,8 @@ Directory.CreateDirectory(storageRoot);
 
 builder.Services.AddSingleton<IGameRepository>(_ => new FileGameRepository(storageRoot));
 builder.Services.AddSingleton<IProfileRepository>(_ => new FileProfileRepository(storageRoot));
+builder.Services.AddSingleton<TriggerEvaluationService>();
+builder.Services.AddHostedService<TriggerBackgroundWorker>();
 
 // Configuration binding for auth token (env: GAMEBOT_AUTH_TOKEN)
 var authToken = builder.Configuration["Service:Auth:Token"]
@@ -120,6 +124,8 @@ app.MapGameEndpoints();
 app.MapProfileEndpoints();
 // ADB diagnostics endpoints (protected if token set)
 app.MapAdbEndpoints();
+// Triggers endpoints (protected if token set)
+app.MapTriggersEndpoints();
 
 app.Run();
 

--- a/src/GameBot.Service/Properties/AssemblyInfo.cs
+++ b/src/GameBot.Service/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GameBot.UnitTests")]

--- a/tests/contract/PlatformSupport.cs
+++ b/tests/contract/PlatformSupport.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/tests/integration/GamesProfilesTests.cs
+++ b/tests/integration/GamesProfilesTests.cs
@@ -12,6 +12,7 @@ public class GamesProfilesTests
     {
         Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
         Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+        TestEnvironment.PrepareCleanDataDir();
     }
 
     [Fact]

--- a/tests/integration/GamesProfilesTests.cs
+++ b/tests/integration/GamesProfilesTests.cs
@@ -23,7 +23,7 @@ public class GamesProfilesTests
         var client = app.CreateClient();
         client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
 
-        var create = await client.PostAsJsonAsync("/games", new { name = "Game A", description = "desc" }).ConfigureAwait(true);
+    var create = await client.PostAsJsonAsync(new Uri("/games", UriKind.Relative), new { name = "Game A", description = "desc" }).ConfigureAwait(true);
         create.StatusCode.Should().Be(HttpStatusCode.Created);
         var game = await create.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(true);
         var id = game!["id"].ToString();
@@ -44,7 +44,7 @@ public class GamesProfilesTests
         client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
 
     // Create a game
-    var gameResp = await client.PostAsJsonAsync("/games", new { name = "Game B", description = "desc" }).ConfigureAwait(true);
+    var gameResp = await client.PostAsJsonAsync(new Uri("/games", UriKind.Relative), new { name = "Game B", description = "desc" }).ConfigureAwait(true);
         gameResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(true);
         var gameId = game!["id"]!.ToString();
@@ -88,16 +88,16 @@ public class GamesProfilesTests
         client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
 
         // Create a game
-        var g = await client.PostAsJsonAsync("/games", new { name = "Game B", description = "desc" }).ConfigureAwait(true);
+    var g = await client.PostAsJsonAsync(new Uri("/games", UriKind.Relative), new { name = "Game B", description = "desc" }).ConfigureAwait(true);
     var gBody = await g.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(true);
         var gameId = gBody!["id"].ToString();
 
         // Create two profiles, one for this game, one for another
         var profileReq = new { name = "P1", gameId, steps = new object[] { new { type = "tap", args = new { x = 1, y = 2 } } } };
-    var p1 = await client.PostAsJsonAsync("/profiles", profileReq).ConfigureAwait(true);
+    var p1 = await client.PostAsJsonAsync(new Uri("/profiles", UriKind.Relative), profileReq).ConfigureAwait(true);
         p1.StatusCode.Should().Be(HttpStatusCode.Created);
 
-    var p2 = await client.PostAsJsonAsync("/profiles", new { name = "P2", gameId = "other-game", steps = Array.Empty<object>() }).ConfigureAwait(true);
+    var p2 = await client.PostAsJsonAsync(new Uri("/profiles", UriKind.Relative), new { name = "P2", gameId = "other-game", steps = Array.Empty<object>() }).ConfigureAwait(true);
         p2.StatusCode.Should().Be(HttpStatusCode.Created);
 
         // Filter

--- a/tests/integration/HealthEndpointTests.cs
+++ b/tests/integration/HealthEndpointTests.cs
@@ -11,6 +11,7 @@ public class HealthEndpointTests
     public HealthEndpointTests()
     {
         Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+        TestEnvironment.PrepareCleanDataDir();
     }
 
     [Fact]

--- a/tests/integration/MetricsEndpointTests.cs
+++ b/tests/integration/MetricsEndpointTests.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests;
+
+public class MetricsEndpointTests
+{
+    public MetricsEndpointTests()
+    {
+        Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+        Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+        TestEnvironment.PrepareCleanDataDir();
+    }
+
+    [Fact]
+    public async Task MetricsEndpointReturnsSnapshot()
+    {
+        using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+        var resp = await client.GetAsync(new Uri("/metrics/triggers", UriKind.Relative)).ConfigureAwait(true);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await resp.Content.ReadFromJsonAsync<Dictionary<string, long>>().ConfigureAwait(true);
+        json.Should().NotBeNull();
+        json!.Should().ContainKey("evaluations");
+        json!.Should().ContainKey("skippedNoSessions");
+        json!.Should().ContainKey("overlapSkipped");
+        json!.Should().ContainKey("lastCycleDurationMs");
+    }
+}

--- a/tests/integration/PlatformSupport.cs
+++ b/tests/integration/PlatformSupport.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/tests/integration/ResourceLimitsTests.cs
+++ b/tests/integration/ResourceLimitsTests.cs
@@ -28,10 +28,10 @@ public class ResourceLimitsTests
     var devs = await client.GetFromJsonAsync<List<Dictionary<string, object>>>(new Uri("/adb/devices", UriKind.Relative)).ConfigureAwait(true);
     if (devs is null || devs.Count == 0) return;
     var serial = devs[0]["serial"]!.ToString();
-    var first = await client.PostAsJsonAsync("/sessions", new { gameId = "g1", adbSerial = serial }).ConfigureAwait(true);
+    var first = await client.PostAsJsonAsync(new Uri("/sessions", UriKind.Relative), new { gameId = "g1", adbSerial = serial }).ConfigureAwait(true);
         first.StatusCode.Should().Be(HttpStatusCode.Created);
 
-    var second = await client.PostAsJsonAsync("/sessions", new { gameId = "g2", adbSerial = serial }).ConfigureAwait(true);
+    var second = await client.PostAsJsonAsync(new Uri("/sessions", UriKind.Relative), new { gameId = "g2", adbSerial = serial }).ConfigureAwait(true);
         second.StatusCode.Should().Be((HttpStatusCode)429);
     }
 
@@ -48,7 +48,7 @@ public class ResourceLimitsTests
     var devs2 = await client.GetFromJsonAsync<List<Dictionary<string, object>>>(new Uri("/adb/devices", UriKind.Relative)).ConfigureAwait(true);
     if (devs2 is null || devs2.Count == 0) return;
     var serial2 = devs2[0]["serial"]!.ToString();
-    var createResp = await client.PostAsJsonAsync("/sessions", new { gameId = "g1", adbSerial = serial2 }).ConfigureAwait(true);
+    var createResp = await client.PostAsJsonAsync(new Uri("/sessions", UriKind.Relative), new { gameId = "g1", adbSerial = serial2 }).ConfigureAwait(true);
         createResp.EnsureSuccessStatusCode();
     var created = await createResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(true);
         var id = created!["id"].ToString();

--- a/tests/integration/ResourceLimitsTests.cs
+++ b/tests/integration/ResourceLimitsTests.cs
@@ -12,6 +12,7 @@ public class ResourceLimitsTests
     {
         Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
         Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+        TestEnvironment.PrepareCleanDataDir();
     }
 
     [Fact]

--- a/tests/integration/SessionInputTests.cs
+++ b/tests/integration/SessionInputTests.cs
@@ -12,6 +12,7 @@ public class SessionInputTests
     {
         Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
         Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+        TestEnvironment.PrepareCleanDataDir();
     }
 
     [Fact]

--- a/tests/integration/SessionInputTests.cs
+++ b/tests/integration/SessionInputTests.cs
@@ -26,7 +26,7 @@ public class SessionInputTests
     // Check devices and skip if none to avoid flakiness without ADB
     // Force stub mode for inputs test to avoid external ADB process hangs
     // Do NOT request adbSerial so session runs without ADB even if devices exist
-    var createResp = await client.PostAsJsonAsync("/sessions", new { gameId = "test-game" }).ConfigureAwait(true);
+    var createResp = await client.PostAsJsonAsync(new Uri("/sessions", UriKind.Relative), new { gameId = "test-game" }).ConfigureAwait(true);
     var created = await createResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(true);
         var id = created!["id"].ToString();
 

--- a/tests/integration/SnapshotTests.cs
+++ b/tests/integration/SnapshotTests.cs
@@ -26,7 +26,7 @@ public class SnapshotTests
     var devs = await client.GetFromJsonAsync<List<Dictionary<string, object>>>(new Uri("/adb/devices", UriKind.Relative)).ConfigureAwait(true);
     if (devs is null || devs.Count == 0) return;
     var serial = devs[0]["serial"]!.ToString();
-    var createResp = await client.PostAsJsonAsync("/sessions", new { gameId = "test-game", adbSerial = serial }).ConfigureAwait(true);
+    var createResp = await client.PostAsJsonAsync(new Uri("/sessions", UriKind.Relative), new { gameId = "test-game", adbSerial = serial }).ConfigureAwait(true);
     var created = await createResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(true);
         var id = created!["id"].ToString();
 

--- a/tests/integration/SnapshotTests.cs
+++ b/tests/integration/SnapshotTests.cs
@@ -12,6 +12,7 @@ public class SnapshotTests
     {
         Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
         Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+        TestEnvironment.PrepareCleanDataDir();
     }
 
     [Fact]

--- a/tests/integration/TestEnvironment.cs
+++ b/tests/integration/TestEnvironment.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+
+namespace GameBot.IntegrationTests;
+
+internal static class TestEnvironment
+{
+    // Creates a fresh, empty data directory and points the service to it.
+    public static string PrepareCleanDataDir()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "GameBotTests");
+        var dir = Path.Combine(baseDir, Guid.NewGuid().ToString("N"));
+        if (Directory.Exists(dir))
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ }
+        }
+        Directory.CreateDirectory(dir);
+        Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", dir);
+        return dir;
+    }
+}

--- a/tests/integration/TriggerEvaluationTests.cs
+++ b/tests/integration/TriggerEvaluationTests.cs
@@ -60,4 +60,50 @@ public class TriggerEvaluationTests
         var res = await testResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         ((System.Text.Json.JsonElement)res!["status"]).GetString().Should().Be("Pending");
     }
+
+    [Fact]
+    public async Task DelayTriggerRespectsCooldown()
+    {
+        Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+        using var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+        // Create game and profile
+        var gameResp = await client.PostAsJsonAsync("/games", new { name = "G2", description = "d" });
+        gameResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var gameId = game!["id"]!.ToString();
+
+        var profResp = await client.PostAsJsonAsync("/profiles", new { name = "P2", gameId, steps = Array.Empty<object>() });
+        profResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var prof = await profResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var profileId = prof!["id"]!.ToString();
+
+        // Create a delay trigger with 0s delay and 2s cooldown
+        var trigCreate = new { type = "delay", enabled = true, cooldownSeconds = 2, @params = new { seconds = 0 } };
+        var tResp = await client.PostAsJsonAsync($"/profiles/{profileId}/triggers", trigCreate);
+        tResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var tBody = await tResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var triggerId = tBody!["id"]!.ToString();
+
+        // First test -> Satisfied
+        var testResp1 = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+        testResp1.StatusCode.Should().Be(HttpStatusCode.OK);
+        var res1 = await testResp1.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        ((System.Text.Json.JsonElement)res1!["status"]).GetString().Should().Be("Satisfied");
+
+        // Immediate second test -> Cooldown
+        var testResp2 = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+        testResp2.StatusCode.Should().Be(HttpStatusCode.OK);
+        var res2 = await testResp2.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        ((System.Text.Json.JsonElement)res2!["status"]).GetString().Should().Be("Cooldown");
+
+        // After cooldown window -> Satisfied again
+        await Task.Delay(2100);
+        var testResp3 = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+        testResp3.StatusCode.Should().Be(HttpStatusCode.OK);
+        var res3 = await testResp3.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        ((System.Text.Json.JsonElement)res3!["status"]).GetString().Should().Be("Satisfied");
+    }
 }

--- a/tests/integration/TriggerEvaluationTests.cs
+++ b/tests/integration/TriggerEvaluationTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests;
+
+public class TriggerEvaluationTests
+{
+    public TriggerEvaluationTests()
+    {
+        Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+        Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+        TestEnvironment.PrepareCleanDataDir();
+    }
+
+    [Fact]
+    public async Task ImageTriggerTestEndpointReturnsPendingWithoutScreen()
+    {
+        Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+        using var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+        // Create game and profile
+        var gameResp = await client.PostAsJsonAsync("/games", new { name = "G", description = "d" });
+        gameResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var gameId = game!["id"]!.ToString();
+
+        var profResp = await client.PostAsJsonAsync("/profiles", new { name = "P", gameId, steps = Array.Empty<object>() });
+        profResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var prof = await profResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var profileId = prof!["id"]!.ToString();
+
+        // Create an image trigger (no actual screen; should be Pending)
+        var trigCreate = new
+        {
+            type = "image-match",
+            enabled = true,
+            cooldownSeconds = 60,
+            @params = new
+            {
+                referenceImageId = "tpl",
+                region = new { x = 0.0, y = 0.0, width = 1.0, height = 1.0 },
+                similarityThreshold = 0.9
+            }
+        };
+        var tResp = await client.PostAsJsonAsync($"/profiles/{profileId}/triggers", trigCreate);
+        tResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var tBody = await tResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var triggerId = tBody!["id"]!.ToString();
+
+        // Test trigger (Pending because screen source returns null by default)
+        var testResp = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+        testResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var res = await testResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        ((System.Text.Json.JsonElement)res!["status"]).GetString().Should().Be("Pending");
+    }
+}

--- a/tests/integration/TriggerEvaluationTests.cs
+++ b/tests/integration/TriggerEvaluationTests.cs
@@ -26,12 +26,12 @@ public class TriggerEvaluationTests
         client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
 
         // Create game and profile
-        var gameResp = await client.PostAsJsonAsync("/games", new { name = "G", description = "d" });
+    var gameResp = await client.PostAsJsonAsync(new Uri("/games", UriKind.Relative), new { name = "G", description = "d" });
         gameResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         var gameId = game!["id"]!.ToString();
 
-        var profResp = await client.PostAsJsonAsync("/profiles", new { name = "P", gameId, steps = Array.Empty<object>() });
+    var profResp = await client.PostAsJsonAsync(new Uri("/profiles", UriKind.Relative), new { name = "P", gameId, steps = Array.Empty<object>() });
         profResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var prof = await profResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         var profileId = prof!["id"]!.ToString();
@@ -49,13 +49,13 @@ public class TriggerEvaluationTests
                 similarityThreshold = 0.9
             }
         };
-        var tResp = await client.PostAsJsonAsync($"/profiles/{profileId}/triggers", trigCreate);
+    var tResp = await client.PostAsJsonAsync(new Uri($"/profiles/{profileId}/triggers", UriKind.Relative), trigCreate);
         tResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var tBody = await tResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         var triggerId = tBody!["id"]!.ToString();
 
         // Test trigger (Pending because screen source returns null by default)
-        var testResp = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+    var testResp = await client.PostAsync(new Uri($"/profiles/{profileId}/triggers/{triggerId}/test", UriKind.Relative), null);
         testResp.StatusCode.Should().Be(HttpStatusCode.OK);
         var res = await testResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         ((System.Text.Json.JsonElement)res!["status"]).GetString().Should().Be("Pending");
@@ -70,38 +70,38 @@ public class TriggerEvaluationTests
         client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
 
         // Create game and profile
-        var gameResp = await client.PostAsJsonAsync("/games", new { name = "G2", description = "d" });
+    var gameResp = await client.PostAsJsonAsync(new Uri("/games", UriKind.Relative), new { name = "G2", description = "d" });
         gameResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         var gameId = game!["id"]!.ToString();
 
-        var profResp = await client.PostAsJsonAsync("/profiles", new { name = "P2", gameId, steps = Array.Empty<object>() });
+    var profResp = await client.PostAsJsonAsync(new Uri("/profiles", UriKind.Relative), new { name = "P2", gameId, steps = Array.Empty<object>() });
         profResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var prof = await profResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         var profileId = prof!["id"]!.ToString();
 
         // Create a delay trigger with 0s delay and 2s cooldown
         var trigCreate = new { type = "delay", enabled = true, cooldownSeconds = 2, @params = new { seconds = 0 } };
-        var tResp = await client.PostAsJsonAsync($"/profiles/{profileId}/triggers", trigCreate);
+    var tResp = await client.PostAsJsonAsync(new Uri($"/profiles/{profileId}/triggers", UriKind.Relative), trigCreate);
         tResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var tBody = await tResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         var triggerId = tBody!["id"]!.ToString();
 
         // First test -> Satisfied
-        var testResp1 = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+    var testResp1 = await client.PostAsync(new Uri($"/profiles/{profileId}/triggers/{triggerId}/test", UriKind.Relative), null);
         testResp1.StatusCode.Should().Be(HttpStatusCode.OK);
         var res1 = await testResp1.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         ((System.Text.Json.JsonElement)res1!["status"]).GetString().Should().Be("Satisfied");
 
         // Immediate second test -> Cooldown
-        var testResp2 = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+    var testResp2 = await client.PostAsync(new Uri($"/profiles/{profileId}/triggers/{triggerId}/test", UriKind.Relative), null);
         testResp2.StatusCode.Should().Be(HttpStatusCode.OK);
         var res2 = await testResp2.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         ((System.Text.Json.JsonElement)res2!["status"]).GetString().Should().Be("Cooldown");
 
         // After cooldown window -> Satisfied again
         await Task.Delay(2100);
-        var testResp3 = await client.PostAsync($"/profiles/{profileId}/triggers/{triggerId}/test", null);
+    var testResp3 = await client.PostAsync(new Uri($"/profiles/{profileId}/triggers/{triggerId}/test", UriKind.Relative), null);
         testResp3.StatusCode.Should().Be(HttpStatusCode.OK);
         var res3 = await testResp3.Content.ReadFromJsonAsync<Dictionary<string, object>>();
         ((System.Text.Json.JsonElement)res3!["status"]).GetString().Should().Be("Satisfied");

--- a/tests/unit/AdbScreenSourceTests.cs
+++ b/tests/unit/AdbScreenSourceTests.cs
@@ -1,0 +1,29 @@
+using System.Drawing;
+using GameBot.Emulator.Session;
+using GameBot.Domain.Profiles.Evaluators;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GameBot.UnitTests;
+
+public class AdbScreenSourceTests
+{
+    private sealed class DummySessionManager : ISessionManager
+    {
+        public int ActiveCount => 0;
+        public bool CanCreateSession => false;
+        public EmulatorSession CreateSession(string gameIdOrPath, string? profileId = null, string? preferredDeviceSerial = null) => throw new NotImplementedException();
+        public EmulatorSession? GetSession(string id) => null;
+        public bool StopSession(string id) => false;
+        public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+    }
+
+    [Fact(DisplayName="AdbScreenSource returns null with no sessions")]
+    public void ReturnsNullWithoutSessions()
+    {
+        var src = new AdbScreenSource(new DummySessionManager(), NullLogger<AdbScreenSource>.Instance, NullLogger<GameBot.Emulator.Adb.AdbClient>.Instance);
+        var bmp = src.GetLatestScreenshot();
+        Assert.Null(bmp);
+    }
+}

--- a/tests/unit/AdbScreenSourceTests.cs
+++ b/tests/unit/AdbScreenSourceTests.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using GameBot.Emulator.Session;
 using GameBot.Domain.Profiles.Evaluators;
+using GameBot.Domain.Sessions; // Needed for EmulatorSession type
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -14,6 +15,7 @@ public class AdbScreenSourceTests
         public bool CanCreateSession => false;
         public EmulatorSession CreateSession(string gameIdOrPath, string? profileId = null, string? preferredDeviceSerial = null) => throw new NotImplementedException();
         public EmulatorSession? GetSession(string id) => null;
+        public IReadOnlyCollection<EmulatorSession> ListSessions() => Array.Empty<EmulatorSession>();
         public bool StopSession(string id) => false;
         public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
         public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());

--- a/tests/unit/Emulator/Triggers/ImageMatchEvaluatorAdvancedTests.cs
+++ b/tests/unit/Emulator/Triggers/ImageMatchEvaluatorAdvancedTests.cs
@@ -1,0 +1,81 @@
+using System.Drawing;
+using GameBot.Domain.Profiles;
+using GameBot.Domain.Profiles.Evaluators;
+using Xunit;
+
+namespace GameBot.Unit.Emulator.Triggers;
+
+public sealed class ImageMatchEvaluatorAdvancedTests
+{
+    private static Bitmap MakeSolid(int w, int h, Color c)
+    {
+        var bmp = new Bitmap(w, h);
+        using var g = Graphics.FromImage(bmp);
+        g.Clear(c);
+        return bmp;
+    }
+
+    [Fact]
+    public void ExactMatch_ShouldYieldHighSimilarity()
+    {
+        var store = new MemoryReferenceImageStore();
+        var tpl = MakeSolid(10, 10, Color.White);
+        store.Add("tpl", tpl);
+        using var screen = MakeSolid(100, 100, Color.White);
+        var screenSrc = new SingleBitmapScreenSource(() => (Bitmap)screen.Clone());
+        var eval = new ImageMatchEvaluator(store, screenSrc);
+        var trig = new ProfileTrigger
+        {
+            Id = "t1",
+            Type = TriggerType.ImageMatch,
+            Enabled = true,
+            Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new Region { X = 0, Y = 0, Width = 1, Height = 1 }, SimilarityThreshold = 0.9 }
+        };
+        var res = eval.Evaluate(trig, DateTimeOffset.UtcNow);
+        Assert.Equal(TriggerStatus.Satisfied, res.Status);
+        Assert.True(res.Similarity!.Value >= 0.95);
+    }
+
+    [Fact]
+    public void Mismatch_ShouldYieldLowSimilarity()
+    {
+        var store = new MemoryReferenceImageStore();
+        var tpl = MakeSolid(10, 10, Color.White);
+        store.Add("tpl", tpl);
+        using var screen = MakeSolid(100, 100, Color.Black);
+        var screenSrc = new SingleBitmapScreenSource(() => (Bitmap)screen.Clone());
+        var eval = new ImageMatchEvaluator(store, screenSrc);
+        var trig = new ProfileTrigger
+        {
+            Id = "t1",
+            Type = TriggerType.ImageMatch,
+            Enabled = true,
+            Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new Region { X = 0, Y = 0, Width = 1, Height = 1 }, SimilarityThreshold = 0.9 }
+        };
+        var res = eval.Evaluate(trig, DateTimeOffset.UtcNow);
+        Assert.Equal(TriggerStatus.Pending, res.Status);
+        Assert.True(res.Similarity!.Value <= 0.1);
+    }
+
+    [Fact]
+    public void RegionSmallerThanTemplate_ShouldNotMatch()
+    {
+        var store = new MemoryReferenceImageStore();
+        var tpl = MakeSolid(50, 50, Color.White);
+        store.Add("tpl", tpl);
+        using var screen = MakeSolid(100, 100, Color.White);
+        // Region 10x10 smaller than 50x50 template
+        var screenSrc = new SingleBitmapScreenSource(() => (Bitmap)screen.Clone());
+        var eval = new ImageMatchEvaluator(store, screenSrc);
+        var trig = new ProfileTrigger
+        {
+            Id = "t1",
+            Type = TriggerType.ImageMatch,
+            Enabled = true,
+            Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new Region { X = 0, Y = 0, Width = 0.1, Height = 0.1 }, SimilarityThreshold = 0.9 }
+        };
+        var res = eval.Evaluate(trig, DateTimeOffset.UtcNow);
+        Assert.Equal(TriggerStatus.Pending, res.Status);
+        Assert.True(res.Similarity!.Value <= 0.01);
+    }
+}

--- a/tests/unit/Emulator/Triggers/ImageMatchEvaluatorAdvancedTests.cs
+++ b/tests/unit/Emulator/Triggers/ImageMatchEvaluatorAdvancedTests.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using GameBot.Domain.Profiles;
 using GameBot.Domain.Profiles.Evaluators;
+using DomainRegion = GameBot.Domain.Profiles.Region;
 using Xunit;
 
 namespace GameBot.Unit.Emulator.Triggers;
@@ -16,11 +17,11 @@ public sealed class ImageMatchEvaluatorAdvancedTests
     }
 
     [Fact]
-    public void ExactMatch_ShouldYieldHighSimilarity()
+    public void ExactMatchShouldYieldHighSimilarity()
     {
         var store = new MemoryReferenceImageStore();
-        var tpl = MakeSolid(10, 10, Color.White);
-        store.Add("tpl", tpl);
+    using var tpl = MakeSolid(10, 10, Color.White);
+    store.Add("tpl", (Bitmap)tpl.Clone());
         using var screen = MakeSolid(100, 100, Color.White);
         var screenSrc = new SingleBitmapScreenSource(() => (Bitmap)screen.Clone());
         var eval = new ImageMatchEvaluator(store, screenSrc);
@@ -29,7 +30,7 @@ public sealed class ImageMatchEvaluatorAdvancedTests
             Id = "t1",
             Type = TriggerType.ImageMatch,
             Enabled = true,
-            Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new Region { X = 0, Y = 0, Width = 1, Height = 1 }, SimilarityThreshold = 0.9 }
+        Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new DomainRegion { X = 0, Y = 0, Width = 1, Height = 1 }, SimilarityThreshold = 0.9 }
         };
         var res = eval.Evaluate(trig, DateTimeOffset.UtcNow);
         Assert.Equal(TriggerStatus.Satisfied, res.Status);
@@ -37,11 +38,11 @@ public sealed class ImageMatchEvaluatorAdvancedTests
     }
 
     [Fact]
-    public void Mismatch_ShouldYieldLowSimilarity()
+    public void MismatchShouldYieldLowSimilarity()
     {
         var store = new MemoryReferenceImageStore();
-        var tpl = MakeSolid(10, 10, Color.White);
-        store.Add("tpl", tpl);
+    using var tpl = MakeSolid(10, 10, Color.White);
+    store.Add("tpl", (Bitmap)tpl.Clone());
         using var screen = MakeSolid(100, 100, Color.Black);
         var screenSrc = new SingleBitmapScreenSource(() => (Bitmap)screen.Clone());
         var eval = new ImageMatchEvaluator(store, screenSrc);
@@ -50,7 +51,7 @@ public sealed class ImageMatchEvaluatorAdvancedTests
             Id = "t1",
             Type = TriggerType.ImageMatch,
             Enabled = true,
-            Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new Region { X = 0, Y = 0, Width = 1, Height = 1 }, SimilarityThreshold = 0.9 }
+        Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new DomainRegion { X = 0, Y = 0, Width = 1, Height = 1 }, SimilarityThreshold = 0.9 }
         };
         var res = eval.Evaluate(trig, DateTimeOffset.UtcNow);
         Assert.Equal(TriggerStatus.Pending, res.Status);
@@ -58,11 +59,11 @@ public sealed class ImageMatchEvaluatorAdvancedTests
     }
 
     [Fact]
-    public void RegionSmallerThanTemplate_ShouldNotMatch()
+    public void RegionSmallerThanTemplateShouldNotMatch()
     {
         var store = new MemoryReferenceImageStore();
-        var tpl = MakeSolid(50, 50, Color.White);
-        store.Add("tpl", tpl);
+    using var tpl = MakeSolid(50, 50, Color.White);
+    store.Add("tpl", (Bitmap)tpl.Clone());
         using var screen = MakeSolid(100, 100, Color.White);
         // Region 10x10 smaller than 50x50 template
         var screenSrc = new SingleBitmapScreenSource(() => (Bitmap)screen.Clone());
@@ -72,7 +73,7 @@ public sealed class ImageMatchEvaluatorAdvancedTests
             Id = "t1",
             Type = TriggerType.ImageMatch,
             Enabled = true,
-            Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new Region { X = 0, Y = 0, Width = 0.1, Height = 0.1 }, SimilarityThreshold = 0.9 }
+        Params = new ImageMatchParams { ReferenceImageId = "tpl", Region = new DomainRegion { X = 0, Y = 0, Width = 0.1, Height = 0.1 }, SimilarityThreshold = 0.9 }
         };
         var res = eval.Evaluate(trig, DateTimeOffset.UtcNow);
         Assert.Equal(TriggerStatus.Pending, res.Status);

--- a/tests/unit/Emulator/Triggers/ImageMatchEvaluatorTests.cs
+++ b/tests/unit/Emulator/Triggers/ImageMatchEvaluatorTests.cs
@@ -1,0 +1,64 @@
+using System.Drawing;
+using GameBot.Domain.Profiles;
+using DomainRegion = GameBot.Domain.Profiles.Region;
+using Xunit;
+
+namespace GameBot.Unit.Emulator.Triggers;
+
+public sealed class ImageMatchEvaluatorTests
+{
+    private static ProfileTrigger CreateTrigger(double threshold) => new()
+    {
+        Id = "t1",
+        Type = TriggerType.ImageMatch,
+        Enabled = true,
+        CooldownSeconds = 60,
+        Params = new ImageMatchParams
+        {
+            ReferenceImageId = "ref1",
+            Region = new DomainRegion { X = 0, Y = 0, Width = 1, Height = 1 },
+            SimilarityThreshold = threshold
+        }
+    };
+
+    [Fact]
+    public void BelowThresholdShouldRemainPending()
+    {
+        var trigger = CreateTrigger(0.9);
+        var evaluator = new StubImageMatchEvaluator(0.85);
+        var result = evaluator.Evaluate(trigger, DateTimeOffset.UtcNow);
+    Assert.Equal(TriggerStatus.Pending, result.Status);
+    Assert.NotNull(result.Similarity);
+    Assert.Equal(0.85, result.Similarity!.Value, 3);
+    }
+
+    [Fact]
+    public void AboveThresholdShouldBeSatisfied()
+    {
+        var trigger = CreateTrigger(0.8);
+        var evaluator = new StubImageMatchEvaluator(0.92);
+        var result = evaluator.Evaluate(trigger, DateTimeOffset.UtcNow);
+    Assert.Equal(TriggerStatus.Satisfied, result.Status);
+    Assert.Equal(0.92, result.Similarity!.Value, 3);
+    }
+
+    // Simple stub evaluator for unit testing logic boundaries
+    private sealed class StubImageMatchEvaluator : ITriggerEvaluator
+    {
+        private readonly double _similarity;
+        public StubImageMatchEvaluator(double similarity) => _similarity = similarity;
+        public bool CanEvaluate(ProfileTrigger trigger) => trigger.Enabled && trigger.Type == TriggerType.ImageMatch;
+        public TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now)
+        {
+            var p = (ImageMatchParams)trigger.Params;
+            var status = _similarity >= p.SimilarityThreshold ? TriggerStatus.Satisfied : TriggerStatus.Pending;
+            return new TriggerEvaluationResult
+            {
+                Status = status,
+                Similarity = _similarity,
+                EvaluatedAt = now,
+                Reason = status == TriggerStatus.Satisfied ? "similarity_met" : "similarity_below_threshold"
+            };
+        }
+    }
+}

--- a/tests/unit/Emulator/Triggers/TimeTriggerEvaluatorsTests.cs
+++ b/tests/unit/Emulator/Triggers/TimeTriggerEvaluatorsTests.cs
@@ -1,0 +1,83 @@
+using GameBot.Domain.Profiles;
+using GameBot.Domain.Profiles.Evaluators;
+using Xunit;
+
+namespace GameBot.Unit.Emulator.Triggers;
+
+public sealed class TimeTriggerEvaluatorsTests
+{
+    private static ProfileTrigger MakeDelay(int seconds, DateTimeOffset? enabledAt = null) => new()
+    {
+        Id = "d1",
+        Type = TriggerType.Delay,
+        Enabled = true,
+        EnabledAt = enabledAt,
+        Params = new DelayParams { Seconds = seconds }
+    };
+
+    private static ProfileTrigger MakeSchedule(DateTimeOffset ts, DateTimeOffset? enabledAt = null) => new()
+    {
+        Id = "s1",
+        Type = TriggerType.Schedule,
+        Enabled = true,
+        EnabledAt = enabledAt,
+        Params = new ScheduleParams { Timestamp = ts }
+    };
+
+    [Fact]
+    public void DelayNotYetElapsedShouldRemainPending()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var trig = MakeDelay(10, now);
+        var eval = new DelayTriggerEvaluator();
+        var res = eval.Evaluate(trig, now.AddSeconds(5));
+        Assert.Equal(TriggerStatus.Pending, res.Status);
+        Assert.Equal("waiting_delay", res.Reason);
+    }
+
+    [Fact]
+    public void DelayElapsedShouldBeSatisfied()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var trig = MakeDelay(5, now);
+        var eval = new DelayTriggerEvaluator();
+        var res = eval.Evaluate(trig, now.AddSeconds(6));
+        Assert.Equal(TriggerStatus.Satisfied, res.Status);
+        Assert.Equal("delay_elapsed", res.Reason);
+    }
+
+    [Fact]
+    public void ScheduleFutureTimePending()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var trig = MakeSchedule(now.AddSeconds(30), now);
+        var eval = new ScheduleTriggerEvaluator();
+        var res = eval.Evaluate(trig, now.AddSeconds(10));
+        Assert.Equal(TriggerStatus.Pending, res.Status);
+        Assert.Equal("waiting_for_time", res.Reason);
+    }
+
+    [Fact]
+    public void ScheduleTimeReachedSatisfied()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var ts = now.AddSeconds(15);
+        var trig = MakeSchedule(ts, now);
+        var eval = new ScheduleTriggerEvaluator();
+        var res = eval.Evaluate(trig, ts.AddSeconds(1));
+        Assert.Equal(TriggerStatus.Satisfied, res.Status);
+        Assert.Equal("time_reached", res.Reason);
+    }
+
+    [Fact]
+    public void ScheduleEnabledAfterPastTimeDisabled()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var past = now.AddSeconds(-30);
+        var trig = MakeSchedule(past, now);
+        var eval = new ScheduleTriggerEvaluator();
+        var res = eval.Evaluate(trig, now);
+        Assert.Equal(TriggerStatus.Disabled, res.Status);
+        Assert.Equal("scheduled_time_in_past_when_enabled", res.Reason);
+    }
+}

--- a/tests/unit/EvaluationCoordinatorTests.cs
+++ b/tests/unit/EvaluationCoordinatorTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GameBot.Domain.Profiles;
+using GameBot.Domain.Services;
+using Xunit;
+
+namespace GameBot.UnitTests
+{
+    internal sealed class InMemoryProfileRepo : IProfileRepository
+    {
+        private readonly List<AutomationProfile> _items;
+        public InMemoryProfileRepo(IEnumerable<AutomationProfile> seed) => _items = seed.ToList();
+        public Task<AutomationProfile> AddAsync(AutomationProfile profile, CancellationToken ct = default)
+        {
+            _items.Add(profile);
+            return Task.FromResult(profile);
+        }
+        public Task<AutomationProfile?> GetAsync(string id, CancellationToken ct = default)
+            => Task.FromResult(_items.FirstOrDefault(p => p.Id == id));
+        public Task<IReadOnlyList<AutomationProfile>> ListAsync(string? gameId = null, CancellationToken ct = default)
+            => Task.FromResult((IReadOnlyList<AutomationProfile>)_items.Where(p => gameId == null || p.GameId == gameId).ToList());
+        public Task<AutomationProfile?> UpdateAsync(AutomationProfile profile, CancellationToken ct = default)
+            => Task.FromResult<AutomationProfile?>(profile);
+    }
+
+    internal sealed class ImmediateDelayEvaluator : ITriggerEvaluator
+    {
+        public bool CanEvaluate(ProfileTrigger trigger) => trigger.Type == TriggerType.Delay && trigger.Params is DelayParams;
+        public TriggerEvaluationResult Evaluate(ProfileTrigger trigger, DateTimeOffset now)
+            => new TriggerEvaluationResult { Status = TriggerStatus.Satisfied, EvaluatedAt = now };
+    }
+
+    public class EvaluationCoordinatorTests
+    {
+        [Fact(DisplayName="Coordinator evaluates and persists timestamps")]
+        public async Task EvaluateAndPersist()
+        {
+            var profile = new AutomationProfile
+            {
+                Id = "p1",
+                Name = "P1",
+                GameId = "g1"
+            };
+            profile.Triggers.Add(new ProfileTrigger
+            {
+                Id = "t1",
+                Type = TriggerType.Delay,
+                Params = new DelayParams { Seconds = 0 }
+            });
+
+            var repo = new InMemoryProfileRepo(new[] { profile });
+            var service = new TriggerEvaluationService(new ITriggerEvaluator[] { new ImmediateDelayEvaluator() });
+            var coord = new TriggerEvaluationCoordinator(repo, service);
+
+            var count = await coord.EvaluateAllAsync();
+            Assert.Equal(1, count);
+            Assert.NotNull(profile.Triggers[0].LastEvaluatedAt);
+            Assert.NotNull(profile.Triggers[0].LastFiredAt);
+        }
+    }
+}

--- a/tests/unit/GameBot.UnitTests.csproj
+++ b/tests/unit/GameBot.UnitTests.csproj
@@ -21,5 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\GameBot.Emulator\GameBot.Emulator.csproj" />
     <ProjectReference Include="..\..\src\GameBot.Domain\GameBot.Domain.csproj" />
+    <ProjectReference Include="..\..\src\GameBot.Service\GameBot.Service.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/unit/PlatformSupport.cs
+++ b/tests/unit/PlatformSupport.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/tests/unit/ProfilesSerializationTests.cs
+++ b/tests/unit/ProfilesSerializationTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using GameBot.Domain.Profiles;
+using Xunit;
+
+namespace GameBot.UnitTests
+{
+    public class ProfilesSerializationTests
+    {
+        private static string CreateTempRoot()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "GameBotTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            return root;
+        }
+
+    [Fact(DisplayName="DelayTrigger RoundTrips")]
+    public async Task DelayTriggerRoundTrips()
+        {
+            var root = CreateTempRoot();
+            var repo = new FileProfileRepository(root);
+
+            var profile = new AutomationProfile
+            {
+                Id = string.Empty,
+                Name = "p1",
+                GameId = "g1"
+            };
+            profile.Triggers.Add(new ProfileTrigger
+            {
+                Id = "t1",
+                Type = TriggerType.Delay,
+                Params = new DelayParams { Seconds = 2 }
+            });
+
+            var added = await repo.AddAsync(profile);
+            var fetched = await repo.GetAsync(added.Id);
+
+            Assert.NotNull(fetched);
+            Assert.Single(fetched!.Triggers);
+            Assert.IsType<DelayParams>(fetched.Triggers[0].Params);
+            Assert.Equal(2, ((DelayParams)fetched.Triggers[0].Params).Seconds);
+        }
+
+    [Fact(DisplayName="ScheduleTrigger RoundTrips")]
+    public async Task ScheduleTriggerRoundTrips()
+        {
+            var root = CreateTempRoot();
+            var repo = new FileProfileRepository(root);
+
+            var now = DateTimeOffset.UtcNow;
+            var profile = new AutomationProfile
+            {
+                Id = string.Empty,
+                Name = "p2",
+                GameId = "g2"
+            };
+            profile.Triggers.Add(new ProfileTrigger
+            {
+                Id = "t2",
+                Type = TriggerType.Schedule,
+                Params = new ScheduleParams { Timestamp = now }
+            });
+
+            var added = await repo.AddAsync(profile);
+            var fetched = await repo.GetAsync(added.Id);
+
+            Assert.NotNull(fetched);
+            Assert.Single(fetched!.Triggers);
+            var p = Assert.IsType<ScheduleParams>(fetched.Triggers[0].Params);
+            Assert.Equal(now.ToUnixTimeSeconds(), p.Timestamp.ToUnixTimeSeconds());
+        }
+
+    [Fact(DisplayName="ImageMatchTrigger RoundTrips")]
+    public async Task ImageMatchTriggerRoundTrips()
+        {
+            var root = CreateTempRoot();
+            var repo = new FileProfileRepository(root);
+
+            var profile = new AutomationProfile
+            {
+                Id = string.Empty,
+                Name = "p3",
+                GameId = "g3"
+            };
+            profile.Triggers.Add(new ProfileTrigger
+            {
+                Id = "t3",
+                Type = TriggerType.ImageMatch,
+                Params = new ImageMatchParams
+                {
+                    ReferenceImageId = "ref1",
+                    Region = new Region { X = 0, Y = 0, Width = 0.5, Height = 0.5 },
+                    SimilarityThreshold = 0.9
+                }
+            });
+
+            var added = await repo.AddAsync(profile);
+            var fetched = await repo.GetAsync(added.Id);
+
+            Assert.NotNull(fetched);
+            Assert.Single(fetched!.Triggers);
+            var p = Assert.IsType<ImageMatchParams>(fetched.Triggers[0].Params);
+            Assert.Equal("ref1", p.ReferenceImageId);
+            Assert.Equal(0.9, p.SimilarityThreshold, 3);
+            Assert.Equal(0.5, p.Region.Width, 3);
+        }
+
+    [Fact(DisplayName="TextMatchTrigger RoundTrips")]
+    public async Task TextMatchTriggerRoundTrips()
+        {
+            var root = CreateTempRoot();
+            var repo = new FileProfileRepository(root);
+
+            var profile = new AutomationProfile
+            {
+                Id = string.Empty,
+                Name = "p4",
+                GameId = "g4"
+            };
+            profile.Triggers.Add(new ProfileTrigger
+            {
+                Id = "t4",
+                Type = TriggerType.TextMatch,
+                Params = new TextMatchParams
+                {
+                    Target = "hello",
+                    Region = new Region { X = 0.1, Y = 0.2, Width = 0.3, Height = 0.4 },
+                    ConfidenceThreshold = 0.8,
+                    Mode = "found"
+                }
+            });
+
+            var added = await repo.AddAsync(profile);
+            var fetched = await repo.GetAsync(added.Id);
+
+            Assert.NotNull(fetched);
+            Assert.Single(fetched!.Triggers);
+            var p = Assert.IsType<TextMatchParams>(fetched.Triggers[0].Params);
+            Assert.Equal("hello", p.Target);
+            Assert.Equal(0.3, p.Region.Width, 3);
+            Assert.Equal("found", p.Mode);
+        }
+    }
+}

--- a/tests/unit/TriggerBackgroundWorkerTests.cs
+++ b/tests/unit/TriggerBackgroundWorkerTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Service.Hosted;
+using GameBot.Domain.Services;
+using GameBot.Emulator.Session;
+using GameBot.Domain.Sessions; // Needed for EmulatorSession type
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace GameBot.UnitTests;
+
+public class TriggerBackgroundWorkerTests
+{
+    [Fact]
+    public async Task Skips_Evaluation_When_No_Sessions()
+    {
+        var logger = NullLogger<TriggerBackgroundWorker>.Instance;
+        var coordinator = new FakeCoordinator();
+        var sessions = new FakeSessions(activeCount: 0);
+        var options = new StaticOptions(new TriggerWorkerOptions
+        {
+            IntervalSeconds = 1,
+            IdleBackoffSeconds = 1,
+            SkipWhenNoSessions = true,
+            GameFilter = null
+        });
+
+        var worker = new TriggerBackgroundWorker(logger, coordinator, sessions, options);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(1200));
+
+        await worker.StartAsync(cts.Token);
+        // Wait until cancellation fires and worker stops
+        await worker.StopAsync(CancellationToken.None);
+
+        coordinator.CallCount.Should().Be(0, because: "no sessions should skip evaluation cycles");
+    }
+
+    [Fact]
+    public async Task Evaluates_When_Sessions_Exist_And_Passes_Filter()
+    {
+        var logger = NullLogger<TriggerBackgroundWorker>.Instance;
+        var coordinator = new FakeCoordinator();
+        var sessions = new FakeSessions(activeCount: 1);
+        var options = new StaticOptions(new TriggerWorkerOptions
+        {
+            IntervalSeconds = 1,
+            IdleBackoffSeconds = 1,
+            SkipWhenNoSessions = true,
+            GameFilter = "game-123"
+        });
+
+        var worker = new TriggerBackgroundWorker(logger, coordinator, sessions, options);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(1500));
+
+        await worker.StartAsync(cts.Token);
+        await worker.StopAsync(CancellationToken.None);
+
+        coordinator.CallCount.Should().BeGreaterOrEqualTo(1);
+        coordinator.LastFilter.Should().Be("game-123");
+    }
+
+    private sealed class FakeCoordinator : ITriggerEvaluationCoordinator
+    {
+        public int CallCount { get; private set; }
+        public string? LastFilter { get; private set; }
+
+        public Task<int> EvaluateAllAsync(string? gameIdFilter, CancellationToken ct)
+        {
+            CallCount++;
+            LastFilter = gameIdFilter;
+            return Task.FromResult(0);
+        }
+    }
+
+    private sealed class FakeSessions : ISessionManager
+    {
+        public FakeSessions(int activeCount) { ActiveCount = activeCount; }
+        public int ActiveCount { get; set; }
+        public bool CanCreateSession => false;
+        public EmulatorSession CreateSession(string gameIdOrPath, string? profileId = null, string? preferredDeviceSerial = null) => throw new NotImplementedException();
+        public EmulatorSession? GetSession(string id) => null;
+        public IReadOnlyCollection<EmulatorSession> ListSessions() => Array.Empty<EmulatorSession>();
+        public bool StopSession(string id) => false;
+    public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+    }
+
+    private sealed class StaticOptions : IOptionsMonitor<TriggerWorkerOptions>
+    {
+        public StaticOptions(TriggerWorkerOptions value) { CurrentValue = value; }
+        public TriggerWorkerOptions CurrentValue { get; }
+        public TriggerWorkerOptions Get(string? name) => CurrentValue;
+        public IDisposable OnChange(Action<TriggerWorkerOptions, string?> listener) => DummyDisposable.Instance;
+
+        private sealed class DummyDisposable : IDisposable
+        {
+            public static readonly DummyDisposable Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/unit/TriggerEvaluationMetricsTests.cs
+++ b/tests/unit/TriggerEvaluationMetricsTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Service.Hosted;
+using Xunit;
+
+namespace GameBot.UnitTests;
+
+public class TriggerEvaluationMetricsTests
+{
+    [Fact]
+    public void IncrementsAndDuration_Work()
+    {
+        var m = new TriggerEvaluationMetrics();
+
+        m.Evaluations.Should().Be(0);
+        m.SkippedNoSessions.Should().Be(0);
+        m.OverlapSkipped.Should().Be(0);
+        m.LastCycleDurationMs.Should().Be(0);
+
+        m.IncrementEvaluations(3);
+        m.IncrementSkippedNoSessions();
+        m.IncrementOverlapSkipped();
+        m.RecordCycleDuration(42);
+
+        m.Evaluations.Should().Be(3);
+        m.SkippedNoSessions.Should().Be(1);
+        m.OverlapSkipped.Should().Be(1);
+        m.LastCycleDurationMs.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task ThreadSafety_ForConcurrentUpdates()
+    {
+        var m = new TriggerEvaluationMetrics();
+        var tasks = Enumerable.Range(0, 10).Select(async _ =>
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                m.IncrementEvaluations(1);
+                m.IncrementSkippedNoSessions();
+                m.IncrementOverlapSkipped();
+                m.RecordCycleDuration(i);
+                await Task.Yield();
+            }
+        });
+
+        await Task.WhenAll(tasks);
+
+        m.Evaluations.Should().Be(10 * 1000);
+        m.SkippedNoSessions.Should().Be(10 * 1000);
+        m.OverlapSkipped.Should().Be(10 * 1000);
+        m.LastCycleDurationMs.Should().BeGreaterOrEqualTo(0);
+    }
+}

--- a/tests/unit/TriggerEvaluationMetricsTests.cs
+++ b/tests/unit/TriggerEvaluationMetricsTests.cs
@@ -10,7 +10,7 @@ namespace GameBot.UnitTests;
 public class TriggerEvaluationMetricsTests
 {
     [Fact]
-    public void IncrementsAndDuration_Work()
+    public void IncrementsAndDurationWork()
     {
         var m = new TriggerEvaluationMetrics();
 
@@ -31,7 +31,7 @@ public class TriggerEvaluationMetricsTests
     }
 
     [Fact]
-    public async Task ThreadSafety_ForConcurrentUpdates()
+    public async Task ThreadSafetyForConcurrentUpdates()
     {
         var m = new TriggerEvaluationMetrics();
         var tasks = Enumerable.Range(0, 10).Select(async _ =>


### PR DESCRIPTION
Adds triggers to the profiles
Adds /metrics/triggers endpoint exposing evaluations, skipped cycles, overlap skips, and last cycle duration.
Introduces integration test MetricsEndpointTests with bearer auth.
Refactors background worker metrics wiring.
All builds and tests passing on 001-profile-triggers and master post-merge simulation.