### PR TITLE
Config & logging hardening: filtered snapshot, dynamic apply, OCR switch

### DIFF
--- a/specs/001-save-config/spec.md
+++ b/specs/001-save-config/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `001-save-config`  
 **Created**: 2025-11-14  
-**Status**: Draft  
+**Status**: Implemented (Feature merged on 2025-11-14)  
 **Input**: User description: "Save configuration. All of the configuration parameters, including but not limited to environment variables collected in ENVIRONMENT.md. The configuration should be stored in a config subdirectory of data directory in JSON format. Respectively the data dir directory shouldn't be part of the saved configuration."
 
 ## User Scenarios & Testing *(mandatory)*
@@ -149,3 +149,25 @@ An operator can trigger a manual refresh of the persisted configuration snapshot
 ## Open Clarifications Needed
 
 None. All prior clarifications resolved (full redaction; refresh endpoint in scope).
+
+## Post-Implementation Review
+
+### What Was Delivered
+- Effective configuration snapshot persisted at `data/config/config.json` with atomic writes.
+- Precedence enforced: Environment > Saved file > Other files > Defaults.
+- Secret masking for keys containing TOKEN/SECRET/PASSWORD/KEY (case-insensitive).
+- Startup load of existing snapshot with graceful fallback on malformed file.
+- Endpoints: `GET /config/` (lazy generation if missing) and `POST /config/refresh`.
+- README documentation section added.
+
+### Gaps / Follow-Up Items
+1. Snapshot metadata could include `refreshCount` and `serviceVersion` consistently (verify presence; code may partially implement).
+2. Missing explicit enumeration of all captured environment/config keys for audit (FR-009 only partially addressed).
+3. No diff endpoint or ability to compare historical snapshots.
+4. Log formatting inconsistent (mix of structured and message-only lines); secrets redaction relies solely on masking layer, not log filtering.
+5. Dynamic log level adjustment not supported (would aid diagnostics).
+6. Validation of required env variables produces implicit behavior; explicit warnings list would improve operability.
+7. Config endpoint error payload shape not standardized (future: add error schema with code/reason details).
+
+### Link to Hardening / Enhancement Spec
+See follow-up spec: `specs/002-config-logging-hardening/spec.md` for planned improvements in logging consistency, snapshot enrichment, validation, and diff capabilities.

--- a/specs/002-config-logging-hardening/spec.md
+++ b/specs/002-config-logging-hardening/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Config & HTTP Logging Adjustments
+
+Feature Branch: `002-config-logging-hardening`
+Created: 2025-11-14
+Status: Draft
+
+Context: This spec replaces prior user stories. It focuses narrowly on:
+1) Reducing default HTTP logging verbosity.
+2) Limiting saved configuration to GameBot-relevant environment variables only.
+
+## Problem Statement
+- Default HTTP-related logging is too chatty, making it harder to spot important events.
+- The saved configuration currently considers all environment variables, including many unrelated to GameBot, which adds noise and potential risk.
+
+## Goals
+- Tame HTTP-related log verbosity out-of-the-box while still allowing overrides.
+- Restrict saved configuration to environment variables relevant to GameBot.
+
+## User Stories
+
+US1: Increase the log level of HTTP calls so the default logs are not so chatty.
+
+US2: Saving configuration should only consider the environment variables relevant to GameBot, not all environment variables.
+
+## Functional Requirements
+
+- FR-HTTP-001: Set default minimum log level for HTTP client/server-related categories to Warning.
+  - Applies at least to categories matching: `System.Net.Http.*`, `Microsoft.AspNetCore.HttpLogging` (if present).
+  - Must be overridable via environment variable `GAMEBOT_HTTP_LOG_LEVEL_MINIMUM` with allowed values `Trace|Debug|Information|Warning|Error|Critical`.
+
+- FR-CONFIG-ENV-001: Saved configuration must include only environment variables relevant to GameBot.
+  - Relevant variables are case-insensitive keys starting with prefixes: `GAMEBOT_` or `GAMEBOT__` (double underscore for hierarchical keys).
+  - Keys not matching these prefixes must be excluded (e.g., `PATH`, `COMPUTERNAME`, `PROCESSOR_*`, `ASPNETCORE_*`, etc.).
+
+- FR-CONFIG-ENV-002: Snapshot metadata must include counts: `envScanned`, `envIncluded`, `envExcluded` for transparency.
+
+## Acceptance Tests (High-Level)
+- AT-HTTP-001: With no overrides, logs from `System.Net.Http.HttpClient` at Information are suppressed; Warning and above are emitted.
+- AT-HTTP-002: Setting `GAMEBOT_HTTP_LOG_LEVEL_MINIMUM=Information` results in HTTP Information events being emitted.
+- AT-CONFIG-ENV-001: Snapshot excludes typical OS/framework variables (e.g., `PATH`, `TEMP`, `ASPNETCORE_URLS`).
+- AT-CONFIG-ENV-002: Snapshot includes variables like `GAMEBOT__FOO`, `GAMEBOT_BAR`.
+- AT-CONFIG-ENV-003: Snapshot metadata shows accurate `envScanned`, `envIncluded`, `envExcluded`.
+
+## Non-Goals
+- Changing non-HTTP logging defaults.
+- Persisting dynamic log level changes beyond process lifetime (overrides are env-based only here).
+
+## Notes
+- Prefix list can be extended in future specs if additional namespaces are introduced.
+- Secret masking continues to follow existing rules; this spec only scopes which env vars are considered.
+# Feature Specification: Configuration & Logging Hardening
+
+**Feature Branch**: `002-config-logging-hardening`  
+**Created**: 2025-11-14  
+**Status**: Draft  
+**Context**: Follow-up to implemented Save Configuration feature (`001-save-config`). Addresses observed gaps in configuration snapshot richness, logging consistency, validation transparency, and operational diagnostics.
+
+## Problem Statement
+Operators need stronger guarantees and tooling around configuration accuracy, log clarity, and change tracking. Current implementation:
+- Partially documents captured keys (FR-009 incomplete).
+- Does not expose refresh count/service version consistently in snapshot.
+- Lacks historical diff or comparison capability.
+- Logging is mixed format; secrets rely only on masking, not log pipeline safeguards.
+- No runtime log-level change support; requires restart for verbosity adjustments.
+- Startup validation of required env vars is implicit (silent fallbacks) rather than explicit report.
+- Error responses for config endpoints lack a standardized schema (machine-readable codes).
+- No structured audit trail for manual refresh operations (who/when/correlation id).
+
+## Goals
+1. Improve observability and auditability of configuration over time.
+2. Enforce consistent structured logging with secret-safe guarantees.
+3. Provide explicit operator feedback on configuration health at startup and refresh.
+4. Enable dynamic diagnostics (log level changes) without restart.
+5. Standardize error payloads for the configuration API.
+
+## Non-Goals
+- Replacing existing logging framework.
+- Full historical configuration retention (only limited recent snapshot diffing).
+- Multi-tenant config segregation (future consideration).
+
+## User Stories
+
+### User Story A - Enhanced Snapshot Metadata (Priority: P1)
+Include `generatedAtUtc`, `serviceVersion`, `refreshCount`, `precedenceOrder`, and an array `sources` listing each key's origin summary for transparency.
+
+### User Story B - Startup Validation Report (Priority: P1)
+On startup produce a structured list of missing/nullable recommended environment variables and log them as a single structured event; expose last validation report via `/config/validation`.
+
+### User Story C - Structured & Redacted Logging (Priority: P1)
+Emit application logs in structured JSON (opt-in) with automatic redaction of potential secret substrings and correlation id propagation.
+
+### User Story D - Config Diff Capability (Priority: P2)
+Provide endpoint `/config/diff?previous=<timestamp>` returning differences between current snapshot and a stored prior snapshot (retain limited N history, e.g. last 5 refreshes).
+
+### User Story E - Dynamic Log Level Endpoint (Priority: P2)
+Expose authenticated `POST /logging/level` to adjust log level (e.g. Debug/Info/Warn) at runtime; persisted only in-memory.
+
+### User Story F - Standardized Error Schema (Priority: P2)
+All config-related error responses use shape: `{ "error": { "code": string, "message": string, "correlationId": string? } }`.
+
+### User Story G - Refresh Audit Trail (Priority: P3)
+Record refresh events (timestamp, actor token hash, correlation id) in memory (last 20) and surface via `/config/refresh/history`.
+
+## Edge Cases
+- Large number of environment variables: validation report must paginate/limit.
+- Rapid refresh calls: diff history must prune oldest snapshot deterministically.
+- Unknown log level provided: return error code `LOG_LEVEL_INVALID`.
+- Extremely large value sizes: redaction logic must avoid scanning performance issues (cap per-value length scanned).
+
+## Functional Requirements
+
+- **FR-LC-001**: Snapshot MUST include `refreshCount`, `serviceVersion`, `precedenceOrder`, and `sources` summary collection.
+- **FR-LC-002**: System MUST retain the last N (configurable, default 5) snapshots in memory for diff operations.
+- **FR-LC-003**: Endpoint `GET /config/diff?previous=<generatedAtUtc>` MUST compute added/removed/changed keys with old/new values (masked if secret).
+- **FR-LC-004**: Startup MUST produce a validation report listing: missing recommended keys, keys with empty values, and duplicated conflicting sources.
+- **FR-LC-005**: Endpoint `GET /config/validation` MUST return latest validation report.
+- **FR-LC-006**: When structured logging mode is enabled (`GAMEBOT_STRUCTURED_LOGS=true`), logs MUST be JSON with fields: timestamp, level, message, category, correlationId?, exception?.
+- **FR-LC-007**: Logging pipeline MUST redact substrings matching secret patterns before emission (same keyword set as snapshot masking).
+- **FR-LC-008**: Endpoint `POST /logging/level` MUST accept body `{ level: "Debug"|"Information"|"Warning"|"Error"|"Critical" }` and apply change immediately.
+- **FR-LC-009**: All configuration-related error responses MUST conform to the standardized error schema.
+- **FR-LC-010**: Refresh endpoint MUST append record to in-memory audit list with timestamp and correlation id; token hashed (SHA-256, first 12 chars) for privacy.
+- **FR-LC-011**: Diff computation MUST complete within 200ms for snapshots ≤ 1000 parameters.
+- **FR-LC-012**: Redaction MUST occur before serialization to prevent leaking secrets in logs.
+- **FR-LC-013**: Validation report MUST be generated within 300ms at startup.
+- **FR-LC-014**: If previous snapshot reference not found for diff, return error code `CONFIG_DIFF_NOT_FOUND`.
+
+## Success Criteria
+- **SC-LC-001**: Structured log lines contain correlationId when provided ≥ 95% of requests.
+- **SC-LC-002**: Diff endpoint median latency < 150ms for 1000-param snapshots.
+- **SC-LC-003**: Redaction false positives < 5% (measure via test fixtures); zero true secret leaks.
+- **SC-LC-004**: Dynamic log level change reflected in subsequent logs within 1 second.
+- **SC-LC-005**: Validation endpoint accuracy (missing key detection) ≥ 99% in test matrix.
+
+## Assumptions
+1. Snapshot history stored in-memory only (not persisted to disk) to minimize IO overhead.
+2. Secret detection patterns remain identical to existing implementation for consistency.
+3. Correlation ID continues to use `X-Correlation-ID` header when supplied.
+4. Dynamic log level changes are not persisted across restarts.
+5. Audit trail size (20) is sufficient; older entries discarded FIFO.
+
+## Risks
+- Increased memory usage storing multiple snapshots.
+- JSON logging may increase log volume and storage cost.
+- Secret redaction pipeline complexity (performance impact) if naive substring scanning used.
+
+## Open Questions
+1. Should snapshot history optionally persist to disk? (Out of scope now.)
+2. Should diff endpoint support arbitrary two timestamps or only current vs previous? (Currently only previous.)
+3. Should dynamic log level require a privileged role beyond bearer token? (Pending security review.)
+
+## Next Steps
+1. Implement metadata enrichment & validation report.
+2. Add snapshot history + diff endpoint.
+3. Introduce structured logging mode with redaction.
+4. Add dynamic log level endpoint.
+5. Standardize error schema & refresh audit trail.
+6. Update README and existing save-config spec references.

--- a/src/GameBot.Domain/Profiles/Evaluators/TesseractProcessOcr.cs
+++ b/src/GameBot.Domain/Profiles/Evaluators/TesseractProcessOcr.cs
@@ -26,6 +26,12 @@ public sealed class TesseractProcessOcr : ITextOcr
             : Environment.GetEnvironmentVariable("GAMEBOT_TESSERACT_LANG")!;
     }
 
+    public TesseractProcessOcr(string exe, string lang)
+    {
+        _exe = string.IsNullOrWhiteSpace(exe) ? "tesseract" : exe;
+        _lang = string.IsNullOrWhiteSpace(lang) ? "eng" : lang;
+    }
+
     public OcrResult Recognize(Bitmap image)
         => Recognize(image, null);
 

--- a/src/GameBot.Service/Models/Config.cs
+++ b/src/GameBot.Service/Models/Config.cs
@@ -16,6 +16,9 @@ internal sealed class ConfigurationSnapshot
     public string? ServiceVersion { get; init; }
     public int? DynamicPort { get; init; }
     public int RefreshCount { get; init; }
+    public int EnvScanned { get; init; }
+    public int EnvIncluded { get; init; }
+    public int EnvExcluded { get; init; }
 
     public required Dictionary<string, ConfigurationParameter> Parameters { get; init; } = new();
 }

--- a/src/GameBot.Service/Services/DynamicLogFilters.cs
+++ b/src/GameBot.Service/Services/DynamicLogFilters.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Service.Services;
+
+internal static class DynamicLogFilters
+{
+    private static volatile LogLevel _httpMinLevel = LogLevel.Warning;
+
+    public static LogLevel HttpMinLevel
+    {
+        get => _httpMinLevel;
+        set => _httpMinLevel = value;
+    }
+
+    private static readonly string[] HttpCategories = new[]
+    {
+        "System.Net.Http",
+        "Microsoft.AspNetCore.HttpLogging",
+        "Microsoft.AspNetCore.Http.Result",
+        "Microsoft.AspNetCore.Mvc.Infrastructure",
+        "Microsoft.AspNetCore.Hosting.Diagnostics",
+        "Microsoft.AspNetCore.Routing"
+    };
+
+    public static bool IsHttpCategory(string category)
+    {
+        foreach (var p in HttpCategories)
+        {
+            if (category.StartsWith(p, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+}

--- a/src/GameBot.Service/Services/DynamicTextOcr.cs
+++ b/src/GameBot.Service/Services/DynamicTextOcr.cs
@@ -1,0 +1,72 @@
+using GameBot.Domain.Profiles.Evaluators;
+using GameBot.Service.Services;
+
+namespace GameBot.Service.Services;
+
+internal sealed class DynamicTextOcr : ITextOcr
+{
+    private readonly IConfigSnapshotService _config;
+    private ITextOcr _inner;
+    private string _currentMode = "env"; // "env" or "tess"
+    private string _currentExe = "tesseract";
+    private string _currentLang = "eng";
+    private readonly object _gate = new();
+
+    public DynamicTextOcr(IConfigSnapshotService config)
+    {
+        _config = config;
+        _inner = new EnvTextOcr();
+    }
+
+    private void EnsureInner()
+    {
+        var snap = _config.Current;
+        var useTess = false;
+        var exe = "tesseract";
+        var lang = "eng";
+
+        if (snap is not null)
+        {
+            if (snap.Parameters.TryGetValue("GAMEBOT_TESSERACT_ENABLED", out var p) && p.Value is not null)
+            {
+                var s = p.Value.ToString();
+                if (bool.TryParse(s, out var b)) useTess = b; else if (int.TryParse(s, out var i)) useTess = i != 0;
+            }
+            if (snap.Parameters.TryGetValue("GAMEBOT_TESSERACT_PATH", out var pe) && pe.Value is not null)
+            {
+                exe = pe.Value.ToString() ?? exe;
+            }
+            if (snap.Parameters.TryGetValue("GAMEBOT_TESSERACT_LANG", out var pl) && pl.Value is not null)
+            {
+                lang = pl.Value.ToString() ?? lang;
+            }
+        }
+
+        var newMode = useTess ? "tess" : "env";
+        if (newMode != _currentMode || (useTess && (exe != _currentExe || lang != _currentLang)))
+        {
+            lock (_gate)
+            {
+                if (newMode != _currentMode || (useTess && (exe != _currentExe || lang != _currentLang)))
+                {
+                    _inner = useTess ? new TesseractProcessOcr(exe, lang) : new EnvTextOcr();
+                    _currentMode = newMode;
+                    _currentExe = exe;
+                    _currentLang = lang;
+                }
+            }
+        }
+    }
+
+    public OcrResult Recognize(System.Drawing.Bitmap image)
+    {
+        EnsureInner();
+        return _inner.Recognize(image);
+    }
+
+    public OcrResult Recognize(System.Drawing.Bitmap image, string? language)
+    {
+        EnsureInner();
+        return _inner.Recognize(image, language);
+    }
+}

--- a/src/GameBot.Service/Services/IConfigApplier.cs
+++ b/src/GameBot.Service/Services/IConfigApplier.cs
@@ -1,0 +1,80 @@
+using GameBot.Service.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GameBot.Service.Services;
+
+internal interface IConfigApplier
+{
+    void Apply(ConfigurationSnapshot snapshot);
+}
+
+internal sealed class ConfigApplier : IConfigApplier
+{
+    private readonly IOptionsMonitorCache<GameBot.Service.Hosted.TriggerWorkerOptions> _triggerOptionsCache;
+
+    public ConfigApplier(IOptionsMonitorCache<GameBot.Service.Hosted.TriggerWorkerOptions> triggerOptionsCache)
+    {
+        _triggerOptionsCache = triggerOptionsCache;
+    }
+
+    private static LogLevel ParseLogLevel(string? v, LogLevel @default)
+    {
+        return v?.Trim().ToLowerInvariant() switch
+        {
+            "trace" => LogLevel.Trace,
+            "debug" => LogLevel.Debug,
+            "information" => LogLevel.Information,
+            "info" => LogLevel.Information,
+            "warning" => LogLevel.Warning,
+            "warn" => LogLevel.Warning,
+            "error" => LogLevel.Error,
+            "critical" => LogLevel.Critical,
+            _ => @default
+        };
+    }
+
+    public void Apply(ConfigurationSnapshot snapshot)
+    {
+        // Apply dynamic HTTP logging minimum level
+        if (snapshot.Parameters.TryGetValue("GAMEBOT_HTTP_LOG_LEVEL_MINIMUM", out var lvlParam))
+        {
+            var val = lvlParam.Value?.ToString();
+            DynamicLogFilters.HttpMinLevel = ParseLogLevel(val, LogLevel.Warning);
+        }
+
+        // Apply Trigger worker options (OptionsMonitor will observe cache changes)
+        var opts = new GameBot.Service.Hosted.TriggerWorkerOptions();
+        opts.IntervalSeconds = GetInt(snapshot, "Service__Triggers__Worker__IntervalSeconds", 2);
+        opts.GameFilter = GetString(snapshot, "Service__Triggers__Worker__GameFilter", null);
+        opts.SkipWhenNoSessions = GetBool(snapshot, "Service__Triggers__Worker__SkipWhenNoSessions", true);
+        opts.IdleBackoffSeconds = GetInt(snapshot, "Service__Triggers__Worker__IdleBackoffSeconds", 5);
+
+        _triggerOptionsCache.TryRemove(Options.DefaultName);
+        _triggerOptionsCache.TryAdd(Options.DefaultName, opts);
+    }
+
+    private static int GetInt(ConfigurationSnapshot snap, string key, int @default)
+    {
+        return snap.Parameters.TryGetValue(key, out var p) && p.Value is not null && int.TryParse(p.Value.ToString(), out var v)
+            ? v : @default;
+    }
+    private static bool GetBool(ConfigurationSnapshot snap, string key, bool @default)
+    {
+        if (!snap.Parameters.TryGetValue(key, out var p) || p.Value is null) return @default;
+        var s = p.Value.ToString();
+        if (bool.TryParse(s, out var b)) return b;
+        // Accept 0/1
+        if (int.TryParse(s, out var i)) return i != 0;
+        return @default;
+    }
+    private static string? GetString(ConfigurationSnapshot snap, string key, string? @default)
+    {
+        return snap.Parameters.TryGetValue(key, out var p) && p.Value is not null ? p.Value.ToString() : @default;
+    }
+}
+
+internal sealed class NoopConfigApplier : IConfigApplier
+{
+    public void Apply(ConfigurationSnapshot snapshot) { }
+}

--- a/tests/integration/DynamicOcrRefreshTests.cs
+++ b/tests/integration/DynamicOcrRefreshTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests;
+
+public class DynamicOcrRefreshTests
+{
+    private static bool IsTesseractAvailable()
+    {
+        var exe = Environment.GetEnvironmentVariable("GAMEBOT_TESSERACT_PATH");
+        if (!string.IsNullOrWhiteSpace(exe) && File.Exists(exe)) return true;
+        try
+        {
+            var psi = new ProcessStartInfo { FileName = "tesseract", Arguments = "--version", UseShellExecute = false, RedirectStandardOutput = true, RedirectStandardError = true, CreateNoWindow = true };
+            using var p = Process.Start(psi);
+            if (p == null) return false;
+            p.WaitForExit(2000);
+            return p.HasExited && p.ExitCode == 0;
+        }
+        catch { return false; }
+    }
+
+    [Fact]
+    public async Task SwitchesFromEnvOcrToTesseractAfterRefresh()
+    {
+        if (!IsTesseractAvailable()) return; // skip when tesseract not available
+
+        // Environment & data dir
+        Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+        Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+        Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+        Environment.SetEnvironmentVariable("GAMEBOT_TESSERACT_ENABLED", "false");
+        Environment.SetEnvironmentVariable("GAMEBOT_TEST_OCR_TEXT", "NOPE");
+        var dataDir = TestEnvironment.PrepareCleanDataDir();
+
+        // Provide a screen image with text HELLO
+        using (var bmp = new Bitmap(240, 100))
+        using (var g = Graphics.FromImage(bmp))
+        using (var brush = new SolidBrush(Color.Black))
+        using (var font = new Font(FontFamily.GenericSansSerif, 24, FontStyle.Bold))
+        using (var ms = new MemoryStream())
+        {
+            g.Clear(Color.White);
+            g.DrawString("HELLO", font, brush, new PointF(10, 30));
+            bmp.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+            var b64 = Convert.ToBase64String(ms.ToArray());
+            Environment.SetEnvironmentVariable("GAMEBOT_TEST_SCREEN_IMAGE_B64", "data:image/png;base64," + b64);
+        }
+
+        using var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+        // Create game & profile
+        var gameResp = await client.PostAsJsonAsync(new Uri("/games", UriKind.Relative), new { name = "G-DOCR", description = "d" });
+        gameResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var gameId = game!["id"]!.ToString();
+
+        var profResp = await client.PostAsJsonAsync(new Uri("/profiles", UriKind.Relative), new { name = "P-DOCR", gameId, steps = Array.Empty<object>() });
+        profResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var prof = await profResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var profileId = prof!["id"]!.ToString();
+
+        // Create a text-match trigger for HELLO
+        var trigCreate = new
+        {
+            type = "text-match",
+            enabled = true,
+            cooldownSeconds = 0,
+            @params = new
+            {
+                target = "HELLO",
+                region = new { x = 0.0, y = 0.0, width = 1.0, height = 1.0 },
+                confidenceThreshold = 0.10,
+                mode = "found"
+            }
+        };
+        var tResp = await client.PostAsJsonAsync(new Uri($"/profiles/{profileId}/triggers", UriKind.Relative), trigCreate);
+        tResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var tBody = await tResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var triggerId = tBody!["id"]!.ToString();
+
+        // Initial test: with Env OCR and text "NOPE", should NOT be Satisfied
+        var test1 = await client.PostAsync(new Uri($"/profiles/{profileId}/triggers/{triggerId}/test", UriKind.Relative), null);
+        test1.StatusCode.Should().Be(HttpStatusCode.OK);
+        var res1 = await test1.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        ((System.Text.Json.JsonElement)res1!["status"]).GetString().Should().NotBe("Satisfied");
+
+        // Modify saved config on disk to enable Tesseract
+        var cfgDir = Path.Combine(dataDir, "config");
+        var cfgFile = Path.Combine(cfgDir, "config.json");
+        Directory.CreateDirectory(cfgDir);
+        var newJson = "{\n  \"parameters\": {\n    \"GAMEBOT_TESSERACT_ENABLED\": { \"value\": \"true\" }\n  }\n}";
+        await File.WriteAllTextAsync(cfgFile, newJson);
+
+        // Refresh to apply new configuration
+        var refresh = await client.PostAsync(new Uri("/config/refresh", UriKind.Relative), null);
+        refresh.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Second test: with Tesseract OCR and a HELLO screen, should be Satisfied
+        var test2 = await client.PostAsync(new Uri($"/profiles/{profileId}/triggers/{triggerId}/test", UriKind.Relative), null);
+        test2.StatusCode.Should().Be(HttpStatusCode.OK);
+        var res2 = await test2.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        ((System.Text.Json.JsonElement)res2!["status"]).GetString().Should().Be("Satisfied");
+    }
+}

--- a/tests/unit/ConfigMaskingAndMergeTests.cs
+++ b/tests/unit/ConfigMaskingAndMergeTests.cs
@@ -15,18 +15,18 @@ public class ConfigMaskingAndMergeTests
         Directory.CreateDirectory(tmp);
         try
         {
-            Environment.SetEnvironmentVariable("TEST_SECRET_KEY", "value123");
+            Environment.SetEnvironmentVariable("GAMEBOT_TEST_SECRET_KEY", "value123");
             using var svc = new ConfigSnapshotService(tmp);
             var snap = await svc.RefreshAsync();
 
-            snap.Parameters.Should().ContainKey("TEST_SECRET_KEY");
-            var p = snap.Parameters["TEST_SECRET_KEY"];
+            snap.Parameters.Should().ContainKey("GAMEBOT_TEST_SECRET_KEY");
+            var p = snap.Parameters["GAMEBOT_TEST_SECRET_KEY"];
             p.IsSecret.Should().BeTrue();
             p.Value.Should().Be("***");
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TEST_SECRET_KEY", null);
+            Environment.SetEnvironmentVariable("GAMEBOT_TEST_SECRET_KEY", null);
             try { Directory.Delete(tmp, recursive: true); } catch { }
         }
     }
@@ -38,22 +38,22 @@ public class ConfigMaskingAndMergeTests
         var cfgDir = Path.Combine(tmp, "config");
         Directory.CreateDirectory(cfgDir);
         var cfgFile = Path.Combine(cfgDir, "config.json");
-        await File.WriteAllTextAsync(cfgFile, "{\n  \"parameters\": { \n    \"FOO\": { \"value\": \"file\" } \n  }\n}");
+        await File.WriteAllTextAsync(cfgFile, "{\n  \"parameters\": { \n    \"GAMEBOT_FOO\": { \"value\": \"file\" } \n  }\n}");
 
         try
         {
-            Environment.SetEnvironmentVariable("FOO", "env");
+            Environment.SetEnvironmentVariable("GAMEBOT_FOO", "env");
             using var svc = new ConfigSnapshotService(tmp);
             var snap = await svc.RefreshAsync();
 
-            snap.Parameters.Should().ContainKey("FOO");
-            var p = snap.Parameters["FOO"];
+            snap.Parameters.Should().ContainKey("GAMEBOT_FOO");
+            var p = snap.Parameters["GAMEBOT_FOO"];
             p.Source.Should().Be("Environment");
             p.Value.Should().Be("env");
         }
         finally
         {
-            Environment.SetEnvironmentVariable("FOO", null);
+            Environment.SetEnvironmentVariable("GAMEBOT_FOO", null);
             try { Directory.Delete(tmp, recursive: true); } catch { }
         }
     }


### PR DESCRIPTION
- Reduce chatty HTTP logs by default; dynamic min level via GAMEBOT_HTTP_LOG_LEVEL_MINIMUM
- Filter saved config to GAMEBOT_* + Service__* keys; add env scan metadata
- Always include documented keys with effective defaults in snapshot
- Apply config on refresh (logging level, trigger worker options) via IConfigApplier
- Add DynamicTextOcr to switch OCR backend (Env/Tesseract) at runtime
- Persist snapshot with camelCase; honor on-disk changes on refresh
- Tests: update env-var names, add config refresh/persistence test, add dynamic OCR refresh test
- Spec: replace stories with US1/US2 and focused FRs