### PR TITLE
OCR: TSV confidence integration + cooldown default to 0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-05
 - Reuse file-based JSON configuration persisted under `data/config` (no new store) (001-runtime-logging-control)
 - C# / .NET 9 + GameBot.Domain repositories, GameBot.Emulator.Session, TriggerEvaluationService (no new external packages) (001-fix-trigger-evaluate)
 - File-based JSON repositories under `data/` (001-fix-trigger-evaluate)
+- C# / .NET 9 (align with existing services) + External Tesseract CLI (no new managed package) (001-ocr-confidence-refactor)
+- None added; transient temp files only (001-ocr-confidence-refactor)
 
 - .NET 8 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
 
@@ -33,9 +35,9 @@ After running `dotnet test -c Debug --logger trx;`, execute `scripts/analyze-tes
 Coding style: Follow standard .NET 8 C# conventions
 
 ## Recent Changes
+- 001-ocr-confidence-refactor: Added C# / .NET 9 (align with existing services) + External Tesseract CLI (no new managed package)
 - 001-fix-trigger-evaluate: Added C# / .NET 9 + GameBot.Domain repositories, GameBot.Emulator.Session, TriggerEvaluationService (no new external packages)
 - 001-runtime-logging-control: Added C# 13 / .NET 9 + ASP.NET Core Minimal API, Microsoft.Extensions.Logging configuration pipeline, existing JSON config repository
-- 001-tesseract-logging: Added C# 13 / .NET 9 + Tesseract CLI, System.Diagnostics.Process, Microsoft.Extensions.Logging, Serilog, xUnit + coverlet for coverage enforcement
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/scripts/local-verify-tesseract.ps1
+++ b/scripts/local-verify-tesseract.ps1
@@ -1,0 +1,17 @@
+Param()
+
+Write-Host "Verifying Tesseract availability..."
+$exe = $env:GAMEBOT_TESSERACT_PATH
+if ([string]::IsNullOrWhiteSpace($exe)) { $exe = "tesseract" }
+$found = $false
+try {
+  $version = & $exe --version 2>$null | Select-Object -First 1
+  if ($LASTEXITCODE -eq 0 -and $version) { $found = $true }
+} catch { }
+if (-not $found) {
+  Write-Host "Tesseract NOT found (checked '$exe'). Set GAMEBOT_TESSERACT_PATH or install tesseract."; exit 1
+}
+Write-Host "Tesseract found: $version"
+$vars = @('GAMEBOT_TESSERACT_PATH','GAMEBOT_TESSERACT_LANG','GAMEBOT_TESSERACT_PSM','GAMEBOT_TESSERACT_OEM')
+foreach ($v in $vars) { $val = (Get-Item env:$v -ErrorAction SilentlyContinue).Value; Write-Host "$v=$val" }
+exit 0

--- a/specs/001-ocr-confidence-refactor/checklists/requirements.md
+++ b/specs/001-ocr-confidence-refactor/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: OCR Confidence via TSV
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-26
+**Feature**: ../spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Ready for `/speckit.plan`.

--- a/specs/001-ocr-confidence-refactor/contracts/ocr-evaluation.openapi.yaml
+++ b/specs/001-ocr-confidence-refactor/contracts/ocr-evaluation.openapi.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.3
+info:
+  title: OCR Evaluation
+  version: 1.0.0
+paths:
+  /triggers/{id}/test-ocr:
+    post:
+      summary: Test OCR trigger evaluation with TSV confidence
+      operationId: TestOcrTrigger
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                imageBase64:
+                  type: string
+                  description: PNG image encoded as Base64
+              required: [imageBase64]
+      responses:
+        '200':
+          description: OCR evaluation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OcrEvaluationResult'
+components:
+  schemas:
+    OcrToken:
+      type: object
+      properties:
+        text: { type: string }
+        left: { type: integer, minimum: 0 }
+        top: { type: integer, minimum: 0 }
+        width: { type: integer, minimum: 1 }
+        height: { type: integer, minimum: 1 }
+        lineIndex: { type: integer, minimum: 0 }
+        wordIndex: { type: integer, minimum: 0 }
+        confidence: { type: integer, minimum: -1, maximum: 100 }
+      required: [text,left,top,width,height,lineIndex,wordIndex,confidence]
+    OcrEvaluationResult:
+      type: object
+      properties:
+        tokens:
+          type: array
+          items: { $ref: '#/components/schemas/OcrToken' }
+        confidence:
+          type: number
+          description: Mean per-word confidence (excluding -1 and empty text)
+          minimum: 0
+          maximum: 100
+        text:
+          type: string
+        reason:
+          type: string
+          nullable: true
+      required: [tokens,confidence,text]

--- a/specs/001-ocr-confidence-refactor/data-model.md
+++ b/specs/001-ocr-confidence-refactor/data-model.md
@@ -1,0 +1,37 @@
+# Data Model: OCR Confidence via TSV
+
+## Entities
+
+### OCRToken
+| Field | Type | Rules |
+|-------|------|-------|
+| text | string | Trimmed; may be empty; if empty excluded from aggregation |
+| left | int | >=0 |
+| top | int | >=0 |
+| width | int | >0 |
+| height | int | >0 |
+| lineIndex | int | >=0 |
+| wordIndex | int | >=0 within line |
+| confidence | int | -1 or 0..100; -1 excluded from aggregation |
+
+### OcrEvaluationResult
+| Field | Type | Rules |
+|-------|------|-------|
+| tokens | List<OCRToken> | Ordered by (lineIndex, wordIndex) |
+| confidence | double | Mean of token.confidence (excluding -1, empty text) 0..100; fractional allowed |
+| text | string | Concatenation of token.text with single spaces per line word separation |
+| reason | string? | Non-empty when confidence==0 due to failure or no text |
+
+## State & Transitions
+- Generation: Produced per OCR invocation; immutable snapshot.
+- Failure Path: tokens empty; confidence=0; reason populated (e.g., `tesseract_error`, `no_text_detected`).
+
+## Validation Summary
+- Aggregation excludes tokens where confidence == -1 or text is empty/whitespace.
+- If all tokens excluded → confidence=0; reason=`no_valid_tokens`.
+
+## Derived Values
+- text constructed during parse to avoid second pass.
+
+## Notes
+- Future extension: Add block/paragraph grouping without altering existing fields.

--- a/specs/001-ocr-confidence-refactor/plan.md
+++ b/specs/001-ocr-confidence-refactor/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: OCR Confidence via TSV
+
+**Branch**: `001-ocr-confidence-refactor` | **Date**: 2025-11-26 | **Spec**: `specs/001-ocr-confidence-refactor/spec.md`
+**Input**: Feature specification for OCR confidence refactor (TSV parsing)
+
+**Note**: This template is filled in by the `/speckit.plan` command. Refer to the command help for execution workflow.
+
+## Summary
+
+Introduce accurate OCR confidence by invoking Tesseract with TSV output, parsing per-word confidence (`conf`), exposing tokens and aggregate confidence (mean of non -1 values) while preserving existing output fields. Replace heuristic character-ratio confidence with TSV-driven calculation. Provide robust error handling and deterministic aggregation.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: C# / .NET 9 (align with existing services)  
+**Primary Dependencies**: External Tesseract CLI (no new managed package)  
+**Storage**: None added; transient temp files only  
+**Testing**: xUnit (unit: TSV parsing, integration: trigger evaluation with OCR)  
+**Target Platform**: Windows (CI), should remain cross-platform where Tesseract available  
+**Project Type**: Service + domain library  
+**Performance Goals**: OCR invocation time p95 ≤ 1500ms for 1080p screenshot; parsing overhead ≤ 5ms  
+**Constraints**: Memory footprint per OCR ≤ 40MB; temp files cleaned; no leaked processes  
+**Scale/Scope**: Up to 10 OCR evaluations per minute per session typical; design for 100 concurrent sessions
+
+**Clarifications (Resolved in research.md)**:
+1. Aggregation: Arithmetic mean chosen over median/weighted area.
+2. Hierarchy: Flatten tokens with line & word indexes only.
+3. Normalization: Keep 0-100 scale (integer per token, double aggregate).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Validate planned work against the GameBot Constitution:
+- Code Quality: planned tooling (lint/format/static analysis), modularity approach, security scanning.
+- Testing: unit/integration plan, coverage targets, determinism strategy, CI gating.
+- UX Consistency: interface conventions (CLI/API/logs), error messaging, versioning for changes.
+- Performance: declared budgets/targets and measurement approach for hot paths.
+
+Initial Alignment:
+- Code Quality: Encapsulate TSV parsing in dedicated class (`TesseractTsvParser`); small methods <50 LOC; no new deps.
+- Testing: Add unit tests for parser (valid TSV, noise rows, empty output); integration test ensures trigger uses new confidence.
+- UX Consistency: Preserve previous `OcrResult` fields; add `confidence` (aggregate) and `tokens[].confidence`; stable JSON.
+- Performance: Single pass parse; avoid unnecessary allocations (reuse StringSplit); measure parsing with stopwatch in tests.
+
+Gate Status: PASS (all clarifications resolved; no blockers.)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: Utilize existing domain service layout; new parser in `src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs`; extend `OcrResult` or introduce `OcrDetailedResult`. Modify `TesseractProcessOcr` to request TSV (`... stdout tsv` pattern) and build tokens.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |
+
+## Phase 1 Outputs Summary
+- research.md generated with decisions on aggregation, hierarchy, normalization.
+- data-model.md defines OCRToken and OcrEvaluationResult.
+- contracts/ocr-evaluation.openapi.yaml adds endpoint schema (if exposed for testing).
+- quickstart.md documents usage & environment variables.
+- Agent context updated (copilot-instructions.md).
+
+## Post-Design Constitution Re-Check
+- Code Quality: Parser planned small & test-covered (OK)
+- Testing: Unit + integration additions outlined (OK)
+- UX Consistency: Non-breaking schema extension (OK)
+- Performance: Budget specified; single-pass parse (OK)
+Gate: PASS

--- a/specs/001-ocr-confidence-refactor/quickstart.md
+++ b/specs/001-ocr-confidence-refactor/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart: OCR Confidence via TSV
+
+## Goal
+Use Tesseract TSV output to obtain reliable per-word confidence and aggregate it for trigger evaluation.
+
+## Prerequisites
+- Tesseract installed and accessible on PATH or `GAMEBOT_TESSERACT_PATH` set.
+- .NET 9 SDK.
+
+## Invocation Pattern
+```
+tesseract input.png stdout -l eng --psm 6 --oem 1 tsv
+```
+Reads TSV rows including `conf` column.
+
+## Integration Steps
+1. Capture in-memory `Bitmap` from emulator session.
+2. Save to temp PNG path.
+3. Execute Tesseract with TSV output to stdout.
+4. Parse TSV lines (skip header) into `OCRToken` list.
+5. Compute aggregate confidence: arithmetic mean of confidences excluding -1 & empty text tokens.
+6. Return `OcrEvaluationResult` to trigger evaluation logic.
+
+## Error Handling
+- Non-zero exit: return empty tokens, confidence=0, reason=`tesseract_error`.
+- Missing `conf` column: reason=`tsv_format_unexpected`.
+- No valid tokens: reason=`no_valid_tokens`.
+
+## Testing
+- Unit: parser with sample TSV fixture (normal, noise rows, malformed).
+- Integration: trigger evaluation uses aggregated confidence threshold.
+
+## Environment Variables
+- `GAMEBOT_TESSERACT_PATH`: overrides tesseract executable.
+- `GAMEBOT_TESSERACT_LANG`: language (default `eng`).
+- `GAMEBOT_TESSERACT_PSM`: page segmentation mode.
+- `GAMEBOT_TESSERACT_OEM`: OCR engine mode.
+
+## Next
+Implement parser and modify `TesseractProcessOcr` to use TSV path; update tests.

--- a/specs/001-ocr-confidence-refactor/research.md
+++ b/specs/001-ocr-confidence-refactor/research.md
@@ -1,0 +1,52 @@
+# Research: OCR Confidence via TSV
+
+## Clarifications Resolved
+
+### 1. Aggregation Method
+- Decision: Use arithmetic mean of non -1 token confidences.
+- Rationale: Simple, widely understood; avoids bias toward longer words; stable across varied token counts.
+- Alternatives Considered:
+  - Median: More robust to outliers but less sensitive to overall quality distribution.
+  - Weighted by bbox area: Risks inflating large noisy regions; adds complexity without clear benefit.
+
+### 2. Token Hierarchy Exposure
+- Decision: Flatten tokens but retain line index and word order; do not surface block/paragraph hierarchy initially.
+- Rationale: Current consumers only need per-word confidence; hierarchy adds complexity; can extend later without breaking.
+- Alternatives Considered: Full hierarchy model (block/para/line/word) increases payload and parsing overhead; not needed yet.
+
+### 3. Confidence Normalization Format
+- Decision: Keep integer 0-100 as provided by Tesseract; aggregate will also be double 0-100 (may include fractional).
+- Rationale: Consistency with raw Tesseract output; avoids confusion converting scales; existing consumers already treat confidence as (0-1 or percentage?) will adapt with doc.
+- Alternatives Considered: 0-1 double scale introduces conversion overhead and potential misinterpretation.
+
+## Additional Decisions
+
+### TSV Invocation Pattern
+- Decision: Invoke: `tesseract <input> stdout -l <lang> --psm <psm> --oem <oem> tsv` capturing stdout;
+  parse rows skipping header line; fallback to legacy .txt if TSV fails.
+- Rationale: Direct stdout reduces temp file clutter; TSV required for per-word confidence.
+- Alternatives: Output to temp file `<output>.tsv`; more cleanup required.
+
+### Error Handling
+- Decision: On non-zero exit or empty TSV, return empty tokens, confidence=0, reason set accordingly.
+- Rationale: Simplifies downstream; explicit reason allows trigger logic.
+- Alternatives: Throw exceptions—would complicate trigger evaluation.
+
+### Parsing Strategy
+- Decision: Split lines; skip header; use `StringSplitOptions.None` for positional fields; validate column count; parse conf as int; treat conf <0 as -1.
+- Alternatives: Regex parse slower; CSV library unnecessary overhead.
+
+### Performance Considerations
+- Decision: Single pass parse; allocate token list with capacity guessed from line count; avoid boxing for loops.
+- Rationale: Minimizes overhead under high session concurrency.
+
+## Risks & Mitigations
+- Risk: Tesseract version differences in TSV columns — Mitigation: Validate header contains `conf` and expected columns; abort if mismatch.
+- Risk: Large images slow OCR — Mitigation: PSM setting (default 6) documented; encourage cropping upstream.
+- Risk: Memory leaks via unreleased Bitmaps — Mitigation: Caller responsibility; document in quickstart.
+
+## Open Questions (None Remaining)
+- All previous NEEDS CLARIFICATION markers resolved.
+
+## Summary
+Decisions prioritize simplicity, determinism, and extensibility. TSV parsing replaces heuristic confidence, providing reliable data for trigger evaluation.

--- a/specs/001-ocr-confidence-refactor/spec.md
+++ b/specs/001-ocr-confidence-refactor/spec.md
@@ -1,0 +1,197 @@
+# Feature Specification: OCR Confidence via TSV
+
+**Feature Branch**: `001-ocr-confidence-refactor`  
+**Created**: 2025-11-26  
+**Status**: Draft  
+**Input**: User description: "Improvment in OCR is needed. Calculating Confidence is wrong, tesseract should be started with the parameter tsv that reports the correct confidence. In order to make use of it, refactoring of tesseract output is required."
+
+## User Scenarios & Testing (mandatory)
+
+### User Story 1 - Accurate OCR confidence (Priority: P1)
+
+As a rule developer, I need OCR evaluations to report correct per-word confidence so that triggers based on text reliability make correct decisions.
+
+**Why this priority**: Incorrect confidence leads to false positives/negatives in automation decisions.
+
+**Independent Test**: Provide a fixed image with known readable text; evaluation returns per-word confidences matching Tesseract TSV conf field and aggregates consistently.
+
+**Acceptance Scenarios**:
+
+1. Given a test image with clear printed text, When OCR evaluation runs, Then TSV output is parsed and the reported confidences equal TSV `conf` values for corresponding tokens.
+2. Given mixed-quality text (some blurred), When OCR evaluation runs, Then low-confidence tokens have lower numeric confidence than clear tokens and aggregate reflects weighted average rules.
+
+---
+
+### User Story 2 - Configurable aggregation (Priority: P2)
+
+As a rule developer, I want a consistent, documented confidence aggregation for multi-token matches so that trigger thresholds are predictable.
+
+**Why this priority**: Different aggregations change trigger results; consistency is required.
+
+**Independent Test**: For a known TSV row set, the computed aggregate confidence matches the documented formula.
+
+**Acceptance Scenarios**:
+
+1. Given tokens with confidences [95, 80, 70], When aggregated, Then the final confidence equals the defined method (default: arithmetic mean of matched tokens, excluding -1/noise).
+
+---
+
+### User Story 3 - Backward-safe output contract (Priority: P3)
+
+As a consumer of OCR results, I need the output schema to include per-token confidence and overall confidence without breaking existing fields.
+
+**Why this priority**: Avoid downstream breaking changes while enabling better decisions.
+
+**Independent Test**: Schema validation passes; existing fields preserved; new fields present with correct values.
+
+**Acceptance Scenarios**:
+
+1. Given prior JSON structure, When the new evaluator runs, Then the previous fields are present and populated; additional `tokens[].confidence` and `confidence` are included.
+
+### Edge Cases
+
+- Empty or non-text images produce zero tokens and confidence is 0 with reason "no_text_detected".
+- TSV `conf` may be -1 for noise; these tokens are excluded from aggregation but retained in tokens with confidence = -1.
+- Multi-line and multi-block text preserves reading order; aggregation only considers matched tokens per query/match scope.
+
+## Requirements (mandatory)
+
+### Functional Requirements
+
+- FR-001: System MUST invoke Tesseract with TSV output mode for OCR confidence extraction.
+- FR-002: System MUST parse TSV output and map fields (level, page_num, block_num, par_num, line_num, word_num, left, top, width, height, conf, text).
+- FR-003: System MUST populate per-token confidence from TSV `conf` as integer 0-100 (or -1 for noise).
+- FR-004: System MUST compute overall confidence for a match as arithmetic mean of included token confidences, excluding -1 values.
+- FR-005: System MUST expose both overall confidence and tokens[].confidence in the OCR evaluation result contract.
+- FR-006: System MUST return a deterministic confidence for identical inputs.
+- FR-007: System MUST treat empty or whitespace-only tokens as excluded from aggregation.
+- FR-008: System MUST fail gracefully with descriptive reason if Tesseract execution fails (non-zero exit) and set confidence to 0.
+- FR-009: System MUST document aggregation method in specs and tests.
+
+### Key Entities
+
+- OCRToken: text, bbox (left, top, width, height), confidence, line, order.
+- OcrEvaluationResult: tokens[], confidence (0-100), text (full concatenation), reason.
+
+## Success Criteria (mandatory)
+
+### Measurable Outcomes
+
+- SC-001: For test images with known quality, token confidences equal TSV `conf` values within exact match (integer) for 95% of tokens.
+- SC-002: Aggregate confidence differs from a baseline heuristic by >30% on low-quality samples, reducing false positives by 50% in trigger tests.
+- SC-003: 100% of OCR evaluations complete with non-zero TSV rows on test assets return confidence between 0 and 100 with no parsing errors.
+- SC-004: Downstream tests consuming OCR results remain passing; no breaking schema changes.# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]

--- a/specs/001-ocr-confidence-refactor/tasks.md
+++ b/specs/001-ocr-confidence-refactor/tasks.md
@@ -2,11 +2,11 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm Tesseract availability and path detection via `GAMEBOT_TESSERACT_PATH` (scripts/local-verify-tesseract.ps1)
-- [ ] T002 Add sample TSV fixture assets (tests/TestAssets/ocr/tsv/clear_text.tsv)
-- [ ] T003 Add mixed-quality TSV fixture (tests/TestAssets/ocr/tsv/mixed_quality.tsv)
-- [ ] T004 Add malformed TSV fixture (tests/TestAssets/ocr/tsv/malformed.tsv)
-- [ ] T005 Document required env vars in `ENVIRONMENT.md` (append OCR section)
+- [X] T001 Confirm Tesseract availability and path detection via `GAMEBOT_TESSERACT_PATH` (scripts/local-verify-tesseract.ps1)
+- [X] T002 Add sample TSV fixture assets (tests/TestAssets/ocr/tsv/clear_text.tsv)
+- [X] T003 Add mixed-quality TSV fixture (tests/TestAssets/ocr/tsv/mixed_quality.tsv)
+- [X] T004 Add malformed TSV fixture (tests/TestAssets/ocr/tsv/malformed.tsv)
+- [X] T005 Document required env vars in `ENVIRONMENT.md` (append OCR section)
 
 ## Phase 2: Foundational
 

--- a/specs/001-ocr-confidence-refactor/tasks.md
+++ b/specs/001-ocr-confidence-refactor/tasks.md
@@ -10,10 +10,10 @@
 
 ## Phase 2: Foundational
 
-- [ ] T006 Create `src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs`
-- [ ] T007 Implement TSV header validation in parser file
-- [ ] T008 Implement TSV row parsing & token construction in parser file
-- [ ] T009 Implement aggregation helper excluding -1 & empty tokens in parser file
+- [X] T006 Create `src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs`
+- [X] T007 Implement TSV header validation in parser file
+- [X] T008 Implement TSV row parsing & token construction in parser file
+- [X] T009 Implement aggregation helper excluding -1 & empty tokens in parser file
 - [ ] T010 Add unit tests for header validation (tests/unit/Ocr/TesseractTsvParserHeaderTests.cs)
 - [ ] T011 Add unit tests for row parsing (tests/unit/Ocr/TesseractTsvParserRowsTests.cs)
 - [ ] T012 Add unit tests for aggregation (tests/unit/Ocr/TesseractTsvParserAggregationTests.cs)

--- a/specs/001-ocr-confidence-refactor/tasks.md
+++ b/specs/001-ocr-confidence-refactor/tasks.md
@@ -1,0 +1,91 @@
+# Tasks: OCR Confidence via TSV
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm Tesseract availability and path detection via `GAMEBOT_TESSERACT_PATH` (scripts/local-verify-tesseract.ps1)
+- [ ] T002 Add sample TSV fixture assets (tests/TestAssets/ocr/tsv/clear_text.tsv)
+- [ ] T003 Add mixed-quality TSV fixture (tests/TestAssets/ocr/tsv/mixed_quality.tsv)
+- [ ] T004 Add malformed TSV fixture (tests/TestAssets/ocr/tsv/malformed.tsv)
+- [ ] T005 Document required env vars in `ENVIRONMENT.md` (append OCR section)
+
+## Phase 2: Foundational
+
+- [ ] T006 Create `src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs`
+- [ ] T007 Implement TSV header validation in parser file
+- [ ] T008 Implement TSV row parsing & token construction in parser file
+- [ ] T009 Implement aggregation helper excluding -1 & empty tokens in parser file
+- [ ] T010 Add unit tests for header validation (tests/unit/Ocr/TesseractTsvParserHeaderTests.cs)
+- [ ] T011 Add unit tests for row parsing (tests/unit/Ocr/TesseractTsvParserRowsTests.cs)
+- [ ] T012 Add unit tests for aggregation (tests/unit/Ocr/TesseractTsvParserAggregationTests.cs)
+- [ ] T013 Add unit tests for malformed TSV handling (tests/unit/Ocr/TesseractTsvParserMalformedTests.cs)
+- [ ] T014 Integrate parser into `TesseractProcessOcr` (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
+- [ ] T015 Replace legacy confidence heuristic with TSV aggregate (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
+- [ ] T016 Add fallback to legacy text mode when TSV fails (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
+- [ ] T017 Extend `OcrResult` or create `OcrEvaluationResult` DTO (src/GameBot.Domain/Triggers/Evaluators/OcrEvaluationResult.cs)
+- [ ] T018 Adapt trigger evaluation to use new confidence property (src/GameBot.Domain/Services/TriggerEvaluationService.cs)
+- [ ] T019 Update OpenAPI contract for OCR test endpoint (specs/001-ocr-confidence-refactor/contracts/ocr-evaluation.openapi.yaml)
+
+## Phase 3: User Story 1 (Accurate OCR confidence)
+
+- [ ] T020 [US1] Add integration test with clear text image (tests/integration/OcrConfidenceClearTextTests.cs)
+- [ ] T021 [P] [US1] Add integration test with mixed-quality image (tests/integration/OcrConfidenceMixedQualityTests.cs)
+- [ ] T022 [US1] Assert per-token confidence matches TSV conf values (tests/integration/OcrConfidenceClearTextTests.cs)
+- [ ] T023 [P] [US1] Assert low-quality tokens have reduced confidence (tests/integration/OcrConfidenceMixedQualityTests.cs)
+- [ ] T024 [US1] Add test for noise tokens (confidence -1 excluded) (tests/integration/OcrConfidenceNoiseTests.cs)
+- [ ] T025 [US1] Add performance timing assertion (parse <5ms) (tests/integration/OcrConfidencePerformanceTests.cs)
+- [ ] T026 [US1] Update quickstart with token confidence example (specs/001-ocr-confidence-refactor/quickstart.md)
+
+## Phase 4: User Story 2 (Configurable aggregation)
+
+- [ ] T027 [US2] Implement aggregation strategy interface (src/GameBot.Domain/Triggers/Evaluators/IAggregationStrategy.cs)
+- [ ] T028 [P] [US2] Implement MeanAggregationStrategy (src/GameBot.Domain/Triggers/Evaluators/MeanAggregationStrategy.cs)
+- [ ] T029 [US2] Wire strategy selection (environment/config) (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
+- [ ] T030 [US2] Add unit tests for mean strategy correctness (tests/unit/Ocr/AggregationStrategyMeanTests.cs)
+- [ ] T031 [P] [US2] Add test verifying exclusion of -1 tokens (tests/unit/Ocr/AggregationStrategyExclusionsTests.cs)
+- [ ] T032 [US2] Document aggregation configuration (specs/001-ocr-confidence-refactor/quickstart.md)
+
+## Phase 5: User Story 3 (Backward-safe output contract)
+
+- [ ] T033 [US3] Preserve legacy fields in `OcrResult` (src/GameBot.Domain/Triggers/Evaluators/OcrEvaluationResult.cs)
+- [ ] T034 [US3] Add tokens[].confidence & aggregate confidence (src/GameBot.Domain/Triggers/Evaluators/OcrEvaluationResult.cs)
+- [ ] T035 [US3] Update API serialization mapping (src/GameBot.Service/Endpoints/TriggersEndpoints.cs)
+- [ ] T036 [US3] Add contract tests for schema stability (tests/contract/OcrResultSchemaTests.cs)
+- [ ] T037 [P] [US3] Add integration test asserting legacy fields present (tests/integration/OcrResultBackwardCompatTests.cs)
+- [ ] T038 [US3] Add JSON sample to README (README.md)
+- [ ] T039 [US3] Update changelog with non-breaking addition (CHANGELOG.md)
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T040 Add logging for TSV invocation duration (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
+- [ ] T041 Add structured log for parse error reason (src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs)
+- [ ] T042 Add benchmark harness (tests/perf/OcrParsingBenchmarks.cs)
+- [ ] T043 Add doc section to ENVIRONMENT.md for performance tuning (ENVIRONMENT.md)
+- [ ] T044 Final pass: ensure memory cleanup of temp files (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
+- [ ] T045 Add coverage report validation for new code (tools/coverage/coverage-ocr.conf)
+- [ ] T046 Update spec success criteria with measured values (specs/001-ocr-confidence-refactor/spec.md)
+- [ ] T047 PR review checklist entry (specs/001-ocr-confidence-refactor/checklists/requirements.md)
+
+## Dependencies & Story Order
+1. Phase 1 must complete before TSV parser implementation.
+2. Phase 2 foundational tasks required before any user story tests.
+3. User Story 1 (Phase 3) delivers MVP (accurate confidence).
+4. User Story 2 builds on parser (strategy abstraction).
+5. User Story 3 depends on new result fields from earlier phases.
+
+## Parallel Execution Examples
+- T020 and T021 can run in parallel (distinct test files & fixtures).
+- T028 and T031 can run in parallel (separate aggregation tests/implementation).
+- T037 and T036 can run in parallel (integration vs contract tests).
+
+## Independent Test Criteria Per Story
+- US1: Clear text & mixed-quality images produce expected token confidences and aggregate metrics without schema break.
+- US2: Mean aggregation yields documented result; exclusion logic validated; switching strategy configurable (future extension baseline set).
+- US3: Legacy consumers still parse original fields; new confidence fields present; contract tests pass.
+
+## MVP Scope
+Deliver Phase 1–3 (Setup, Foundational, User Story 1) for initial accuracy improvements; defer strategy abstraction & backward-compat validation if necessary.
+
+## Format Validation
+All tasks follow: `- [ ] T### optional [P] optional [US#] Description with file path`.
+
+*** End of Tasks ***

--- a/specs/001-ocr-confidence-refactor/tasks.md
+++ b/specs/001-ocr-confidence-refactor/tasks.md
@@ -14,10 +14,10 @@
 - [X] T007 Implement TSV header validation in parser file
 - [X] T008 Implement TSV row parsing & token construction in parser file
 - [X] T009 Implement aggregation helper excluding -1 & empty tokens in parser file
-- [ ] T010 Add unit tests for header validation (tests/unit/Ocr/TesseractTsvParserHeaderTests.cs)
-- [ ] T011 Add unit tests for row parsing (tests/unit/Ocr/TesseractTsvParserRowsTests.cs)
-- [ ] T012 Add unit tests for aggregation (tests/unit/Ocr/TesseractTsvParserAggregationTests.cs)
-- [ ] T013 Add unit tests for malformed TSV handling (tests/unit/Ocr/TesseractTsvParserMalformedTests.cs)
+- [X] T010 Add unit tests for header validation (tests/unit/Ocr/TesseractTsvParserHeaderTests.cs)
+- [X] T011 Add unit tests for row parsing (tests/unit/Ocr/TesseractTsvParserRowsTests.cs)
+- [X] T012 Add unit tests for aggregation (tests/unit/Ocr/TesseractTsvParserAggregationTests.cs)
+- [X] T013 Add unit tests for malformed TSV handling (tests/unit/Ocr/TesseractTsvParserMalformedTests.cs)
 - [ ] T014 Integrate parser into `TesseractProcessOcr` (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
 - [ ] T015 Replace legacy confidence heuristic with TSV aggregate (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)
 - [ ] T016 Add fallback to legacy text mode when TSV fails (src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs)

--- a/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
@@ -13,6 +13,7 @@ internal readonly record struct OcrToken(
   int Confidence);
 
 internal static class TesseractTsvParser {
+  private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");
   private static readonly char[] LineSplit = new[] { '\n', '\r' };
 
   public static IReadOnlyList<OcrToken> Parse(string? tsv, out double aggregateConfidence, out string? reason) {
@@ -39,14 +40,14 @@ internal static class TesseractTsvParser {
       var cols = line.Split('\t');
       if (cols.Length < 12) continue; // skip malformed
       // Parse needed columns; tolerate parse failures by skipping row
-      if (!int.TryParse(cols[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var level)) continue; // level
-      if (!int.TryParse(cols[5], NumberStyles.Integer, CultureInfo.InvariantCulture, out var wordNum)) continue; // word_num
-      if (!int.TryParse(cols[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var lineNum)) continue; // line_num
-      if (!int.TryParse(cols[6], NumberStyles.Integer, CultureInfo.InvariantCulture, out var left)) continue;
-      if (!int.TryParse(cols[7], NumberStyles.Integer, CultureInfo.InvariantCulture, out var top)) continue;
-      if (!int.TryParse(cols[8], NumberStyles.Integer, CultureInfo.InvariantCulture, out var width)) continue;
-      if (!int.TryParse(cols[9], NumberStyles.Integer, CultureInfo.InvariantCulture, out var height)) continue;
-      if (!int.TryParse(cols[10], NumberStyles.Integer, CultureInfo.InvariantCulture, out var conf)) conf = -1;
+      if (!int.TryParse(cols[0], NumberStyles.Integer, EnUs, out var level)) continue; // level
+      if (!int.TryParse(cols[5], NumberStyles.Integer, EnUs, out var wordNum)) continue; // word_num
+      if (!int.TryParse(cols[4], NumberStyles.Integer, EnUs, out var lineNum)) continue; // line_num
+      if (!int.TryParse(cols[6], NumberStyles.Integer, EnUs, out var left)) continue;
+      if (!int.TryParse(cols[7], NumberStyles.Integer, EnUs, out var top)) continue;
+      if (!int.TryParse(cols[8], NumberStyles.Integer, EnUs, out var width)) continue;
+      if (!int.TryParse(cols[9], NumberStyles.Integer, EnUs, out var height)) continue;
+      if (!int.TryParse(cols[10], NumberStyles.Integer, EnUs, out var conf)) conf = -1;
       var text = cols[11] ?? string.Empty;
       var trimmed = text.Trim();
       if (level != 5 || trimmed.Length == 0) continue; // only include word-level tokens with text

--- a/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
@@ -39,6 +39,7 @@ internal static class TesseractTsvParser {
       var cols = line.Split('\t');
       if (cols.Length < 12) continue; // skip malformed
       // Parse needed columns; tolerate parse failures by skipping row
+      if (!int.TryParse(cols[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var level)) continue; // level
       if (!int.TryParse(cols[5], NumberStyles.Integer, CultureInfo.InvariantCulture, out var wordNum)) continue; // word_num
       if (!int.TryParse(cols[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var lineNum)) continue; // line_num
       if (!int.TryParse(cols[6], NumberStyles.Integer, CultureInfo.InvariantCulture, out var left)) continue;
@@ -48,6 +49,7 @@ internal static class TesseractTsvParser {
       if (!int.TryParse(cols[10], NumberStyles.Integer, CultureInfo.InvariantCulture, out var conf)) conf = -1;
       var text = cols[11] ?? string.Empty;
       var trimmed = text.Trim();
+      if (level != 5 || trimmed.Length == 0) continue; // only include word-level tokens with text
       var token = new OcrToken(trimmed, left, top, width, height, lineNum, wordNum, conf);
       tokens.Add(token);
       if (conf >= 0 && conf <= 100 && trimmed.Length > 0) {

--- a/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+
+namespace GameBot.Domain.Triggers.Evaluators;
+
+internal readonly record struct OcrToken(
+  string Text,
+  int Left,
+  int Top,
+  int Width,
+  int Height,
+  int LineIndex,
+  int WordIndex,
+  int Confidence);
+
+internal static class TesseractTsvParser {
+  private static readonly char[] LineSplit = new[] { '\n', '\r' };
+
+  public static IReadOnlyList<OcrToken> Parse(string? tsv, out double aggregateConfidence, out string? reason) {
+    aggregateConfidence = 0;
+    reason = null;
+    if (string.IsNullOrWhiteSpace(tsv)) {
+      reason = "empty_tsv";
+      return Array.Empty<OcrToken>();
+    }
+    var lines = tsv.Split(LineSplit, StringSplitOptions.RemoveEmptyEntries);
+    if (lines.Length == 0) { reason = "no_lines"; return Array.Empty<OcrToken>(); }
+    // Header validation
+    var header = lines[0].Trim();
+    if (!header.Contains("conf", StringComparison.Ordinal)) {
+      reason = "tsv_format_unexpected";
+      return Array.Empty<OcrToken>();
+    }
+    var tokens = new List<OcrToken>(Math.Max(4, lines.Length - 1));
+    int validForAggregation = 0;
+    int confidenceSum = 0;
+    for (int i = 1; i < lines.Length; i++) {
+      var line = lines[i];
+      // Expected 12 columns per spec: level page_num block_num par_num line_num word_num left top width height conf text
+      var cols = line.Split('\t');
+      if (cols.Length < 12) continue; // skip malformed
+      // Parse needed columns; tolerate parse failures by skipping row
+      if (!int.TryParse(cols[5], NumberStyles.Integer, CultureInfo.InvariantCulture, out var wordNum)) continue; // word_num
+      if (!int.TryParse(cols[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var lineNum)) continue; // line_num
+      if (!int.TryParse(cols[6], NumberStyles.Integer, CultureInfo.InvariantCulture, out var left)) continue;
+      if (!int.TryParse(cols[7], NumberStyles.Integer, CultureInfo.InvariantCulture, out var top)) continue;
+      if (!int.TryParse(cols[8], NumberStyles.Integer, CultureInfo.InvariantCulture, out var width)) continue;
+      if (!int.TryParse(cols[9], NumberStyles.Integer, CultureInfo.InvariantCulture, out var height)) continue;
+      if (!int.TryParse(cols[10], NumberStyles.Integer, CultureInfo.InvariantCulture, out var conf)) conf = -1;
+      var text = cols[11] ?? string.Empty;
+      var trimmed = text.Trim();
+      var token = new OcrToken(trimmed, left, top, width, height, lineNum, wordNum, conf);
+      tokens.Add(token);
+      if (conf >= 0 && conf <= 100 && trimmed.Length > 0) {
+        confidenceSum += conf;
+        validForAggregation++;
+      }
+    }
+    if (validForAggregation == 0) {
+      aggregateConfidence = 0;
+      reason = tokens.Count == 0 ? "no_tokens" : "no_valid_tokens";
+      return tokens;
+    }
+    aggregateConfidence = confidenceSum / (double)validForAggregation;
+    return tokens;
+  }
+}

--- a/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs
@@ -10,7 +10,7 @@ internal readonly record struct OcrToken(
   int Height,
   int LineIndex,
   int WordIndex,
-  int Confidence);
+  double Confidence);
 
 internal static class TesseractTsvParser {
   private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");
@@ -33,7 +33,7 @@ internal static class TesseractTsvParser {
     }
     var tokens = new List<OcrToken>(Math.Max(4, lines.Length - 1));
     int validForAggregation = 0;
-    int confidenceSum = 0;
+    double confidenceSum = 0;
     for (int i = 1; i < lines.Length; i++) {
       var line = lines[i];
       // Expected 12 columns per spec: level page_num block_num par_num line_num word_num left top width height conf text
@@ -47,7 +47,7 @@ internal static class TesseractTsvParser {
       if (!int.TryParse(cols[7], NumberStyles.Integer, EnUs, out var top)) continue;
       if (!int.TryParse(cols[8], NumberStyles.Integer, EnUs, out var width)) continue;
       if (!int.TryParse(cols[9], NumberStyles.Integer, EnUs, out var height)) continue;
-      if (!int.TryParse(cols[10], NumberStyles.Integer, EnUs, out var conf)) conf = -1;
+      if (!double.TryParse(cols[10], NumberStyles.Float | NumberStyles.AllowThousands, EnUs, out var conf)) conf = -1;
       var text = cols[11] ?? string.Empty;
       var trimmed = text.Trim();
       if (level != 5 || trimmed.Length == 0) continue; // only include word-level tokens with text

--- a/src/GameBot.Domain/Triggers/Trigger.cs
+++ b/src/GameBot.Domain/Triggers/Trigger.cs
@@ -50,7 +50,7 @@ public sealed class Trigger {
   public required TriggerType Type { get; set; }
   public bool Enabled { get; set; } = true;
   public DateTimeOffset? EnabledAt { get; set; }
-  public int CooldownSeconds { get; set; } = 60;
+  public int CooldownSeconds { get; set; }
   public DateTimeOffset? LastFiredAt { get; set; }
   public DateTimeOffset? LastEvaluatedAt { get; set; }
   public TriggerEvaluationResult? LastResult { get; set; }

--- a/tesseract.txt
+++ b/tesseract.txt
@@ -1,0 +1,53 @@
+Usage:
+  tesseract.exe --help | --help-extra | --help-psm | --help-oem | --version
+  tesseract.exe --list-langs [--tessdata-dir PATH]
+  tesseract.exe --print-fonts-table [options...] [configfile...]
+  tesseract.exe --print-parameters [options...] [configfile...]
+  tesseract.exe imagename|imagelist|stdin outputbase|stdout [options...] [configfile...]
+
+OCR options:
+  --tessdata-dir PATH   Specify the location of tessdata path.
+  --user-words PATH     Specify the location of user words file.
+  --user-patterns PATH  Specify the location of user patterns file.
+  --dpi VALUE           Specify DPI for input image.
+  --loglevel LEVEL      Specify logging level. LEVEL can be
+                        ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL or OFF.
+  -l LANG[+LANG]        Specify language(s) used for OCR.
+  -c VAR=VALUE          Set value for config variables.
+                        Multiple -c arguments are allowed.
+  --psm PSM|NUM         Specify page segmentation mode.
+  --oem OEM|NUM         Specify OCR Engine mode.
+NOTE: These options must occur before any configfile.
+
+Page segmentation modes (PSM):
+  0|osd_only                Orientation and script detection (OSD) only.
+  1|auto_osd                Automatic page segmentation with OSD.
+  2|auto_only               Automatic page segmentation, but no OSD, or OCR. (not implemented)
+  3|auto                    Fully automatic page segmentation, but no OSD. (Default)
+  4|single_column           Assume a single column of text of variable sizes.
+  5|single_block_vert_text  Assume a single uniform block of vertically aligned text.
+  6|single_block            Assume a single uniform block of text.
+  7|single_line             Treat the image as a single text line.
+  8|single_word             Treat the image as a single word.
+  9|circle_word             Treat the image as a single word in a circle.
+ 10|single_char             Treat the image as a single character.
+ 11|sparse_text             Sparse text. Find as much text as possible in no particular order.
+ 12|sparse_text_osd         Sparse text with OSD.
+ 13|raw_line                Raw line. Treat the image as a single text line,
+                            bypassing hacks that are Tesseract-specific.
+
+OCR Engine modes (OEM):
+  0|tesseract_only          Legacy engine only.
+  1|lstm_only               Neural nets LSTM engine only.
+  2|tesseract_lstm_combined Legacy + LSTM engines.
+  3|default                 Default, based on what is available.
+
+Single options:
+  -h, --help            Show minimal help message.
+  --help-extra          Show extra help for advanced users.
+  --help-psm            Show page segmentation modes.
+  --help-oem            Show OCR Engine modes.
+  -v, --version         Show version information.
+  --list-langs          List available languages for tesseract engine.
+  --print-fonts-table   Print tesseract fonts table.
+  --print-parameters    Print tesseract parameters.

--- a/tests/TestAssets/Ocr/tsv/clear_text.tsv
+++ b/tests/TestAssets/Ocr/tsv/clear_text.tsv
@@ -1,0 +1,9 @@
+level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	text
+1	1	0	0	0	0	0	0	0	0	-1	
+2	1	1	0	0	0	10	20	500	60	-1	
+3	1	1	1	0	0	10	20	500	60	-1	
+4	1	1	1	1	0	10	20	500	60	-1	
+5	1	1	1	1	1	12	22	80	20	95	HELLO
+5	1	1	1	1	2	100	22	90	20	93	WORLD
+5	1	1	1	1	3	195	22	60	20	92	FROM
+5	1	1	1	1	4	260	22	75	20	90	GAMEBOT

--- a/tests/TestAssets/Ocr/tsv/malformed.tsv
+++ b/tests/TestAssets/Ocr/tsv/malformed.tsv
@@ -1,0 +1,4 @@
+level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	text
+5	1	1	1	MISSING_FIELD	1	10	20	80	20	90
+BADLINE
+5	1	1	1	1	2	95	20	70	20	50	TEXT

--- a/tests/TestAssets/Ocr/tsv/mixed_quality.tsv
+++ b/tests/TestAssets/Ocr/tsv/mixed_quality.tsv
@@ -1,0 +1,6 @@
+level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	text
+5	1	1	1	1	1	10	20	80	20	88	SHARP
+5	1	1	1	1	2	95	20	70	20	55	BLURRY
+5	1	1	1	1	3	170	20	65	20	40	NOISY
+5	1	1	1	1	4	240	20	75	20	92	CLEAR
+5	1	1	1	1	5	320	20	55	20	-1	#

--- a/tests/unit/Domain/TriggerDefaultsTests.cs
+++ b/tests/unit/Domain/TriggerDefaultsTests.cs
@@ -1,0 +1,13 @@
+using FluentAssertions;
+using GameBot.Domain.Triggers;
+using Xunit;
+
+namespace GameBot.UnitTests.Domain;
+
+public sealed class TriggerDefaultsTests {
+  [Fact]
+  public void NewTriggerDefaultsToZeroCooldown() {
+    var trigger = new Trigger { Id = "t", Type = TriggerType.Delay, Enabled = true, Params = new DelayParams { Seconds = 0 } };
+    trigger.CooldownSeconds.Should().Be(0);
+  }
+}

--- a/tests/unit/Ocr/TesseractTsvParserAggregationTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserAggregationTests.cs
@@ -1,0 +1,20 @@
+using GameBot.Domain.Triggers.Evaluators;
+using FluentAssertions;
+using Xunit;
+
+namespace GameBot.UnitTests.Ocr;
+
+public sealed class TesseractTsvParserAggregationTests {
+  private static string ReadFixture(string name) => File.ReadAllText(Path.Combine("tests","TestAssets","ocr","tsv", name));
+
+  [Fact]
+  public void Parse_MixedQualityFixture_ExcludesNoiseAndComputesMean() {
+    var tsv = ReadFixture("mixed_quality.tsv");
+    var tokens = TesseractTsvParser.Parse(tsv, out var agg, out var reason);
+    tokens.Count.Should().Be(5); // includes noise token (#) with -1
+    agg.Should().BeApproximately(68.75, 0.0001); // (88+55+40+92)/4
+    reason.Should().BeNull();
+    tokens.Where(t => t.Confidence >= 0).Count().Should().Be(4);
+    tokens.Single(t => t.Text == "#").Confidence.Should().Be(-1);
+  }
+}

--- a/tests/unit/Ocr/TesseractTsvParserAggregationTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserAggregationTests.cs
@@ -5,10 +5,19 @@ using Xunit;
 namespace GameBot.UnitTests.Ocr;
 
 public sealed class TesseractTsvParserAggregationTests {
-  private static string ReadFixture(string name) => File.ReadAllText(Path.Combine("tests","TestAssets","ocr","tsv", name));
+  private static string ReadFixture(string name) {
+    var dir = AppContext.BaseDirectory;
+    while (!string.IsNullOrEmpty(dir) && !Directory.Exists(Path.Combine(dir, "TestAssets"))) {
+      var parent = Path.GetDirectoryName(dir);
+      if (parent == null || parent == dir) break;
+      dir = parent;
+    }
+    var path = Path.Combine(dir, "TestAssets", "ocr", "tsv", name);
+    return File.ReadAllText(path);
+  }
 
   [Fact]
-  public void Parse_MixedQualityFixture_ExcludesNoiseAndComputesMean() {
+  public void ParseMixedQualityFixtureExcludesNoiseAndComputesMean() {
     var tsv = ReadFixture("mixed_quality.tsv");
     var tokens = TesseractTsvParser.Parse(tsv, out var agg, out var reason);
     tokens.Count.Should().Be(5); // includes noise token (#) with -1

--- a/tests/unit/Ocr/TesseractTsvParserHeaderTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserHeaderTests.cs
@@ -6,7 +6,7 @@ namespace GameBot.UnitTests.Ocr;
 
 public sealed class TesseractTsvParserHeaderTests {
   [Fact]
-  public void Parse_MissingConfHeader_ReturnsEmptyAndFormatReason() {
+  public void ParseMissingConfHeaderReturnsEmptyAndFormatReason() {
     var tsv = "level\tpage_num\tother\ttext"; // header without conf
     var tokens = TesseractTsvParser.Parse(tsv + "\n", out var agg, out var reason);
     tokens.Should().BeEmpty();

--- a/tests/unit/Ocr/TesseractTsvParserHeaderTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserHeaderTests.cs
@@ -1,0 +1,16 @@
+using GameBot.Domain.Triggers.Evaluators;
+using FluentAssertions;
+using Xunit;
+
+namespace GameBot.UnitTests.Ocr;
+
+public sealed class TesseractTsvParserHeaderTests {
+  [Fact]
+  public void Parse_MissingConfHeader_ReturnsEmptyAndFormatReason() {
+    var tsv = "level\tpage_num\tother\ttext"; // header without conf
+    var tokens = TesseractTsvParser.Parse(tsv + "\n", out var agg, out var reason);
+    tokens.Should().BeEmpty();
+    agg.Should().Be(0);
+    reason.Should().Be("tsv_format_unexpected");
+  }
+}

--- a/tests/unit/Ocr/TesseractTsvParserMalformedTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserMalformedTests.cs
@@ -1,0 +1,19 @@
+using GameBot.Domain.Triggers.Evaluators;
+using FluentAssertions;
+using Xunit;
+
+namespace GameBot.UnitTests.Ocr;
+
+public sealed class TesseractTsvParserMalformedTests {
+  private static string ReadFixture(string name) => File.ReadAllText(Path.Combine("tests","TestAssets","ocr","tsv", name));
+
+  [Fact]
+  public void Parse_MalformedFixture_SkipsInvalidRowsAndAggregatesValid() {
+    var tsv = ReadFixture("malformed.tsv");
+    var tokens = TesseractTsvParser.Parse(tsv, out var agg, out var reason);
+    tokens.Count.Should().Be(1); // only TEXT row valid
+    tokens[0].Text.Should().Be("TEXT");
+    agg.Should().Be(50);
+    reason.Should().BeNull();
+  }
+}

--- a/tests/unit/Ocr/TesseractTsvParserMalformedTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserMalformedTests.cs
@@ -5,10 +5,19 @@ using Xunit;
 namespace GameBot.UnitTests.Ocr;
 
 public sealed class TesseractTsvParserMalformedTests {
-  private static string ReadFixture(string name) => File.ReadAllText(Path.Combine("tests","TestAssets","ocr","tsv", name));
+  private static string ReadFixture(string name) {
+    var dir = AppContext.BaseDirectory;
+    while (!string.IsNullOrEmpty(dir) && !Directory.Exists(Path.Combine(dir, "TestAssets"))) {
+      var parent = Path.GetDirectoryName(dir);
+      if (parent == null || parent == dir) break;
+      dir = parent;
+    }
+    var path = Path.Combine(dir, "TestAssets", "ocr", "tsv", name);
+    return File.ReadAllText(path);
+  }
 
   [Fact]
-  public void Parse_MalformedFixture_SkipsInvalidRowsAndAggregatesValid() {
+  public void ParseMalformedFixtureSkipsInvalidRowsAndAggregatesValid() {
     var tsv = ReadFixture("malformed.tsv");
     var tokens = TesseractTsvParser.Parse(tsv, out var agg, out var reason);
     tokens.Count.Should().Be(1); // only TEXT row valid

--- a/tests/unit/Ocr/TesseractTsvParserRowsTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserRowsTests.cs
@@ -5,14 +5,24 @@ using Xunit;
 namespace GameBot.UnitTests.Ocr;
 
 public sealed class TesseractTsvParserRowsTests {
-  private static string ReadFixture(string name) => File.ReadAllText(Path.Combine("tests","TestAssets","ocr","tsv", name));
+  private static readonly int[] ExpectedClearTextConf = {95,93,92,90};
+  private static string ReadFixture(string name) {
+    var dir = AppContext.BaseDirectory;
+    while (!string.IsNullOrEmpty(dir) && !Directory.Exists(Path.Combine(dir, "TestAssets"))) {
+      var parent = Path.GetDirectoryName(dir);
+      if (parent == null || parent == dir) break;
+      dir = parent;
+    }
+    var path = Path.Combine(dir, "TestAssets", "ocr", "tsv", name);
+    return File.ReadAllText(path);
+  }
 
   [Fact]
-  public void Parse_ClearTextFixture_ParsesAllTokensAndAggregateMean() {
+  public void ParseClearTextFixtureParsesAllTokensAndAggregateMean() {
     var tsv = ReadFixture("clear_text.tsv");
     var tokens = TesseractTsvParser.Parse(tsv, out var agg, out var reason);
     tokens.Count.Should().Be(4);
-    tokens.Select(t => t.Confidence).Should().BeEquivalentTo(new[]{95,93,92,90});
+    tokens.Select(t => t.Confidence).Should().BeEquivalentTo(ExpectedClearTextConf);
     agg.Should().BeApproximately(92.5, 0.0001);
     reason.Should().BeNull();
   }

--- a/tests/unit/Ocr/TesseractTsvParserRowsTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserRowsTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace GameBot.UnitTests.Ocr;
 
 public sealed class TesseractTsvParserRowsTests {
-  private static readonly int[] ExpectedClearTextConf = {95,93,92,90};
+  private static readonly double[] ExpectedClearTextConf = {95,93,92,90};
   private static string ReadFixture(string name) {
     var dir = AppContext.BaseDirectory;
     while (!string.IsNullOrEmpty(dir) && !Directory.Exists(Path.Combine(dir, "TestAssets"))) {

--- a/tests/unit/Ocr/TesseractTsvParserRowsTests.cs
+++ b/tests/unit/Ocr/TesseractTsvParserRowsTests.cs
@@ -1,0 +1,19 @@
+using GameBot.Domain.Triggers.Evaluators;
+using FluentAssertions;
+using Xunit;
+
+namespace GameBot.UnitTests.Ocr;
+
+public sealed class TesseractTsvParserRowsTests {
+  private static string ReadFixture(string name) => File.ReadAllText(Path.Combine("tests","TestAssets","ocr","tsv", name));
+
+  [Fact]
+  public void Parse_ClearTextFixture_ParsesAllTokensAndAggregateMean() {
+    var tsv = ReadFixture("clear_text.tsv");
+    var tokens = TesseractTsvParser.Parse(tsv, out var agg, out var reason);
+    tokens.Count.Should().Be(4);
+    tokens.Select(t => t.Confidence).Should().BeEquivalentTo(new[]{95,93,92,90});
+    agg.Should().BeApproximately(92.5, 0.0001);
+    reason.Should().BeNull();
+  }
+}

--- a/tests/unit/Triggers/TesseractProcessOcrTests.cs
+++ b/tests/unit/Triggers/TesseractProcessOcrTests.cs
@@ -66,7 +66,7 @@ namespace GameBot.Tests.Unit.Triggers {
       Assert.NotNull(method);
       var args = method.Invoke(ocr, new object[] { "input.png", "output", "eng" }) as System.Collections.Generic.IReadOnlyList<string>;
       Assert.NotNull(args);
-      Assert.Collection(args!,
+        Assert.Collection(args!,
           item => Assert.Equal("input.png", item),
           item => Assert.Equal("output", item),
           item => Assert.Equal("-l", item),
@@ -74,7 +74,9 @@ namespace GameBot.Tests.Unit.Triggers {
           item => Assert.Equal("--psm", item),
           item => Assert.Equal("4", item),
           item => Assert.Equal("--oem", item),
-          item => Assert.Equal("1", item));
+          item => Assert.Equal("1", item),
+          item => Assert.Equal("-c", item),
+          item => Assert.Equal("tessedit_create_tsv=1", item));
     }
 
     [Fact]


### PR DESCRIPTION
Summary
- Integrate Tesseract TSV into OCR pipeline and compute confidence from TSV per-token confidences.
- Default trigger cooldown set to 0 (was 60s); added unit test to lock default.

Details
- Tesseract invocation: add \-c tessedit_create_tsv=1\ so Tesseract emits \output.tsv\ alongside \output.txt\.
- TSV parsing: new/updated \TesseractTsvParser\ parses word-level rows (level=5), en-US numeric parsing, floating-point confidences, aggregates mean excluding invalid (-1) and empty text.
- Confidence source: prefer TSV aggregate (scaled to 0..1). Fallback to legacy text heuristic only when TSV missing or parse fails.
- Text when no .txt: reconstruct text from TSV tokens via line/word ordering.
- ComputeConfidence: detects TSV input and returns TSV aggregate when present; otherwise uses text heuristic.
- Locale robustness: force en-US for TSV numeric parsing to avoid locale-dependent failures.
- Cooldown: remove implicit throttling by changing default cooldown to 0. Unit test added (\TriggerDefaultsTests\).

Files (highlights)
- \src/GameBot.Domain/Triggers/Evaluators/TesseractProcessOcr.cs\: TSV arg, TSV parsing + text reconstruction, cleanup, ComputeConfidence TSV path.
- \src/GameBot.Domain/Triggers/Evaluators/TesseractTsvParser.cs\: en-US parsing; double confidences; word-level filtering; aggregate mean.
- \src/GameBot.Domain/Triggers/Trigger.cs\: default CooldownSeconds = 0 (via default int).
- Tests under \	ests/unit\: updated OCR tests; added TriggerDefaults test; fixtures under \	ests/TestAssets/Ocr/tsv\.

Testing
- All tests pass locally: 120 passed, 0 failed.
- Verified TSV-only case doesnt return empty result; text reconstructs correctly.

Notes
- No persistence changes. ENV docs previously updated for OCR setup.
- Backwards compatible: existing triggers unaffected; cooldown behavior only changes for new triggers relying on default.
