### PR TITLE
docs(spec/plan): Image match detections  spec, plan, research, contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ _ReSharper.Caches/
 
 data.old/ 
 tools/
+
+# PR helper files (do not commit)
+PR_BODY.md
+PR_BODY*.md

--- a/specs/001-image-match-detections/checklists/requirements.md
+++ b/specs/001-image-match-detections/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Image Match Detections
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-02
+**Feature**: ../spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist generated after initial spec creation; ready for `/speckit.plan`.

--- a/specs/001-image-match-detections/contracts/openapi-image-detections.yaml
+++ b/specs/001-image-match-detections/contracts/openapi-image-detections.yaml
@@ -1,0 +1,109 @@
+openapi: 3.0.3
+info:
+  title: Image Detections API
+  version: 1.0.0
+paths:
+  /images/detect:
+    post:
+      summary: Detect occurrences of a stored reference image in the current screenshot
+      operationId: detectImageMatches
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DetectRequest'
+      responses:
+        '200':
+          description: Detection results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetectResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Reference image not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    DetectRequest:
+      type: object
+      required: [ referenceImageId ]
+      properties:
+        referenceImageId:
+          type: string
+          description: Identifier of a previously stored reference image
+        threshold:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          default: 0.8
+        maxResults:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+        overlap:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          default: 0.3
+    DetectResponse:
+      type: object
+      properties:
+        matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/MatchResult'
+        limitsHit:
+          type: boolean
+          description: True if limited by maxResults or timeout
+    MatchResult:
+      type: object
+      properties:
+        bbox:
+          $ref: '#/components/schemas/NormalizedRect'
+        confidence:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+    NormalizedRect:
+      type: object
+      required: [ x, y, width, height ]
+      properties:
+        x:
+          type: number
+          minimum: 0
+          maximum: 1
+        y:
+          type: number
+          minimum: 0
+          maximum: 1
+        width:
+          type: number
+          minimum: 0
+          maximum: 1
+        height:
+          type: number
+          minimum: 0
+          maximum: 1
+    Error:
+      type: object
+      required: [ code, message ]
+      properties:
+        code:
+          type: string
+          enum: [ invalid_request, not_found ]
+        message:
+          type: string

--- a/specs/001-image-match-detections/data-model.md
+++ b/specs/001-image-match-detections/data-model.md
@@ -1,0 +1,30 @@
+# Data Model: Image Match Detections
+
+Date: 2025-12-02
+
+## Request
+
+- `referenceImageId` (string): Existing stored image ID.
+- `threshold` (number [0..1], default 0.8): Minimum confidence to include.
+- `maxResults` (int, default 10, 1..100): Maximum matches to return.
+- `overlap` (number [0..1], default 0.3): IoU threshold for NMS suppression.
+
+## Response
+
+- `matches` (array of `MatchResult`)
+- `limitsHit` (boolean, optional): True if truncated by `maxResults` or timeout.
+
+### MatchResult
+
+- `bbox` (object): Normalized rectangle relative to screenshot
+  - `x` (number [0..1])
+  - `y` (number [0..1])
+  - `width` (number [0..1])
+  - `height` (number [0..1])
+- `confidence` (number [0..1])
+
+## Errors
+
+- `invalid_request`: Missing fields or invalid ranges.
+- `not_found`: Unknown `referenceImageId`.
+- `timeout`: Operation exceeded configured limit (200 OK with `limitsHit=true` preferred; TBD during implementation).

--- a/specs/001-image-match-detections/plan.md
+++ b/specs/001-image-match-detections/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Image Match Detections
+
+**Branch**: `001-image-match-detections` | **Date**: 2025-12-02 | **Spec**: `/specs/001-image-match-detections/spec.md`
+**Input**: Feature specification from `/specs/001-image-match-detections/spec.md`
+
+**Note**: This plan will guide execution across design, implementation, and testing.
+
+## Summary
+
+Add an additive image detection capability that finds zero or more occurrences of a stored reference image within the current screenshot, returning normalized bounding boxes and confidences in [0,1]. This does not replace existing endpoints. We will integrate a self-contained computer vision library that bundles native assets (no external installs), apply normalized cross-correlation/template matching, and perform non-maximum suppression to remove overlapping duplicates. New endpoints will expose this functionality alongside the existing `/images` API.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9 (Domain + Service)  
+**Primary Dependencies**: OpenCvSharp4 + `OpenCvSharp4.runtime.win` (bundled native libs; no external install)  
+**Storage**: Reuse existing file-based reference images under `data/images`  
+**Testing**: xUnit + FluentAssertions; integration via `WebApplicationFactory<Program>`; contract tests for API schema  
+**Target Platform**: Windows  
+**Project Type**: ASP.NET Core Minimal API  
+**Performance Goals**: p95 detection < 400 ms at 1080p with 128×128 template; ≤ 10 results returned by default  
+**Constraints**: No breaking changes; no external system dependencies; deterministic results for same inputs  
+**Scale/Scope**: Single-node service; tens of detections per call; templates up to ~256×256 (initial)
+
+## Constitution Check
+
+Validate planned work against the GameBot Constitution:
+- Code Quality: Keep detection logic encapsulated (e.g., `TemplateMatcher` service) with narrow DI surface; enable analyzers and CA rules; no secrets; logging with structured events.
+- Testing: Unit tests for matcher and NMS; golden-image tests for correctness; integration tests for endpoint (thresholds, overlaps, limits); contract tests validate schema.
+- UX Consistency: New endpoint naming, status codes, and error payloads align with existing conventions; normalized coordinates and confidence semantics documented.
+- Performance: Budgets defined above; include a simple benchmark harness and timeouts; guard max results; pre-convert to grayscale where helpful.
+
+Re-check at design freeze to ensure no regressions to existing contracts.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-image-match-detections/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── contracts/
+   └── openapi-image-detections.yaml
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   └── Vision/
+│       ├── ITemplateMatcher.cs
+│       ├── TemplateMatcher.cs          # OpenCV-based template matching + NMS
+│       └── Nms.cs                      # Non-maximum suppression utility
+├── GameBot.Service/
+│   └── Endpoints/
+│       ├── ImageDetectionsEndpoints.cs # New additive endpoints
+│       └── ImageReferencesEndpoints.cs # Unchanged (existing)
+
+tests/
+├── unit/
+│   ├── TemplateMatcherTests.cs         # NCC mapping, thresholding, multi-match
+│   └── NmsTests.cs                     # Overlap suppression correctness
+├── integration/
+│   └── ImageDetectionsEndpointTests.cs # API behavior, limits, errors
+└── contract/
+   └── ImageDetectionsContractTests.cs # OpenAPI schema conformance
+```
+
+**Structure Decision**: Add a small `Vision` area under Domain for the matcher and utilities; expose via new Service endpoints; preserve existing endpoints and evaluators.
+
+## Phased Plan
+
+1. Phase 0 – Research
+  - Decide library: OpenCvSharp4 with `runtime.win` for bundled native assets.
+  - Validate packaging/bitness and licensing; ensure Windows Server compatibility.
+  - Spike: run template matching (TM_CCOEFF_NORMED) and measure on sample images.
+
+2. Phase 1 – Design
+  - Define request/response contract and OpenAPI (`openapi-image-detections.yaml`).
+  - Specify normalized bbox convention and confidence semantics.
+  - Design NMS (IoU-based) with tunable overlap (default 0.3).
+  - Define config: `MaxResults` default 10; timeout 500 ms; optional overrides.
+
+3. Phase 2 – Implementation
+  - Add `OpenCvSharp4` packages to Domain project; wire DI for `ITemplateMatcher`.
+  - Implement grayscale conversion, NCC, thresholding, peak finding, and NMS.
+  - Implement new endpoints and input validation using existing logging patterns.
+
+4. Phase 3 – Testing
+  - Unit: synthetic images for known matches; NMS correctness; bounds/edge cases.
+  - Integration: endpoint happy path, empty result, invalid ID, limits, timeouts.
+  - Contract: validate JSON schema against OpenAPI; ensure no breaks to existing endpoints.
+
+5. Phase 4 – Performance & Hardening
+  - Micro-benchmark typical sizes; verify budgets; optimize buffer reuse.
+  - Add safeguards against oversized templates; clamp and fast-fail.
+  - Observability: structured timings + counts at debug level.
+
+6. Phase 5 – Docs & Release
+  - Update README and specs quickstart; add examples.
+  - Changelog entry; feature flag note if applicable.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| New dependency (OpenCvSharp4) | Enables robust, bundled CV without external install | Re-implementing CV is error-prone; ImageSharp lacks fast NCC and peak finding |

--- a/specs/001-image-match-detections/quickstart.md
+++ b/specs/001-image-match-detections/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart: Image Match Detections
+
+## Upload or verify a reference image
+
+```bash
+curl -X POST http://localhost:5187/images \
+  -H "Content-Type: application/json" \
+  -d '{"id":"Home","data":"<base64_png>","overwrite":true}'
+```
+
+## Detect matches for a reference image
+
+```bash
+curl -X POST http://localhost:5187/images/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "referenceImageId":"Home",
+    "threshold":0.85,
+    "maxResults":10,
+    "overlap":0.3
+  }'
+```
+
+Example response:
+
+```json
+{
+  "matches": [
+    { "bbox": {"x":0.12,"y":0.45,"width":0.08,"height":0.08}, "confidence":0.93 },
+    { "bbox": {"x":0.61,"y":0.47,"width":0.08,"height":0.08}, "confidence":0.89 }
+  ],
+  "limitsHit": false
+}
+```
+
+## Notes
+
+- Coordinates are normalized to the current screenshot size.
+- Confidence is in [0,1]; tune `threshold` to balance precision/recall.
+- Set `maxResults` and `overlap` for stricter de-duplication.

--- a/specs/001-image-match-detections/research.md
+++ b/specs/001-image-match-detections/research.md
@@ -1,0 +1,39 @@
+# Research: Image Match Detections
+
+Date: 2025-12-02  
+Feature: specs/001-image-match-detections/spec.md
+
+## Options Considered
+
+- OpenCvSharp4 (+ OpenCvSharp4.runtime.win)
+  - Pros: Mature template matching (TM_CCOEFF_NORMED), fast; packages bundle native DLLs for Windows; good community.
+  - Cons: Native interop; ensure x64 process; larger deployment size.
+
+- Emgu CV
+  - Pros: Comprehensive wrapper over OpenCV.
+  - Cons: Licensing/packaging complexity; heavier; less straightforward bundling.
+
+- SixLabors.ImageSharp only
+  - Pros: Pure managed; simple packaging.
+  - Cons: Lacks optimized NCC/peak detection; would require custom implementation; likely slower.
+
+## Decision
+
+Choose OpenCvSharp4 with `OpenCvSharp4.runtime.win` to satisfy "no external installs" while leveraging optimized OpenCV functions.
+
+## Feasibility Spike
+
+- Implement TM_CCOEFF_NORMED on sample 1080p screenshots with 128×128 templates.
+- Extract response peaks above threshold; apply IoU-based NMS (0.3 default).
+- Expect sub-400ms p95 on target hardware per success criteria.
+
+## Risks & Mitigations
+
+- Bitness mismatch: enforce x64 build; verify RID-specific assets.
+- Deployment size: measure package impact; acceptable for service.
+- Performance variance: add timeout and cap results; consider early stopping if needed.
+
+## References
+
+- OpenCV Template Matching: https://docs.opencv.org/4.x/d4/dc6/tutorial_py_template_matching.html
+- OpenCvSharp GitHub: https://github.com/shimat/opencvsharp

--- a/specs/001-image-match-detections/spec.md
+++ b/specs/001-image-match-detections/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Image Match Detections
+
+**Feature Branch**: `001-image-match-detections`  
+**Created**: 2025-12-02  
+**Status**: Draft  
+**Input**: User description: "Introducing improved image matching trigger. I need a new image matching functionality (don't replace, but extend the old endpoints), given a reference image and the certainty set by the trigger, the system should try to find the image, possibly multiple times, within current screenshot and return the list of positions along with certainties for these positions. Use an external library, for example OpenCV or something similar for this. Don't depend on externally installed binaries/libraries, bring everything into the application that it needs in runtime."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Find all matches in current screenshot (Priority: P1)
+
+As an automation author, I want to request all occurrences of a stored reference image in the current screenshot, filtered by a similarity threshold, so I can act on each detected position.
+
+**Why this priority**: Core value of feature; enables multi-target actions in a single evaluation.
+
+**Independent Test**: Upload a known reference image, request detections with a threshold, and verify the response contains all expected positions with confidences above the threshold.
+
+**Acceptance Scenarios**:
+
+1. Given a valid reference image ID and a similarity threshold, When requesting detections, Then the system returns a list of matches with positions and confidences ≥ threshold.
+2. Given no matches above threshold, When requesting detections, Then the system returns an empty list and 200 OK.
+
+---
+
+### User Story 2 - Preserve existing endpoints and triggers (Priority: P2)
+
+As a service integrator, I want existing image endpoints and trigger evaluation behavior to remain unchanged, while new detection capability is exposed via additional endpoints, so existing clients are not broken.
+
+**Why this priority**: Backward compatibility for existing automation flows.
+
+**Independent Test**: Execute existing POST/GET/DELETE image endpoints and trigger evaluation flows; verify no behavior change and that new detection endpoint is additive.
+
+**Acceptance Scenarios**:
+
+1. Given existing endpoints, When used as before, Then behavior and payloads remain unchanged.
+2. Given the new detection endpoint, When called, Then it does not alter stored images or trigger configs unless explicitly requested.
+
+---
+
+### User Story 3 - Bounded, normalized output (Priority: P3)
+
+As a client, I want match positions expressed in a normalized coordinate system and confidences in [0,1], so my logic is resolution-independent and thresholds are portable.
+
+**Why this priority**: Simplifies cross-device automation and testing.
+
+**Independent Test**: Validate that positions are normalized to screenshot dimensions and confidences are clamped to [0,1].
+
+**Acceptance Scenarios**:
+
+1. Given a 1920x1080 screenshot, When matches are reported, Then x,y,width,height are in [0,1] relative to screenshot size.
+2. Given any detector output, When serialized, Then confidence is in [0,1] and monotonic with similarity.
+
+---
+
+### Edge Cases
+
+- Reference image larger than screenshot or region → return empty matches.
+- Threshold = 1.0 (only perfect matches) and 0.0 (all detections) → handle without error.
+- Overlapping detections → apply non-maximum suppression rules to avoid duplicate near-identical boxes.
+- Screenshot unavailable or null → return 200 with empty list and an explanatory reason.
+- Invalid or missing reference image ID → 404 not found with standard error shape (no changes to existing behaviors).
+- Extremely large images or many detections → enforce max results and timeout safeguards; return partial results with a clear indicator when limits reached.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a new detection operation that returns zero or more matches of a stored reference image within the current screenshot without altering existing endpoints.
+- **FR-002**: System MUST accept: reference image identifier, similarity threshold, and optional maxResults; SHOULD accept optional suppression overlap parameter for de-duplication.
+- **FR-003**: System MUST return a list of matches, each with: normalized bounding box `{x,y,width,height}` relative to current screenshot and a `confidence` in [0,1].
+- **FR-004**: System MUST bundle any detection library assets required at runtime; MUST NOT require users to install external system dependencies.
+- **FR-005**: System MUST behave deterministically for a given screenshot and reference image with the same parameters (idempotent read operation).
+- **FR-006**: System MUST gracefully handle no-screen or invalid reference image by returning an empty list or standardized not-found error (consistent with existing service errors).
+- **FR-007**: System MUST enforce performance and safety guards: a configurable timeout and a maximum number of returned matches.
+- **FR-008**: System MUST document the API contract (request/response fields, ranges, limits) alongside existing images contract without breaking changes.
+- **FR-009**: System SHOULD provide consistent similarity semantics with existing triggers (confidence monotonic with similarity, range [0,1]).
+- **FR-010**: System SHOULD support normalized coordinates regardless of screen resolution; internal pixel math MUST be accurate to avoid off-by-one at edges.
+
+### Assumptions
+
+- The detection operates on the latest full screenshot (no streaming/video pipeline required).
+- Scale and rotation invariance are out of scope initially; detection assumes equal scale and upright orientation; clients can provide appropriately scaled references if needed.
+- Existing image storage and validation (IDs, formats) continue to apply without change.
+
+### Key Entities *(include if feature involves data)*
+
+- **ReferenceImage**: Existing stored image identified by `referenceImageId`.
+- **MatchRequest**: Parameters for a detection query: `referenceImageId`, `threshold` [0..1], `maxResults` (default reasonable), optional `overlap` for suppression.
+- **MatchResult**: A single detection result: `bbox` `{x,y,width,height}` normalized to screenshot, `confidence` [0..1].
+- **MatchResponse**: Collection of `MatchResult` plus optional `limitsHit` boolean if results were truncated or timeout occurred.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For 1080p screenshots and 128x128 references, 95% of detection requests complete under 400 ms on target hardware with `maxResults=10`.
+- **SC-002**: On a curated validation set, precision ≥ 0.95 at the configured threshold; recall ≥ 0.90 up to `maxResults`.
+- **SC-003**: Existing image endpoints and trigger evaluations exhibit no behavior change (zero regressions in existing contract and integration tests).
+- **SC-004**: No external runtime dependencies required by consumers; a clean machine can run detections without additional installs.

--- a/specs/001-image-storage/RELEASE_NOTES.md
+++ b/specs/001-image-storage/RELEASE_NOTES.md
@@ -1,0 +1,33 @@
+# Release 2025-11-28: Persistent Reference Images, Logging, and Tests
+
+## Highlights
+- Persistent reference image storage under `data/images` with atomic writes
+- Structured LoggerMessage logging for `/images` endpoints
+- Standardized error responses: `invalid_request`, `invalid_image`, `not_found`
+- Increased coverage: evaluator edge cases and endpoint error paths
+- CI stability fixes: storage isolation via `Service__Storage__Root` + `GAMEBOT_DATA_DIR`, persistence test robustness
+- Evaluator stability: replace GDI+ `Bitmap.Clone` with `Graphics.DrawImage`
+
+## Details
+- Domain
+  - `ImageMatchEvaluator`: 24bpp conversion via draw, avoid intermittent GDI+ OOM
+  - `ReferenceImageStore`: PNG persistence with atomic replace; `Exists/Delete` support
+- Service
+  - `Program`: registers disk-backed `IReferenceImageStore` at `Path.Combine(storageRoot, "images")`
+  - `ImageReferencesEndpoints`: POST/GET/DELETE with structured logs and standardized errors; POST returns `overwrite` flag
+- Tests
+  - Integration: persistence across restart; error paths for `/images`
+  - Unit: evaluator edge cases (missing ref, null screen, template > region, constant equal/different)
+  - Test infra: `TestEnvironment` sets both `GAMEBOT_DATA_DIR` and `Service__Storage__Root`
+
+## How to Validate
+- Upload a 1x1 PNG to `/images`; GET should return 200 before and after restart
+- POST same id twice; second response includes `overwrite: true`
+- Error paths:
+  - POST with empty fields → 400 `invalid_request`
+  - POST invalid base64 → 400 `invalid_image`
+  - GET/DELETE missing → 404 `not_found`
+
+## Links
+- PR: #16
+- CHANGELOG updated under Unreleased (now included in this release)

--- a/tests/contract/xunit.runner.json
+++ b/tests/contract/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}

--- a/tests/integration/DisableParallelization.cs
+++ b/tests/integration/DisableParallelization.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/integration/xunit.runner.json
+++ b/tests/integration/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}

--- a/tests/unit/DisableParallelization.cs
+++ b/tests/unit/DisableParallelization.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/unit/xunit.runner.json
+++ b/tests/unit/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}


### PR DESCRIPTION
This PR adds the planning artifacts for the Image Match Detections feature.

Summary
- Additive detection capability to find multiple occurrences of a stored reference image in the current screenshot.
- Returns normalized bounding boxes and confidence [0,1]; applies non-maximum suppression.
- New endpoint (no breaking changes to existing /images endpoints): POST /images/detect.
- No external installs; plan to bundle OpenCV runtime via managed package (OpenCvSharp4.runtime.win).

Artifacts
- specs/001-image-match-detections/spec.md
- specs/001-image-match-detections/plan.md
- specs/001-image-match-detections/research.md
- specs/001-image-match-detections/data-model.md
- specs/001-image-match-detections/quickstart.md
- specs/001-image-match-detections/contracts/openapi-image-detections.yaml
- specs/001-image-match-detections/checklists/requirements.md

Notes
- Implementation to follow in subsequent PRs per the plan.
- Existing endpoints and triggers remain unchanged.