### PR TITLE
docs: Quickstart for Sequence Logic Blocks

### DIFF
--- a/specs/001-image-storage/RELEASE_NOTES.md
+++ b/specs/001-image-storage/RELEASE_NOTES.md
@@ -1,0 +1,33 @@
+# Release 2025-11-28: Persistent Reference Images, Logging, and Tests
+
+## Highlights
+- Persistent reference image storage under `data/images` with atomic writes
+- Structured LoggerMessage logging for `/images` endpoints
+- Standardized error responses: `invalid_request`, `invalid_image`, `not_found`
+- Increased coverage: evaluator edge cases and endpoint error paths
+- CI stability fixes: storage isolation via `Service__Storage__Root` + `GAMEBOT_DATA_DIR`, persistence test robustness
+- Evaluator stability: replace GDI+ `Bitmap.Clone` with `Graphics.DrawImage`
+
+## Details
+- Domain
+  - `ImageMatchEvaluator`: 24bpp conversion via draw, avoid intermittent GDI+ OOM
+  - `ReferenceImageStore`: PNG persistence with atomic replace; `Exists/Delete` support
+- Service
+  - `Program`: registers disk-backed `IReferenceImageStore` at `Path.Combine(storageRoot, "images")`
+  - `ImageReferencesEndpoints`: POST/GET/DELETE with structured logs and standardized errors; POST returns `overwrite` flag
+- Tests
+  - Integration: persistence across restart; error paths for `/images`
+  - Unit: evaluator edge cases (missing ref, null screen, template > region, constant equal/different)
+  - Test infra: `TestEnvironment` sets both `GAMEBOT_DATA_DIR` and `Service__Storage__Root`
+
+## How to Validate
+- Upload a 1x1 PNG to `/images`; GET should return 200 before and after restart
+- POST same id twice; second response includes `overwrite: true`
+- Error paths:
+  - POST with empty fields → 400 `invalid_request`
+  - POST invalid base64 → 400 `invalid_image`
+  - GET/DELETE missing → 404 `not_found`
+
+## Links
+- PR: #16
+- CHANGELOG updated under Unreleased (now included in this release)

--- a/specs/001-sequence-logic/checklists/requirements.md
+++ b/specs/001-sequence-logic/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Sequence Logic Blocks
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-17
+**Feature**: specs/001-sequence-logic/spec.md
+
+## Content Quality
+
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous
+- [ ] Success criteria are measurable
+- [ ] Success criteria are technology-agnostic (no implementation details)
+- [ ] All acceptance scenarios are defined
+- [ ] Edge cases are identified
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [ ] All functional requirements have clear acceptance criteria
+- [ ] User scenarios cover primary flows
+- [ ] Feature meets measurable outcomes defined in Success Criteria
+- [ ] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/001-sequence-logic/checklists/requirements.md
+++ b/specs/001-sequence-logic/checklists/requirements.md
@@ -6,28 +6,28 @@
 
 ## Content Quality
 
-- [ ] No implementation details (languages, frameworks, APIs)
-- [ ] Focused on user value and business needs
-- [ ] Written for non-technical stakeholders
-- [ ] All mandatory sections completed
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
 
 ## Requirement Completeness
 
 - [X] No [NEEDS CLARIFICATION] markers remain
-- [ ] Requirements are testable and unambiguous
-- [ ] Success criteria are measurable
-- [ ] Success criteria are technology-agnostic (no implementation details)
-- [ ] All acceptance scenarios are defined
-- [ ] Edge cases are identified
-- [ ] Scope is clearly bounded
-- [ ] Dependencies and assumptions identified
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
 
 ## Feature Readiness
 
-- [ ] All functional requirements have clear acceptance criteria
-- [ ] User scenarios cover primary flows
-- [ ] Feature meets measurable outcomes defined in Success Criteria
-- [ ] No implementation details leak into specification
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
 
 ## Notes
 

--- a/specs/001-sequence-logic/checklists/requirements.md
+++ b/specs/001-sequence-logic/checklists/requirements.md
@@ -13,7 +13,7 @@
 
 ## Requirement Completeness
 
-- [ ] No [NEEDS CLARIFICATION] markers remain
+- [X] No [NEEDS CLARIFICATION] markers remain
 - [ ] Requirements are testable and unambiguous
 - [ ] Success criteria are measurable
 - [ ] Success criteria are technology-agnostic (no implementation details)

--- a/specs/001-sequence-logic/contracts/sequences-blocks.md
+++ b/specs/001-sequence-logic/contracts/sequences-blocks.md
@@ -1,0 +1,79 @@
+# Contracts — Sequence Blocks API Additions
+
+## Sequence JSON Schema Extensions
+
+- `blocks`: array of `Block` objects
+- `Block` discriminated by `type`: `repeatCount` | `repeatUntil` | `while` | `ifElse`
+- `steps`: array of `Step | Block`
+- `timeoutMs`, `maxIterations`, `cadenceMs`, `control`, `condition`, `elseSteps`
+
+### OpenAPI Snippet (conceptual)
+
+```yaml
+components:
+  schemas:
+    Condition:
+      type: object
+      required: [source, targetId, mode]
+      properties:
+        source:
+          type: string
+          enum: [image, text, trigger]
+        targetId:
+          type: string
+        mode:
+          type: string
+          enum: [Present, Absent]
+        confidenceThreshold:
+          type: number
+          minimum: 0
+          maximum: 1
+        region:
+          $ref: '#/components/schemas/Rect'
+        language:
+          type: string
+    Block:
+      type: object
+      required: [type, steps]
+      properties:
+        type:
+          type: string
+          enum: [repeatCount, repeatUntil, while, ifElse]
+        steps:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/Step'
+              - $ref: '#/components/schemas/Block'
+        timeoutMs:
+          type: integer
+          minimum: 0
+        maxIterations:
+          type: integer
+          minimum: 1
+        cadenceMs:
+          type: integer
+          minimum: 50
+          maximum: 5000
+        control:
+          type: object
+          properties:
+            breakOn:
+              $ref: '#/components/schemas/Condition'
+            continueOn:
+              $ref: '#/components/schemas/Condition'
+        condition:
+          $ref: '#/components/schemas/Condition'
+        elseSteps:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/Step'
+              - $ref: '#/components/schemas/Block'
+```
+
+## Endpoints
+
+- `POST /api/sequences` — accepts extended schema
+- `GET /api/sequences/{id}` — returns extended schema
+- `POST /api/sequences/{id}/execute` — returns extended `BlockResult` telemetry

--- a/specs/001-sequence-logic/data-model.md
+++ b/specs/001-sequence-logic/data-model.md
@@ -1,0 +1,54 @@
+# Data Model — Sequence Logic Blocks
+
+## Entities
+
+### Sequence
+- `id`: string
+- `name`: string
+- `steps`: [Step]
+- `blocks`: [Block] | optional; supports nesting within `steps`
+
+### Step
+- `order`: int
+- `commandId`: string
+- `delayMs`: int? (>=0)
+- `delayRangeMs`: { `min`: int>=0, `max`: int>=`min` }
+- `gate`: Gate? (existing)
+
+### Block (union by `type`)
+- `type`: enum(`repeatCount`,`repeatUntil`,`while`,`ifElse`)
+- `steps`: [Step|Block] (nested)
+- `timeoutMs`: int? (>=0) — required when loop and `maxIterations` not set
+- `maxIterations`: int? (>=1) — required when loop and `timeoutMs` not set
+- `cadenceMs`: int? (default 100; bounds 50–5000)
+- `control`: { `breakOn`: Condition? , `continueOn`: Condition? } — optional loop control
+- `condition`: Condition? — required for `repeatUntil`/`while` and `ifElse`
+- `elseSteps`: [Step|Block] — only for `ifElse`
+
+### Condition
+- `source`: enum(`image`,`text`,`trigger`)
+- `targetId`: string
+- `mode`: enum(`Present`,`Absent`)
+- `confidenceThreshold`: float? (0..1) — for `image`/`text`
+- `region`: { `x`,`y`,`width`,`height` }? — normalized (0..1), optional for `image`
+- `language`: string? — optional for `text`
+
+### Telemetry (execution result additions)
+- `blocks`: [BlockResult]
+
+### BlockResult
+- `blockType`: string
+- `iterations`: int
+- `evaluations`: int
+- `branchTaken`: string? (`then`/`else`)
+- `durationMs`: int
+- `appliedDelayMs`: int
+- `status`: string (`Succeeded`|`Failed`|`Skipped`)
+
+## Validation Rules
+- Delay precedence: `delayRangeMs` overrides `delayMs` when present
+- Loop safeguards: require either `timeoutMs` or `maxIterations`
+- Cadence bounds: 50–5000ms
+- Condition presence: required for `repeatUntil`,`while`,`ifElse`
+- `elseSteps` only valid when `type=ifElse`
+- Nested blocks allowed; treat `steps` as heterogeneous array of `Step|Block`

--- a/specs/001-sequence-logic/plan.md
+++ b/specs/001-sequence-logic/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: Sequence Logic Blocks (Loops & Conditionals)
+
+**Branch**: `001-sequence-logic` | **Date**: 2025-12-17 | **Spec**: specs/001-sequence-logic/spec.md
+**Input**: Feature specification from `/specs/001-sequence-logic/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. Refer to the command help for execution workflow.
+
+## Summary
+
+Add declarative control blocks to Command Sequences: fixed-count loops, repeat-until/while condition loops (image/text/trigger-based), and if/then/else branching. Enforce safeguards (`timeoutMs`/`maxIterations`) and capture telemetry per block. Technical approach: extend sequence JSON schema with `blocks` supporting nesting, reuse existing detection/trigger evaluation for conditions, add loop control (`break`/`continue`) semantics, and update endpoints and runner logic iteratively with unit/integration tests and structured logging.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: C# / .NET 9  
+**Primary Dependencies**: Existing detection (OpenCV image-match), OCR (Tesseract), trigger evaluation services  
+**Storage**: File-backed JSON under `data/commands/sequences`  
+**Testing**: xUnit unit + integration; WebApplicationFactory for service endpoints  
+**Target Platform**: Windows
+**Project Type**: ASP.NET Core Minimal API (service) + Domain libs  
+**Performance Goals**: p95 sequence execution control decisions within 100ms cadence; no observed infinite loops; negligible overhead vs baseline  
+**Constraints**: Polling cadence bounded 50–5000ms; enforce `timeoutMs` or `maxIterations` per loop; memory stable within existing budgets  
+**Scale/Scope**: Feature confined to sequence execution paths; no new external services
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Validate planned work against the GameBot Constitution:
+- Code Quality: planned tooling (lint/format/static analysis), modularity approach, security scanning.
+- Testing: unit/integration plan, coverage targets, determinism strategy, CI gating.
+- UX Consistency: interface conventions (CLI/API/logs), error messaging, versioning for changes.
+- Performance: declared budgets/targets and measurement approach for hot paths.
+
+Quality gates mapped: lint/static analysis enforced (CA rules), structured logging via LoggerMessage, unit+integration coverage added; UX aligns with existing API conventions; performance budgets declared for control path cadence; no hot-path regressions expected. Re-evaluate after design artifacts are produced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+**Structure Decision**: Single repository with existing service/domain/tests layout; extend domain (`src/GameBot.Domain/Commands`) and service (`src/GameBot.Service/Program.cs`) with sequence blocks; add docs under `specs/001-sequence-logic/`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/001-sequence-logic/quickstart.md
+++ b/specs/001-sequence-logic/quickstart.md
@@ -1,0 +1,98 @@
+# Quickstart — Sequence Logic Blocks
+
+## Setup
+
+```powershell
+$env:GAMEBOT_AUTH_TOKEN = "test-token"
+$env:GAMEBOT_DATA_DIR = (Join-Path $PWD 'data')
+```
+
+## Repeat N Times
+
+```json
+{
+  "id": "sample-repeat",
+  "name": "Repeat N",
+  "blocks": [
+    {
+      "type": "repeatCount",
+      "maxIterations": 3,
+      "steps": [ { "order": 1, "commandId": "cmd-collect" } ]
+    }
+  ]
+}
+```
+
+## Repeat Until Detected
+
+```json
+{
+  "id": "sample-until",
+  "name": "Until Image",
+  "blocks": [
+    {
+      "type": "repeatUntil",
+      "timeoutMs": 2000,
+      "cadenceMs": 100,
+      "condition": { "source": "image", "targetId": "home_button", "mode": "Present", "confidenceThreshold": 0.9 },
+      "steps": [ { "order": 1, "commandId": "cmd-open" } ]
+    }
+  ]
+}
+```
+
+## If/Then/Else Branch
+
+```json
+{
+  "id": "sample-branch",
+  "name": "Branch by Trigger",
+  "blocks": [
+    {
+      "type": "ifElse",
+      "condition": { "source": "trigger", "targetId": "readyTrigger", "mode": "Present" },
+      "steps": [ { "order": 1, "commandId": "cmd-start" } ],
+      "elseSteps": [ { "order": 1, "commandId": "cmd-wait" } ]
+    }
+  ]
+}
+```
+
+## Loop Control
+
+```json
+{
+  "id": "sample-control",
+  "name": "Break/Continue",
+  "blocks": [
+    {
+      "type": "repeatCount",
+      "maxIterations": 10,
+      "control": {
+        "breakOn": { "source": "text", "targetId": "errorBanner", "mode": "Present" },
+        "continueOn": { "source": "image", "targetId": "busySpinner", "mode": "Present", "confidenceThreshold": 0.95 }
+      },
+      "steps": [ { "order": 1, "commandId": "cmd-step" } ]
+    }
+  ]
+}
+```
+
+## Create & Execute
+
+### Run the service
+
+Start the API in another terminal:
+
+```powershell
+dotnet run -c Debug --project src/GameBot.Service
+```
+
+### Create a sequence and execute it
+
+```powershell
+$headers = @{ Authorization = 'Bearer test-token' }
+$body = Get-Content sample-repeat.json -Raw
+Invoke-RestMethod -Uri "http://localhost:5000/api/sequences" -Method POST -Headers $headers -ContentType 'application/json' -Body $body
+Invoke-RestMethod -Uri "http://localhost:5000/api/sequences/sample-repeat/execute" -Method POST -Headers $headers -Body ''
+```

--- a/specs/001-sequence-logic/research.md
+++ b/specs/001-sequence-logic/research.md
@@ -1,0 +1,28 @@
+# Research — Sequence Logic Blocks
+
+## Decisions
+
+- Nested Blocks: Allow unlimited nesting (author guidance to keep shallow where possible)
+  - Rationale: Enables expressive flows without arbitrary limits; safeguards avoid runaway execution
+  - Alternatives: Max depth 2 or 3 (simpler mental model), Disallow nesting (split across sequences)
+
+- Loop Control: Support `break` and `continue`
+  - Rationale: Precise control during iteration; common patterns for retries and skip conditions
+  - Alternatives: Break-only (less flexible), No control (rely solely on count/conditions)
+
+- Condition Sources: Include `triggerId` status alongside image/text
+  - Rationale: Leverages existing trigger evaluation; richer branching without new primitives
+  - Alternatives: Image/text only (focus), Variables/state (more complexity and authoring semantics)
+
+## Best Practices
+
+- Safeguards: Require `timeoutMs` or `maxIterations` for loops; enforce cadence bounds (50–5000ms)
+- Telemetry: Record iterations, evaluations, branch decisions, durations, applied delays per block
+- Logging: Use `LoggerMessage` for structured, analyzer-compliant logging
+- Validation: Clear error codes/messages for invalid configs (missing safeguards, out-of-range cadence, unknown condition targets)
+
+## Patterns
+
+- Polling: Backoff cadence optionally configurable; default 100ms
+- Detection: Reuse image/text detection and trigger evaluation; confidence thresholds documented
+- Compatibility: Sequences without blocks execute unchanged; blocks nest within step groups deterministically

--- a/specs/001-sequence-logic/spec.md
+++ b/specs/001-sequence-logic/spec.md
@@ -27,6 +27,7 @@ Conditions may reference image/text detection or trigger status by `triggerId`.
 - Q: For repeat-until/while loop iteration ordering, when is the condition evaluated relative to executing steps? → A: Check before steps; execute only if not satisfied.
 - Q: When should `breakOn`/`continueOn` be evaluated within loop iterations? → A: Evaluate at start and between steps; `breakOn` at start or between steps; `continueOn` only between steps.
 - Q: What telemetry granularity should loops capture? → A: Compact per-iteration summaries: index, decision (normal/break/continue), duration.
+- Q: If both `timeoutMs` and `maxIterations` are provided, how should they be enforced? → A: Enforce both; stop on the first safeguard hit.
 
 ## Actors
 - Operator: Authors sequences and reviews results.
@@ -143,6 +144,7 @@ As an Operator, I declare `break` or `continue` within a loop to control executi
 - **FR-17**: Loop semantics (gate-first): For `repeatUntil` and `while`, evaluate the condition at the beginning of each iteration; if satisfied, exit the loop without executing steps for that iteration (no-op when already satisfied).
 - **FR-18**: Loop control evaluation order: Evaluate `breakOn` at the start of each iteration and between steps; evaluate `continueOn` only between steps to skip remaining steps in the current iteration and proceed to the next.
 - **FR-19**: Telemetry detail: Emit compact per-iteration summaries for loop blocks including `iterationIndex`, `decision` ("normal" | "break" | "continue"), and `durationMs`; avoid full per-step, per-iteration payloads by default.
+- **FR-20**: Combined safeguards: If both `timeoutMs` and `maxIterations` are configured, enforce both and terminate the loop on whichever threshold is reached first (first-hit wins).
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/001-sequence-logic/spec.md
+++ b/specs/001-sequence-logic/spec.md
@@ -28,6 +28,7 @@ Conditions may reference image/text detection or trigger status by `triggerId`.
 - Q: When should `breakOn`/`continueOn` be evaluated within loop iterations? → A: Evaluate at start and between steps; `breakOn` at start or between steps; `continueOn` only between steps.
 - Q: What telemetry granularity should loops capture? → A: Compact per-iteration summaries: index, decision (normal/break/continue), duration.
 - Q: If both `timeoutMs` and `maxIterations` are provided, how should they be enforced? → A: Enforce both; stop on the first safeguard hit.
+- Q: For `repeatCount`, should `cadenceMs` apply between iterations and what default to use? → A: Apply cadence between iterations; default 0ms for `repeatCount`.
 
 ## Actors
 - Operator: Authors sequences and reviews results.
@@ -145,6 +146,7 @@ As an Operator, I declare `break` or `continue` within a loop to control executi
 - **FR-18**: Loop control evaluation order: Evaluate `breakOn` at the start of each iteration and between steps; evaluate `continueOn` only between steps to skip remaining steps in the current iteration and proceed to the next.
 - **FR-19**: Telemetry detail: Emit compact per-iteration summaries for loop blocks including `iterationIndex`, `decision` ("normal" | "break" | "continue"), and `durationMs`; avoid full per-step, per-iteration payloads by default.
 - **FR-20**: Combined safeguards: If both `timeoutMs` and `maxIterations` are configured, enforce both and terminate the loop on whichever threshold is reached first (first-hit wins).
+- **FR-21**: `repeatCount` pacing: Apply `cadenceMs` between iterations when provided; default to 0ms for `repeatCount` blocks (no implicit delay). When set, cadence bounds (50–5000ms) apply.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/001-sequence-logic/spec.md
+++ b/specs/001-sequence-logic/spec.md
@@ -25,6 +25,7 @@ Conditions may reference image/text detection or trigger status by `triggerId`.
 ### Session 2025-12-17
 
 - Q: For repeat-until/while loop iteration ordering, when is the condition evaluated relative to executing steps? → A: Check before steps; execute only if not satisfied.
+- Q: When should `breakOn`/`continueOn` be evaluated within loop iterations? → A: Evaluate at start and between steps; `breakOn` at start or between steps; `continueOn` only between steps.
 
 ## Actors
 - Operator: Authors sequences and reviews results.
@@ -139,6 +140,7 @@ As an Operator, I declare `break` or `continue` within a loop to control executi
 - **FR-15**: Backward compatibility for sequences without blocks.
 - **FR-16**: Support loop control: `break` to exit the loop; `continue` to skip to the next iteration.
 - **FR-17**: Loop semantics (gate-first): For `repeatUntil` and `while`, evaluate the condition at the beginning of each iteration; if satisfied, exit the loop without executing steps for that iteration (no-op when already satisfied).
+- **FR-18**: Loop control evaluation order: Evaluate `breakOn` at the start of each iteration and between steps; evaluate `continueOn` only between steps to skip remaining steps in the current iteration and proceed to the next.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/001-sequence-logic/spec.md
+++ b/specs/001-sequence-logic/spec.md
@@ -14,11 +14,11 @@ Enable richer sequence orchestration using standard control blocks: repeat steps
 - Blocks can group multiple steps and apply delays/gating within the group.
 - Execution results include per-block/per-step telemetry (iterations, condition outcomes, durations).
 
-[NEEDS CLARIFICATION: Should nested blocks be allowed, and if so, what maximum depth (e.g., up to 3 levels) to ensure readability and safety?]
+Nested blocks are allowed without a fixed maximum depth. Authors should prefer shallow nesting for readability; safeguards apply at every level to prevent unbounded execution.
 
-[NEEDS CLARIFICATION: Do we expose `break`/`continue` semantics to authors (e.g., break on error within loop) or keep loops strictly driven by count/condition?]
+Loop control supports both `break` (exit loop) and `continue` (skip to next iteration) when declared within loop blocks.
 
-[NEEDS CLARIFICATION: Beyond image/text, should conditional sources include trigger IDs, simple variables/state (e.g., last command result), or remain limited to detection gates for now?]
+Conditions may reference image/text detection or trigger status by `triggerId`.
 
 ## Actors
 - Operator: Authors sequences and reviews results.
@@ -83,6 +83,19 @@ As an Operator, I define a condition referencing a detection target; if `Present
 1. **Given** `if` with `Present`, **When** condition holds, **Then** branch A executes and B is skipped.
 2. **Given** `if` with `Absent`, **When** condition does not hold, **Then** branch B executes.
 
+### User Story 4 - Loop Control (Priority: P2)
+
+As an Operator, I declare `break` or `continue` within a loop to control execution.
+
+**Why this priority**: Provides precise control during iteration without altering conditions.
+
+**Independent Test**: Configure a loop with `continue` on a non-critical failure and `break` on a critical error; assert iteration counts and exit behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a loop with `continue` on a transient detection miss, **When** the miss occurs, **Then** the iteration skips remaining steps and proceeds to the next iteration.
+2. **Given** a loop with `break` on a critical condition, **When** the condition occurs, **Then** the loop exits immediately and subsequent steps do not run.
+
 ---
 
 [Add more user stories as needed, each with an assigned priority]
@@ -108,7 +121,7 @@ As an Operator, I define a condition referencing a detection target; if `Present
 - **FR-03**: Support `while` loops based on condition `Present`/`Absent` with cadence and safety bounds.
 - **FR-04**: Support `if` with optional `else` around step groups; condition sources align with detection gates.
 - **FR-05**: Require at least one safeguard (`timeoutMs` or `maxIterations`) per loop.
-- **FR-06**: Conditions support image/text targets with confidence threshold and optional region/language.
+- **FR-06**: Conditions support image/text targets, trigger status by `triggerId`, confidence threshold, and optional region/language.
 - **FR-07**: Polling cadence defaults to 100ms (configurable; bounds 50–5000ms).
 - **FR-08**: Record per-block metrics: `evaluations`, `iterations`, `branchTaken`, `durationMs`, `appliedDelayMs`.
 - **FR-09**: On condition timeout, set sequence status to `Failed` and stop execution.
@@ -118,12 +131,13 @@ As an Operator, I define a condition referencing a detection target; if `Present
 - **FR-13**: Emit structured logs for block start/end, condition checks, branch decisions, and loop iteration counts.
 - **FR-14**: Enforce bearer auth on non-health endpoints (`401` on missing/invalid token).
 - **FR-15**: Backward compatibility for sequences without blocks.
+- **FR-16**: Support loop control: `break` to exit the loop; `continue` to skip to the next iteration.
 
 ### Key Entities *(include if feature involves data)*
 
 - **Sequence**: Declarative container of steps and blocks.
 - **Block**: `repeatCount`, `repeatUntil`, `while`, `ifElse`; parameters include safeguards and cadence.
-- **Condition**: Target (`image`/`text`), `present`/`absent`, confidence threshold, optional region/language.
+- **Condition**: Target (`image`/`text`) or `triggerId`, `present`/`absent`, confidence threshold, optional region/language.
 - **Telemetry**: Iterations, evaluations, branch decisions, durations, applied delays, status per block.
 
 ## Success Criteria *(mandatory)*

--- a/specs/001-sequence-logic/spec.md
+++ b/specs/001-sequence-logic/spec.md
@@ -20,6 +20,12 @@ Loop control supports both `break` (exit loop) and `continue` (skip to next iter
 
 Conditions may reference image/text detection or trigger status by `triggerId`.
 
+## Clarifications
+
+### Session 2025-12-17
+
+- Q: For repeat-until/while loop iteration ordering, when is the condition evaluated relative to executing steps? → A: Check before steps; execute only if not satisfied.
+
 ## Actors
 - Operator: Authors sequences and reviews results.
 - Automation Client: Calls sequence endpoints to create and execute.
@@ -132,6 +138,7 @@ As an Operator, I declare `break` or `continue` within a loop to control executi
 - **FR-14**: Enforce bearer auth on non-health endpoints (`401` on missing/invalid token).
 - **FR-15**: Backward compatibility for sequences without blocks.
 - **FR-16**: Support loop control: `break` to exit the loop; `continue` to skip to the next iteration.
+- **FR-17**: Loop semantics (gate-first): For `repeatUntil` and `while`, evaluate the condition at the beginning of each iteration; if satisfied, exit the loop without executing steps for that iteration (no-op when already satisfied).
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/001-sequence-logic/spec.md
+++ b/specs/001-sequence-logic/spec.md
@@ -1,0 +1,141 @@
+# Sequence Logic Blocks (Loops & Conditionals)
+
+**Feature Branch**: `001-sequence-logic`  
+**Created**: 2025-12-17  
+**Status**: Draft  
+**Input**: Sequence blocks for loops and conditions: repeat steps N times, repeat until image/text detected, if/then/else; consider additional control blocks if needed
+
+## Overview
+Enable richer sequence orchestration using standard control blocks: repeat steps a fixed number of times, repeat-until a condition is met (e.g., image/text detection), and conditional branching (if/then/else). This expands existing Command Sequences into structured flows that can express retries, polling, and decision-making without custom code.
+
+## Assumptions
+- Conditions leverage existing detection capabilities (image/text) and trigger evaluation semantics.
+- Infinite loops are prevented via required safeguards (max iterations or timeout).
+- Blocks can group multiple steps and apply delays/gating within the group.
+- Execution results include per-block/per-step telemetry (iterations, condition outcomes, durations).
+
+[NEEDS CLARIFICATION: Should nested blocks be allowed, and if so, what maximum depth (e.g., up to 3 levels) to ensure readability and safety?]
+
+[NEEDS CLARIFICATION: Do we expose `break`/`continue` semantics to authors (e.g., break on error within loop) or keep loops strictly driven by count/condition?]
+
+[NEEDS CLARIFICATION: Beyond image/text, should conditional sources include trigger IDs, simple variables/state (e.g., last command result), or remain limited to detection gates for now?]
+
+## Actors
+- Operator: Authors sequences and reviews results.
+- Automation Client: Calls sequence endpoints to create and execute.
+- Service: Executes blocks, evaluates conditions, enforces timeouts/safety.
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Repeat N Times (Priority: P1)
+
+As an Operator, I define a block to run steps exactly `N` times.
+
+**Why this priority**: Fixed-count loops are foundational and widely used.
+
+**Independent Test**: Execute a sequence with `repeatCount: 3` over one step and assert exactly 3 executions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step and `repeatCount: 5`, **When** executing, **Then** the step runs 5 times.
+2. **Given** `repeatCount: 0`, **When** executing, **Then** the block is skipped and telemetry reflects 0 iterations.
+
+---
+
+### User Story 2 - Repeat Until Detected (Priority: P1)
+
+As an Operator, I define a block that polls image/text presence until success or timeout.
+
+**Why this priority**: Poll-until-success is critical for UI readiness gates.
+
+**Independent Test**: Execute until an image appears; assert stop-on-success. Inject absence to assert timeout fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** `repeatUntil` on `image: Present`, **When** detection succeeds, **Then** the loop exits and the next step runs.
+2. **Given** `repeatUntil` with `timeoutMs: 2000`, **When** detection fails within timeout, **Then** sequence status is `Failed`.
+
+---
+
+### User Story 3 - If/Then/Else Branch (Priority: P2)
+
+As an Operator, I define a condition referencing a detection target; if `Present`, run branch A else branch B.
+
+**Why this priority**: Decision-making enables divergent flows without code.
+
+**Independent Test**: Mock present/absent outcomes and assert the chosen branch.
+
+**Acceptance Scenarios**:
+
+1. **Given** `if` with `Present`, **When** condition holds, **Then** branch A executes and B is skipped.
+2. **Given** `if` with `Absent`, **When** condition does not hold, **Then** branch B executes.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+- Loop with both `maxIterations` and `timeoutMs`: ensure stop occurs on first safeguard hit.
+- Cadence too low/high: enforce bounds and return validation error on out-of-range.
+- Condition flip-flop: ensure `while` exits correctly and does not oscillate.
+- Nested blocks (if supported): ensure clear evaluation order and result aggregation.
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-01**: Support `repeatCount` loops over a group of steps; executes exactly N iterations.
+- **FR-02**: Support `repeatUntil` loops that evaluate a condition at a fixed cadence until success or timeout.
+- **FR-03**: Support `while` loops based on condition `Present`/`Absent` with cadence and safety bounds.
+- **FR-04**: Support `if` with optional `else` around step groups; condition sources align with detection gates.
+- **FR-05**: Require at least one safeguard (`timeoutMs` or `maxIterations`) per loop.
+- **FR-06**: Conditions support image/text targets with confidence threshold and optional region/language.
+- **FR-07**: Polling cadence defaults to 100ms (configurable; bounds 50–5000ms).
+- **FR-08**: Record per-block metrics: `evaluations`, `iterations`, `branchTaken`, `durationMs`, `appliedDelayMs`.
+- **FR-09**: On condition timeout, set sequence status to `Failed` and stop execution.
+- **FR-10**: Delay precedence: `delayRangeMs` overrides `delayMs` when present.
+- **FR-11**: Validate and persist blocks via API; invalid configs return `400` with reason codes.
+- **FR-12**: Execute blocks deterministically per declared order; results conform to contracts.
+- **FR-13**: Emit structured logs for block start/end, condition checks, branch decisions, and loop iteration counts.
+- **FR-14**: Enforce bearer auth on non-health endpoints (`401` on missing/invalid token).
+- **FR-15**: Backward compatibility for sequences without blocks.
+
+### Key Entities *(include if feature involves data)*
+
+- **Sequence**: Declarative container of steps and blocks.
+- **Block**: `repeatCount`, `repeatUntil`, `while`, `ifElse`; parameters include safeguards and cadence.
+- **Condition**: Target (`image`/`text`), `present`/`absent`, confidence threshold, optional region/language.
+- **Telemetry**: Iterations, evaluations, branch decisions, durations, applied delays, status per block.
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-01**: Authors complete a tutorial to create loop/conditional sequences in under 30 minutes.
+- **SC-02**: 95% of executions produce correct branch/loop counts across 100-run tests.
+- **SC-03**: Typical loop exits occur within configured timeout windows and cadence; no unbounded loops.
+- **SC-04**: Validation prevents invalid configurations; error messages enable correction within 1 iteration.

--- a/specs/001-sequence-logic/spec.md
+++ b/specs/001-sequence-logic/spec.md
@@ -26,6 +26,7 @@ Conditions may reference image/text detection or trigger status by `triggerId`.
 
 - Q: For repeat-until/while loop iteration ordering, when is the condition evaluated relative to executing steps? → A: Check before steps; execute only if not satisfied.
 - Q: When should `breakOn`/`continueOn` be evaluated within loop iterations? → A: Evaluate at start and between steps; `breakOn` at start or between steps; `continueOn` only between steps.
+- Q: What telemetry granularity should loops capture? → A: Compact per-iteration summaries: index, decision (normal/break/continue), duration.
 
 ## Actors
 - Operator: Authors sequences and reviews results.
@@ -141,6 +142,7 @@ As an Operator, I declare `break` or `continue` within a loop to control executi
 - **FR-16**: Support loop control: `break` to exit the loop; `continue` to skip to the next iteration.
 - **FR-17**: Loop semantics (gate-first): For `repeatUntil` and `while`, evaluate the condition at the beginning of each iteration; if satisfied, exit the loop without executing steps for that iteration (no-op when already satisfied).
 - **FR-18**: Loop control evaluation order: Evaluate `breakOn` at the start of each iteration and between steps; evaluate `continueOn` only between steps to skip remaining steps in the current iteration and proceed to the next.
+- **FR-19**: Telemetry detail: Emit compact per-iteration summaries for loop blocks including `iterationIndex`, `decision` ("normal" | "break" | "continue"), and `durationMs`; avoid full per-step, per-iteration payloads by default.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/001-sequence-logic/tasks.md
+++ b/specs/001-sequence-logic/tasks.md
@@ -1,0 +1,83 @@
+# Tasks — Sequence Logic Blocks (Loops & Conditionals)
+
+Feature: Sequence Logic Blocks (Loops & Conditionals)
+Branch: 001-sequence-logic
+
+## Phase 1: Setup
+
+- [ ] T001 Create domain folders for blocks and conditions in src/GameBot.Domain/Commands/Blocks
+- [ ] T002 [P] Create service DTO stubs for blocks in src/GameBot.Service/Contracts/Sequences
+
+## Phase 2: Foundational
+
+- [ ] T003 Define `Block` union (`repeatCount`,`repeatUntil`,`while`,`ifElse`) in src/GameBot.Domain/Commands/Blocks/Block.cs
+- [ ] T004 Define `Condition` and `BlockResult` types in src/GameBot.Domain/Commands/Blocks/Condition.cs and src/GameBot.Domain/Commands/Blocks/BlockResult.cs
+- [ ] T005 Extend `CommandSequence` with `blocks` and serialization in src/GameBot.Domain/Commands/CommandSequence.cs
+- [ ] T006 Persist `blocks` in repository load/save in src/GameBot.Domain/Commands/Repositories/SequenceRepository.cs
+- [ ] T007 Add API model binding + validation for `blocks` in src/GameBot.Service/Program.cs
+
+## Phase 3: User Story 1 — Repeat N Times (P1)
+
+- Story Goal: Execute grouped steps exactly N iterations.
+- Independent Test Criteria: A sequence with `repeatCount: 3` runs the step group three times; `repeatCount: 0` skips and records 0 iterations.
+
+- [ ] T008 [US1] Implement `repeatCount` execution in src/GameBot.Domain/Services/SequenceRunner.cs
+- [ ] T009 [P] [US1] Validate `repeatCount >= 0` and reject negative in src/GameBot.Service/Program.cs
+- [ ] T010 [US1] Capture `iterations` and `durationMs` telemetry per block in src/GameBot.Domain/Services/SequenceRunner.cs
+
+## Phase 4: User Story 2 — Repeat Until Detected (P1)
+
+- Story Goal: Poll condition (image/text/trigger) until success or timeout.
+- Independent Test Criteria: Stop-on-success when detection meets `Present`; timeout causes `Failed` status.
+
+- [ ] T011 [US2] Implement `repeatUntil` with `timeoutMs` and `cadenceMs` in src/GameBot.Domain/Services/SequenceRunner.cs
+- [ ] T012 [P] [US2] Integrate detection/trigger evaluation services in src/GameBot.Domain/Services/TriggerEvaluationService.cs
+- [ ] T013 [US2] On timeout, mark sequence `Failed` and exit early in src/GameBot.Domain/Services/SequenceRunner.cs
+
+## Phase 5: User Story 3 — If/Then/Else Branch (P2)
+
+- Story Goal: Execute then/else branches based on condition outcome.
+- Independent Test Criteria: Present → then branch only; Absent → else branch only.
+
+- [ ] T014 [US3] Implement `ifElse` branching in src/GameBot.Domain/Services/SequenceRunner.cs
+- [ ] T015 [P] [US3] Validate `elseSteps` only allowed for `ifElse` in src/GameBot.Service/Program.cs
+- [ ] T016 [US3] Record `branchTaken` and timings in src/GameBot.Domain/Services/SequenceRunner.cs
+
+## Phase 6: User Story 4 — Loop Control (P2)
+
+- Story Goal: Support `break` and `continue` within loops for precise control.
+- Independent Test Criteria: `continue` skips remaining steps this iteration; `break` exits loop immediately.
+
+- [ ] T017 [US4] Implement `breakOn` evaluation in src/GameBot.Domain/Services/SequenceRunner.cs
+- [ ] T018 [P] [US4] Implement `continueOn` evaluation in src/GameBot.Domain/Services/SequenceRunner.cs
+- [ ] T019 [US4] Telemetry for control decisions and iteration counts in src/GameBot.Domain/Services/SequenceRunner.cs
+
+## Final Phase: Polish & Cross-Cutting
+
+- [ ] T020 [P] Add LoggerMessage events for block start/end, evaluations, and decisions in src/GameBot.Domain/Services/SequenceRunner.cs
+- [ ] T021 Ensure backward compatibility for sequences without `blocks` in src/GameBot.Domain/Services/SequenceRunner.cs
+- [ ] T022 [P] Refresh contracts doc with examples in specs/001-sequence-logic/contracts/sequences-blocks.md
+
+## Dependencies (Story Order)
+
+- US1 (Repeat N) → US2 (Repeat Until) → US3 (If/Else) → US4 (Loop Control)
+- Foundational tasks must complete before any user story tasks.
+
+## Parallel Execution Examples
+
+- US1: T009 (validation) can run in parallel with T008 (runner) since files differ.
+- US2: T012 (service integration) can run in parallel with T011 (runner loop).
+- US3: T015 (validation) can run in parallel with T014 (branch logic).
+- US4: T018 (continue) can run in parallel with T017 (break) within separate implementations.
+- Polish: T020 (logging) can run in parallel with T022 (docs).
+
+## Implementation Strategy
+
+- MVP: Deliver US1 only (Repeat N Times) after Foundational; independently testable and valuable.
+- Incremental: Add US2, then US3, then US4; validate at each phase with independent criteria.
+- Safeguards: Enforce `timeoutMs`/`maxIterations`, cadence bounds, and clear validation messages.
+
+## Format Validation
+
+- All tasks use required checklist format with IDs and file paths.
+- Story-specific tasks include `[US#]` labels; parallelizable tasks include `[P]` markers.


### PR DESCRIPTION
Adds specs/001-sequence-logic/quickstart.md with setup, examples (repeatCount, repeatUntil, ifElse, loop control), and run instructions. No runtime/code changes. Also aligns with existing planning artifacts in specs/001-sequence-logic.