### PR TITLE
docs(release): 2025-11-28 notes + NCC mapping fix

### DIFF
--- a/specs/001-image-storage/RELEASE_NOTES.md
+++ b/specs/001-image-storage/RELEASE_NOTES.md
@@ -1,0 +1,33 @@
+# Release 2025-11-28: Persistent Reference Images, Logging, and Tests
+
+## Highlights
+- Persistent reference image storage under `data/images` with atomic writes
+- Structured LoggerMessage logging for `/images` endpoints
+- Standardized error responses: `invalid_request`, `invalid_image`, `not_found`
+- Increased coverage: evaluator edge cases and endpoint error paths
+- CI stability fixes: storage isolation via `Service__Storage__Root` + `GAMEBOT_DATA_DIR`, persistence test robustness
+- Evaluator stability: replace GDI+ `Bitmap.Clone` with `Graphics.DrawImage`
+
+## Details
+- Domain
+  - `ImageMatchEvaluator`: 24bpp conversion via draw, avoid intermittent GDI+ OOM
+  - `ReferenceImageStore`: PNG persistence with atomic replace; `Exists/Delete` support
+- Service
+  - `Program`: registers disk-backed `IReferenceImageStore` at `Path.Combine(storageRoot, "images")`
+  - `ImageReferencesEndpoints`: POST/GET/DELETE with structured logs and standardized errors; POST returns `overwrite` flag
+- Tests
+  - Integration: persistence across restart; error paths for `/images`
+  - Unit: evaluator edge cases (missing ref, null screen, template > region, constant equal/different)
+  - Test infra: `TestEnvironment` sets both `GAMEBOT_DATA_DIR` and `Service__Storage__Root`
+
+## How to Validate
+- Upload a 1x1 PNG to `/images`; GET should return 200 before and after restart
+- POST same id twice; second response includes `overwrite: true`
+- Error paths:
+  - POST with empty fields → 400 `invalid_request`
+  - POST invalid base64 → 400 `invalid_image`
+  - GET/DELETE missing → 404 `not_found`
+
+## Links
+- PR: #16
+- CHANGELOG updated under Unreleased (now included in this release)

--- a/src/GameBot.Domain/Triggers/Evaluators/ImageMatchEvaluator.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/ImageMatchEvaluator.cs
@@ -55,13 +55,12 @@ public sealed class ImageMatchEvaluator : ITriggerEvaluator {
     if (IsConstant(tplGray, out var tplVal) && IsConstant(regionGray, out var regVal)) {
       return Math.Abs(tplVal - regVal) < 1e-6 ? 1.0 : 0.0;
     }
-    double best = -1;
+    double best = double.NegativeInfinity;
     for (int y = 0; y <= regionGray.Height - tplGray.Height; y++)
       for (int x = 0; x <= regionGray.Width - tplGray.Width; x++) {
         var ncc = Ncc(regionGray, tplGray, x, y);
         if (ncc > best) best = ncc;
       }
-    if (best < 0) return 0d;
     return Math.Max(0, Math.Min(1, (best + 1) / 2.0));
   }
 


### PR DESCRIPTION
﻿Adds specs/001-image-storage/RELEASE_NOTES.md for the 2025-11-28 release. No code changes.

### Additional Change
- Fix: map NCC [-1,1] to [0,1] smoothly; remove negative floor in src/GameBot.Domain/Triggers/Evaluators/ImageMatchEvaluator.cs to preserve negative correlations.
