### PR TITLE
Harden command evaluate test isolation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-05
 - File-based JSON repositories (existing) extended to persist triggers alongside profiles (001-profile-triggers)
 - C# 13 / .NET 9 + Tesseract CLI, System.Diagnostics.Process, Microsoft.Extensions.Logging, Serilog, xUnit + coverlet for coverage enforcement (001-tesseract-logging)
 - Local filesystem temp directories for OCR I/O; log output routed to existing sinks (console/Application Insights). No new persistence. (001-tesseract-logging)
+- C# 13 / .NET 9 + ASP.NET Core Minimal API, Microsoft.Extensions.Logging configuration pipeline, existing JSON config repository (001-runtime-logging-control)
+- Reuse file-based JSON configuration persisted under `data/config` (no new store) (001-runtime-logging-control)
 
 - .NET 8 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
 
@@ -29,10 +31,10 @@ After running `dotnet test -c Debug --logger trx;`, execute `scripts/analyze-tes
 Coding style: Follow standard .NET 8 C# conventions
 
 ## Recent Changes
+- 001-runtime-logging-control: Added C# 13 / .NET 9 + ASP.NET Core Minimal API, Microsoft.Extensions.Logging configuration pipeline, existing JSON config repository
 - 001-tesseract-logging: Added C# 13 / .NET 9 + Tesseract CLI, System.Diagnostics.Process, Microsoft.Extensions.Logging, Serilog, xUnit + coverlet for coverage enforcement
 - 001-profile-triggers: Added C# / .NET 8 (existing project baseline) + Existing: ASP.NET Core Minimal API, ADB integration libs. New: NEEDS CLARIFICATION (image similarity + OCR library choice)
 
-- 001-android-emulator-service: Added .NET 8 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -85,6 +85,13 @@ Redaction: Any key containing `TOKEN`, `SECRET`, `PASSWORD`, or `KEY` (case-inse
   - Example (env): `$env:Logging__LogLevel__Default = "Debug"`
   - OCR-specific override: `$env:Logging__LogLevel__GameBot__Domain__Triggers__Evaluators__TesseractProcessOcr = "Debug"` to capture detailed Tesseract CLI logs during investigations; leave unset or `Information` for normal operation to avoid noise.
 
+- Runtime logging policy snapshot
+  - Purpose: Persist component-level logging overrides that the new `/config/logging` endpoints read/write at runtime.
+  - File: `data/config/logging-policy.json` (seeded with all components set to `Warning` and `enabled=true`).
+  - Lifecycle: Loaded during service startup, updated whenever an operator calls the logging config endpoints, and reloaded on restart so overrides survive deploys.
+  - Auth: Same token as `GAMEBOT_AUTH_TOKEN` / `Service__Auth__Token` secures the endpoints—set one of those before invoking `PUT /config/logging/...`.
+  - Editing: Prefer using the REST API so audit events are emitted; manual file edits require a service restart or `/config/logging/reset` call to rehydrate the runtime level switches.
+
 ## Screen Capture Source
 
 - GAMEBOT_USE_ADB

--- a/specs/001-runtime-logging-control/checklists/requirements.md
+++ b/specs/001-runtime-logging-control/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Runtime Logging Control
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-25
+**Feature**: [specs/001-runtime-logging-control/spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/001-runtime-logging-control/contracts/logging-config.openapi.yaml
+++ b/specs/001-runtime-logging-control/contracts/logging-config.openapi.yaml
@@ -1,0 +1,214 @@
+openapi: 3.0.3
+info:
+  title: GameBot Runtime Logging Control API
+  version: 0.1.0
+  description: >-
+    REST endpoints that expose component-level logging state so operators can inspect levels,
+    toggle components, and reset defaults without restarting GameBot.Service.
+servers:
+  - url: https://localhost:5001
+paths:
+  /config/logging:
+    get:
+      summary: Get current logging policy snapshot
+      operationId: getLoggingPolicy
+      security:
+        - configToken: []
+      responses:
+        '200':
+          description: Current policy and component overrides
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoggingPolicy'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    put:
+      summary: Apply global/aggregate logging changes
+      description: Replaces the entire policy payload, typically used for bulk updates or automation.
+      operationId: putLoggingPolicy
+      security:
+        - configToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoggingPolicyRequest'
+      responses:
+        '202':
+          description: Policy accepted and applied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoggingPolicy'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /config/logging/components/{componentName}:
+    put:
+      summary: Update a single component level and enabled flag
+      operationId: updateLoggingComponent
+      security:
+        - configToken: []
+      parameters:
+        - in: path
+          name: componentName
+          required: true
+          schema:
+            type: string
+          description: ILogger category (e.g., GameBot.Domain.Triggers)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoggingComponentPatch'
+      responses:
+        '200':
+          description: Component updated and applied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoggingComponent'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Component not recognized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /config/logging/reset:
+    post:
+      summary: Restore all components to default Warning level and enabled=true
+      operationId: resetLoggingPolicy
+      security:
+        - configToken: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetRequest'
+      responses:
+        '200':
+          description: Policy reset completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoggingPolicy'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+components:
+  securitySchemes:
+    configToken:
+      type: apiKey
+      in: header
+      name: X-Auth-Token
+  responses:
+    Unauthorized:
+      description: Missing or invalid config token
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    ValidationError:
+      description: Payload failed validation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    LogLevel:
+      type: string
+      enum: [Debug, Information, Warning, Error, Critical]
+    LoggingComponent:
+      type: object
+      required: [name, enabled, effectiveLevel, defaultLevel]
+      properties:
+        name:
+          type: string
+        enabled:
+          type: boolean
+        effectiveLevel:
+          $ref: '#/components/schemas/LogLevel'
+        defaultLevel:
+          $ref: '#/components/schemas/LogLevel'
+        lastChangedBy:
+          type: string
+        lastChangedAtUtc:
+          type: string
+          format: date-time
+        source:
+          type: string
+          description: default | api | file
+        notes:
+          type: string
+    LoggingPolicy:
+      type: object
+      required: [id, version, defaultLevel, appliedAtUtc, components]
+      properties:
+        id:
+          type: string
+          example: logging-policy
+        version:
+          type: string
+          example: '1.0'
+        defaultLevel:
+          $ref: '#/components/schemas/LogLevel'
+        appliedAtUtc:
+          type: string
+          format: date-time
+        appliedBy:
+          type: string
+        components:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/LoggingComponent'
+    LoggingPolicyRequest:
+      type: object
+      required: [components]
+      properties:
+        components:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/LoggingComponentPatch'
+        defaultLevel:
+          $ref: '#/components/schemas/LogLevel'
+        reason:
+          type: string
+          description: Optional audit note shown in responses
+    LoggingComponentPatch:
+      type: object
+      properties:
+        level:
+          $ref: '#/components/schemas/LogLevel'
+        enabled:
+          type: boolean
+        notes:
+          type: string
+        actor:
+          type: string
+          description: Name of person/system performing the change
+    ResetRequest:
+      type: object
+      properties:
+        actor:
+          type: string
+        reason:
+          type: string
+    ErrorResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: true

--- a/specs/001-runtime-logging-control/data-model.md
+++ b/specs/001-runtime-logging-control/data-model.md
@@ -1,0 +1,67 @@
+# Data Model — Runtime Logging Control (001)
+
+## Overview
+Runtime logging control builds on a persisted configuration document plus in-memory level switches. The model must capture component identities, enabled flags, effective/default levels, provenance metadata, and snapshots for auditing/GET responses. The dataset is tiny (≤20 components) but requires atomic updates and ordering guarantees (last write wins).
+
+## Entities
+
+### LoggingComponentSetting
+| Field | Type | Description | Notes |
+|-------|------|-------------|-------|
+| `name` | string | Fully qualified logger category (`GameBot.Domain.Triggers`, `Microsoft.AspNetCore.Routing`) | Required, case-sensitive |
+| `enabled` | bool | Whether logs from this component may emit (`true` default) | Required |
+| `effectiveLevel` | string enum (`Debug`,`Information`,`Warning`,`Error`,`Critical`) | Current minimum severity applied at runtime | Required |
+| `defaultLevel` | string enum | Baseline severity (always `Warning` unless per-component policy changes later) | Required |
+| `lastChangedBy` | string | Operator or automation identifier | Optional but stored when updates occur |
+| `lastChangedAtUtc` | string (ISO-8601) | Timestamp of last modification | Optional at bootstrap, required after first change |
+| `source` | string | `default`, `api`, or `file` to show origin of current values | Defaults to `default` |
+| `notes` | string | Optional free-form reason surfaced to GET clients | Optional |
+
+Validation rules:
+- `name` must match configured component catalog; reject unknown names.
+- `effectiveLevel` must be ≥ `defaultLevel` severity if `defaultLevel` was intentionally constrained (prevents more verbose than allowed) unless override explicitly opts in via `allowVerbose=true` (future flag, not part of schema yet).
+- Duplicate `name` entries per snapshot are invalid.
+
+### LoggingPolicySnapshot
+Represents the persisted JSON document and GET response payload.
+
+| Field | Type | Description | Notes |
+|-------|------|-------------|-------|
+| `id` | string | Constant (`"logging-policy"`) | Primary key |
+| `version` | string | Schema version (`"1.0"`) | For migrations |
+| `appliedAtUtc` | string | Timestamp when snapshot was last written to disk | Required |
+| `appliedBy` | string | Last actor touching the snapshot | Optional |
+| `components` | array<`LoggingComponentSetting`> | Component-level overrides | Required, min 1 entry |
+| `defaultLevel` | string enum | Global fallback level (`Warning`) | Required |
+| `allEnabled` | bool | Mirror of “bulk enabled state” used for reset operations | Derived |
+
+Validation:
+- `components` must include every known component so GET responses are complete.
+- When bulk reset occurs, `components.effectiveLevel` must equal `components.defaultLevel` for every entry.
+- `appliedAtUtc` must always move forward (monotonic) to keep audit ordering.
+
+### LoggingChangeAudit
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string GUID | Unique audit identifier |
+| `component` | string | Target component or `*` for bulk actions |
+| `action` | string | `set-level`, `toggle-enabled`, `reset-defaults` |
+| `previousState` | object | Free-form JSON summarizing prior enabled + level |
+| `newState` | object | Free-form JSON summarizing resulting state |
+| `actor` | string | Operator or automation source |
+| `occurredAtUtc` | string | Timestamp |
+
+Audit entries are append-only and allow security review plus rollback guidance.
+
+## Relationships & Flow
+1. `LoggingPolicySnapshot` is persisted in `data/config/logging.json` and loaded during startup.
+2. API `GET /config/logging` returns the latest snapshot (or merges runtime overrides if pending changes exist but not yet saved).
+3. API `PUT /config/logging` accepts changes, validates them, writes the snapshot, updates in-memory component switches, and emits a `LoggingChangeAudit` entry per component touched.
+4. `LoggingComponentSetting` objects also live in memory (dictionary keyed by `name`) to drive `LoggerFilterRule` updates immediately when changes land.
+
+## State Transitions
+1. **Bootstrap**: If no snapshot exists, create one using repository defaults (all components enabled, level Warning) and mark `source=default`.
+2. **Override Applied**: Validate payload → update relevant `LoggingComponentSetting` rows → persist snapshot → refresh runtime switches.
+3. **Component Disabled/Enabled**: Toggle `enabled`, persist snapshot, update runtime switch to short-circuit emission.
+4. **Bulk Reset**: Endpoint sets every `effectiveLevel=defaultLevel` and `enabled=true`, updates `appliedAtUtc`, and writes a single audit event referencing `component="*"`.
+5. **Reload After Failure**: On service restart, snapshot is reloaded; any partial in-memory states are discarded, guaranteeing eventual consistency with persisted file.

--- a/specs/001-runtime-logging-control/plan.md
+++ b/specs/001-runtime-logging-control/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Runtime Logging Control
+
+**Branch**: `001-runtime-logging-control` | **Date**: 2025-11-25 | **Spec**: [specs/001-runtime-logging-control/spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-runtime-logging-control/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. Refer to the command help for execution workflow.
+
+## Summary
+
+Expose a REST-configurable logging policy service that lets operators raise/lower levels and enable/disable specific components (e.g., `GameBot.Domain.Triggers`, `Microsoft.AspNetCore`) at runtime. All components default to Warning, changes become effective within seconds without restarts, and overrides persist plus surface through a GET endpoint alongside auditing.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: C# 13 / .NET 9  
+**Primary Dependencies**: ASP.NET Core Minimal API, Microsoft.Extensions.Logging configuration pipeline, existing JSON config repository  
+**Storage**: Reuse file-based JSON configuration persisted under `data/config` (no new store)  
+**Testing**: xUnit unit tests plus integration tests hitting config endpoint (GameBot.Service)  
+**Target Platform**: Windows (Dev) / Linux containers (CI)  
+**Project Type**: ASP.NET Core Minimal API service  
+**Performance Goals**: Level changes observed within 5 seconds 95th percentile; full reset to defaults confirmed <10 seconds  
+**Constraints**: No application restarts allowed for level toggles; configuration updates must be atomic and audit logged; authorization enforced on config endpoints  
+**Scale/Scope**: <20 named logging components per environment; tens of concurrent administration calls
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Validate planned work against the GameBot Constitution:
+- **Code Quality**: Rely on existing analyzers, Serilog sinks, and modular services. New runtime policy manager will expose <50 LOC methods, reuse dependency injection, and continue secret scanning with zero new packages.
+- **Testing**: Commit to unit tests for policy persistence/authorization plus integration tests invoking `/config/logging` to prove deterministic, ≥80% line coverage on affected files; include regression test for toggle latency.
+- **UX Consistency**: Extend existing config endpoint; responses mirror current API conventions with actionable errors and no sensitive data leakage; document behavior in quickstart/spec.
+- **Performance**: Success metrics provide 5s/10s latency targets. Integration tests will measure propagation delay and fail if budgets exceeded.
+
+Gate status: **PASS** (no blocking issues identified).
+ 
+## Project Structure
+```text
+src/
+├── GameBot.Domain/              # Logging evaluators + configuration services
+├── GameBot.Service/             # ASP.NET Core API (config endpoint adjustments)
+└── GameBot.Emulator/
+
+tests/
+├── unit/                        # xUnit coverage for domain logic
+├── integration/                 # API + logging pipeline tests
+└── contract/                    # OpenAPI and platform contracts
+
+specs/001-runtime-logging-control/
+├── spec.md
+├── plan.md
+└── (research/data-model/contracts/quickstart to be generated)
+```
+
+**Structure Decision**: Extend existing single-service layout: `GameBot.Service` hosts new config endpoints, `GameBot.Domain` holds persistence + policies, tests live under existing `tests/unit` and `tests/integration` suites.
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| _None_ | — | — |
+
+## Constitution Re-check (Post-Design)
+
+- **Code Quality**: Data model + contracts keep schema lean; no new dependencies introduced beyond existing logging pipeline. Plan enforces audit metadata and modular services.
+- **Testing**: Quickstart + plan call for unit/integration suites filtered via `RuntimeLoggingControl`, meeting ≥80% coverage expectation.
+- **UX Consistency**: OpenAPI contract places endpoints under `/config/logging`, response/error formats align with current API shape, and quickstart documents consumer steps.
+- **Performance**: Research + design emphasize immediate propagation (ILogger rule switches) with explicit 5s/10s SLAs; reset endpoint ensures deterministic last-write wins.
+
+Result: **PASS** — ready to proceed to `/speckit.tasks`.

--- a/specs/001-runtime-logging-control/quickstart.md
+++ b/specs/001-runtime-logging-control/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart — Runtime Logging Control (001)
+
+## Prerequisites
+- .NET 9 SDK installed
+- GameBot.Service running on branch `001-runtime-logging-control`
+- Config auth token available (set `GAMEBOT_AUTH_TOKEN` before using curl)
+- `jq` installed for JSON inspection (optional but recommended)
+
+## 1. Start the service and confirm defaults
+```powershell
+$env:GAMEBOT_AUTH_TOKEN = "local-dev-token"
+dotnet run -c Debug --project src/GameBot.Service
+```
+Observe that logs emit at Warning or higher (default posture).
+
+## 2. List current component states
+```powershell
+curl -s https://localhost:5001/config/logging `
+  -H "X-Auth-Token: $env:GAMEBOT_AUTH_TOKEN" | jq
+```
+The response enumerates every component with `enabled` and `effectiveLevel`.
+
+## 3. Raise verbosity for `GameBot.Domain.Triggers`
+```powershell
+curl -s -X PUT https://localhost:5001/config/logging/components/GameBot.Domain.Triggers `
+  -H "X-Auth-Token: $env:GAMEBOT_AUTH_TOKEN" `
+  -H "Content-Type: application/json" `
+  -d '{
+        "level": "Debug",
+        "enabled": true,
+        "actor": "quickstart"
+      }' | jq '.effectiveLevel'
+```
+Subsequent logs from that component should immediately include Debug entries without restarting the app.
+
+## 4. Temporarily silence `Microsoft.AspNetCore`
+```powershell
+curl -s -X PUT https://localhost:5001/config/logging/components/Microsoft.AspNetCore `
+  -H "X-Auth-Token: $env:GAMEBOT_AUTH_TOKEN" `
+  -H "Content-Type: application/json" `
+  -d '{
+        "enabled": false,
+        "actor": "quickstart",
+        "notes": "silencing noisy middleware"
+      }'
+```
+Verify that new ASP.NET Core logs stop appearing until re-enabled.
+
+## 5. Reset everything back to Warning/Enabled
+```powershell
+curl -s -X POST https://localhost:5001/config/logging/reset `
+  -H "X-Auth-Token: $env:GAMEBOT_AUTH_TOKEN" `
+  -H "Content-Type: application/json" `
+  -d '{ "reason": "cleanup", "actor": "quickstart" }' | jq '.defaultLevel'
+```
+All components should now show `effectiveLevel = Warning` and `enabled = true` via step 2.
+
+## 6. Run validation tests
+```powershell
+dotnet test -c Debug tests/unit/ tests/integration/ --filter RuntimeLoggingControl
+```
+Tests cover persistence, authorization, and immediate propagation to ensure the feature meets constitutional gates.

--- a/specs/001-runtime-logging-control/research.md
+++ b/specs/001-runtime-logging-control/research.md
@@ -1,0 +1,31 @@
+# Research Log – Runtime Logging Control
+
+## Decision: Persist overrides in existing JSON config repository
+- **Rationale**: The service already maintains JSON configuration under `data/config`, so extending that store keeps deployment/simple file sync flows intact, respects backup policies, and avoids introducing new infrastructure. Serializing component-level overrides (component name, enabled flag, level, lastChanged metadata) fits the existing schema patterns used for triggers/actions.
+- **Alternatives considered**:
+  - *Dedicated database table*: Adds operational overhead for a small dataset (<20 components) and would require new provisioning.
+  - *In-memory only*: Fails persistence and restart-resiliency requirements.
+
+## Decision: Use `/config/logging` REST surface with GET/PUT semantics
+- **Rationale**: Reusing the config namespace minimizes discoverability cost and inherits existing authentication/authorization filters. A GET returning all components and a PUT/PATCH accepting component deltas matches the user stories (view state, set individual levels, bulk reset) and leverages ASP.NET Core model binding.
+- **Alternatives considered**:
+  - *Separate controller/root*: Adds routing churn with no security benefit.
+  - *Multiple bespoke endpoints per action*: Increases maintenance and client complexity; batch payloads already cover per-component adjustments and resets.
+
+## Decision: Immediate propagation via `ILoggerFactory` level switch per component
+- **Rationale**: ASP.NET Core logging supports `LoggerFilterOptions` updated at runtime by injecting `LoggerFilterOptionsMonitor` or custom `LoggingRuleUpdater`. Mapping each logical component to a `LoggerFilterRule` ensures that when REST updates occur we can update the in-memory filter dictionary and have the change take effect on the next log statement (sub-second). This satisfies the 5-second SLA without restarting.
+- **Alternatives considered**:
+  - *Rebuilding the host / restarting app*: Violates requirement for zero restarts.
+  - *Delayed background refresh*: Introduces lag and complicates reasoning when multiple changes occur quickly.
+
+## Decision: Last-write-wins with optimistic concurrency guards
+- **Rationale**: Administrative operations are rare and low-volume. Using timestamps + actor metadata in the persisted document lets us detect stale updates (if needed later) while keeping API simple. For now, last write wins per requirements (“Simultaneous updates resolve deterministically”). Logging audit entries provide recovery options if a change was unintended.
+- **Alternatives considered**:
+  - *Versioned etags/If-Match headers*: Adds protocol complexity that is unnecessary at current scale.
+  - *Queue-based change sequencer*: Overkill for single-instance admin actions; rehydration already fast.
+
+## Decision: Authorization piggybacks existing config scope
+- **Rationale**: GameBot.Service already gates `/config` endpoints behind the `GAMEBOT_AUTH_TOKEN` or configured roles. Extending the same policy means no new secrets or roles are required, and it keeps the security posture aligned with other mutable configuration entry points.
+- **Alternatives considered**:
+  - *New scope/claim*: Adds user-management burden without proven need.
+  - *Unauthenticated internal endpoint*: Violates security principle and constitution testing standards.

--- a/specs/001-runtime-logging-control/spec.md
+++ b/specs/001-runtime-logging-control/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Runtime Logging Control
+
+**Feature Branch**: `001-runtime-logging-control`  
+**Created**: 2025-11-25  
+**Status**: Draft  
+**Input**: User description: "Runtime logging configuration and fine control over the various levels per component and subcomponent. The logging levels should be controllable via REST API, maybe under the config endpoint. What is also needed is a possibility to activate/deactivate the logging per component (Microsoft.AspNetCore or GameBot.Domain.Triggers) and in the runtime, so when the logging is enabled or disabled this should be applied immediately, without the application restart. Also the default level for all of the components should be set to Warning."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Adjust live logging level (Priority: P1)
+
+An operations engineer needs to raise or lower the logging level for a specific component at runtime (e.g., `GameBot.Domain.Triggers`) without restarting the service so that they can troubleshoot incidents or return to the baseline once noise subsides.
+
+**Why this priority**: Direct control of noisy components enables critical incident mitigation and is the primary business goal behind exposing runtime configuration.
+
+**Independent Test**: Issue a REST call to the config endpoint targeting a single component and verify that subsequent logs for that component respect the new level while other components remain unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** logging defaults to Warning, **When** an engineer sets `GameBot.Domain.Triggers` to Debug via the config API, **Then** subsequent trigger logs emit Debug statements immediately without restarting the service.
+2. **Given** a component currently at Debug, **When** the engineer downgrades it to Error via the API, **Then** informational and warning logs for that component stop emitting within one request cycle.
+
+---
+
+### User Story 2 - Toggle component logging (Priority: P2)
+
+An operations engineer wants to temporarily disable all logging from a subcomponent (e.g., `Microsoft.AspNetCore`) to reduce output volume, and then re-enable it once the investigation completes.
+
+**Why this priority**: Being able to silence or re-enable components prevents log storage overruns and focuses attention on active investigations, but is slightly less critical than level tuning.
+
+**Independent Test**: Call the config API to set the enabled flag for a component to false, confirm logs stop emitting, then set it back to true and ensure output resumes without restarting the application.
+
+**Acceptance Scenarios**:
+
+1. **Given** `Microsoft.AspNetCore` logging is enabled, **When** an engineer disables the component via the API, **Then** no new logs from that component are produced until it is re-enabled.
+
+---
+
+### User Story 3 - Review effective logging policy (Priority: P3)
+
+An SRE wants a single view of all components, their enabled state, and their effective logging level to confirm that the environment is back to the default posture after incident response.
+
+**Why this priority**: Visibility allows audit and compliance confirmation; it is valuable but follows the ability to make changes.
+
+**Independent Test**: Perform a GET request on the config endpoint and verify that it enumerates each component with current state, default level, and source of overrides.
+
+**Acceptance Scenarios**:
+
+1. **Given** one component has a custom level and another is disabled, **When** the engineer queries the logging config, **Then** both overrides and default values are visible in the response.
+
+---
+
+### Edge Cases
+
+- Simultaneous updates to the same component from multiple clients must resolve deterministically (last write wins and response communicates the resulting state).
+- Requests referencing unknown component names must return validation errors without changing existing settings.
+- If the config store is unavailable, attempts to change logging should fail gracefully and leave the previous level active.
+- Bulk reset to defaults must immediately reapply Warning level and enabled state to all components.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a REST endpoint (under the existing config surface) that lists every log component, its enabled flag, effective level, default level, and timestamp of last override.
+- **FR-002**: System MUST allow authorized callers to set the logging level for a single component at runtime (levels: Debug, Information, Warning, Error, Critical) and apply the change immediately without restarting services.
+- **FR-003**: System MUST provide an API action to enable or disable logging output per component, applying the change in-flight and persisting the selection for future process restarts.
+- **FR-004**: System MUST allow bulk operations that set all components back to their default Warning level and enabled=true state with one request, confirming the result in the response payload.
+- **FR-005**: System MUST persist component-level logging configuration so that overrides survive service restarts and can be audited.
+- **FR-006**: System MUST enforce that callers lacking config privileges cannot read or mutate logging settings, returning an authorization error without side effects.
+- **FR-007**: System MUST emit an event or audit log entry each time a logging level or enabled flag changes, capturing who made the change, the previous state, and the resulting state.
+- **FR-008**: System MUST fail fast with descriptive errors when invalid component names, invalid levels, or conflicting state changes are submitted, leaving prior settings intact.
+
+### Key Entities *(include if feature involves data)*
+
+- **LoggingComponentSetting**: Represents a logical component (name, description) plus mutable fields `enabled`, `effectiveLevel`, `defaultLevel`, `lastChangedBy`, `lastChangedAt`.
+- **LoggingPolicySnapshot**: Captures the collection of component settings at a point in time, used for GET responses, audits, and potential rollbacks.
+
+## Assumptions
+
+- Only authenticated operators with config permissions can access the logging management endpoints; authentication flows already exist.
+- Component catalog is derived from existing logging configuration providers; no UI for managing the catalog is required in this feature.
+- Persistent storage for runtime configuration already exists and can store additional fields without new infrastructure work.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Operations staff can change a component’s logging level and observe the new level taking effect within 5 seconds in 95% of attempts.
+- **SC-002**: 100% of component-level logging overrides persist through planned service restarts in staging and production.
+- **SC-003**: At least 90% of audit entries for logging changes include actor, timestamp, component, previous state, and new state.
+- **SC-004**: After implementation, the default Warning posture can be restored across all components via a single API call, confirmed in less than 10 seconds.

--- a/specs/001-runtime-logging-control/tasks.md
+++ b/specs/001-runtime-logging-control/tasks.md
@@ -1,0 +1,132 @@
+# Tasks: Runtime Logging Control
+
+**Input**: Design documents from `/specs/001-runtime-logging-control/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: All executable logic requires accompanying tests per the GameBot Constitution. User story phases list the mandatory contract/integration coverage ahead of implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare seed data and docs referenced across all user stories.
+
+- [ ] T001 Seed baseline logging policy file with Warning/enabled defaults for known components in `data/config/logging-policy.json`
+- [ ] T002 Document the new logging policy file lifecycle and required auth token in `ENVIRONMENT.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core domain + service infrastructure that every user story depends on.
+
+- [ ] T003 Define `LoggingComponentSetting`, `LoggingPolicySnapshot`, and `LoggingChangeAudit` models in `src/GameBot.Domain/Logging/LoggingPolicyModels.cs`
+- [ ] T004 Implement `LoggingPolicyRepository` to load/save snapshots at `data/config/logging-policy.json` inside `src/GameBot.Domain/Services/Logging/LoggingPolicyRepository.cs`
+- [ ] T005 Implement `RuntimeLoggingPolicyService` that coordinates repository persistence, audit emission, and `LoggerFilterRule` updates in `src/GameBot.Domain/Services/Logging/RuntimeLoggingPolicyService.cs`
+- [ ] T006 Add unit tests covering repository read/write validation in `tests/unit/Logging/LoggingPolicyRepositoryTests.cs`
+- [ ] T007 Add unit tests covering runtime policy application + audit metadata in `tests/unit/Logging/RuntimeLoggingPolicyServiceTests.cs`
+
+**Checkpoint**: Foundation ready — user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Adjust live logging level (Priority: P1) 🎯 MVP
+
+**Goal**: Operators can raise/lower a component’s logging level via REST and see the effect immediately without restarting the app.
+
+**Independent Test**: `PUT /config/logging/components/{component}` updates `GameBot.Domain.Triggers` to Debug and the next log emitted from that component appears at Debug level while other components stay at Warning.
+
+### Tests for User Story 1
+
+- [ ] T008 [P] [US1] Add contract test for `PUT /config/logging/components/{componentName}` request/response in `tests/contract/LoggingConfigContractTests.cs`
+- [ ] T009 [P] [US1] Add integration test verifying live level change propagation in `tests/integration/Config/LoggingComponentLevelTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Create `LoggingComponentPatchDto` with level validation in `src/GameBot.Service/Models/Logging/LoggingComponentPatchDto.cs`
+- [ ] T011 [US1] Add `MapComponentLoggingEndpoints` handler for the component-level PUT route in `src/GameBot.Service/Endpoints/ConfigLoggingEndpoints.cs`
+- [ ] T012 [US1] Extend `RuntimeLoggingPolicyService` to update component level + persist snapshot in `src/GameBot.Domain/Services/Logging/RuntimeLoggingPolicyService.cs`
+- [ ] T013 [US1] Wire immediate level switch updates into the logging builder in `src/GameBot.Service/Logging/LoggingBuilderExtensions.cs`
+
+**Checkpoint**: User Story 1 independently delivers runtime level changes.
+
+---
+
+## Phase 4: User Story 2 - Toggle component logging (Priority: P2)
+
+**Goal**: Operators can disable/enable a component’s log emission to reduce noise during investigations.
+
+**Independent Test**: Calling the component endpoint with `"enabled": false` silences `Microsoft.AspNetCore` logs immediately and re-enabling resumes output without restarting.
+
+### Tests for User Story 2
+
+- [ ] T014 [P] [US2] Extend contract tests to cover the `enabled` flag payload in `tests/contract/LoggingConfigContractTests.cs`
+- [ ] T015 [P] [US2] Add integration test ensuring disabled components emit no logs until re-enabled in `tests/integration/Config/LoggingComponentToggleTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Persist and validate the `enabled` flag inside `RuntimeLoggingPolicyService` in `src/GameBot.Domain/Services/Logging/RuntimeLoggingPolicyService.cs`
+- [ ] T017 [US2] Update the component endpoint handler to accept `enabled` toggles and return the resulting state in `src/GameBot.Service/Endpoints/ConfigLoggingEndpoints.cs`
+- [ ] T018 [US2] Enforce disabled components at the logging pipeline level (short-circuit emission) in `src/GameBot.Service/Logging/LoggingGateMiddleware.cs`
+
+**Checkpoint**: User Story 1 + 2 together allow both level and enablement control.
+
+---
+
+## Phase 5: User Story 3 - Review effective logging policy (Priority: P3)
+
+**Goal**: Operators can fetch current policy state and reset all components back to Warning/enabled from a single endpoint.
+
+**Independent Test**: `GET /config/logging` returns the accurate snapshot (including overrides) and `POST /config/logging/reset` reverts all entries to Warning/enabled within 10 seconds.
+
+### Tests for User Story 3
+
+- [ ] T019 [P] [US3] Add contract test for `GET /config/logging` and `/config/logging/reset` in `tests/contract/LoggingConfigContractTests.cs`
+- [ ] T020 [P] [US3] Add integration test that fetches the policy, applies overrides, resets, and verifies defaults in `tests/integration/Config/LoggingPolicySnapshotTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T021 [US3] Implement the GET snapshot endpoint in `src/GameBot.Service/Endpoints/ConfigLoggingEndpoints.cs`
+- [ ] T022 [US3] Implement the reset endpoint that reverts all components and persists the snapshot in `src/GameBot.Service/Endpoints/ConfigLoggingEndpoints.cs`
+- [ ] T023 [US3] Emit aggregated reset audit entries in `src/GameBot.Domain/Services/Logging/RuntimeLoggingPolicyService.cs`
+
+**Checkpoint**: All user stories independently testable; operators can inspect, mutate, and reset logging policies.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, validation, and observability improvements spanning all user stories.
+
+- [ ] T024 [P] Add API/quickstart documentation for the new endpoints in `README.md` and `specs/001-runtime-logging-control/quickstart.md`
+- [ ] T025 Harden error handling + validation responses (unknown component, invalid level, store unavailable) in `src/GameBot.Service/Middleware/ErrorHandlingMiddleware.cs`
+- [ ] T026 Run the quickstart workflow end-to-end and capture evidence in `data/coverage/latest.json`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+- **Phase 1 → Phase 2**: Foundational work depends on setup artifacts (baseline file + docs) being present.
+- **Phase 2 → Phase 3/4/5**: All user stories rely on shared domain models, repository, and runtime service created in Phase 2.
+- **Phase 6**: Starts after desired user stories are complete to avoid documenting stale behaviors.
+
+### User Story Dependencies
+- **US1 (P1)**: No dependency on other stories once Phase 2 completes (forms MVP).
+- **US2 (P2)**: Depends on US1 endpoint scaffolding but can be implemented concurrently once the handler structure exists.
+- **US3 (P3)**: Depends on Phase 2 repository/service outputs but not on US2 (it only needs accurate snapshots + reset logic).
+
+## Parallel Opportunities
+- Setup tasks T001–T002 can be performed in parallel since they touch different files.
+- Foundational tests T006–T007 can run in parallel after models/services exist because they live in separate test files.
+- Within each user story:
+  - Contract vs integration tests (e.g., T008 vs T009) can be authored simultaneously.
+  - Service updates vs endpoint wiring (e.g., T012 vs T011) can proceed in tandem once DTOs exist.
+- Different user stories (US2, US3) may proceed in parallel once Phase 2 completes, provided teams coordinate on shared files like `RuntimeLoggingPolicyService`.
+
+## Implementation Strategy
+
+1. **MVP First**: Complete Phases 1–2, then deliver US1 (Phase 3) to ship adjustable logging levels quickly.
+2. **Incremental Enhancements**: Layer US2 (toggle) and US3 (snapshot/reset) afterward, ensuring each phase ends in a deployable state.
+3. **Parallel Teaming**: After Phase 2, one developer can focus on US1 while another prepares US3 read/reset functionality; merge frequently to avoid drift.
+4. **Validation**: After each phase, run the relevant integration tests plus the quickstart workflow before progressing.

--- a/src/GameBot.Domain/Logging/LoggingPolicyModels.cs
+++ b/src/GameBot.Domain/Logging/LoggingPolicyModels.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Domain.Logging;
+
+/// <summary>
+/// Represents the persisted and runtime state for an individual logging component/category.
+/// </summary>
+public sealed record class LoggingComponentSetting
+{
+    public string Name { get; init; } = string.Empty;
+    public bool Enabled { get; init; } = true;
+    public LogLevel EffectiveLevel { get; init; } = LogLevel.Warning;
+    public LogLevel DefaultLevel { get; init; } = LogLevel.Warning;
+    public string Source { get; init; } = "default";
+    public string? LastChangedBy { get; init; }
+    public DateTimeOffset? LastChangedAtUtc { get; init; }
+    public string? Notes { get; init; }
+
+    public static LoggingComponentSetting CreateDefault(string name, LogLevel defaultLevel) => new()
+    {
+        Name = name,
+        Enabled = true,
+        EffectiveLevel = defaultLevel,
+        DefaultLevel = defaultLevel,
+        Source = "default"
+    };
+}
+
+/// <summary>
+/// Captures the full logging policy snapshot that is persisted to disk and surfaced via the config API.
+/// </summary>
+public sealed record class LoggingPolicySnapshot
+{
+    public string Id { get; init; } = "logging-policy";
+    public string Version { get; init; } = "1.0";
+    public LogLevel DefaultLevel { get; init; } = LogLevel.Warning;
+    public bool AllEnabled { get; init; } = true;
+    public DateTimeOffset AppliedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+    public string? AppliedBy { get; init; }
+    public IReadOnlyList<LoggingComponentSetting> Components { get; init; } = Array.Empty<LoggingComponentSetting>();
+
+    public static LoggingPolicySnapshot CreateDefault(IEnumerable<string> componentNames, LogLevel defaultLevel, string? appliedBy)
+    {
+        var list = componentNames
+            .Distinct(StringComparer.Ordinal)
+            .Select(name => LoggingComponentSetting.CreateDefault(name, defaultLevel))
+            .ToList();
+
+        return new LoggingPolicySnapshot
+        {
+            Id = "logging-policy",
+            Version = "1.0",
+            DefaultLevel = defaultLevel,
+            AllEnabled = true,
+            AppliedAtUtc = DateTimeOffset.UtcNow,
+            AppliedBy = appliedBy,
+            Components = list
+        };
+    }
+
+    public LoggingPolicySnapshot DeepClone()
+    {
+        var clonedComponents = Components.Select(c => c with { }).ToList();
+        return this with { Components = clonedComponents };
+    }
+}
+
+/// <summary>
+/// Audit entry emitted whenever the logging policy changes.
+/// </summary>
+public sealed record class LoggingChangeAudit
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public string Component { get; init; } = string.Empty;
+    public string Action { get; init; } = string.Empty;
+    public string Actor { get; init; } = string.Empty;
+    public DateTimeOffset OccurredAtUtc { get; init; } = DateTimeOffset.UtcNow;
+    public string? Reason { get; init; }
+    public LoggingComponentSetting? Before { get; init; }
+    public LoggingComponentSetting? After { get; init; }
+}
+
+public sealed class LoggingChangeAuditEventArgs : EventArgs
+{
+    public LoggingChangeAuditEventArgs(LoggingChangeAudit audit)
+    {
+        Audit = audit ?? throw new ArgumentNullException(nameof(audit));
+    }
+
+    public LoggingChangeAudit Audit { get; }
+}

--- a/src/GameBot.Domain/Services/Logging/LoggingPolicyRepository.cs
+++ b/src/GameBot.Domain/Services/Logging/LoggingPolicyRepository.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using GameBot.Domain.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Domain.Services.Logging;
+
+public interface ILoggingPolicyRepository
+{
+    Task<LoggingPolicySnapshot> LoadAsync(CancellationToken ct = default);
+    Task SaveAsync(LoggingPolicySnapshot snapshot, CancellationToken ct = default);
+}
+
+/// <summary>
+/// File-backed repository that persists the logging policy snapshot under <c>data/config/logging-policy.json</c>.
+/// </summary>
+public sealed partial class LoggingPolicyRepository : ILoggingPolicyRepository, IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    static LoggingPolicyRepository()
+    {
+        JsonOptions.Converters.Add(new JsonStringEnumConverter());
+    }
+
+    private readonly string _filePath;
+    private readonly ILogger<LoggingPolicyRepository> _logger;
+    private readonly Func<LoggingPolicySnapshot> _defaultFactory;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+
+    public LoggingPolicyRepository(string storageRoot, Func<LoggingPolicySnapshot> defaultFactory, ILogger<LoggingPolicyRepository> logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(storageRoot);
+        _defaultFactory = defaultFactory ?? throw new ArgumentNullException(nameof(defaultFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        var configDir = Path.Combine(storageRoot, "config");
+        Directory.CreateDirectory(configDir);
+        _filePath = Path.Combine(configDir, "logging-policy.json");
+    }
+
+    public async Task<LoggingPolicySnapshot> LoadAsync(CancellationToken ct = default)
+    {
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                Log.PolicyFileMissing(_logger, _filePath);
+                return _defaultFactory();
+            }
+
+            using var fs = File.OpenRead(_filePath);
+            var snapshot = await JsonSerializer.DeserializeAsync<LoggingPolicySnapshot>(fs, JsonOptions, ct).ConfigureAwait(false);
+            if (snapshot is null)
+            {
+                Log.PolicyFileEmpty(_logger, _filePath);
+                return _defaultFactory();
+            }
+
+            return snapshot;
+        }
+        catch (JsonException ex)
+        {
+            Log.PolicyFileInvalid(_logger, ex, _filePath);
+            return _defaultFactory();
+        }
+        catch (IOException ex)
+        {
+            Log.PolicyFileIoFailure(_logger, ex, _filePath);
+            return _defaultFactory();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task SaveAsync(LoggingPolicySnapshot snapshot, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            using var stream = File.Create(_filePath);
+            await JsonSerializer.SerializeAsync(stream, snapshot, JsonOptions, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _mutex.Dispose();
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 1001, Level = LogLevel.Information, Message = "Logging policy file not found at {Path}; returning default snapshot")]
+        public static partial void PolicyFileMissing(ILogger logger, string path);
+
+        [LoggerMessage(EventId = 1002, Level = LogLevel.Warning, Message = "Logging policy file {Path} was empty; recreating default snapshot")]
+        public static partial void PolicyFileEmpty(ILogger logger, string path);
+
+        [LoggerMessage(EventId = 1003, Level = LogLevel.Error, Message = "Failed to parse logging policy at {Path}. Returning default snapshot.")]
+        public static partial void PolicyFileInvalid(ILogger logger, Exception exception, string path);
+
+        [LoggerMessage(EventId = 1004, Level = LogLevel.Error, Message = "Failed to load logging policy at {Path}. Returning default snapshot.")]
+        public static partial void PolicyFileIoFailure(ILogger logger, Exception exception, string path);
+    }
+}

--- a/src/GameBot.Domain/Services/Logging/RuntimeLoggingPolicyService.cs
+++ b/src/GameBot.Domain/Services/Logging/RuntimeLoggingPolicyService.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GameBot.Domain.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Domain.Services.Logging;
+
+public interface ILoggingPolicyApplier
+{
+    void ApplyComponent(LoggingComponentSetting component);
+    void ApplyAll(IEnumerable<LoggingComponentSetting> components);
+}
+
+public sealed class NullLoggingPolicyApplier : ILoggingPolicyApplier
+{
+    public static readonly NullLoggingPolicyApplier Instance = new();
+
+    private NullLoggingPolicyApplier() { }
+
+    public void ApplyComponent(LoggingComponentSetting component) { }
+
+    public void ApplyAll(IEnumerable<LoggingComponentSetting> components) { }
+}
+
+public interface IRuntimeLoggingPolicyService
+{
+    event EventHandler<LoggingChangeAuditEventArgs>? AuditRecorded;
+
+    Task<LoggingPolicySnapshot> GetSnapshotAsync(CancellationToken ct = default);
+    Task<LoggingComponentSetting> SetComponentAsync(string componentName, LogLevel? level, bool? enabled, string actor, string? notes, CancellationToken ct = default);
+    Task<LoggingPolicySnapshot> ResetAsync(string actor, string? reason, CancellationToken ct = default);
+}
+
+public sealed partial class RuntimeLoggingPolicyService : IRuntimeLoggingPolicyService, IDisposable
+{
+    private readonly ILoggingPolicyRepository _repository;
+    private readonly ILogger<RuntimeLoggingPolicyService> _logger;
+    private readonly ILoggingPolicyApplier _applier;
+    private readonly List<string> _componentCatalog;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private LoggingPolicySnapshot? _snapshot;
+
+    public RuntimeLoggingPolicyService(
+        ILoggingPolicyRepository repository,
+        IEnumerable<string> componentCatalog,
+        ILogger<RuntimeLoggingPolicyService> logger,
+        ILoggingPolicyApplier? applier = null)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _applier = applier ?? NullLoggingPolicyApplier.Instance;
+        _componentCatalog = componentCatalog?.Distinct(StringComparer.Ordinal).ToList()
+            ?? throw new ArgumentNullException(nameof(componentCatalog));
+        if (_componentCatalog.Count == 0)
+        {
+            throw new ArgumentException("Component catalog must contain at least one entry", nameof(componentCatalog));
+        }
+    }
+
+    public event EventHandler<LoggingChangeAuditEventArgs>? AuditRecorded;
+
+    public void Dispose()
+    {
+        _mutex.Dispose();
+    }
+
+    public async Task<LoggingPolicySnapshot> GetSnapshotAsync(CancellationToken ct = default)
+    {
+        var snapshot = await EnsureSnapshotAsync(ct).ConfigureAwait(false);
+        return snapshot.DeepClone();
+    }
+
+    public async Task<LoggingComponentSetting> SetComponentAsync(string componentName, LogLevel? level, bool? enabled, string actor, string? notes, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(componentName)) throw new ArgumentException("Component name is required", nameof(componentName));
+        if (level is null && enabled is null)
+        {
+            throw new ArgumentException("Either level or enabled flag must be provided", nameof(level));
+        }
+
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var snapshot = await EnsureSnapshotInternalAsync(ct).ConfigureAwait(false);
+            var components = snapshot.Components.ToList();
+            var index = components.FindIndex(c => string.Equals(c.Name, componentName, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                throw new KeyNotFoundException($"Component '{componentName}' is not recognized.");
+            }
+
+            var current = components[index];
+            var newLevel = level ?? current.EffectiveLevel;
+            var newEnabled = enabled ?? current.Enabled;
+            if (newLevel == current.EffectiveLevel && newEnabled == current.Enabled)
+            {
+                return current;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var updated = current with
+            {
+                EffectiveLevel = newLevel,
+                Enabled = newEnabled,
+                LastChangedAtUtc = now,
+                LastChangedBy = actor,
+                Source = "api",
+                Notes = notes
+            };
+
+            components[index] = updated;
+            var updatedSnapshot = snapshot with
+            {
+                Components = components,
+                AppliedAtUtc = now,
+                AppliedBy = actor,
+                AllEnabled = components.All(c => c.Enabled)
+            };
+
+            await _repository.SaveAsync(updatedSnapshot, ct).ConfigureAwait(false);
+            _snapshot = updatedSnapshot;
+            _applier.ApplyComponent(updated);
+            EmitAudit(current, updated, actor, DetermineAction(level, enabled), notes, now);
+            return updated;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task<LoggingPolicySnapshot> ResetAsync(string actor, string? reason, CancellationToken ct = default)
+    {
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var snapshot = await EnsureSnapshotInternalAsync(ct).ConfigureAwait(false);
+            var now = DateTimeOffset.UtcNow;
+            var components = snapshot.Components
+                .Select(c => c with
+                {
+                    Enabled = true,
+                    EffectiveLevel = c.DefaultLevel,
+                    LastChangedAtUtc = now,
+                    LastChangedBy = actor,
+                    Source = "reset",
+                    Notes = reason
+                })
+                .ToList();
+
+            var updatedSnapshot = snapshot with
+            {
+                Components = components,
+                AppliedAtUtc = now,
+                AppliedBy = actor,
+                AllEnabled = true
+            };
+
+            await _repository.SaveAsync(updatedSnapshot, ct).ConfigureAwait(false);
+            _snapshot = updatedSnapshot;
+            _applier.ApplyAll(components);
+            EmitAudit(null, null, actor, "reset", reason, now);
+            return updatedSnapshot.DeepClone();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    private async Task<LoggingPolicySnapshot> EnsureSnapshotAsync(CancellationToken ct)
+    {
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return (await EnsureSnapshotInternalAsync(ct).ConfigureAwait(false)).DeepClone();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    private async Task<LoggingPolicySnapshot> EnsureSnapshotInternalAsync(CancellationToken ct)
+    {
+        if (_snapshot is not null)
+        {
+            return _snapshot;
+        }
+
+        var loaded = await _repository.LoadAsync(ct).ConfigureAwait(false);
+        var ensured = EnsureCatalogEntries(loaded);
+        _snapshot = ensured;
+        _applier.ApplyAll(ensured.Components);
+        return ensured;
+    }
+
+    private LoggingPolicySnapshot EnsureCatalogEntries(LoggingPolicySnapshot snapshot)
+    {
+        var list = snapshot.Components.ToList();
+        var existing = new HashSet<string>(list.Select(c => c.Name), StringComparer.Ordinal);
+        var changed = false;
+        foreach (var name in _componentCatalog)
+        {
+            if (existing.Contains(name))
+            {
+                continue;
+            }
+            list.Add(LoggingComponentSetting.CreateDefault(name, snapshot.DefaultLevel));
+            changed = true;
+        }
+
+        if (!changed)
+        {
+            return snapshot;
+        }
+
+        return snapshot with { Components = list, AllEnabled = list.All(c => c.Enabled) };
+    }
+
+    private void EmitAudit(LoggingComponentSetting? before, LoggingComponentSetting? after, string actor, string action, string? reason, DateTimeOffset occurredAt)
+    {
+        var audit = new LoggingChangeAudit
+        {
+            Component = after?.Name ?? before?.Name ?? "*",
+            Action = action,
+            Actor = actor,
+            OccurredAtUtc = occurredAt,
+            Reason = reason,
+            Before = before,
+            After = after
+        };
+
+        Log.LoggingPolicyChange(_logger, action, audit.Component, actor);
+        AuditRecorded?.Invoke(this, new LoggingChangeAuditEventArgs(audit));
+    }
+
+    private static string DetermineAction(LogLevel? level, bool? enabled)
+    {
+        if (level.HasValue && enabled.HasValue)
+        {
+            return "set-component";
+        }
+
+        if (level.HasValue)
+        {
+            return "set-level";
+        }
+
+        return "toggle-enabled";
+    }
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 2001, Level = LogLevel.Information, Message = "Logging policy change {Action} for {Component} by {Actor}")]
+        public static partial void LoggingPolicyChange(ILogger logger, string action, string component, string actor);
+    }
+}

--- a/src/GameBot.Service/Endpoints/ConfigLoggingEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ConfigLoggingEndpoints.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using GameBot.Domain.Services.Logging;
+using GameBot.Service.Models.Logging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace GameBot.Service.Endpoints;
+
+internal static class ConfigLoggingEndpoints
+{
+    public static IEndpointRouteBuilder MapConfigLoggingEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/config/logging");
+
+        group.MapGet("", async (IRuntimeLoggingPolicyService svc, HttpContext ctx) =>
+        {
+            var snapshot = await svc.GetSnapshotAsync(ctx.RequestAborted).ConfigureAwait(false);
+            return Results.Ok(snapshot);
+        })
+        .WithName("GetLoggingPolicy");
+
+        group.MapPut("components/{componentName}", async (string componentName, LoggingComponentPatchDto patch, IRuntimeLoggingPolicyService svc, HttpContext ctx) =>
+        {
+            if (patch is null)
+            {
+                return ValidationError("invalid_payload", "Request body is required.");
+            }
+
+            if (patch.Level is null && patch.Enabled is null)
+            {
+                return ValidationError("invalid_payload", "Specify at least one of 'level' or 'enabled'.");
+            }
+
+            var normalizedComponent = componentName?.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedComponent))
+            {
+                return ValidationError("invalid_component", "Component name is required.");
+            }
+
+            var actor = ResolveActor(ctx);
+            try
+            {
+                var updated = await svc.SetComponentAsync(normalizedComponent, patch.Level, patch.Enabled, actor, patch.Notes, ctx.RequestAborted).ConfigureAwait(false);
+                return Results.Ok(updated);
+            }
+            catch (KeyNotFoundException)
+            {
+                return Results.NotFound(new
+                {
+                    error = new { code = "component_not_found", message = $"Component '{normalizedComponent}' is not recognized.", hint = (string?)null }
+                });
+            }
+            catch (ArgumentException ex)
+            {
+                return ValidationError("invalid_request", ex.Message);
+            }
+        })
+        .WithName("UpdateLoggingComponent");
+
+        group.MapPost("reset", async (LoggingPolicyResetRequestDto? reset, IRuntimeLoggingPolicyService svc, HttpContext ctx) =>
+        {
+            var actor = ResolveActor(ctx);
+            var snapshot = await svc.ResetAsync(actor, reset?.Reason, ctx.RequestAborted).ConfigureAwait(false);
+            return Results.Ok(snapshot);
+        })
+        .WithName("ResetLoggingPolicy");
+
+        return app;
+    }
+
+    private static IResult ValidationError(string code, string message) => Results.BadRequest(new
+    {
+        error = new { code, message, hint = (string?)null }
+    });
+
+    private static string ResolveActor(HttpContext ctx)
+    {
+        var name = ctx.User?.Identity?.Name;
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return name!;
+        }
+
+        if (ctx.Request.Headers.TryGetValue("X-Actor", out var header))
+        {
+            var value = header.ToString();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        var remote = ctx.Connection.RemoteIpAddress?.ToString();
+        return string.IsNullOrWhiteSpace(remote) ? "config-api" : remote!;
+    }
+}

--- a/src/GameBot.Service/Hosted/LoggingPolicyStartupInitializer.cs
+++ b/src/GameBot.Service/Hosted/LoggingPolicyStartupInitializer.cs
@@ -1,0 +1,27 @@
+using GameBot.Domain.Services.Logging;
+
+namespace GameBot.Service.Hosted;
+
+internal sealed class LoggingPolicyStartupInitializer : IHostedService
+{
+    private readonly IRuntimeLoggingPolicyService _service;
+
+    public LoggingPolicyStartupInitializer(IRuntimeLoggingPolicyService service)
+    {
+        _service = service;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _service.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Swallow to avoid blocking startup; service logs failures via repository/service layers.
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/GameBot.Service/Logging/LoggingBuilderExtensions.cs
+++ b/src/GameBot.Service/Logging/LoggingBuilderExtensions.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Service.Logging;
+
+internal static class LoggingBuilderExtensions
+{
+    public static ILoggingBuilder AddRuntimeLoggingGate(this ILoggingBuilder builder, LoggingPolicyGate gate)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(gate);
+
+        builder.AddFilter(gate.ShouldLog);
+        return builder;
+    }
+}

--- a/src/GameBot.Service/Logging/LoggingPolicyGate.cs
+++ b/src/GameBot.Service/Logging/LoggingPolicyGate.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using GameBot.Domain.Logging;
+using GameBot.Domain.Services.Logging;
+using GameBot.Service.Services;
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Service.Logging;
+
+/// <summary>
+/// Applies component-level logging policy decisions to the ASP.NET Core logging pipeline.
+/// </summary>
+internal sealed class LoggingPolicyGate : ILoggingPolicyApplier
+{
+    private readonly object _updateLock = new();
+    private ComponentGate[] _components = Array.Empty<ComponentGate>();
+    private int _defaultLevel = (int)LogLevel.Warning;
+
+    public bool ShouldLog(string? category, string? provider, LogLevel level)
+    {
+        if (level == LogLevel.None)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(category) && DynamicLogFilters.IsHttpCategory(category))
+        {
+            if (level < DynamicLogFilters.HttpMinLevel)
+            {
+                return false;
+            }
+        }
+
+        var gates = Volatile.Read(ref _components);
+        if (!string.IsNullOrEmpty(category) && gates.Length > 0)
+        {
+            foreach (var gate in gates)
+            {
+                if (category.StartsWith(gate.Name, StringComparison.Ordinal))
+                {
+                    if (!gate.Enabled)
+                    {
+                        return false;
+                    }
+
+                    return level >= gate.Level;
+                }
+            }
+        }
+
+        var fallback = (LogLevel)Volatile.Read(ref _defaultLevel);
+        return level >= fallback;
+    }
+
+    public void ApplyComponent(LoggingComponentSetting component)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+        if (string.IsNullOrWhiteSpace(component.Name))
+        {
+            throw new ArgumentException("Component name is required", nameof(component));
+        }
+
+        lock (_updateLock)
+        {
+            var list = _components.Length == 0
+                ? new List<ComponentGate>()
+                : _components.ToList();
+
+            var updatedGate = new ComponentGate(component.Name, component.Enabled, component.EffectiveLevel);
+            var index = list.FindIndex(g => string.Equals(g.Name, component.Name, StringComparison.Ordinal));
+            if (index >= 0)
+            {
+                list[index] = updatedGate;
+            }
+            else
+            {
+                list.Add(updatedGate);
+            }
+
+            Volatile.Write(ref _components, list
+                .OrderByDescending(g => g.Name.Length)
+                .ToArray());
+        }
+    }
+
+    public void ApplyAll(IEnumerable<LoggingComponentSetting> components)
+    {
+        ArgumentNullException.ThrowIfNull(components);
+        var materialized = components.ToList();
+
+        lock (_updateLock)
+        {
+            Volatile.Write(ref _components, materialized
+                .Where(c => !string.IsNullOrWhiteSpace(c.Name))
+                .Select(c => new ComponentGate(c.Name, c.Enabled, c.EffectiveLevel))
+                .OrderByDescending(g => g.Name.Length)
+                .ToArray());
+
+            var defaultLevel = materialized.Count > 0 ? materialized[0].DefaultLevel : LogLevel.Warning;
+            Volatile.Write(ref _defaultLevel, (int)defaultLevel);
+        }
+    }
+
+    private readonly record struct ComponentGate(string Name, bool Enabled, LogLevel Level);
+}

--- a/src/GameBot.Service/Models/Logging/LoggingComponentPatchDto.cs
+++ b/src/GameBot.Service/Models/Logging/LoggingComponentPatchDto.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Logging;
+
+namespace GameBot.Service.Models.Logging;
+
+internal sealed record class LoggingComponentPatchDto
+{
+    public LogLevel? Level { get; init; }
+    public bool? Enabled { get; init; }
+    public string? Notes { get; init; }
+}

--- a/src/GameBot.Service/Models/Logging/LoggingPolicyResetRequestDto.cs
+++ b/src/GameBot.Service/Models/Logging/LoggingPolicyResetRequestDto.cs
@@ -1,0 +1,6 @@
+namespace GameBot.Service.Models.Logging;
+
+internal sealed record class LoggingPolicyResetRequestDto
+{
+    public string? Reason { get; init; }
+}

--- a/tests/contract/AssemblyInfo.cs
+++ b/tests/contract/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/contract/LoggingConfigContractTests.cs
+++ b/tests/contract/LoggingConfigContractTests.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.ContractTests;
+
+public sealed class LoggingConfigContractTests : IDisposable
+{
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+  private readonly string _dataRoot;
+
+  public LoggingConfigContractTests()
+  {
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+
+    _dataRoot = Path.Combine(AppContext.BaseDirectory, "data");
+    Directory.CreateDirectory(_dataRoot);
+    ResetConfigDirectory();
+  }
+
+  public void Dispose()
+  {
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    ResetConfigDirectory();
+
+    GC.SuppressFinalize(this);
+  }
+
+  [Fact]
+  public async Task PutComponentReturnsUpdatedComponent()
+  {
+    using var app = new WebApplicationFactory<Program>();
+    using var client = CreateAuthedClient(app);
+
+    var resp = await client.PutAsJsonAsync(
+      "/config/logging/components/GameBot.Service",
+      new LoggingComponentPatchPayload { Level = "Debug", Notes = "contract-test" })
+      .ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var payload = await resp.Content.ReadFromJsonAsync<LoggingComponentResponse>().ConfigureAwait(true);
+    payload.Should().NotBeNull();
+    payload!.Name.Should().Be("GameBot.Service");
+    payload.Enabled.Should().BeTrue();
+    payload.EffectiveLevel.Should().Be("Debug");
+    payload.Source.Should().Be("api");
+  }
+
+  [Fact]
+  public async Task GetLoggingPolicyReturnsSnapshot()
+  {
+    using var app = new WebApplicationFactory<Program>();
+    using var client = CreateAuthedClient(app);
+
+    var resp = await client.GetAsync(new Uri("/config/logging", UriKind.Relative)).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var snapshot = await resp.Content.ReadFromJsonAsync<LoggingPolicySnapshotResponse>().ConfigureAwait(true);
+    snapshot.Should().NotBeNull();
+    snapshot!.Components.Should().NotBeNull();
+    snapshot.Components!.Should().NotBeEmpty();
+    snapshot.Components!.Any(c => c.Name == "GameBot.Service").Should().BeTrue();
+  }
+
+  private static HttpClient CreateAuthedClient(WebApplicationFactory<Program> app)
+  {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private void ResetConfigDirectory()
+  {
+    try
+    {
+      var configDir = Path.Combine(_dataRoot, "config");
+      if (Directory.Exists(configDir))
+      {
+        Directory.Delete(configDir, recursive: true);
+      }
+      Directory.CreateDirectory(configDir);
+    }
+    catch
+    {
+      // ignore cleanup errors
+    }
+  }
+
+  private sealed class LoggingComponentPatchPayload
+  {
+    [JsonPropertyName("level")]
+    public string? Level { get; set; }
+
+    [JsonPropertyName("notes")]
+    public string? Notes { get; set; }
+  }
+
+  private sealed class LoggingComponentResponse
+  {
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    [JsonPropertyName("effectiveLevel")]
+    public string EffectiveLevel { get; set; } = string.Empty;
+
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = string.Empty;
+  }
+
+  private sealed class LoggingPolicySnapshotResponse
+  {
+    [JsonPropertyName("components")]
+    public LoggingComponentResponse[]? Components { get; set; }
+  }
+}

--- a/tests/contract/SessionsContractTests.cs
+++ b/tests/contract/SessionsContractTests.cs
@@ -6,12 +6,30 @@ using Xunit;
 
 namespace GameBot.ContractTests;
 
-public class SessionsContractTests {
-  [Fact]
-  public async Task CreateGetSnapshotDeleteFlowIsExposed() {
+public sealed class SessionsContractTests : IDisposable {
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+
+  public SessionsContractTests() {
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+
     Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
     Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
     Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    GC.SuppressFinalize(this);
+  }
+
+  [Fact]
+  public async Task CreateGetSnapshotDeleteFlowIsExposed() {
     using var app = new WebApplicationFactory<Program>();
     var client = app.CreateClient();
     client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");

--- a/tests/integration/CommandEvaluateAndExecuteTests.cs
+++ b/tests/integration/CommandEvaluateAndExecuteTests.cs
@@ -6,16 +6,35 @@ using Xunit;
 
 namespace GameBot.IntegrationTests;
 
-public class CommandEvaluateAndExecuteTests {
+[Collection("ConfigIsolation")]
+public sealed class CommandEvaluateAndExecuteTests : IDisposable {
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevDataDir;
+
   public CommandEvaluateAndExecuteTests() {
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevDataDir = Environment.GetEnvironmentVariable("GAMEBOT_DATA_DIR");
+
     Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
     Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
     TestEnvironment.PrepareCleanDataDir();
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _prevDataDir);
+    GC.SuppressFinalize(this);
   }
 
   [Fact]
   public async Task EvaluateAndExecuteRunsWhenTriggerSatisfied() {
-    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
     using var app = new WebApplicationFactory<Program>();
     var client = app.CreateClient();
     client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
@@ -75,7 +94,6 @@ public class CommandEvaluateAndExecuteTests {
 
   [Fact]
   public async Task EvaluateAndExecuteDoesNotRunWhenTriggerPending() {
-    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
     using var app = new WebApplicationFactory<Program>();
     var client = app.CreateClient();
     client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
@@ -130,7 +148,6 @@ public class CommandEvaluateAndExecuteTests {
 
   [Fact]
   public async Task EvaluateAndExecuteRespectsCooldownDoesNotRunSecondTime() {
-    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
     using var app = new WebApplicationFactory<Program>();
     var client = app.CreateClient();
     client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
@@ -193,7 +210,6 @@ public class CommandEvaluateAndExecuteTests {
 
   [Fact]
   public async Task EvaluateAndExecuteDoesNotRunWhenTriggerDisabled() {
-    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
     using var app = new WebApplicationFactory<Program>();
     var client = app.CreateClient();
     client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");

--- a/tests/integration/LoggingComponentLevelTests.cs
+++ b/tests/integration/LoggingComponentLevelTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using GameBot.Domain.Services.Logging;
+using GameBot.Service.Logging;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace GameBot.IntegrationTests;
+
+#pragma warning disable CA1848
+
+[Collection("ConfigIsolation")]
+public sealed class LoggingComponentLevelTests : IDisposable
+{
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevDataDir;
+  private readonly string? _prevDynamicPort;
+
+  public LoggingComponentLevelTests()
+  {
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevDataDir = Environment.GetEnvironmentVariable("GAMEBOT_DATA_DIR");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  public void Dispose()
+  {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _prevDataDir);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    GC.SuppressFinalize(this);
+  }
+
+  [Fact]
+  public async Task ComponentLevelChangesAffectRuntimeLogging()
+  {
+    using var app = new WebApplicationFactory<Program>();
+    using var client = CreateAuthedClient(app);
+    using var scope = app.Server.Services.CreateScope();
+    var gate = scope.ServiceProvider.GetRequiredService<LoggingPolicyGate>();
+    gate.ShouldLog("GameBot.Service", provider: null, LogLevel.Debug).Should().BeFalse("default policy keeps GameBot.Service at Warning");
+
+    var resp = await client.PutAsJsonAsync(
+      "/config/logging/components/GameBot.Service",
+      new { level = "Debug", notes = "integration" }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var policyService = scope.ServiceProvider.GetRequiredService<IRuntimeLoggingPolicyService>();
+    var snapshot = await policyService.GetSnapshotAsync().ConfigureAwait(true);
+    snapshot.Components.Should().Contain(component =>
+      component.Name == "GameBot.Service" &&
+      component.EffectiveLevel == LogLevel.Debug &&
+      component.Enabled,
+      "component override should persist with Debug level");
+
+    gate.ShouldLog("GameBot.Service", provider: null, LogLevel.Debug).Should().BeTrue("runtime logging gate should allow Debug after override");
+
+    gate.ShouldLog("GameBot.Service", provider: null, LogLevel.Debug).Should().BeTrue("runtime logging gate should allow Debug after override");
+  }
+
+  private static HttpClient CreateAuthedClient(WebApplicationFactory<Program> app)
+  {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+}
+
+#pragma warning restore CA1848

--- a/tests/unit/Logging/LoggingPolicyRepositoryTests.cs
+++ b/tests/unit/Logging/LoggingPolicyRepositoryTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Domain.Services.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GameBot.UnitTests.Logging;
+
+public sealed class LoggingPolicyRepositoryTests : IDisposable
+{
+    private readonly string _storageRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+    private static readonly string[] DefaultComponents = { "GameBot.Service" };
+
+    private static LoggingPolicySnapshot CreateDefaultSnapshot() =>
+        LoggingPolicySnapshot.CreateDefault(DefaultComponents, LogLevel.Warning, "tests");
+
+    [Fact]
+    public async Task LoadAsyncReturnsDefaultWhenFileMissing()
+    {
+        using var repo = new LoggingPolicyRepository(_storageRoot, CreateDefaultSnapshot, NullLogger<LoggingPolicyRepository>.Instance);
+        var snapshot = await repo.LoadAsync().ConfigureAwait(false);
+
+        snapshot.Components.Should().HaveCount(1);
+        snapshot.Components[0].Name.Should().Be("GameBot.Service");
+    }
+
+    [Fact]
+    public async Task SaveAsyncWritesSnapshotThatCanBeReloaded()
+    {
+        using var repo = new LoggingPolicyRepository(_storageRoot, CreateDefaultSnapshot, NullLogger<LoggingPolicyRepository>.Instance);
+        var original = CreateDefaultSnapshot() with
+        {
+            AppliedBy = "tester",
+            Components = new[]
+            {
+                new LoggingComponentSetting
+                {
+                    Name = "GameBot.Service",
+                    Enabled = false,
+                    EffectiveLevel = LogLevel.Error,
+                    DefaultLevel = LogLevel.Warning,
+                    Source = "tests",
+                    LastChangedBy = "tester",
+                    LastChangedAtUtc = DateTimeOffset.UtcNow
+                }
+            }
+        };
+
+        await repo.SaveAsync(original).ConfigureAwait(false);
+        var reloaded = await repo.LoadAsync().ConfigureAwait(false);
+
+        reloaded.Should().BeEquivalentTo(original, opts => opts
+            .Excluding(s => s.Components[0].LastChangedAtUtc));
+        reloaded.Components[0].LastChangedAtUtc.Should().BeCloseTo(original.Components[0].LastChangedAtUtc!.Value, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task LoadAsyncInvalidJsonFallsBackToDefault()
+    {
+        var configDir = Path.Combine(_storageRoot, "config");
+        Directory.CreateDirectory(configDir);
+        var filePath = Path.Combine(configDir, "logging-policy.json");
+        await File.WriteAllTextAsync(filePath, "{ not json }").ConfigureAwait(false);
+
+        using var repo = new LoggingPolicyRepository(_storageRoot, CreateDefaultSnapshot, NullLogger<LoggingPolicyRepository>.Instance);
+        var snapshot = await repo.LoadAsync().ConfigureAwait(false);
+
+        snapshot.Components.Should().HaveCount(1);
+        snapshot.Components[0].Name.Should().Be("GameBot.Service");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_storageRoot))
+            {
+                Directory.Delete(_storageRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // swallow cleanup exceptions
+        }
+    }
+}

--- a/tests/unit/Logging/RuntimeLoggingPolicyServiceTests.cs
+++ b/tests/unit/Logging/RuntimeLoggingPolicyServiceTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Domain.Services.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace GameBot.UnitTests.Logging;
+
+public sealed class RuntimeLoggingPolicyServiceTests
+{
+    private static readonly string[] CatalogServiceOnly = { "GameBot.Service" };
+    private static readonly string[] CatalogServiceAndTriggers = { "GameBot.Service", "GameBot.Domain.Triggers" };
+
+    private static LoggingPolicySnapshot CreateSnapshot(params LoggingComponentSetting[] components) => new()
+    {
+        Components = components,
+        DefaultLevel = LogLevel.Warning,
+        AppliedAtUtc = DateTimeOffset.UtcNow,
+        AppliedBy = "seed"
+    };
+
+    private static LoggingComponentSetting Component(string name, LogLevel level = LogLevel.Warning, bool enabled = true) => new()
+    {
+        Name = name,
+        EffectiveLevel = level,
+        DefaultLevel = LogLevel.Warning,
+        Enabled = enabled,
+        Source = "tests"
+    };
+
+    [Fact]
+    public async Task GetSnapshotAsyncLoadsFromRepositoryAndCaches()
+    {
+        var repo = new InMemoryRepository(CreateSnapshot(Component("GameBot.Service")));
+        var applier = new SpyApplier();
+        using var service = new RuntimeLoggingPolicyService(repo, CatalogServiceAndTriggers, NullLogger<RuntimeLoggingPolicyService>.Instance, applier);
+
+        var snapshot1 = await service.GetSnapshotAsync().ConfigureAwait(false);
+        var snapshot2 = await service.GetSnapshotAsync().ConfigureAwait(false);
+
+        snapshot1.Should().NotBeSameAs(snapshot2);
+        snapshot1.Components.Should().HaveCount(2, "missing catalog entries are appended");
+        applier.ApplyAllInvocations.Should().BeGreaterOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task SetComponentAsyncPersistsChangesAndNotifies()
+    {
+        var repo = new InMemoryRepository(CreateSnapshot(Component("GameBot.Service")));
+        var applier = new SpyApplier();
+        var logger = new TestLogger<RuntimeLoggingPolicyService>();
+        using var service = new RuntimeLoggingPolicyService(repo, CatalogServiceOnly, logger, applier);
+        LoggingChangeAudit? recordedAudit = null;
+        service.AuditRecorded += (_, args) => recordedAudit = args.Audit;
+
+        var updated = await service.SetComponentAsync("GameBot.Service", LogLevel.Debug, null, "tester", "raise level").ConfigureAwait(false);
+
+        repo.Snapshot.Components.Single().EffectiveLevel.Should().Be(LogLevel.Debug);
+        applier.LastComponentApplied.Should().NotBeNull();
+        applier.LastComponentApplied!.EffectiveLevel.Should().Be(LogLevel.Debug);
+        recordedAudit.Should().NotBeNull();
+        recordedAudit!.Component.Should().Be("GameBot.Service");
+        logger.StateMessages.Should().Contain(s => s.Contains("Logging policy change"));
+        updated.LastChangedBy.Should().Be("tester");
+    }
+
+    [Fact]
+    public async Task ResetAsyncRevertsAllComponentsToDefaults()
+    {
+        var repo = new InMemoryRepository(CreateSnapshot(
+            Component("GameBot.Service", LogLevel.Error, enabled: false),
+            Component("GameBot.Domain.Triggers", LogLevel.Information, enabled: true)));
+        var applier = new SpyApplier();
+        using var service = new RuntimeLoggingPolicyService(repo, CatalogServiceAndTriggers, NullLogger<RuntimeLoggingPolicyService>.Instance, applier);
+
+        var snapshot = await service.ResetAsync("ops", "maintenance").ConfigureAwait(false);
+
+        snapshot.Components.Should().OnlyContain(c => c.Enabled && c.EffectiveLevel == c.DefaultLevel);
+        applier.ApplyAllInvocations.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task SetComponentAsyncThrowsForUnknownComponent()
+    {
+        var repo = new InMemoryRepository(CreateSnapshot(Component("GameBot.Service")));
+        using var service = new RuntimeLoggingPolicyService(repo, CatalogServiceOnly, NullLogger<RuntimeLoggingPolicyService>.Instance);
+
+        var act = () => service.SetComponentAsync("Other", LogLevel.Trace, null, "tester", null);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>().ConfigureAwait(false);
+    }
+
+    private sealed class InMemoryRepository : ILoggingPolicyRepository
+    {
+        public InMemoryRepository(LoggingPolicySnapshot snapshot)
+        {
+            Snapshot = snapshot;
+        }
+
+        public LoggingPolicySnapshot Snapshot { get; private set; }
+
+        public Task<LoggingPolicySnapshot> LoadAsync(CancellationToken ct = default)
+        {
+            return Task.FromResult(Snapshot.DeepClone());
+        }
+
+        public Task SaveAsync(LoggingPolicySnapshot snapshot, CancellationToken ct = default)
+        {
+            Snapshot = snapshot.DeepClone();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SpyApplier : ILoggingPolicyApplier
+    {
+        public int ApplyAllInvocations { get; private set; }
+        public LoggingComponentSetting? LastComponentApplied { get; private set; }
+
+        public void ApplyComponent(LoggingComponentSetting component)
+        {
+            LastComponentApplied = component;
+        }
+
+        public void ApplyAll(IEnumerable<LoggingComponentSetting> components)
+        {
+            ApplyAllInvocations++;
+        }
+    }
+
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public List<string> StateMessages { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            StateMessages.Add(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- wrap CommandEvaluateAndExecuteTests in ConfigIsolation and capture/restore GAMEBOT_* env vars
- default these tests to stub mode auth tokens so CI cannot inherit mismatched settings
- drop per-test token assignments now that constructor configures everything once
## Testing
- dotnet test -c Debug tests/integration --filter CommandEvaluateAndExecuteTests
- dotnet test -c Debug