### PR TITLE
Semantic Actions UI: perf probes, docs, and completion

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,5 +74,6 @@ Common commands and expected duration:
 
 ### GitHub Client Usage
 When interacting with GitHub repositories:
+- use git CLI for low-level operations like commits, branches, and pushes
 - use gh CLI for operations like cloning, creating branches, and managing pull requests
 <!-- MANUAL ADDITIONS END -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,8 @@ Coding style: Follow standard .NET 9 C# conventions
 
 
 ### Terminal Reuse & No-Close Policy
+- When performing multi-step operations, retain terminal state between commands to preserve context.
+- Avoid closing the terminal session unless explicitly required by the operation.
 
 ## Terminal Command Guidelines
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,11 @@ tests/
 
 ## Commands
 
+## Development environment
+- Development is done on Windows, using Visual Studio Code
+- Don't use Linux/WSL commands for development, as some dependencies (ADB, Tesseract, System.Drawing) are Windows-specific
+- Always use powershell commands and syntax in scripts and documentation
+
 # Add commands for .NET 9 C#
 
 ## Test Failure Analysis

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-05
 - File-backed JSON under `data/commands/sequences` (001-sequence-logic)
 - TypeScript (ES2020), React 18 + React, React DOM, Vite, @vitejs/plugin-react (001-authoring-crud-ui)
 - None client-side (in-memory state); persistence via backend API (001-authoring-crud-ui)
+- TypeScript (ES2020) + React 18 (Vite 5) + React, Vite toolchain, existing GameBot Service API (action types/actions) (001-semantic-actions-ui)
+- No new client persistence; uses backend for actions. Client state is in-memory form state. (001-semantic-actions-ui)
 
 - .NET 9 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
 
@@ -44,9 +46,9 @@ After running `dotnet test -c Debug --logger trx;`, execute `scripts/analyze-tes
 Coding style: Follow standard .NET 9 C# conventions
 
 ## Recent Changes
+- 001-semantic-actions-ui: Added TypeScript (ES2020) + React 18 (Vite 5) + React, Vite toolchain, existing GameBot Service API (action types/actions)
 - 001-authoring-crud-ui: Added TypeScript (ES2020), React 18 + React, React DOM, Vite, @vitejs/plugin-react
 - 001-web-ui-authoring: Added TypeScript (ES2020), React 18, Vite 5 + React, Vite, @vitejs/plugin-react
-- 001-sequence-logic: Added C# / .NET 9 + Existing detection (OpenCV image-match), OCR (Tesseract), trigger evaluation services
 
 
 <!-- MANUAL ADDITIONS START -->
@@ -54,9 +56,6 @@ Coding style: Follow standard .NET 9 C# conventions
 
 
 ### Terminal Reuse & No-Close Policy
-- always wait for the command to complete without user intervention
-- do not close the terminal unless explicitly instructed by the user
-- reuse the terminal for multiple commands to maintain context
 
 ## Terminal Command Guidelines
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Atomic, file-backed executable units (e.g., a tap sequence or composite of low-l
 - Create: `POST /actions` → body includes a name and action definition (input steps).
 - Execute against a session: `POST /sessions/{id}/execute-action?actionId={actionId}` → `{ accepted }`.
 
+Built-in action types (served by `/api/action-types` and executed by `SessionManager`):
+- `tap`: required `x`, `y` (0–5000); optional `mode` (`fast`/`slow`).
+- `swipe`: required `x1`, `y1`, `x2`, `y2` (0–5000); optional `durationMs` (0–5000).
+- `key`: required `key` (symbolic name such as HOME, BACK, ESCAPE, ENTER, A–Z); optional `keyCode` (numeric Android key code).
+
 Example action definition (simplified):
 ```json
 {

--- a/specs/001-semantic-actions-ui/checklists/requirements.md
+++ b/specs/001-semantic-actions-ui/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Semantic Actions UI
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-27
+**Feature**: [specs/001-semantic-actions-ui/spec.md](specs/001-semantic-actions-ui/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items now pass; clarifications resolved per user choices (backend authoritative source, no invalid draft saves, preview out of scope this release).

--- a/specs/001-semantic-actions-ui/contracts/actions.openapi.yaml
+++ b/specs/001-semantic-actions-ui/contracts/actions.openapi.yaml
@@ -1,0 +1,268 @@
+openapi: 3.0.3
+info:
+  title: Semantic Actions API
+  version: "0.1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /action-types:
+    get:
+      summary: List action types and attribute definitions
+      responses:
+        '200':
+          description: Action type catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ActionType'
+  /action-types/{key}:
+    get:
+      summary: Get a specific action type definition
+      parameters:
+        - in: path
+          name: key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Action type definition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionType'
+        '404':
+          description: Not found
+  /actions:
+    get:
+      summary: List actions
+      parameters:
+        - in: query
+          name: type
+          schema:
+            type: string
+            description: Filter by action type key
+      responses:
+        '200':
+          description: Action list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Action'
+    post:
+      summary: Create an action
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActionCreate'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Action'
+        '400':
+          description: Validation failed
+  /actions/{id}:
+    get:
+      summary: Get an action
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Action
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Action'
+        '404':
+          description: Not found
+    put:
+      summary: Update an action
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActionUpdate'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Action'
+        '400':
+          description: Validation failed
+        '404':
+          description: Not found
+  /actions/{id}/duplicate:
+    post:
+      summary: Duplicate an existing action
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Duplicated action
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Action'
+        '404':
+          description: Not found
+  /actions/validate:
+    post:
+      summary: Validate an action payload without persisting
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActionCreate'
+      responses:
+        '200':
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResult'
+        '400':
+          description: Invalid request
+components:
+  schemas:
+    ActionType:
+      type: object
+      required: [key, displayName, version, attributeDefinitions]
+      properties:
+        key:
+          type: string
+        displayName:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+        attributeDefinitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttributeDefinition'
+    AttributeDefinition:
+      type: object
+      required: [key, label, dataType]
+      properties:
+        key:
+          type: string
+        label:
+          type: string
+        dataType:
+          type: string
+          enum: [string, number, boolean, enum]
+        required:
+          type: boolean
+          default: false
+        constraints:
+          type: object
+          properties:
+            min:
+              type: number
+            max:
+              type: number
+            pattern:
+              type: string
+            allowedValues:
+              type: array
+              items:
+                type: string
+            defaultValue:
+              nullable: true
+        helpText:
+          type: string
+    Action:
+      type: object
+      required: [id, name, type, attributes]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          additionalProperties: true
+        validationStatus:
+          type: string
+          enum: [valid, invalid]
+        validationMessages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationMessage'
+        createdBy:
+          type: string
+        updatedBy:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+    ActionCreate:
+      type: object
+      required: [name, type, attributes]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          additionalProperties: true
+    ActionUpdate:
+      allOf:
+        - $ref: '#/components/schemas/ActionCreate'
+      required: [name, type, attributes]
+    ValidationResult:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [valid, invalid]
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationMessage'
+    ValidationMessage:
+      type: object
+      required: [field, message]
+      properties:
+        field:
+          type: string
+        severity:
+          type: string
+          enum: [error, warning]
+        message:
+          type: string

--- a/specs/001-semantic-actions-ui/data-model.md
+++ b/specs/001-semantic-actions-ui/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Semantic Actions UI
+
+**Feature**: [specs/001-semantic-actions-ui/spec.md](specs/001-semantic-actions-ui/spec.md)  
+**Date**: 2025-12-27
+
+## Entities
+
+### Action
+- **id**: unique identifier
+- **name**: display name shown in UI lists
+- **type**: reference to ActionType key
+- **attributes**: map of `key -> value` constrained by the selected ActionType’s AttributeDefinitions
+- **validationStatus**: enum { valid, invalid }
+- **validationMessages**: array of field-level issues (key, message)
+- **createdBy / updatedBy**: audit fields
+- **updatedAt**: timestamp for concurrency hints
+
+### ActionType
+- **key**: unique type identifier
+- **displayName**: user-facing name
+- **description**: short description of intent
+- **version**: schema version for compatibility checks
+- **attributeDefinitions**: ordered collection of AttributeDefinition entries
+
+### AttributeDefinition
+- **key**: machine-readable attribute name
+- **label**: user-facing label
+- **dataType**: enum { string, number, boolean, enum }
+- **required**: boolean
+- **constraints**: optional range (min, max), pattern (regex), allowedValues (for enum), defaultValue
+- **helpText**: guidance shown in UI
+
+### ValidationMessage
+- **field**: attribute key or general
+- **severity**: enum { error, warning }
+- **message**: user-facing guidance
+
+## Relationships
+- `Action.type` references `ActionType.key`.
+- `Action.attributes` keys must correspond to the selected `ActionType.attributeDefinitions.key` set.
+- Validation results are derived from comparing `Action.attributes` against `AttributeDefinition` constraints.
+
+## Derived/Behavioral Notes
+- Switching `Action.type` triggers compatibility checks: attributes with matching keys and compatible data types are retained; others require discard confirmation.
+- Attribute rendering is driven by `AttributeDefinition` (dataType → control; constraints → validation logic).
+- Validation occurs client-side before save and must align with backend rules sourced from the authoritative schema.

--- a/specs/001-semantic-actions-ui/plan.md
+++ b/specs/001-semantic-actions-ui/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Semantic Actions UI
+
+**Branch**: `[001-semantic-actions-ui]` | **Date**: 2025-12-27 | **Spec**: [specs/001-semantic-actions-ui/spec.md](specs/001-semantic-actions-ui/spec.md)
+**Input**: Feature specification from `/specs/001-semantic-actions-ui/spec.md`
+
+## Summary
+
+- Deliver a semantic, form-based UI for authoring actions without JSON, driven by backend action-type definitions.
+- Client-side validation mirrors backend rules; invalid actions cannot be saved (no draft saves). Real-time preview is out of scope.
+- Scope covers create, edit (with type-change safeguards), duplicate, a11y basics, and performance budgets defined in research.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2020) + React 18 (Vite 5)  
+**Primary Dependencies**: React, Vite toolchain, existing GameBot Service API (action types/actions)  
+**Storage**: No new client persistence; uses backend for actions. Client state is in-memory form state.  
+**Testing**: Vitest + React Testing Library for UI; existing backend tests remain via xUnit.  
+**Target Platform**: Web (desktop browsers); development on Windows.  
+**Project Type**: Web (frontend consuming backend API).  
+**Performance Goals**: Action-type fetch p95 < 1s; initial form render p95 < 1s; validation feedback perceived < 100ms; filtering 200 actions < 300ms.  
+**Constraints**: Must source action-type catalog dynamically from backend; block invalid saves (no drafts with errors); no real-time preview in this release; maintain accessibility (labels, keyboard navigation, contrast).  
+**Scale/Scope**: Tens to hundreds of actions; per action up to dozens of attributes per type; single authoring surface.
+
+## Constitution Check
+
+- **Code Quality**: Reuse existing lint/format; keep UI components cohesive and small; avoid new deps unless justified; security scanning per repo defaults.  
+- **Testing**: Unit tests for form rendering/validation; integration/e2e for create/edit/duplicate; maintain ≥80% line / ≥70% branch coverage on touched code; deterministic fixtures for backend definitions.  
+- **UX Consistency**: Actionable labels/help/error copy; confirmation on type change; avoid raw JSON exposure; align with existing web-ui styling and navigation.  
+- **Performance**: Budgets declared above; measure with dev tools; avoid blocking network calls on render; cache definitions with short TTL.
+
+Gate status: pass (no violations requiring exceptions).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-semantic-actions-ui/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── tasks.md (Phase 2, created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── src/GameBot.Service
+└── tests/ (unit, integration)
+
+frontend/
+├── src/web-ui
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/ (unit via Vitest; e2e if present)
+```
+
+**Structure Decision**: Use existing backend (GameBot.Service) and frontend (web-ui) directories; no new top-level projects required.
+
+## Complexity Tracking
+
+No constitution violations; tracking not required.
+
+## Phase 0: Research
+- Completed; see [specs/001-semantic-actions-ui/research.md](specs/001-semantic-actions-ui/research.md).
+- Unknowns resolved: backend is authoritative catalog; client-side validation derived from definitions; type-change compatibility rules; performance budgets declared.
+
+## Phase 1: Design & Contracts
+- Data model: [specs/001-semantic-actions-ui/data-model.md](specs/001-semantic-actions-ui/data-model.md)
+- Contracts: [specs/001-semantic-actions-ui/contracts/actions.openapi.yaml](specs/001-semantic-actions-ui/contracts/actions.openapi.yaml)
+- Quickstart: [specs/001-semantic-actions-ui/quickstart.md](specs/001-semantic-actions-ui/quickstart.md)
+- Notes: Schema-driven UI; invalid draft saves blocked; preview out of scope this release.
+
+## Post-Design Constitution Check
+- **Code Quality**: Plan remains within gates; no new dependencies introduced yet.  
+- **Testing**: Unit + integration commitments align with coverage targets.  
+- **UX**: A11y and confirmation patterns included; no raw JSON exposure.  
+- **Performance**: Budgets defined; measurement approach noted.
+
+Gate status: pass.

--- a/specs/001-semantic-actions-ui/quickstart.md
+++ b/specs/001-semantic-actions-ui/quickstart.md
@@ -15,6 +15,8 @@
 ```
 - Ensure the service exposes the action-type catalog endpoint (per contracts) for the UI to render forms.
 
+If you are using a non-default port, export `VITE_API_BASE_URL` in `src/web-ui/.env.local` (copy from `.env.local.example`).
+
 ## Run the web UI
 ```powershell
 # From repo root
@@ -25,10 +27,14 @@
 - The UI should fetch action types from the backend on load; confirm ports match the service configuration.
 
 ## Validate the flow
-1. Load the UI, create an action by selecting a type and filling required attributes. Saving should succeed only when validation passes.
-2. Edit an existing action: change type, observe the confirmation before incompatible attributes are dropped.
-3. Duplicate an action and save the duplicate after validation.
-4. Confirm validation feedback appears immediately for bad inputs (ranges, formats, enums, required fields).
+1. Load the UI and set the API base URL if the backend is not same-origin.
+2. Create an action: select a **Game** (required), pick an **Action Type** (tap, swipe, key), and fill required attributes. Saving should succeed only when validation passes.
+3. Edit an existing action: change type, observe the confirmation before incompatible attributes are dropped.
+4. Duplicate an action from the list, adjust fields, and save the duplicate after validation.
+5. Filter actions by game and type in the list to confirm the browse experience.
+6. Confirm validation feedback appears immediately for bad inputs (ranges, formats, enums, required fields).
+
+Perf instrumentation: open the browser console to see `[perf] action-types.fetch` and `[perf] action-form.render` timings when definitions load and the form renders.
 
 ## Testing
 ```powershell

--- a/specs/001-semantic-actions-ui/quickstart.md
+++ b/specs/001-semantic-actions-ui/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Semantic Actions UI
+
+**Branch**: 001-semantic-actions-ui  
+**Spec**: [specs/001-semantic-actions-ui/spec.md](specs/001-semantic-actions-ui/spec.md)
+
+## Prerequisites
+- Node.js 18+
+- .NET SDK 9 (for the existing GameBot.Service backend)
+- npm (bundled with Node)
+
+## Run the backend (action definitions + persistence)
+```powershell
+# From repo root
+ dotnet run -c Debug --project src/GameBot.Service
+```
+- Ensure the service exposes the action-type catalog endpoint (per contracts) for the UI to render forms.
+
+## Run the web UI
+```powershell
+# From repo root
+ cd src/web-ui
+ npm install
+ npm run dev
+```
+- The UI should fetch action types from the backend on load; confirm ports match the service configuration.
+
+## Validate the flow
+1. Load the UI, create an action by selecting a type and filling required attributes. Saving should succeed only when validation passes.
+2. Edit an existing action: change type, observe the confirmation before incompatible attributes are dropped.
+3. Duplicate an action and save the duplicate after validation.
+4. Confirm validation feedback appears immediately for bad inputs (ranges, formats, enums, required fields).
+
+## Testing
+```powershell
+# Frontend tests (Vitest / React Testing Library if configured in package.json)
+ cd src/web-ui
+ npm test
+
+# Backend tests
+ dotnet test -c Debug
+```
+- Target coverage: ≥80% line, ≥70% branch for touched areas per constitution.
+
+## Artifacts
+- Plan: [specs/001-semantic-actions-ui/plan.md](specs/001-semantic-actions-ui/plan.md)
+- Research: [specs/001-semantic-actions-ui/research.md](specs/001-semantic-actions-ui/research.md)
+- Data model: [specs/001-semantic-actions-ui/data-model.md](specs/001-semantic-actions-ui/data-model.md)
+- Contracts: [specs/001-semantic-actions-ui/contracts/actions.openapi.yaml](specs/001-semantic-actions-ui/contracts/actions.openapi.yaml)

--- a/specs/001-semantic-actions-ui/research.md
+++ b/specs/001-semantic-actions-ui/research.md
@@ -1,0 +1,26 @@
+# Research: Semantic Actions UI
+
+**Date**: 2025-12-27  
+**Feature**: [specs/001-semantic-actions-ui/spec.md](specs/001-semantic-actions-ui/spec.md)
+
+## Findings
+
+- **Decision: Use backend as the authoritative catalog for action types and attribute definitions (fetched on load, cache 5 minutes with ETag/Last-Modified).**  
+  **Rationale**: Keeps UI aligned with server-supported types, avoids client drift, and simplifies updating validation rules. Short cache minimizes stale definitions while limiting redundant fetches.  
+  **Alternatives considered**: Client-managed config file (risk of drift, requires deployments to update); hybrid offline cache with manual refresh (adds UX complexity without a current offline requirement).
+
+- **Decision: Derive client-side validation and form rendering directly from the fetched definitions, mirroring server rules.**  
+  **Rationale**: Ensures parity with backend validation, supports type-specific fields, and blocks invalid saves per spec. Mapping types to controls (text/number/boolean/enum) keeps UX predictable; pattern/range enforcement comes from definitions.  
+  **Alternatives considered**: Hard-coded per-type forms (fragile to backend changes); server-only validation (hurts UX, round trips for simple errors).
+
+- **Decision: Handle action-type changes by preserving only compatible attributes (same key and compatible data type) and requiring confirmation before discarding incompatible attributes.**  
+  **Rationale**: Aligns with spec safeguards, protects user input, and keeps resulting action valid under the new type.  
+  **Alternatives considered**: Blindly drop all attributes on type change (too destructive); always keep all attributes (risks invalid payloads and silent errors).
+
+- **Decision: UX/performance budgets—definition fetch p95 < 1s, initial form render p95 < 1s, validation feedback < 100ms perceived instant, list view of 200 actions filters within < 300ms.**  
+  **Rationale**: Keeps the experience responsive for authoring workflows and meets constitution’s performance declaration requirement.  
+  **Alternatives considered**: No explicit budgets (fails constitution gate); stricter budgets (<500ms for all) not justified by current scale.
+
+## Open Items
+
+- None. All prior clarifications resolved in spec.

--- a/specs/001-semantic-actions-ui/spec.md
+++ b/specs/001-semantic-actions-ui/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Semantic Actions UI
+
+**Feature Branch**: `[001-semantic-actions-ui]`  
+**Created**: 2025-12-27  
+**Status**: Draft  
+**Input**: User description: "Semantic UI for Actions. I need UI to be intelligent and to support the action types that the API supports. The user should be able to specify all supported actions and their attributes that differ, depending on action type, without having to enter JSON. The attribute values should be validated."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Create a valid action without JSON (Priority: P1)
+
+Users select an action type from a list of supported types, see contextual fields that match that type, enter attributes with guidance, and save a valid action without touching raw JSON.
+
+**Why this priority**: This is the core value—enables non-technical users to author actions successfully and quickly.
+
+**Independent Test**: A tester can create a brand-new action end-to-end by selecting a type, completing fields, and saving successfully; no other features are required.
+
+**Acceptance Scenarios**:
+
+1. **Given** no existing actions, **When** the user selects an action type and completes all required attributes with valid values, **Then** the system confirms the action is valid and saves it.
+2. **Given** the user enters an out-of-range or wrong-format value, **When** they attempt to save, **Then** the UI blocks saving and presents clear, field-specific validation guidance.
+
+---
+
+### User Story 2 - Edit an existing action safely (Priority: P2)
+
+Users open an existing action, update attributes, optionally change the action type, and save changes with safeguards (e.g., confirmation when type change discards incompatible attributes).
+
+**Why this priority**: Editing is essential for iteration; safeguards prevent accidental data loss and invalid states.
+
+**Independent Test**: A tester can open an existing action, make valid and invalid edits, observe validation behavior, and save successfully when valid.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing action, **When** the user updates attributes with valid inputs, **Then** the system validates and saves changes.
+2. **Given** an existing action with filled attributes, **When** the user changes the type to one with different attributes, **Then** the UI warns about incompatible attributes and requires explicit confirmation before proceeding.
+
+---
+
+### User Story 3 - Browse and duplicate actions (Priority: P3)
+
+Users view a list of actions, filter by type, and duplicate an action to accelerate authoring.
+
+**Why this priority**: Improves efficiency and discoverability; duplication reduces repetitive manual entry.
+
+**Independent Test**: A tester can filter actions, select one, duplicate it, and save the duplicate after minimal edits.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple actions exist, **When** the user filters by a specific type, **Then** only actions of that type are shown.
+2. **Given** an action is selected, **When** the user chooses Duplicate, **Then** a new unsaved action is created with identical attributes and can be saved after validation.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+- Switching action type after entering attributes: incompatible attributes are discarded only after explicit confirmation; compatible attributes are retained.
+- Required attribute missing: saving is blocked with clear, inline error messages and guidance.
+- Numeric attributes: reject non-numeric input and out-of-range values with precise messages (show allowed ranges).
+- Enumerated attributes: only allow values from defined sets; show friendly labels.
+- Unknown/unsupported action type appears (e.g., backend adds a new type not yet recognized): the UI gracefully prevents selection and instructs users to update definitions.
+- Very large attribute payloads: UI remains responsive; validation completes under reasonable time constraints (see Success Criteria).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The UI MUST present a list of supported action types to the user and allow selecting exactly one type for an action.
+- **FR-002**: The UI MUST render contextual attribute fields based on the selected action type and hide fields irrelevant to that type.
+- **FR-003**: The UI MUST validate attribute values client-side before save: requiredness, allowed ranges, formats, and enumerations must be enforced.
+- **FR-004**: The UI MUST display clear, field-level error messages and guidance when validation fails, preventing ambiguous or generic errors.
+- **FR-005**: The UI MUST block saving when any required attribute is invalid or missing; draft saves are not supported for invalid actions.
+- **FR-006**: On action type change, the UI MUST warn users if any existing attributes will be discarded and require explicit confirmation to proceed.
+- **FR-007**: The system MUST source the catalog of supported action types and their attribute definitions dynamically from the backend as the single authoritative source.
+- **FR-008**: The UI MUST enable editing of existing actions with the same validation guarantees as creation.
+- **FR-009**: The UI SHOULD provide duplication of an existing action to accelerate authoring, with independent validation on the duplicate.
+- **FR-010**: The UI MUST ensure accessibility basics (clear labels, keyboard navigation, readable contrast) so that users can complete authoring without mouse-only interactions.
+- **FR-011**: Real-time preview/simulation is out of scope for this release; authoring focuses on validated form-based entry.
+
+Assumptions: Users are non-technical authors who prefer forms over raw JSON. All validation rules (requiredness, ranges, formats, enums) are available from an authoritative definition. Saving writes through existing backend flows; this spec focuses on user value, not implementation details.
+
+### Key Entities *(include if feature involves data)*
+
+- **Action**: Represents a user-authored instruction; attributes: identifier, display name, `type`, `attributes` (key-value pairs governed by type definition), validation status (valid/invalid with messages).
+- **Attribute Definition**: Describes a single attribute for a given action type; includes label, data type (text, number, boolean, enum), constraints (required, range, pattern, allowed values), help text.
+- **Action Type**: The category of action; defines the set of attribute definitions and any inter-attribute constraints.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: First-time users can create and save a valid action in under 60 seconds.
+- **SC-002**: 90% of users successfully complete action creation on their first attempt.
+- **SC-003**: 100% of invalid attribute inputs are caught before save, with clear guidance enabling correction.
+- **SC-004**: Reduce support requests related to “JSON authoring” by 80% within one release cycle.
+- **SC-005**: Validation feedback appears instantly (perceived as immediate) and does not block normal typing or selection.

--- a/specs/001-semantic-actions-ui/tasks.md
+++ b/specs/001-semantic-actions-ui/tasks.md
@@ -62,12 +62,12 @@ Goal: Allow editing existing actions with safeguards when changing types.
 Independent Test: Tester opens an action, edits values, optionally changes type, confirms discard prompt for incompatible fields, and saves successfully when valid.
 
 ### Tests for User Story 2
-- [ ] T016 [P] [US2] Add edit flow tests (load existing action, type change confirmation, save) in src/web-ui/src/pages/actions/__tests__/EditActionPage.spec.tsx
+- [x] T016 [P] [US2] Add edit flow tests (load existing action, type change confirmation, save) in src/web-ui/src/pages/actions/__tests__/EditActionPage.spec.tsx
 
 ### Implementation for User Story 2
-- [ ] T017 [US2] Load existing action data and populate form in src/web-ui/src/pages/actions/EditActionPage.tsx using actionsApi.get
-- [ ] T018 [US2] Implement type-change compatibility check and confirmation modal in src/web-ui/src/components/actions/ActionForm.tsx
-- [ ] T019 [US2] Add update submission via PUT /actions/{id} with success/error handling in src/web-ui/src/pages/actions/EditActionPage.tsx and src/web-ui/src/services/actionsApi.ts
+- [x] T017 [US2] Load existing action data and populate form in src/web-ui/src/pages/actions/EditActionPage.tsx using actionsApi.get
+- [x] T018 [US2] Implement type-change compatibility check and confirmation modal in src/web-ui/src/components/actions/ActionForm.tsx
+- [x] T019 [US2] Add update submission via PUT /actions/{id} with success/error handling in src/web-ui/src/pages/actions/EditActionPage.tsx and src/web-ui/src/services/actionsApi.ts
 
 **Checkpoint**: User Story 2 independently testable (edit + type-change safeguards).
 
@@ -79,12 +79,12 @@ Goal: Let users browse/filter actions and duplicate an action to accelerate auth
 Independent Test: Tester filters list by type, selects an action, duplicates it, and saves the duplicate after validation.
 
 ### Tests for User Story 3
-- [ ] T020 [P] [US3] Add list filtering and duplicate-flow tests in src/web-ui/src/pages/actions/__tests__/ActionsListPage.spec.tsx
+- [x] T020 [P] [US3] Add list filtering and duplicate-flow tests in src/web-ui/src/pages/actions/__tests__/ActionsListPage.spec.tsx
 
 ### Implementation for User Story 3
-- [ ] T021 [US3] Implement actions list view with type filter and empty/error states in src/web-ui/src/pages/actions/ActionsListPage.tsx
-- [ ] T022 [US3] Wire duplicate action call POST /actions/{id}/duplicate in src/web-ui/src/services/actionsApi.ts and UI trigger in ActionsListPage.tsx
-- [ ] T023 [US3] Support create-from-duplicate prefilled form handoff in src/web-ui/src/pages/actions/CreateActionPage.tsx
+- [x] T021 [US3] Implement actions list view with type filter and empty/error states in src/web-ui/src/pages/actions/ActionsListPage.tsx
+- [x] T022 [US3] Wire duplicate action call POST /actions/{id}/duplicate in src/web-ui/src/services/actionsApi.ts and UI trigger in ActionsListPage.tsx
+- [x] T023 [US3] Support create-from-duplicate prefilled form handoff in src/web-ui/src/pages/actions/CreateActionPage.tsx
 
 **Checkpoint**: User Story 3 independently testable (browse/filter/duplicate flow).
 

--- a/specs/001-semantic-actions-ui/tasks.md
+++ b/specs/001-semantic-actions-ui/tasks.md
@@ -43,14 +43,14 @@ Goal: Enable users to create a valid action via forms without raw JSON.
 Independent Test: Tester creates a new action selecting a type, completing required fields, and saving successfully; invalid inputs block save with field-level errors.
 
 ### Tests for User Story 1
-- [ ] T010 [P] [US1] Add hook/component tests for action-type fetch/cache in src/web-ui/src/services/__tests__/useActionTypes.spec.ts
-- [ ] T011 [P] [US1] Add form rendering and validation tests for required/range/enum fields in src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
+- [x] T010 [P] [US1] Add hook/component tests for action-type fetch/cache in src/web-ui/src/services/__tests__/useActionTypes.spec.ts
+- [x] T011 [P] [US1] Add form rendering and validation tests for required/range/enum fields in src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
 
 ### Implementation for User Story 1
-- [ ] T012 [US1] Implement create action form submission using POST /actions in src/web-ui/src/components/actions/ActionForm.tsx
-- [ ] T013 [US1] Add create page wiring (load definitions, render form, success/error states) in src/web-ui/src/pages/actions/CreateActionPage.tsx
-- [ ] T014 [US1] Enforce client-side validation (requiredness, ranges, patterns, enums) with inline guidance in src/web-ui/src/components/actions/ActionForm.tsx
-- [ ] T015 [US1] Ensure accessibility (labels, keyboard navigation, focus on errors) and loading/error handling in src/web-ui/src/components/actions/ActionForm.tsx and src/web-ui/src/pages/actions/CreateActionPage.tsx
+- [x] T012 [US1] Implement create action form submission using POST /actions in src/web-ui/src/components/actions/ActionForm.tsx
+- [x] T013 [US1] Add create page wiring (load definitions, render form, success/error states) in src/web-ui/src/pages/actions/CreateActionPage.tsx
+- [x] T014 [US1] Enforce client-side validation (requiredness, ranges, patterns, enums) with inline guidance in src/web-ui/src/components/actions/ActionForm.tsx
+- [x] T015 [US1] Ensure accessibility (labels, keyboard navigation, focus on errors) and loading/error handling in src/web-ui/src/components/actions/ActionForm.tsx and src/web-ui/src/pages/actions/CreateActionPage.tsx
 
 **Checkpoint**: User Story 1 independently testable (create flow works, invalid inputs blocked, no JSON editing needed).
 

--- a/specs/001-semantic-actions-ui/tasks.md
+++ b/specs/001-semantic-actions-ui/tasks.md
@@ -92,9 +92,9 @@ Independent Test: Tester filters list by type, selects an action, duplicates it,
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T024 [P] Add lightweight perf logging/metrics around definition fetch and form render in src/web-ui/src/services/actionsApi.ts and src/web-ui/src/components/actions/ActionForm.tsx
-- [ ] T025 [P] Update documentation (quickstart and src/web-ui/README.md) for new flows and env config
-- [ ] T026 Run full test suites (npm test in src/web-ui, dotnet test -c Debug) and record coverage per constitution
+- [x] T024 [P] Add lightweight perf logging/metrics around definition fetch and form render in src/web-ui/src/services/actionsApi.ts and src/web-ui/src/components/actions/ActionForm.tsx
+- [x] T025 [P] Update documentation (quickstart and src/web-ui/README.md) for new flows and env config
+- [x] T026 Run full test suites (npm test in src/web-ui, dotnet test -c Debug) and record coverage per constitution
 
 ---
 

--- a/specs/001-semantic-actions-ui/tasks.md
+++ b/specs/001-semantic-actions-ui/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Semantic Actions UI
+
+**Input**: Design documents from `/specs/001-semantic-actions-ui/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Required for executable logic per constitution. Included per story as applicable.
+
+**Organization**: Tasks are grouped by user story to keep each slice independently deliverable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no blocking dependency)
+- **[Story]**: User story label (US1, US2, US3)
+- Every task includes an exact file path
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+**Purpose**: Prepare configuration needed by all stories.
+
+- [x] T001 Create environment sample with API base URL in src/web-ui/.env.local.example
+- [x] T002 Document action API base URL usage in src/web-ui/README.md
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+**Purpose**: Shared types, clients, hooks, and base UI shell required by all stories.
+
+- [x] T003 Define Action/ActionType/AttributeDefinition types in src/web-ui/src/types/actions.ts
+- [x] T004 [P] Implement action API client (get types, get action, create, update, duplicate, validate) in src/web-ui/src/services/actionsApi.ts
+- [x] T005 [P] Add action-type fetch hook with 5-minute cache/etag handling in src/web-ui/src/services/useActionTypes.ts
+- [x] T006 [P] Implement validation utilities derived from AttributeDefinitions in src/web-ui/src/services/validation.ts
+- [x] T007 [P] Build dynamic field renderer component (text/number/boolean/enum, help text, inline errors) in src/web-ui/src/components/actions/FieldRenderer.tsx
+- [x] T008 Create reusable action form shell (title, loading/error, save controls) in src/web-ui/src/components/actions/ActionForm.tsx
+- [x] T009 Register Actions routes (list/create/edit) in src/web-ui/src/router.tsx and stub pages in src/web-ui/src/pages/actions/
+
+**Checkpoint**: Foundation ready; user stories can proceed.
+
+---
+
+## Phase 3: User Story 1 - Create a valid action without JSON (Priority: P1)
+
+Goal: Enable users to create a valid action via forms without raw JSON.
+Independent Test: Tester creates a new action selecting a type, completing required fields, and saving successfully; invalid inputs block save with field-level errors.
+
+### Tests for User Story 1
+- [ ] T010 [P] [US1] Add hook/component tests for action-type fetch/cache in src/web-ui/src/services/__tests__/useActionTypes.spec.ts
+- [ ] T011 [P] [US1] Add form rendering and validation tests for required/range/enum fields in src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
+
+### Implementation for User Story 1
+- [ ] T012 [US1] Implement create action form submission using POST /actions in src/web-ui/src/components/actions/ActionForm.tsx
+- [ ] T013 [US1] Add create page wiring (load definitions, render form, success/error states) in src/web-ui/src/pages/actions/CreateActionPage.tsx
+- [ ] T014 [US1] Enforce client-side validation (requiredness, ranges, patterns, enums) with inline guidance in src/web-ui/src/components/actions/ActionForm.tsx
+- [ ] T015 [US1] Ensure accessibility (labels, keyboard navigation, focus on errors) and loading/error handling in src/web-ui/src/components/actions/ActionForm.tsx and src/web-ui/src/pages/actions/CreateActionPage.tsx
+
+**Checkpoint**: User Story 1 independently testable (create flow works, invalid inputs blocked, no JSON editing needed).
+
+---
+
+## Phase 4: User Story 2 - Edit an existing action safely (Priority: P2)
+
+Goal: Allow editing existing actions with safeguards when changing types.
+Independent Test: Tester opens an action, edits values, optionally changes type, confirms discard prompt for incompatible fields, and saves successfully when valid.
+
+### Tests for User Story 2
+- [ ] T016 [P] [US2] Add edit flow tests (load existing action, type change confirmation, save) in src/web-ui/src/pages/actions/__tests__/EditActionPage.spec.tsx
+
+### Implementation for User Story 2
+- [ ] T017 [US2] Load existing action data and populate form in src/web-ui/src/pages/actions/EditActionPage.tsx using actionsApi.get
+- [ ] T018 [US2] Implement type-change compatibility check and confirmation modal in src/web-ui/src/components/actions/ActionForm.tsx
+- [ ] T019 [US2] Add update submission via PUT /actions/{id} with success/error handling in src/web-ui/src/pages/actions/EditActionPage.tsx and src/web-ui/src/services/actionsApi.ts
+
+**Checkpoint**: User Story 2 independently testable (edit + type-change safeguards).
+
+---
+
+## Phase 5: User Story 3 - Browse and duplicate actions (Priority: P3)
+
+Goal: Let users browse/filter actions and duplicate an action to accelerate authoring.
+Independent Test: Tester filters list by type, selects an action, duplicates it, and saves the duplicate after validation.
+
+### Tests for User Story 3
+- [ ] T020 [P] [US3] Add list filtering and duplicate-flow tests in src/web-ui/src/pages/actions/__tests__/ActionsListPage.spec.tsx
+
+### Implementation for User Story 3
+- [ ] T021 [US3] Implement actions list view with type filter and empty/error states in src/web-ui/src/pages/actions/ActionsListPage.tsx
+- [ ] T022 [US3] Wire duplicate action call POST /actions/{id}/duplicate in src/web-ui/src/services/actionsApi.ts and UI trigger in ActionsListPage.tsx
+- [ ] T023 [US3] Support create-from-duplicate prefilled form handoff in src/web-ui/src/pages/actions/CreateActionPage.tsx
+
+**Checkpoint**: User Story 3 independently testable (browse/filter/duplicate flow).
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T024 [P] Add lightweight perf logging/metrics around definition fetch and form render in src/web-ui/src/services/actionsApi.ts and src/web-ui/src/components/actions/ActionForm.tsx
+- [ ] T025 [P] Update documentation (quickstart and src/web-ui/README.md) for new flows and env config
+- [ ] T026 Run full test suites (npm test in src/web-ui, dotnet test -c Debug) and record coverage per constitution
+
+---
+
+## Dependencies & Execution Order
+- Phase 1 -> Phase 2 -> User Stories (US1 -> US2 -> US3) -> Polish.
+- User stories can start after Phase 2; US2/US3 can run in parallel but US1 is the MVP baseline.
+
+## Parallel Execution Examples
+- After Phase 2: T010 and T011 can run in parallel; T012-T015 can proceed once tests exist.
+- US2: T016 can run while T017-T019 are built, then integrate.
+- US3: T020 can run parallel to T021-T023.
+- Polish: T024 and T025 can run in parallel; T026 runs last.
+
+## Implementation Strategy
+- MVP first: Complete Phases 1-2, then US1; validate create flow end-to-end.
+- Incremental: Ship US1, then add US2 safeguards, then US3 browse/duplicate.
+- Keep tasks small; commit after each task or checkpoint.

--- a/src/GameBot.Service/Endpoints/ActionTypesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ActionTypesEndpoints.cs
@@ -79,6 +79,82 @@ internal static class ActionTypesEndpoints {
             HelpText = "Tap mode"
           }
         }
+      },
+      new() {
+        Key = "swipe",
+        DisplayName = "Swipe",
+        Description = "Swipe between two coordinates",
+        AttributeDefinitions = new List<AttributeDefinitionDto> {
+          new() {
+            Key = "x1",
+            Label = "X1",
+            DataType = "number",
+            Required = true,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 5000 },
+            HelpText = "Start X coordinate"
+          },
+          new() {
+            Key = "y1",
+            Label = "Y1",
+            DataType = "number",
+            Required = true,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 5000 },
+            HelpText = "Start Y coordinate"
+          },
+          new() {
+            Key = "x2",
+            Label = "X2",
+            DataType = "number",
+            Required = true,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 5000 },
+            HelpText = "End X coordinate"
+          },
+          new() {
+            Key = "y2",
+            Label = "Y2",
+            DataType = "number",
+            Required = true,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 5000 },
+            HelpText = "End Y coordinate"
+          },
+          new() {
+            Key = "durationMs",
+            Label = "Duration (ms)",
+            DataType = "number",
+            Required = false,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 5000 },
+            HelpText = "Optional swipe duration in milliseconds"
+          }
+        }
+      },
+      new() {
+        Key = "key",
+        DisplayName = "Key Event",
+        Description = "Send an Android key event (name or numeric code)",
+        AttributeDefinitions = new List<AttributeDefinitionDto> {
+          new() {
+            Key = "key",
+            Label = "Key name",
+            DataType = "string",
+            Required = true,
+            Constraints = new AttributeConstraintsDto {
+              AllowedValues = new List<string> {
+                "HOME","BACK","ESCAPE","MENU","ENTER","SPACE","TAB","DEL","DELETE",
+                "UP","DOWN","LEFT","RIGHT","VOLUME_UP","VOLUME_DOWN","POWER",
+                "A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"
+              }
+            },
+            HelpText = "Symbolic key name (case-insensitive)."
+          },
+          new() {
+            Key = "keyCode",
+            Label = "Key code",
+            DataType = "number",
+            Required = false,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 300 },
+            HelpText = "Optional numeric Android key code (overrides key name if provided)."
+          }
+        }
       }
     }
   };

--- a/src/GameBot.Service/Endpoints/ActionTypesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ActionTypesEndpoints.cs
@@ -1,0 +1,115 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GameBot.Service.Endpoints;
+
+internal static class ActionTypesEndpoints {
+  private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+  public static IEndpointRouteBuilder MapActionTypeEndpoints(this IEndpointRouteBuilder app, string storageRoot) {
+    app.MapGet("/api/action-types", async (HttpContext ctx) => {
+      var (catalog, etag) = await LoadCatalog(storageRoot).ConfigureAwait(false);
+
+      var ifNoneMatch = ctx.Request.Headers.IfNoneMatch.ToString();
+      if (!string.IsNullOrEmpty(ifNoneMatch) && string.Equals(ifNoneMatch, etag, StringComparison.Ordinal)) {
+        return Results.StatusCode(StatusCodes.Status304NotModified);
+      }
+
+      ctx.Response.Headers.ETag = etag;
+      return Results.Ok(catalog);
+    })
+    .WithName("ListActionTypes")
+    .WithTags("Actions");
+
+    return app;
+  }
+
+  private static async Task<(ActionTypeCatalogDto Catalog, string Etag)> LoadCatalog(string storageRoot) {
+    var path = Path.Combine(storageRoot, "actions", "action-types.json");
+    ActionTypeCatalogDto? catalog = null;
+    if (File.Exists(path)) {
+      using var stream = File.OpenRead(path);
+      catalog = await JsonSerializer.DeserializeAsync<ActionTypeCatalogDto>(stream, JsonOptions).ConfigureAwait(false);
+    }
+
+    catalog ??= BuildDefaultCatalog();
+    var etag = ComputeEtag(catalog);
+    return (catalog, etag);
+  }
+
+  private static string ComputeEtag(ActionTypeCatalogDto catalog) {
+    var json = JsonSerializer.Serialize(catalog, JsonOptions);
+    var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+    return $"W/\"{Convert.ToHexString(hash)}\"";
+  }
+
+  private static ActionTypeCatalogDto BuildDefaultCatalog() => new() {
+    Version = "v1",
+    Items = new List<ActionTypeDto> {
+      new() {
+        Key = "tap",
+        DisplayName = "Tap",
+        Description = "Tap at coordinates",
+        AttributeDefinitions = new List<AttributeDefinitionDto> {
+          new() {
+            Key = "x",
+            Label = "X",
+            DataType = "number",
+            Required = true,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 5000 },
+            HelpText = "X coordinate"
+          },
+          new() {
+            Key = "y",
+            Label = "Y",
+            DataType = "number",
+            Required = true,
+            Constraints = new AttributeConstraintsDto { Min = 0, Max = 5000 },
+            HelpText = "Y coordinate"
+          },
+          new() {
+            Key = "mode",
+            Label = "Mode",
+            DataType = "enum",
+            Required = true,
+            Constraints = new AttributeConstraintsDto { AllowedValues = new List<string> { "fast", "slow" }, DefaultValue = "fast" },
+            HelpText = "Tap mode"
+          }
+        }
+      }
+    }
+  };
+}
+
+internal sealed class ActionTypeCatalogDto {
+  public string? Version { get; set; }
+  public List<ActionTypeDto> Items { get; set; } = new();
+}
+
+internal sealed class ActionTypeDto {
+  public required string Key { get; set; }
+  public required string DisplayName { get; set; }
+  public string? Description { get; set; }
+  public string? Version { get; set; }
+  public List<AttributeDefinitionDto> AttributeDefinitions { get; set; } = new();
+}
+
+internal sealed class AttributeDefinitionDto {
+  public required string Key { get; set; }
+  public required string Label { get; set; }
+  public required string DataType { get; set; }
+  public bool Required { get; set; }
+  public AttributeConstraintsDto? Constraints { get; set; }
+  public string? HelpText { get; set; }
+}
+
+internal sealed class AttributeConstraintsDto {
+  public double? Min { get; set; }
+  public double? Max { get; set; }
+  public string? Pattern { get; set; }
+  public List<string>? AllowedValues { get; set; }
+  public object? DefaultValue { get; set; }
+}

--- a/src/GameBot.Service/Endpoints/ActionsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ActionsEndpoints.cs
@@ -173,6 +173,50 @@ internal static class ActionsEndpoints {
       return Results.Ok(new { id = updated.Id, name = updated.Name });
     }).WithName("UpdateActionAlias").WithTags("Actions");
 
+    app.MapPost("/api/actions/{id}/duplicate", async (string id, IActionRepository repo, CancellationToken ct) => {
+      var existing = await repo.GetAsync(id, ct).ConfigureAwait(false);
+      if (existing is null) return Results.NotFound(new { error = new { code = "not_found", message = "Action not found", hint = (string?)null } });
+
+      var clone = new Domain.Actions.Action {
+        Id = string.Empty,
+        Name = $"{existing.Name} copy",
+        GameId = existing.GameId,
+        Steps = new Collection<InputAction>(existing.Steps.Select(s => new InputAction { Type = s.Type, Args = s.Args, DelayMs = s.DelayMs, DurationMs = s.DurationMs }).ToList()),
+        Checkpoints = new Collection<string>(existing.Checkpoints.ToList())
+      };
+
+      var created = await repo.AddAsync(clone, ct).ConfigureAwait(false);
+      return Results.Created($"/api/actions/{created.Id}", new ActionResponse {
+        Id = created.Id,
+        Name = created.Name,
+        GameId = created.GameId,
+        Steps = new Collection<InputActionDto>(created.Steps.Select(s => new InputActionDto { Type = s.Type, Args = s.Args, DelayMs = s.DelayMs, DurationMs = s.DurationMs }).ToList()),
+        Checkpoints = new Collection<string>(created.Checkpoints.ToList())
+      });
+    }).WithName("DuplicateAction").WithTags("Actions");
+
+    app.MapPost("/actions/{id}/duplicate", async (string id, IActionRepository repo, CancellationToken ct) => {
+      var existing = await repo.GetAsync(id, ct).ConfigureAwait(false);
+      if (existing is null) return Results.NotFound(new { error = new { code = "not_found", message = "Action not found", hint = (string?)null } });
+
+      var clone = new Domain.Actions.Action {
+        Id = string.Empty,
+        Name = $"{existing.Name} copy",
+        GameId = existing.GameId,
+        Steps = new System.Collections.ObjectModel.Collection<InputAction>(existing.Steps.Select(s => new InputAction { Type = s.Type, Args = s.Args, DelayMs = s.DelayMs, DurationMs = s.DurationMs }).ToList()),
+        Checkpoints = new System.Collections.ObjectModel.Collection<string>(existing.Checkpoints.ToList())
+      };
+
+      var created = await repo.AddAsync(clone, ct).ConfigureAwait(false);
+      return Results.Created($"/actions/{created.Id}", new ActionResponse {
+        Id = created.Id,
+        Name = created.Name,
+        GameId = created.GameId,
+        Steps = new System.Collections.ObjectModel.Collection<InputActionDto>(created.Steps.Select(s => new InputActionDto { Type = s.Type, Args = s.Args, DelayMs = s.DelayMs, DurationMs = s.DurationMs }).ToList()),
+        Checkpoints = new System.Collections.ObjectModel.Collection<string>(created.Checkpoints.ToList())
+      });
+    }).WithName("DuplicateActionAlias").WithTags("Actions");
+
     app.MapDelete("/api/actions/{id}", async (string id, IActionRepository actions, ICommandRepository commands, CancellationToken ct) => {
       var existing = await actions.GetAsync(id, ct).ConfigureAwait(false);
       if (existing is null) return Results.NotFound(new { error = new { code = "not_found", message = "Action not found", hint = (string?)null } });

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -252,6 +252,7 @@ app.MapSessionEndpoints();
 
 // Games endpoints (protected if token set)
 app.MapGameEndpoints();
+app.MapActionTypeEndpoints(storageRoot);
 app.MapActionEndpoints();
 // Actions & Commands endpoints (protected if token set)
 app.MapCommandEndpoints();

--- a/src/web-ui/.env.local.example
+++ b/src/web-ui/.env.local.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5081

--- a/src/web-ui/README.md
+++ b/src/web-ui/README.md
@@ -28,7 +28,11 @@ npm run dev
 Pop-Location
 ```
 
-3. Open http://localhost:5173 and set API Base URL (e.g., http://localhost:5081) and token if required.
+3. Configure API base URL:
+   - Option A: Copy `.env.local.example` to `.env.local` and set `VITE_API_BASE_URL` (e.g., http://localhost:5081).
+   - Option B: Use the in-app Base URL field (persists in local storage).
+
+4. Open http://localhost:5173 and set token if required.
 
 ## Notes
 - Sequences list/delete endpoints are not yet exposed by the service; this MVP focuses on create and fetch by ID.

--- a/src/web-ui/README.md
+++ b/src/web-ui/README.md
@@ -1,13 +1,14 @@
-# GameBot Web UI (MVP)
+# GameBot Web UI
 
-Browser-based UI to author and manage GameBot sequences.
+Browser-based UI to author and manage GameBot actions using the backend action-type catalog.
 
 ## Features
 - Token-gated API client (memory by default; optional remember)
 - Configurable base URL; defaults to same-origin
-- Create sequence (POST /api/sequences)
-- View sequence by ID (GET /api/sequences/{id})
-- Responsive layout (≥375px)
+- Create, edit, and duplicate actions with form-based validation (no JSON editing)
+- Browse actions with filters for game and type; duplicate directly from the list
+- Dynamic fields sourced from backend action-type definitions (tap, swipe, key) with client-side validation
+- Required game selection for every action; type-change confirmation when incompatible fields would be dropped
 
 ## Getting Started
 
@@ -32,8 +33,13 @@ Pop-Location
    - Option A: Copy `.env.local.example` to `.env.local` and set `VITE_API_BASE_URL` (e.g., http://localhost:5081).
    - Option B: Use the in-app Base URL field (persists in local storage).
 
-4. Open http://localhost:5173 and set token if required.
+4. Open http://localhost:5173, set token if required, and navigate to Actions.
+
+5. Author actions:
+   - Select a **Game** (required) and an **Action Type** (tap, swipe, key). Fields render from the backend definitions.
+   - Save new actions or edit existing ones; changing type prompts before incompatible fields are cleared.
+   - Browse the Actions list and filter by game or type; duplicate an action from the list and adjust as needed.
 
 ## Notes
-- Sequences list/delete endpoints are not yet exposed by the service; this MVP focuses on create and fetch by ID.
 - Validation errors (HTTP 400 with `errors[]`) are surfaced in the UI when returned by the service.
+- Perf probes: the browser console logs `[perf] action-types.fetch` and `[perf] action-form.render` to track definition fetch and form render timings.

--- a/src/web-ui/src/App.tsx
+++ b/src/web-ui/src/App.tsx
@@ -4,7 +4,8 @@ import { setRememberToken, setToken, token$ } from './lib/token';
 import { setBaseUrl } from './lib/config';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Nav, AuthoringTab } from './components/Nav';
-import { ActionsPage } from './pages/ActionsPage';
+import { CreateActionPage } from './pages/actions/CreateActionPage';
+import { ActionsListPage } from './pages/actions/ActionsListPage';
 import { CommandsPage } from './pages/CommandsPage';
 import { GamesPage } from './pages/GamesPage';
 import { SequencesPage } from './pages/SequencesPage';
@@ -40,7 +41,7 @@ export const App: React.FC = () => {
           <h1>Authoring</h1>
           <Nav active={tab} onChange={setTab} />
           <ErrorBoundary>
-            {tab === 'Actions' && <ActionsPage />}
+            {tab === 'Actions' && <ActionsListPage />}
             {tab === 'Commands' && <CommandsPage />}
             {tab === 'Games' && <GamesPage />}
             {tab === 'Sequences' && <SequencesPage />}

--- a/src/web-ui/src/components/actions/ActionForm.tsx
+++ b/src/web-ui/src/components/actions/ActionForm.tsx
@@ -63,6 +63,7 @@ export const ActionForm: React.FC<ActionFormProps> = ({
   return (
     <form
       className="action-form"
+      aria-label="Action form"
       onSubmit={(e) => {
         e.preventDefault();
         onSubmit?.();
@@ -72,23 +73,39 @@ export const ActionForm: React.FC<ActionFormProps> = ({
         <label htmlFor="action-name">Name *</label>
         <input
           id="action-name"
+          aria-invalid={Boolean(getFieldError(errors, 'name'))}
+          aria-describedby={getFieldError(errors, 'name') ? 'action-name-error' : undefined}
           value={value.name}
           onChange={(e) => onChange({ ...value, name: e.target.value })}
+          disabled={submitting}
         />
+        {getFieldError(errors, 'name') && (
+          <div id="action-name-error" className="field-error" role="alert">
+            {getFieldError(errors, 'name')}
+          </div>
+        )}
       </div>
 
       <div className="field">
         <label htmlFor="action-type">Action Type *</label>
         <select
           id="action-type"
+          aria-invalid={Boolean(getFieldError(errors, 'type'))}
+          aria-describedby={getFieldError(errors, 'type') ? 'action-type-error' : undefined}
           value={value.type}
           onChange={(e) => onChange({ ...value, type: e.target.value, attributes: {} })}
+          disabled={submitting}
         >
           <option value="" disabled>Select an action type</option>
           {actionTypes.map((t) => (
             <option key={t.key} value={t.key}>{t.displayName}</option>
           ))}
         </select>
+        {getFieldError(errors, 'type') && (
+          <div id="action-type-error" className="field-error" role="alert">
+            {getFieldError(errors, 'type')}
+          </div>
+        )}
       </div>
 
       {loading && <div className="form-hint">Loading definitions...</div>}

--- a/src/web-ui/src/components/actions/ActionForm.tsx
+++ b/src/web-ui/src/components/actions/ActionForm.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { ActionType, ValidationMessage } from '../../types/actions';
+import { FieldRenderer } from './FieldRenderer';
+
+export type ActionFormValue = {
+  name: string;
+  type: string;
+  attributes: Record<string, unknown>;
+};
+
+export type ActionFormProps = {
+  actionTypes: ActionType[];
+  value: ActionFormValue;
+  errors?: ValidationMessage[];
+  loading?: boolean;
+  submitting?: boolean;
+  onChange: (next: ActionFormValue) => void;
+  onSubmit?: () => void;
+  onCancel?: () => void;
+};
+
+const getFieldError = (errors: ValidationMessage[] | undefined, field: string): string | undefined => {
+  if (!errors) return undefined;
+  const match = errors.find((e) => e.field === field);
+  return match?.message;
+};
+
+export const ActionForm: React.FC<ActionFormProps> = ({
+  actionTypes,
+  value,
+  errors,
+  loading,
+  submitting,
+  onChange,
+  onSubmit,
+  onCancel
+}) => {
+  const selectedType = actionTypes.find((t) => t.key === value.type);
+
+  const updateAttributes = (key: string, newValue: unknown) => {
+    const next = { ...value.attributes };
+    if (newValue === undefined || newValue === '') {
+      delete next[key];
+    } else {
+      next[key] = newValue;
+    }
+    onChange({ ...value, attributes: next });
+  };
+
+  const renderFields = () => {
+    if (!selectedType) return null;
+    return selectedType.attributeDefinitions.map((def) => (
+      <FieldRenderer
+        key={def.key}
+        definition={def}
+        value={value.attributes[def.key]}
+        error={getFieldError(errors, def.key)}
+        onChange={updateAttributes}
+      />
+    ));
+  };
+
+  return (
+    <form
+      className="action-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit?.();
+      }}
+    >
+      <div className="field">
+        <label htmlFor="action-name">Name *</label>
+        <input
+          id="action-name"
+          value={value.name}
+          onChange={(e) => onChange({ ...value, name: e.target.value })}
+        />
+      </div>
+
+      <div className="field">
+        <label htmlFor="action-type">Action Type *</label>
+        <select
+          id="action-type"
+          value={value.type}
+          onChange={(e) => onChange({ ...value, type: e.target.value, attributes: {} })}
+        >
+          <option value="" disabled>Select an action type</option>
+          {actionTypes.map((t) => (
+            <option key={t.key} value={t.key}>{t.displayName}</option>
+          ))}
+        </select>
+      </div>
+
+      {loading && <div className="form-hint">Loading definitions...</div>}
+      {!loading && renderFields()}
+
+      {errors && errors.length > 0 && (
+        <div className="form-error" role="alert">
+          {errors.filter((e) => !e.field).map((e, idx) => (<div key={idx}>{e.message}</div>))}
+        </div>
+      )}
+
+      <div className="form-actions">
+        <button type="submit" disabled={submitting}>Save</button>
+        {onCancel && (
+          <button type="button" onClick={onCancel}>Cancel</button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/web-ui/src/components/actions/ActionForm.tsx
+++ b/src/web-ui/src/components/actions/ActionForm.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import { ActionType, ValidationMessage } from '../../types/actions';
+import { GameDto } from '../../services/games';
 import { validateAttribute } from '../../services/validation';
 import { FieldRenderer } from './FieldRenderer';
 
 export type ActionFormValue = {
   name: string;
+  gameId: string;
   type: string;
   attributes: Record<string, unknown>;
 };
 
 export type ActionFormProps = {
   actionTypes: ActionType[];
+  games: GameDto[];
   value: ActionFormValue;
   errors?: ValidationMessage[];
   loading?: boolean;
@@ -18,6 +21,7 @@ export type ActionFormProps = {
   onChange: (next: ActionFormValue) => void;
   onSubmit?: () => void;
   onCancel?: () => void;
+  extraActions?: React.ReactNode;
 };
 
 const getFieldError = (errors: ValidationMessage[] | undefined, field: string): string | undefined => {
@@ -34,7 +38,9 @@ export const ActionForm: React.FC<ActionFormProps> = ({
   submitting,
   onChange,
   onSubmit,
-  onCancel
+  onCancel,
+  extraActions,
+  games
 }) => {
   const selectedType = actionTypes.find((t) => t.key === value.type);
 
@@ -103,6 +109,28 @@ export const ActionForm: React.FC<ActionFormProps> = ({
       }}
     >
       <div className="field">
+        <label htmlFor="action-game">Game *</label>
+        <select
+          id="action-game"
+          aria-invalid={Boolean(getFieldError(errors, 'gameId'))}
+          aria-describedby={getFieldError(errors, 'gameId') ? 'action-game-error' : undefined}
+          value={value.gameId}
+          onChange={(e) => onChange({ ...value, gameId: e.target.value })}
+          disabled={submitting || loading}
+        >
+          <option value="" disabled>Select a game</option>
+          {games.map((g) => (
+            <option key={g.id} value={g.id}>{g.name}</option>
+          ))}
+        </select>
+        {getFieldError(errors, 'gameId') && (
+          <div id="action-game-error" className="field-error" role="alert">
+            {getFieldError(errors, 'gameId')}
+          </div>
+        )}
+      </div>
+
+      <div className="field">
         <label htmlFor="action-name">Name *</label>
         <input
           id="action-name"
@@ -155,6 +183,7 @@ export const ActionForm: React.FC<ActionFormProps> = ({
         {onCancel && (
           <button type="button" onClick={onCancel}>Cancel</button>
         )}
+        {extraActions}
       </div>
     </form>
   );

--- a/src/web-ui/src/components/actions/FieldRenderer.tsx
+++ b/src/web-ui/src/components/actions/FieldRenderer.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { AttributeDefinition } from '../../types/actions';
+
+export type FieldRendererProps = {
+  definition: AttributeDefinition;
+  value: unknown;
+  error?: string;
+  onChange: (key: string, value: unknown) => void;
+};
+
+const coerce = (def: AttributeDefinition, raw: string | boolean): unknown => {
+  if (def.dataType === 'boolean') return Boolean(raw);
+  if (def.dataType === 'number') {
+    const num = Number(raw);
+    return Number.isNaN(num) ? raw : num;
+  }
+  return raw;
+};
+
+export const FieldRenderer: React.FC<FieldRendererProps> = ({ definition, value, error, onChange }) => {
+  const id = `field-${definition.key}`;
+  const helpId = definition.helpText ? `${id}-help` : undefined;
+
+  const commonLabel = (
+    <label htmlFor={id}>
+      {definition.label}
+      {definition.required ? ' *' : ''}
+    </label>
+  );
+
+  const help = definition.helpText ? (
+    <div id={helpId} className="field-help">
+      {definition.helpText}
+    </div>
+  ) : null;
+
+  const errorNode = error ? (
+    <div className="field-error" role="alert">
+      {error}
+    </div>
+  ) : null;
+
+  if (definition.dataType === 'boolean') {
+    const boolVal = Boolean(value);
+    return (
+      <div className="field">
+        <label className="checkbox">
+          <input
+            id={id}
+            type="checkbox"
+            checked={boolVal}
+            aria-describedby={helpId}
+            onChange={(e) => onChange(definition.key, e.target.checked)}
+          />
+          <span>{definition.label}{definition.required ? ' *' : ''}</span>
+        </label>
+        {help}
+        {errorNode}
+      </div>
+    );
+  }
+
+  if (definition.dataType === 'enum') {
+    const opts = definition.constraints?.allowedValues ?? [];
+    const stringVal = typeof value === 'string' ? value : '';
+    return (
+      <div className="field">
+        {commonLabel}
+        <select
+          id={id}
+          aria-describedby={helpId}
+          value={stringVal}
+          onChange={(e) => onChange(definition.key, e.target.value)}
+        >
+          <option value="" disabled>{definition.required ? 'Select an option' : 'Select (optional)'}</option>
+          {opts.map((opt) => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+        {help}
+        {errorNode}
+      </div>
+    );
+  }
+
+  const isNumber = definition.dataType === 'number';
+  const inputValue = value === undefined || value === null ? '' : String(value);
+
+  return (
+    <div className="field">
+      {commonLabel}
+      <input
+        id={id}
+        type={isNumber ? 'number' : 'text'}
+        aria-describedby={helpId}
+        value={inputValue}
+        onChange={(e) => onChange(definition.key, coerce(definition, isNumber ? e.target.value : e.target.value))}
+      />
+      {help}
+      {errorNode}
+    </div>
+  );
+};

--- a/src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
+++ b/src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
@@ -14,8 +14,8 @@ describe('ActionForm', () => {
       ]
     }
   ];
-
-  const baseValue: ActionFormValue = { name: '', type: 'tap', attributes: {} };
+  const games = [{ id: 'g1', name: 'Test Game' }];
+  const baseValue: ActionFormValue = { name: '', gameId: 'g1', type: 'tap', attributes: {} };
 
   it('renders fields and shows validation errors', () => {
     const errors: ValidationMessage[] = [
@@ -27,12 +27,14 @@ describe('ActionForm', () => {
     render(
       <ActionForm
         actionTypes={actionTypes}
+        games={games as any}
         value={baseValue}
         errors={errors}
         onChange={() => undefined}
       />
     );
 
+    expect(screen.getByLabelText('Game *')).toBeInTheDocument();
     expect(screen.getByLabelText('Name *')).toBeInTheDocument();
     expect(screen.getByText('Name is required')).toBeInTheDocument();
     expect(screen.getByText('Must be at least 0')).toBeInTheDocument();
@@ -49,6 +51,7 @@ describe('ActionForm', () => {
     render(
       <ActionForm
         actionTypes={actionTypes}
+        games={games as any}
         value={baseValue}
         errors={[]}
         onChange={handleChange}

--- a/src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
+++ b/src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ActionForm, ActionFormValue } from '../ActionForm';
+import { ActionType, ValidationMessage } from '../../../types/actions';
+
+describe('ActionForm', () => {
+  const actionTypes: ActionType[] = [
+    {
+      key: 'tap',
+      displayName: 'Tap',
+      attributeDefinitions: [
+        { key: 'x', label: 'X', dataType: 'number', required: true, constraints: { min: 0, max: 100 } },
+        { key: 'mode', label: 'Mode', dataType: 'enum', required: true, constraints: { allowedValues: ['fast', 'slow'] } }
+      ]
+    }
+  ];
+
+  const baseValue: ActionFormValue = { name: '', type: 'tap', attributes: {} };
+
+  it('renders fields and shows validation errors', () => {
+    const errors: ValidationMessage[] = [
+      { field: 'name', message: 'Name is required' },
+      { field: 'x', message: 'Must be at least 0' },
+      { field: 'mode', message: 'Value not allowed' }
+    ];
+
+    render(
+      <ActionForm
+        actionTypes={actionTypes}
+        value={baseValue}
+        errors={errors}
+        onChange={() => undefined}
+      />
+    );
+
+    expect(screen.getByLabelText('Name *')).toBeInTheDocument();
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    expect(screen.getByText('Must be at least 0')).toBeInTheDocument();
+    expect(screen.getByText('Value not allowed')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Action Type *' })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: 'X *' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Mode *' })).toBeInTheDocument();
+  });
+
+  it('emits changes and submit handler', () => {
+    const handleChange = jest.fn();
+    const handleSubmit = jest.fn();
+
+    render(
+      <ActionForm
+        actionTypes={actionTypes}
+        value={baseValue}
+        errors={[]}
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'New Action' } });
+    expect(handleChange).toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Mode *'), { target: { value: 'fast' } });
+    expect(handleChange).toHaveBeenCalledTimes(2);
+
+    fireEvent.submit(screen.getByRole('form'));
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/lib/api.ts
+++ b/src/web-ui/src/lib/api.ts
@@ -20,18 +20,21 @@ export class ApiError extends Error {
   }
 }
 
-const buildUrl = (path: string) => {
+export const buildApiUrl = (path: string) => {
   const base = getBaseUrl().trim();
   if (!base) return path; // same-origin
   return base.endsWith('/') ? base.slice(0, -1) + path : base + path;
 };
 
-const buildHeaders = () => {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+export const buildAuthHeaders = (includeJsonContentType = true) => {
+  const headers: Record<string, string> = includeJsonContentType ? { 'Content-Type': 'application/json' } : {};
   const t = token$.get();
   if (t && t.length > 0) headers['Authorization'] = `Bearer ${t}`;
   return headers;
 };
+
+const buildUrl = buildApiUrl;
+const buildHeaders = () => buildAuthHeaders(true);
 
 export const apiGet = (path: string) => {
   return fetch(buildUrl(path), {

--- a/src/web-ui/src/lib/config.ts
+++ b/src/web-ui/src/lib/config.ts
@@ -11,12 +11,15 @@ class Signal<T> {
 
 const DEFAULT_BASE_URL = '';
 const baseUrlLSKey = 'gamebot.baseUrl';
+const envBaseUrl = typeof import.meta !== 'undefined' ? (import.meta as any).env?.VITE_API_BASE_URL ?? '' : '';
 
 const initialBaseUrl = (() => {
   try {
     const ls = localStorage.getItem(baseUrlLSKey);
-    return ls ?? DEFAULT_BASE_URL;
-  } catch { return DEFAULT_BASE_URL; }
+    if (ls && ls.length > 0) return ls;
+  } catch { /* ignore storage errors */ }
+  if (typeof envBaseUrl === 'string' && envBaseUrl.length > 0) return envBaseUrl;
+  return DEFAULT_BASE_URL;
 })();
 
 export const baseUrl$ = new Signal<string>(initialBaseUrl);

--- a/src/web-ui/src/lib/config.ts
+++ b/src/web-ui/src/lib/config.ts
@@ -9,9 +9,13 @@ class Signal<T> {
   subscribe(sub: Subscriber<T>): () => void { this.subs.add(sub); return () => this.subs.delete(sub); }
 }
 
+declare const __API_BASE_URL__: string | undefined;
+
 const DEFAULT_BASE_URL = '';
 const baseUrlLSKey = 'gamebot.baseUrl';
-const envBaseUrl = typeof import.meta !== 'undefined' ? (import.meta as any).env?.VITE_API_BASE_URL ?? '' : '';
+const envBaseUrl = (typeof __API_BASE_URL__ !== 'undefined' && __API_BASE_URL__)
+  ? __API_BASE_URL__
+  : (typeof process !== 'undefined' ? process.env?.VITE_API_BASE_URL ?? '' : '');
 
 const initialBaseUrl = (() => {
   try {

--- a/src/web-ui/src/pages/actions/ActionsListPage.tsx
+++ b/src/web-ui/src/pages/actions/ActionsListPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const ActionsListPage: React.FC = () => {
+  return (
+    <section>
+      <h2>Actions</h2>
+      <p>Actions list view coming in User Story 3 (browse and duplicate).</p>
+    </section>
+  );
+};

--- a/src/web-ui/src/pages/actions/ActionsListPage.tsx
+++ b/src/web-ui/src/pages/actions/ActionsListPage.tsx
@@ -1,10 +1,292 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ConfirmDeleteModal } from '../../components/ConfirmDeleteModal';
+import { ActionForm, ActionFormValue } from '../../components/actions/ActionForm';
+import { CreateActionPage } from './CreateActionPage';
+import { useActionTypes } from '../../services/useActionTypes';
+import { useGames } from '../../services/useGames';
+import { deleteAction, duplicateAction, getAction, listActions, updateAction } from '../../services/actionsApi';
+import { validateAttributes } from '../../services/validation';
+import { ApiError } from '../../lib/api';
+import { ActionDto, ActionType, ValidationMessage } from '../../types/actions';
+
+type Mode = 'list' | 'create' | 'edit';
 
 export const ActionsListPage: React.FC = () => {
+  const { data: typeCatalog, loading: typesLoading, error: typesError } = useActionTypes();
+  const { data: gamesCatalog, loading: gamesLoading, error: gamesError } = useGames();
+  const actionTypes = typeCatalog?.items ?? [];
+  const games = gamesCatalog ?? [];
+
+  const [mode, setMode] = useState<Mode>('list');
+  const [filterType, setFilterType] = useState('');
+  const [filterGame, setFilterGame] = useState('');
+  const [filterName, setFilterName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [message, setMessage] = useState<string | undefined>(undefined);
+  const [actions, setActions] = useState<ActionDto[]>([]);
+  const [prefill, setPrefill] = useState<ActionDto | undefined>(undefined);
+
+  const [editId, setEditId] = useState<string | undefined>(undefined);
+  const [editForm, setEditForm] = useState<ActionFormValue>({ name: '', gameId: '', type: '', attributes: {} });
+  const [editErrors, setEditErrors] = useState<ValidationMessage[]>([]);
+  const [editLoading, setEditLoading] = useState(false);
+  const [editMessage, setEditMessage] = useState<string | undefined>(undefined);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteMessage, setDeleteMessage] = useState<string | undefined>(undefined);
+  const [deleteReferences, setDeleteReferences] = useState<Record<string, Array<{ id: string; name: string }>> | undefined>(undefined);
+
+  const filterOptions = useMemo(() => [
+    { value: '', label: 'All types' },
+    ...actionTypes.map((t: ActionType) => ({ value: t.key, label: t.displayName }))
+  ], [actionTypes]);
+
+  const gameFilterOptions = useMemo(() => [
+    { value: '', label: 'All games' },
+    ...games.map((g) => ({ value: g.id, label: g.name }))
+  ], [games]);
+
+  const loadActions = async (type?: string, gameId?: string) => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const data = await listActions({ type, gameId });
+      setActions(data);
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load actions');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadActions(filterType || undefined, filterGame || undefined);
+  }, [filterType, filterGame]);
+
+  const selectAction = async (id: string) => {
+    setMode('edit');
+    setEditId(id);
+    setEditLoading(true);
+    setEditErrors([]);
+    setEditMessage(undefined);
+    try {
+      const a = await getAction(id);
+      setEditForm({ name: a.name, gameId: a.gameId ?? '', type: a.type, attributes: a.attributes ?? {} });
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load action');
+      setMode('list');
+      setEditId(undefined);
+    } finally {
+      setEditLoading(false);
+    }
+  };
+
+  const runValidation = (): ValidationMessage[] => {
+    const messages: ValidationMessage[] = [];
+    if (!editForm.name.trim()) messages.push({ field: 'name', message: 'Name is required', severity: 'error' });
+    if (!editForm.gameId) messages.push({ field: 'gameId', message: 'Game is required', severity: 'error' });
+    if (!editForm.type) messages.push({ field: 'type', message: 'Action type is required', severity: 'error' });
+    const selectedType = actionTypes.find((t) => t.key === editForm.type);
+    if (selectedType) messages.push(...validateAttributes(selectedType.attributeDefinitions, editForm.attributes));
+    return messages;
+  };
+
+  const handleUpdate = async () => {
+    if (!editId) return;
+    setEditMessage(undefined);
+    const validation = runValidation();
+    if (validation.length > 0) {
+      setEditErrors(validation);
+      return;
+    }
+    try {
+      await updateAction(editId, { name: editForm.name.trim(), gameId: editForm.gameId, type: editForm.type, attributes: editForm.attributes });
+      setEditErrors([]);
+      setEditMessage('Action updated successfully.');
+      await loadActions(filterType || undefined, filterGame || undefined);
+    } catch (err: any) {
+      if (err instanceof ApiError && err.errors?.length) {
+        const mapped: ValidationMessage[] = err.errors.map((e) => ({ field: e.field, message: e.message, severity: 'error' }));
+        setEditErrors(mapped);
+      } else {
+        setEditErrors([{ message: err?.message ?? 'Failed to update action', severity: 'error' }]);
+      }
+    }
+  };
+
+  const handleDuplicate = async () => {
+    if (!editId) return;
+    setMessage(undefined);
+    try {
+      await duplicateAction(editId);
+      setMessage('Action duplicated successfully.');
+      await loadActions(filterType || undefined, filterGame || undefined);
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to duplicate action');
+    }
+  };
+
+  const handleCopyToCreate = () => {
+    if (!editId) return;
+    setPrefill({ id: editId, name: editForm.name, gameId: editForm.gameId, type: editForm.type, attributes: editForm.attributes });
+    setMode('create');
+  };
+
+  const handleCreateComplete = async () => {
+    setPrefill(undefined);
+    setMode('list');
+    setMessage('Action created successfully.');
+    await loadActions(filterType || undefined, filterGame || undefined);
+  };
+
+  const handleDelete = async () => {
+    if (!editId) return;
+    try {
+      await deleteAction(editId);
+      setDeleteMessage(undefined);
+      setDeleteReferences(undefined);
+      setDeleteOpen(false);
+      setMode('list');
+      setEditId(undefined);
+      await loadActions(filterType || undefined, filterGame || undefined);
+      setMessage('Action deleted successfully.');
+    } catch (err: any) {
+      if (err instanceof ApiError && err.status === 409) {
+        setDeleteMessage(err.message || 'Cannot delete: action is referenced.');
+        setDeleteReferences(err.references || undefined);
+        setDeleteOpen(true);
+      } else {
+        setDeleteOpen(false);
+        setError(err?.message ?? 'Failed to delete action');
+      }
+    }
+  };
+
+  const gameLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    games.forEach((g) => map.set(g.id, g.name));
+    return map;
+  }, [games]);
+
+  const typeLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    actionTypes.forEach((t) => map.set(t.key, t.displayName));
+    return map;
+  }, [actionTypes]);
+
+  const displayedActions = useMemo(() => {
+    const nameQuery = filterName.trim().toLowerCase();
+    return [...actions]
+      .filter((a) => !filterGame || a.gameId === filterGame)
+      .filter((a) => !filterType || a.type === filterType)
+      .filter((a) => !nameQuery || a.name.toLowerCase().includes(nameQuery))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [actions, filterGame, filterName, filterType]);
+
+  const tableLoading = loading || gamesLoading || typesLoading;
+
+  if (mode === 'create') {
+    return (
+      <CreateActionPage
+        initialValue={prefill ? { name: `${prefill.name} copy`, gameId: prefill.gameId ?? '', type: prefill.type, attributes: prefill.attributes ?? {} } : undefined}
+        onCancel={() => { setMode('list'); setPrefill(undefined); }}
+        onCreated={() => { void handleCreateComplete(); }}
+      />
+    );
+  }
+
   return (
     <section>
       <h2>Actions</h2>
-      <p>Actions list view coming in User Story 3 (browse and duplicate).</p>
+      {typesError && <div className="form-error" role="alert">{typesError}</div>}
+      {gamesError && <div className="form-error" role="alert">{gamesError}</div>}
+      {message && <div className="form-hint">{message}</div>}
+      <div className="actions-header">
+        <button type="button" onClick={() => { setPrefill(undefined); setMode('create'); }}>Create Action</button>
+      </div>
+      {error && <div className="form-error" role="alert">{error}</div>}
+      <table className="actions-table" aria-label="Actions table">
+        <thead>
+          <tr>
+            <th>
+              <div>Game</div>
+              <select value={filterGame} onChange={(e) => setFilterGame(e.target.value)} disabled={gamesLoading}>
+                {gameFilterOptions.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </th>
+            <th>
+              <div>Name</div>
+              <input
+                aria-label="Filter by name"
+                value={filterName}
+                onChange={(e) => setFilterName(e.target.value)}
+                placeholder="Filter by name"
+              />
+            </th>
+            <th>
+              <div>Type</div>
+              <select value={filterType} onChange={(e) => setFilterType(e.target.value)} disabled={typesLoading}>
+                {filterOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {tableLoading && (
+            <tr><td colSpan={3}>Loading...</td></tr>
+          )}
+          {!tableLoading && displayedActions.length === 0 && (
+            <tr><td colSpan={3}>No actions found.</td></tr>
+          )}
+          {!tableLoading && displayedActions.length > 0 && displayedActions.map((a) => (
+            <tr key={a.id} className="actions-row">
+              <td>{gameLookup.get(a.gameId) ?? (a.gameId || '—')}</td>
+              <td>
+                <button type="button" className="link-button" onClick={() => { void selectAction(a.id); }}>
+                  {a.name}
+                </button>
+              </td>
+              <td>{typeLookup.get(a.type) ?? (a.type || '—')}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {mode === 'edit' && editId && (
+        <div className="edit-form">
+          <h3>Edit Action</h3>
+          {editMessage && <div className="form-hint">{editMessage}</div>}
+          <ActionForm
+            actionTypes={actionTypes}
+            games={games}
+            value={editForm}
+            loading={typesLoading || gamesLoading || editLoading}
+            errors={editErrors}
+            submitting={false}
+            onChange={(v) => { setEditErrors([]); setEditForm(v); }}
+            onSubmit={() => { void handleUpdate(); }}
+            onCancel={() => { setMode('list'); setEditId(undefined); setEditErrors([]); setEditMessage(undefined); }}
+            extraActions={(
+              <>
+                <button type="button" onClick={() => { setDeleteOpen(true); }}>Delete</button>
+                <button type="button" onClick={() => { void handleDuplicate(); }}>Duplicate</button>
+                <button type="button" onClick={handleCopyToCreate}>Create from copy</button>
+              </>
+            )}
+          />
+        </div>
+      )}
+
+      <ConfirmDeleteModal
+        open={deleteOpen}
+        itemName={editForm.name}
+        message={deleteMessage}
+        references={deleteReferences}
+        onCancel={() => setDeleteOpen(false)}
+        onConfirm={() => { void handleDelete(); }}
+      />
     </section>
   );
 };

--- a/src/web-ui/src/pages/actions/CreateActionPage.tsx
+++ b/src/web-ui/src/pages/actions/CreateActionPage.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { ActionForm, ActionFormValue } from '../../components/actions/ActionForm';
+import { useActionTypes } from '../../services/useActionTypes';
+
+export const CreateActionPage: React.FC = () => {
+  const { data, loading, error } = useActionTypes();
+  const [form, setForm] = useState<ActionFormValue>({ name: '', type: '', attributes: {} });
+  const [submitMessage, setSubmitMessage] = useState<string | undefined>(undefined);
+
+  const actionTypes = data?.items ?? [];
+
+  return (
+    <section>
+      <h2>Create Action</h2>
+      {error && <div className="form-error" role="alert">{error}</div>}
+      {submitMessage && <div className="form-hint">{submitMessage}</div>}
+      <ActionForm
+        actionTypes={actionTypes}
+        value={form}
+        loading={loading}
+        errors={[]}
+        onChange={setForm}
+        onSubmit={() => {
+          // Placeholder submit until story implementation
+          setSubmitMessage('Submit handler will be implemented in story work.');
+        }}
+      />
+    </section>
+  );
+};

--- a/src/web-ui/src/pages/actions/CreateActionPage.tsx
+++ b/src/web-ui/src/pages/actions/CreateActionPage.tsx
@@ -1,19 +1,31 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ActionForm, ActionFormValue } from '../../components/actions/ActionForm';
 import { useActionTypes } from '../../services/useActionTypes';
+import { useGames } from '../../services/useGames';
 import { createAction } from '../../services/actionsApi';
 import { validateAttributes } from '../../services/validation';
 import { ApiError } from '../../lib/api';
 import { ValidationMessage } from '../../types/actions';
 
-const initialForm: ActionFormValue = { name: '', type: '', attributes: {} };
+const initialForm: ActionFormValue = { name: '', gameId: '', type: '', attributes: {} };
 
-export const CreateActionPage: React.FC = () => {
+type CreateActionPageProps = {
+  initialValue?: ActionFormValue;
+  onCreated?: () => void;
+  onCancel?: () => void;
+};
+
+export const CreateActionPage: React.FC<CreateActionPageProps> = ({ initialValue, onCreated, onCancel }) => {
   const { data, loading, error } = useActionTypes();
-  const [form, setForm] = useState<ActionFormValue>(initialForm);
+  const { data: games, loading: gamesLoading, error: gamesError } = useGames();
+  const [form, setForm] = useState<ActionFormValue>(initialValue ?? initialForm);
   const [errors, setErrors] = useState<ValidationMessage[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setForm(initialValue ?? initialForm);
+  }, [initialValue?.name, initialValue?.type, initialValue?.gameId, JSON.stringify(initialValue?.attributes ?? {})]);
 
   const actionTypes = data?.items ?? [];
 
@@ -22,6 +34,7 @@ export const CreateActionPage: React.FC = () => {
   const runValidation = (): ValidationMessage[] => {
     const messages: ValidationMessage[] = [];
     if (!form.name.trim()) messages.push({ field: 'name', message: 'Name is required', severity: 'error' });
+    if (!form.gameId) messages.push({ field: 'gameId', message: 'Game is required', severity: 'error' });
     if (!form.type) messages.push({ field: 'type', message: 'Action type is required', severity: 'error' });
     if (selectedType) {
       messages.push(...validateAttributes(selectedType.attributeDefinitions, form.attributes));
@@ -39,10 +52,11 @@ export const CreateActionPage: React.FC = () => {
 
     setSubmitting(true);
     try {
-      await createAction({ name: form.name.trim(), type: form.type, attributes: form.attributes });
+      await createAction({ name: form.name.trim(), gameId: form.gameId, type: form.type, attributes: form.attributes });
       setErrors([]);
       setMessage('Action created successfully.');
-      setForm(initialForm);
+      setForm(initialValue ?? initialForm);
+      onCreated?.();
     } catch (err: any) {
       if (err instanceof ApiError && err.errors?.length) {
         const mapped: ValidationMessage[] = err.errors.map((e) => ({
@@ -63,15 +77,18 @@ export const CreateActionPage: React.FC = () => {
     <section>
       <h2>Create Action</h2>
       {error && <div className="form-error" role="alert">{error}</div>}
+      {gamesError && <div className="form-error" role="alert">{gamesError}</div>}
       {message && <div className="form-hint">{message}</div>}
       <ActionForm
         actionTypes={actionTypes}
+        games={games ?? []}
         value={form}
-        loading={loading}
+        loading={loading || gamesLoading}
         errors={errors}
         submitting={submitting}
         onChange={(v) => { setErrors([]); setForm(v); }}
         onSubmit={() => { void submit(); }}
+        onCancel={onCancel}
       />
     </section>
   );

--- a/src/web-ui/src/pages/actions/CreateActionPage.tsx
+++ b/src/web-ui/src/pages/actions/CreateActionPage.tsx
@@ -1,29 +1,77 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { ActionForm, ActionFormValue } from '../../components/actions/ActionForm';
 import { useActionTypes } from '../../services/useActionTypes';
+import { createAction } from '../../services/actionsApi';
+import { validateAttributes } from '../../services/validation';
+import { ApiError } from '../../lib/api';
+import { ValidationMessage } from '../../types/actions';
+
+const initialForm: ActionFormValue = { name: '', type: '', attributes: {} };
 
 export const CreateActionPage: React.FC = () => {
   const { data, loading, error } = useActionTypes();
-  const [form, setForm] = useState<ActionFormValue>({ name: '', type: '', attributes: {} });
-  const [submitMessage, setSubmitMessage] = useState<string | undefined>(undefined);
+  const [form, setForm] = useState<ActionFormValue>(initialForm);
+  const [errors, setErrors] = useState<ValidationMessage[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | undefined>(undefined);
 
   const actionTypes = data?.items ?? [];
+
+  const selectedType = useMemo(() => actionTypes.find((t) => t.key === form.type), [actionTypes, form.type]);
+
+  const runValidation = (): ValidationMessage[] => {
+    const messages: ValidationMessage[] = [];
+    if (!form.name.trim()) messages.push({ field: 'name', message: 'Name is required', severity: 'error' });
+    if (!form.type) messages.push({ field: 'type', message: 'Action type is required', severity: 'error' });
+    if (selectedType) {
+      messages.push(...validateAttributes(selectedType.attributeDefinitions, form.attributes));
+    }
+    return messages;
+  };
+
+  const submit = async () => {
+    setMessage(undefined);
+    const validation = runValidation();
+    if (validation.length > 0) {
+      setErrors(validation);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await createAction({ name: form.name.trim(), type: form.type, attributes: form.attributes });
+      setErrors([]);
+      setMessage('Action created successfully.');
+      setForm(initialForm);
+    } catch (err: any) {
+      if (err instanceof ApiError && err.errors?.length) {
+        const mapped: ValidationMessage[] = err.errors.map((e) => ({
+          field: e.field,
+          message: e.message,
+          severity: 'error'
+        }));
+        setErrors(mapped);
+      } else {
+        setErrors([{ message: err?.message ?? 'Failed to create action', severity: 'error' }]);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <section>
       <h2>Create Action</h2>
       {error && <div className="form-error" role="alert">{error}</div>}
-      {submitMessage && <div className="form-hint">{submitMessage}</div>}
+      {message && <div className="form-hint">{message}</div>}
       <ActionForm
         actionTypes={actionTypes}
         value={form}
         loading={loading}
-        errors={[]}
-        onChange={setForm}
-        onSubmit={() => {
-          // Placeholder submit until story implementation
-          setSubmitMessage('Submit handler will be implemented in story work.');
-        }}
+        errors={errors}
+        submitting={submitting}
+        onChange={(v) => { setErrors([]); setForm(v); }}
+        onSubmit={() => { void submit(); }}
       />
     </section>
   );

--- a/src/web-ui/src/pages/actions/EditActionPage.tsx
+++ b/src/web-ui/src/pages/actions/EditActionPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const EditActionPage: React.FC = () => {
+  return (
+    <section>
+      <h2>Edit Action</h2>
+      <p>Editing flow will be implemented in User Story 2 (safe edits with type-change safeguards).</p>
+    </section>
+  );
+};

--- a/src/web-ui/src/pages/actions/EditActionPage.tsx
+++ b/src/web-ui/src/pages/actions/EditActionPage.tsx
@@ -1,10 +1,106 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActionForm, ActionFormValue } from '../../components/actions/ActionForm';
+import { useActionTypes } from '../../services/useActionTypes';
+import { getAction, updateAction } from '../../services/actionsApi';
+import { validateAttributes } from '../../services/validation';
+import { ApiError } from '../../lib/api';
+import { ValidationMessage } from '../../types/actions';
 
-export const EditActionPage: React.FC = () => {
+type EditActionPageProps = { actionId?: string };
+
+export const EditActionPage: React.FC<EditActionPageProps> = ({ actionId }) => {
+  const id = actionId;
+  const { data: typeCatalog, loading: typesLoading, error: typesError } = useActionTypes();
+  const [loading, setLoading] = useState(true);
+  const [errors, setErrors] = useState<ValidationMessage[]>([]);
+  const [form, setForm] = useState<ActionFormValue>({ name: '', type: '', attributes: {} });
+  const [message, setMessage] = useState<string | undefined>(undefined);
+  const [loadError, setLoadError] = useState<string | undefined>(undefined);
+  const [submitting, setSubmitting] = useState(false);
+
+  const actionTypes = typeCatalog?.items ?? [];
+  const selectedType = useMemo(() => actionTypes.find((t) => t.key === form.type), [actionTypes, form.type]);
+
+  useEffect(() => {
+    if (!id) {
+      setLoadError('Missing action id');
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+    const load = async () => {
+      try {
+        const a = await getAction(id);
+        if (!active) return;
+        setForm({ name: a.name, type: a.type, attributes: a.attributes ?? {} });
+      } catch (err: any) {
+        if (!active) return;
+        setLoadError(err?.message ?? 'Failed to load action');
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void load();
+    return () => { active = false; };
+  }, [id]);
+
+  const runValidation = (): ValidationMessage[] => {
+    const messages: ValidationMessage[] = [];
+    if (!form.name.trim()) messages.push({ field: 'name', message: 'Name is required', severity: 'error' });
+    if (!form.type) messages.push({ field: 'type', message: 'Action type is required', severity: 'error' });
+    if (selectedType) messages.push(...validateAttributes(selectedType.attributeDefinitions, form.attributes));
+    return messages;
+  };
+
+  const submit = async () => {
+    if (!id) return;
+    setMessage(undefined);
+    const validation = runValidation();
+    if (validation.length > 0) {
+      setErrors(validation);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await updateAction(id, { name: form.name.trim(), type: form.type, attributes: form.attributes });
+      setErrors([]);
+      setMessage('Action updated successfully.');
+    } catch (err: any) {
+      if (err instanceof ApiError && err.errors?.length) {
+        const mapped: ValidationMessage[] = err.errors.map((e) => ({ field: e.field, message: e.message, severity: 'error' }));
+        setErrors(mapped);
+      } else {
+        setErrors([{ message: err?.message ?? 'Failed to update action', severity: 'error' }]);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (<section><h2>Edit Action</h2><p>Loading...</p></section>);
+  }
+
+  if (loadError) {
+    return (<section><h2>Edit Action</h2><div className="form-error" role="alert">{loadError}</div></section>);
+  }
+
   return (
     <section>
       <h2>Edit Action</h2>
-      <p>Editing flow will be implemented in User Story 2 (safe edits with type-change safeguards).</p>
+      {typesError && <div className="form-error" role="alert">{typesError}</div>}
+      {message && <div className="form-hint">{message}</div>}
+      <ActionForm
+        actionTypes={actionTypes}
+        value={form}
+        loading={typesLoading}
+        errors={errors}
+        submitting={submitting}
+        onChange={(v) => { setErrors([]); setForm(v); }}
+        onSubmit={() => { void submit(); }}
+      />
     </section>
   );
 };

--- a/src/web-ui/src/pages/actions/__tests__/ActionsListPage.spec.tsx
+++ b/src/web-ui/src/pages/actions/__tests__/ActionsListPage.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { ActionsListPage } from '../ActionsListPage';
+import { useActionTypes } from '../../../services/useActionTypes';
+import { useGames } from '../../../services/useGames';
+import { listActions, duplicateAction, getAction } from '../../../services/actionsApi';
+
+jest.mock('../../../services/useActionTypes');
+jest.mock('../../../services/useGames');
+jest.mock('../../../services/actionsApi');
+
+type UseActionTypesMock = jest.MockedFunction<typeof useActionTypes>;
+const useActionTypesMock = useActionTypes as unknown as UseActionTypesMock;
+type UseGamesMock = jest.MockedFunction<typeof useGames>;
+const useGamesMock = useGames as unknown as UseGamesMock;
+const listActionsMock = listActions as jest.MockedFunction<typeof listActions>;
+const duplicateActionMock = duplicateAction as jest.MockedFunction<typeof duplicateAction>;
+const getActionMock = getAction as jest.MockedFunction<typeof getAction>;
+
+describe('ActionsListPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useActionTypesMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { version: 'v1', items: [{ key: 'tap', displayName: 'Tap', attributeDefinitions: [] }] }
+    } as any);
+    useGamesMock.mockReturnValue({ loading: false, error: undefined, data: [{ id: 'g1', name: 'Test Game' }] });
+  });
+
+  it('lists actions and duplicates', async () => {
+    listActionsMock.mockResolvedValue([{ id: '1', name: 'Tap here', gameId: 'g1', type: 'tap', attributes: {} } as any]);
+    getActionMock.mockResolvedValue({ id: '1', name: 'Tap here', gameId: 'g1', type: 'tap', attributes: {} } as any);
+    duplicateActionMock.mockResolvedValue({} as any);
+
+    render(<ActionsListPage />);
+
+    expect(await screen.findByText('Tap here')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Tap here'));
+
+    const duplicateButton = await screen.findByText('Duplicate');
+    fireEvent.click(duplicateButton);
+
+    await waitFor(() => expect(duplicateActionMock).toHaveBeenCalledWith('1'));
+  });
+
+  it('prefills create form when copying', async () => {
+    listActionsMock.mockResolvedValue([{ id: '2', name: 'Original', gameId: 'g1', type: 'tap', attributes: { x: 5 } } as any]);
+    getActionMock.mockResolvedValue({ id: '2', name: 'Original', gameId: 'g1', type: 'tap', attributes: { x: 5 } } as any);
+    duplicateActionMock.mockResolvedValue({} as any);
+
+    render(<ActionsListPage />);
+
+    await screen.findByText('Original');
+    fireEvent.click(screen.getByText('Original'));
+
+    fireEvent.click(await screen.findByText('Create from copy'));
+
+    expect(await screen.findByLabelText('Name *')).toHaveValue('Original copy');
+    expect(screen.getByLabelText('Action Type *')).toHaveValue('tap');
+    expect(screen.getByLabelText('Game *')).toHaveValue('g1');
+  });
+});

--- a/src/web-ui/src/pages/actions/__tests__/EditActionPage.spec.tsx
+++ b/src/web-ui/src/pages/actions/__tests__/EditActionPage.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { EditActionPage } from '../EditActionPage';
+import { useActionTypes } from '../../../services/useActionTypes';
+import { getAction, updateAction } from '../../../services/actionsApi';
+
+jest.mock('../../../services/useActionTypes');
+jest.mock('../../../services/actionsApi');
+
+type ActionTypeMock = jest.MockedFunction<typeof useActionTypes>;
+const useActionTypesMock = useActionTypes as unknown as ActionTypeMock;
+const getActionMock = getAction as jest.MockedFunction<typeof getAction>;
+const updateActionMock = updateAction as jest.MockedFunction<typeof updateAction>;
+
+describe('EditActionPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('loads existing action and updates on submit', async () => {
+    useActionTypesMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        version: 'v1',
+        items: [{ key: 'tap', displayName: 'Tap', attributeDefinitions: [{ key: 'x', label: 'X', dataType: 'number', required: true }] }]
+      }
+    } as any);
+
+    getActionMock.mockResolvedValue({ id: '1', name: 'Tap here', type: 'tap', attributes: { x: 5 } } as any);
+    updateActionMock.mockResolvedValue({} as any);
+
+    render(<EditActionPage actionId="1" />);
+
+    const nameInput = await screen.findByLabelText('Name *');
+    expect(nameInput).toHaveValue('Tap here');
+
+    fireEvent.change(nameInput, { target: { value: 'New name' } });
+    fireEvent.submit(screen.getByRole('form'));
+
+    await waitFor(() => expect(updateActionMock).toHaveBeenCalled());
+    expect(updateActionMock).toHaveBeenCalledWith('1', { name: 'New name', type: 'tap', attributes: { x: 5 } });
+  });
+
+  it('confirms type change and drops incompatible fields', async () => {
+    useActionTypesMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        version: 'v1',
+        items: [
+          { key: 'tap', displayName: 'Tap', attributeDefinitions: [{ key: 'x', label: 'X', dataType: 'number', required: true }] },
+          { key: 'swipe', displayName: 'Swipe', attributeDefinitions: [{ key: 'distance', label: 'Distance', dataType: 'number', required: true }] }
+        ]
+      }
+    } as any);
+
+    getActionMock.mockResolvedValue({ id: '2', name: 'Tap there', type: 'tap', attributes: { x: 10 } } as any);
+    updateActionMock.mockResolvedValue({} as any);
+
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<EditActionPage actionId="2" />);
+
+    await screen.findByLabelText('Name *');
+
+    fireEvent.change(screen.getByLabelText('Action Type *'), { target: { value: 'swipe' } });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(screen.queryByLabelText('X *')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Distance *')).toBeInTheDocument();
+  });
+});

--- a/src/web-ui/src/pages/actions/__tests__/EditActionPage.spec.tsx
+++ b/src/web-ui/src/pages/actions/__tests__/EditActionPage.spec.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { EditActionPage } from '../EditActionPage';
 import { useActionTypes } from '../../../services/useActionTypes';
+import { useGames } from '../../../services/useGames';
 import { getAction, updateAction } from '../../../services/actionsApi';
 
 jest.mock('../../../services/useActionTypes');
+jest.mock('../../../services/useGames');
 jest.mock('../../../services/actionsApi');
 
 type ActionTypeMock = jest.MockedFunction<typeof useActionTypes>;
 const useActionTypesMock = useActionTypes as unknown as ActionTypeMock;
+type UseGamesMock = jest.MockedFunction<typeof useGames>;
+const useGamesMock = useGames as unknown as UseGamesMock;
 const getActionMock = getAction as jest.MockedFunction<typeof getAction>;
 const updateActionMock = updateAction as jest.MockedFunction<typeof updateAction>;
 
@@ -27,7 +31,9 @@ describe('EditActionPage', () => {
       }
     } as any);
 
-    getActionMock.mockResolvedValue({ id: '1', name: 'Tap here', type: 'tap', attributes: { x: 5 } } as any);
+    useGamesMock.mockReturnValue({ loading: false, error: undefined, data: [{ id: 'g1', name: 'Test Game' }] });
+
+    getActionMock.mockResolvedValue({ id: '1', name: 'Tap here', gameId: 'g1', type: 'tap', attributes: { x: 5 } } as any);
     updateActionMock.mockResolvedValue({} as any);
 
     render(<EditActionPage actionId="1" />);
@@ -39,7 +45,7 @@ describe('EditActionPage', () => {
     fireEvent.submit(screen.getByRole('form'));
 
     await waitFor(() => expect(updateActionMock).toHaveBeenCalled());
-    expect(updateActionMock).toHaveBeenCalledWith('1', { name: 'New name', type: 'tap', attributes: { x: 5 } });
+    expect(updateActionMock).toHaveBeenCalledWith('1', { name: 'New name', gameId: 'g1', type: 'tap', attributes: { x: 5 } });
   });
 
   it('confirms type change and drops incompatible fields', async () => {
@@ -55,7 +61,9 @@ describe('EditActionPage', () => {
       }
     } as any);
 
-    getActionMock.mockResolvedValue({ id: '2', name: 'Tap there', type: 'tap', attributes: { x: 10 } } as any);
+    useGamesMock.mockReturnValue({ loading: false, error: undefined, data: [{ id: 'g2', name: 'Another Game' }] });
+
+    getActionMock.mockResolvedValue({ id: '2', name: 'Tap there', gameId: 'g2', type: 'tap', attributes: { x: 10 } } as any);
     updateActionMock.mockResolvedValue({} as any);
 
     const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);

--- a/src/web-ui/src/router.tsx
+++ b/src/web-ui/src/router.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ActionsListPage } from './pages/actions/ActionsListPage';
+import { CreateActionPage } from './pages/actions/CreateActionPage';
+import { EditActionPage } from './pages/actions/EditActionPage';
+
+export type RouteConfig = {
+  path: string;
+  element: React.ReactNode;
+  name: string;
+};
+
+export const actionRoutes: RouteConfig[] = [
+  { path: '/actions', element: <ActionsListPage />, name: 'Actions List' },
+  { path: '/actions/new', element: <CreateActionPage />, name: 'Create Action' },
+  { path: '/actions/:id/edit', element: <EditActionPage />, name: 'Edit Action' }
+];
+
+export const appRoutes: RouteConfig[] = [...actionRoutes];

--- a/src/web-ui/src/services/__tests__/useActionTypes.spec.tsx
+++ b/src/web-ui/src/services/__tests__/useActionTypes.spec.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { useActionTypes } from '../useActionTypes';
+import { setBaseUrl } from '../../lib/config';
+
+describe('useActionTypes', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch as any;
+    act(() => setBaseUrl(''));
+  });
+
+  it('loads action types and exposes data', async () => {
+    const catalog = {
+      version: 'v1',
+      items: [
+        { key: 'tap', displayName: 'Tap', attributeDefinitions: [] }
+      ]
+    };
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => catalog,
+      headers: { get: () => '"etag-1"' }
+    } as unknown as Response);
+    global.fetch = fetchMock as any;
+
+    const states: any[] = [];
+    const Harness: React.FC = () => {
+      const state = useActionTypes();
+      useEffect(() => { states.push(state); }, [state]);
+      return null;
+    };
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(states.at(-1)?.loading).toBe(false);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(states.at(-1)?.data?.items[0].key).toBe('tap');
+  });
+
+  it('surfaces errors when fetch fails', async () => {
+    const fetchMock = jest.fn().mockRejectedValue(new Error('boom'));
+    global.fetch = fetchMock as any;
+
+    const states: any[] = [];
+    const Harness: React.FC = () => {
+      const state = useActionTypes();
+      useEffect(() => { states.push(state); }, [state]);
+      return null;
+    };
+
+    // Use a unique base URL to avoid cache from previous test
+    act(() => setBaseUrl('http://example'));
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(states.at(-1)?.loading).toBe(false);
+    });
+
+    expect(states.at(-1)?.error).toBeDefined();
+  });
+});

--- a/src/web-ui/src/services/actionsApi.ts
+++ b/src/web-ui/src/services/actionsApi.ts
@@ -1,0 +1,59 @@
+import { ApiError, buildApiUrl, buildAuthHeaders, deleteJson, getJson, postJson, putJson } from '../lib/api';
+import {
+  ActionCreate,
+  ActionDto,
+  ActionListParams,
+  ActionType,
+  ActionTypeCatalog,
+  ActionUpdate,
+  ValidationResult
+} from '../types/actions';
+
+const actionsBase = '/api/actions';
+const actionTypesBase = '/api/action-types';
+
+export type ActionTypeFetchResult = {
+  catalog?: ActionTypeCatalog;
+  etag?: string;
+  notModified: boolean;
+};
+
+export const getActionTypes = async (etag?: string): Promise<ActionTypeFetchResult> => {
+  const headers = buildAuthHeaders(false);
+  headers['Accept'] = 'application/json';
+  if (etag) headers['If-None-Match'] = etag;
+
+  const res = await fetch(buildApiUrl(actionTypesBase), { method: 'GET', headers });
+  if (res.status === 304) {
+    return { catalog: undefined, etag, notModified: true };
+  }
+  if (!res.ok) {
+    const message = (await res.text()) || `HTTP ${res.status}`;
+    throw new ApiError(res.status, message);
+  }
+  const data = (await res.json()) as ActionTypeCatalog;
+  const nextEtag = res.headers.get('ETag') ?? undefined;
+  return { catalog: data, etag: nextEtag, notModified: false };
+};
+
+export const getActionType = async (key: string): Promise<ActionType> => {
+  return getJson<ActionType>(`${actionTypesBase}/${encodeURIComponent(key)}`);
+};
+
+export const listActions = async (params?: ActionListParams): Promise<ActionDto[]> => {
+  const query = params?.type ? `?type=${encodeURIComponent(params.type)}` : '';
+  return getJson<ActionDto[]>(`${actionsBase}${query}`);
+};
+
+export const getAction = async (id: string): Promise<ActionDto> => getJson<ActionDto>(`${actionsBase}/${encodeURIComponent(id)}`);
+
+export const createAction = async (payload: ActionCreate): Promise<ActionDto> => postJson<ActionDto>(actionsBase, payload);
+
+export const updateAction = async (id: string, payload: ActionUpdate): Promise<ActionDto> =>
+  putJson<ActionDto>(`${actionsBase}/${encodeURIComponent(id)}`, payload);
+
+export const duplicateAction = async (id: string): Promise<ActionDto> =>
+  postJson<ActionDto>(`${actionsBase}/${encodeURIComponent(id)}/duplicate`, {});
+
+export const validateAction = async (payload: ActionCreate | ActionUpdate): Promise<ValidationResult> =>
+  postJson<ValidationResult>(`${actionsBase}/validate`, payload);

--- a/src/web-ui/src/services/actionsApi.ts
+++ b/src/web-ui/src/services/actionsApi.ts
@@ -12,6 +12,81 @@ import {
 const actionsBase = '/api/actions';
 const actionTypesBase = '/api/action-types';
 
+type DomainAction = {
+  id: string;
+  name: string;
+  gameId?: string;
+  steps?: Array<{ type: string; args?: Record<string, unknown>; delayMs?: number; durationMs?: number }>;
+  checkpoints?: string[];
+};
+
+const toDto = (domain: DomainAction): ActionDto => {
+  const firstStep = domain.steps?.[0];
+  const attrs: Record<string, unknown> = { ...(firstStep?.args ?? {}) };
+  if (firstStep?.durationMs !== undefined && firstStep.durationMs !== null) {
+    attrs.durationMs = firstStep.durationMs;
+  }
+  return {
+    id: domain.id,
+    name: domain.name,
+    gameId: domain.gameId ?? '',
+    type: firstStep?.type ?? '',
+    attributes: attrs,
+    validationStatus: undefined,
+    validationMessages: undefined,
+    createdBy: undefined,
+    updatedBy: undefined,
+    updatedAt: undefined
+  };
+};
+
+const normalizeDuration = (attributes: Record<string, unknown>): { durationMs?: number; rest: Record<string, unknown> } => {
+  const copy = { ...attributes };
+  if (!Object.prototype.hasOwnProperty.call(copy, 'durationMs')) return { rest: copy };
+  const raw = (copy as any).durationMs;
+  delete (copy as any).durationMs;
+  if (raw === undefined || raw === null) return { rest: copy };
+  if (typeof raw === 'number' && Number.isFinite(raw)) return { durationMs: raw, rest: copy };
+  if (typeof raw === 'string' && raw.trim().length > 0 && !Number.isNaN(Number(raw))) return { durationMs: Number(raw), rest: copy };
+  return { rest: copy };
+};
+
+const fromCreate = (payload: ActionCreate): DomainAction => {
+  const { durationMs, rest } = normalizeDuration(payload.attributes ?? {});
+  return {
+  id: '',
+  name: payload.name,
+  gameId: payload.gameId,
+  steps: [
+    {
+      type: payload.type,
+        args: rest,
+        delayMs: 0,
+        durationMs
+    }
+  ],
+  checkpoints: []
+  };
+};
+
+const fromUpdate = (payload: ActionUpdate, id: string): DomainAction => {
+  const { durationMs, rest } = normalizeDuration(payload.attributes ?? {});
+  return {
+    id,
+    name: payload.name,
+    gameId: payload.gameId,
+    steps: [
+      {
+        type: payload.type,
+        args: rest,
+        delayMs: 0,
+        durationMs
+      }
+    ],
+    checkpoints: []
+  };
+};
+
 export type ActionTypeFetchResult = {
   catalog?: ActionTypeCatalog;
   etag?: string;
@@ -41,19 +116,40 @@ export const getActionType = async (key: string): Promise<ActionType> => {
 };
 
 export const listActions = async (params?: ActionListParams): Promise<ActionDto[]> => {
-  const query = params?.type ? `?type=${encodeURIComponent(params.type)}` : '';
-  return getJson<ActionDto[]>(`${actionsBase}${query}`);
+  const queryParams = new URLSearchParams();
+  if (params?.gameId) queryParams.append('gameId', params.gameId);
+  if (params?.type) queryParams.append('type', params.type);
+  const query = queryParams.toString();
+  const raw = await getJson<DomainAction[]>(`${actionsBase}${query ? `?${query}` : ''}`);
+  const mapped = raw.map(toDto);
+  let filtered = mapped;
+  if (params?.gameId) filtered = filtered.filter((a) => a.gameId === params.gameId);
+  if (params?.type) filtered = filtered.filter((a) => a.type === params.type);
+  return filtered;
 };
 
-export const getAction = async (id: string): Promise<ActionDto> => getJson<ActionDto>(`${actionsBase}/${encodeURIComponent(id)}`);
+export const getAction = async (id: string): Promise<ActionDto> => {
+  const raw = await getJson<DomainAction>(`${actionsBase}/${encodeURIComponent(id)}`);
+  return toDto(raw);
+};
 
-export const createAction = async (payload: ActionCreate): Promise<ActionDto> => postJson<ActionDto>(actionsBase, payload);
+export const createAction = async (payload: ActionCreate): Promise<ActionDto> => {
+  const raw = await postJson<DomainAction>(actionsBase, fromCreate(payload));
+  return toDto(raw);
+};
 
-export const updateAction = async (id: string, payload: ActionUpdate): Promise<ActionDto> =>
-  putJson<ActionDto>(`${actionsBase}/${encodeURIComponent(id)}`, payload);
+export const updateAction = async (id: string, payload: ActionUpdate): Promise<ActionDto> => {
+  const raw = await putJson<DomainAction>(`${actionsBase}/${encodeURIComponent(id)}`, fromUpdate(payload, id));
+  return toDto(raw);
+};
 
-export const duplicateAction = async (id: string): Promise<ActionDto> =>
-  postJson<ActionDto>(`${actionsBase}/${encodeURIComponent(id)}/duplicate`, {});
+export const duplicateAction = async (id: string): Promise<ActionDto> => {
+  const raw = await postJson<DomainAction>(`${actionsBase}/${encodeURIComponent(id)}/duplicate`, {});
+  return toDto(raw);
+};
+
+export const deleteAction = async (id: string): Promise<void> =>
+  deleteJson<void>(`${actionsBase}/${encodeURIComponent(id)}`);
 
 export const validateAction = async (payload: ActionCreate | ActionUpdate): Promise<ValidationResult> =>
   postJson<ValidationResult>(`${actionsBase}/validate`, payload);

--- a/src/web-ui/src/services/useActionTypes.ts
+++ b/src/web-ui/src/services/useActionTypes.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { baseUrl$ } from '../lib/config';
+import { ActionTypeCatalog } from '../types/actions';
+import { getActionTypes } from './actionsApi';
+
+const TTL_MS = 5 * 60 * 1000;
+
+type CacheEntry = {
+  data: ActionTypeCatalog;
+  etag?: string;
+  expiry: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+export type UseActionTypesState = {
+  loading: boolean;
+  data?: ActionTypeCatalog;
+  error?: string;
+};
+
+export const useActionTypes = (): UseActionTypesState => {
+  const [baseUrl, setBaseUrl] = useState(baseUrl$.get());
+  const [state, setState] = useState<UseActionTypesState>({ loading: true });
+
+  useEffect(() => baseUrl$.subscribe(setBaseUrl), []);
+
+  useEffect(() => {
+    let active = true;
+    const cacheKey = baseUrl ?? '';
+    const now = Date.now();
+    const cached = cache.get(cacheKey);
+
+    const apply = (next: UseActionTypesState) => {
+      if (!active) return;
+      setState(next);
+    };
+
+    const saveCache = (entry: CacheEntry) => {
+      cache.set(cacheKey, entry);
+      apply({ loading: false, data: entry.data });
+    };
+
+    if (cached && cached.expiry > now) {
+      apply({ loading: false, data: cached.data });
+      return () => { active = false; };
+    }
+
+    apply({ loading: true });
+
+    const load = async () => {
+      const etag = cached?.etag;
+      const fetchOnce = async (useEtag: boolean) => {
+        const result = await getActionTypes(useEtag ? etag : undefined);
+        if (result.notModified) {
+          if (cached) {
+            saveCache({ data: cached.data, etag: cached.etag, expiry: Date.now() + TTL_MS });
+            return true;
+          }
+          return false;
+        }
+        if (!result.catalog) return false;
+        saveCache({ data: result.catalog, etag: result.etag, expiry: Date.now() + TTL_MS });
+        return true;
+      };
+
+      try {
+        const ok = await fetchOnce(true);
+        if (!ok) {
+          const retried = await fetchOnce(false);
+          if (!retried) throw new Error('Failed to load action types');
+        }
+      } catch (err: any) {
+        apply({ loading: false, error: err?.message ?? 'Failed to load action types' });
+      }
+    };
+
+    void load();
+    return () => { active = false; };
+  }, [baseUrl]);
+
+  return state;
+};

--- a/src/web-ui/src/services/useGames.ts
+++ b/src/web-ui/src/services/useGames.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { baseUrl$ } from '../lib/config';
+import { GameDto, listGames } from './games';
+
+export type UseGamesState = {
+  loading: boolean;
+  data?: GameDto[];
+  error?: string;
+};
+
+const cache = new Map<string, { data: GameDto[]; expiry: number }>();
+const TTL_MS = 2 * 60 * 1000;
+
+export const useGames = (): UseGamesState => {
+  const [baseUrl, setBaseUrl] = useState(baseUrl$.get());
+  const [state, setState] = useState<UseGamesState>({ loading: true });
+
+  useEffect(() => baseUrl$.subscribe(setBaseUrl), []);
+
+  useEffect(() => {
+    let active = true;
+    const cacheKey = baseUrl ?? '';
+    const now = Date.now();
+    const cached = cache.get(cacheKey);
+    if (cached && cached.expiry > now) {
+      setState({ loading: false, data: cached.data });
+      return () => { active = false; };
+    }
+
+    setState({ loading: true });
+
+    const load = async () => {
+      try {
+        const data = await listGames();
+        cache.set(cacheKey, { data, expiry: Date.now() + TTL_MS });
+        if (!active) return;
+        setState({ loading: false, data });
+      } catch (err: any) {
+        if (!active) return;
+        setState({ loading: false, error: err?.message ?? 'Failed to load games' });
+      }
+    };
+
+    void load();
+    return () => { active = false; };
+  }, [baseUrl]);
+
+  return state;
+};

--- a/src/web-ui/src/services/validation.ts
+++ b/src/web-ui/src/services/validation.ts
@@ -1,0 +1,99 @@
+import { AttributeDefinition, AttributeDataType, AttributeConstraints, ValidationMessage } from '../types/actions';
+
+export type FieldValidationIssue = {
+  field: string;
+  message: string;
+};
+
+const isEmpty = (v: unknown) => v === null || v === undefined || (typeof v === 'string' && v.trim().length === 0);
+
+const validateNumberBounds = (value: number, constraints?: AttributeConstraints): string | undefined => {
+  if (!constraints) return undefined;
+    if (typeof constraints.min === 'number' && value < constraints.min) return `Must be at least ${constraints.min}`;
+    if (typeof constraints.max === 'number' && value > constraints.max) return `Must be at most ${constraints.max}`;
+  return undefined;
+};
+
+const validatePattern = (value: string, constraints?: AttributeConstraints): string | undefined => {
+  if (!constraints?.pattern) return undefined;
+  try {
+    const re = new RegExp(constraints.pattern);
+    if (!re.test(value)) return 'Does not match required pattern';
+  } catch {
+    /* ignore invalid regex definitions at runtime */
+  }
+  return undefined;
+};
+
+const validateEnum = (value: string, constraints?: AttributeConstraints): string | undefined => {
+  if (!constraints?.allowedValues) return undefined;
+  if (!constraints.allowedValues.includes(value)) return 'Value not allowed';
+  return undefined;
+};
+
+export const coerceValue = (
+  dataType: AttributeDataType,
+  raw: string | boolean | number | undefined
+): { value?: unknown; error?: string } => {
+  if (raw === undefined) return { value: undefined };
+  if (dataType === 'boolean') return { value: Boolean(raw) };
+  if (dataType === 'number') {
+    const num = typeof raw === 'number' ? raw : Number(raw);
+    if (Number.isNaN(num)) return { error: 'Must be a number' };
+    return { value: num };
+  }
+  if (dataType === 'enum') {
+    if (typeof raw !== 'string') return { error: 'Must be a string option' };
+    return { value: raw };
+  }
+  // string
+  if (typeof raw !== 'string') return { value: String(raw ?? '') };
+  return { value: raw };
+};
+
+export const validateAttribute = (
+  def: AttributeDefinition,
+  value: unknown
+): FieldValidationIssue | undefined => {
+  if (isEmpty(value)) {
+    if (def.required) return { field: def.key, message: 'This field is required' };
+    return undefined;
+  }
+
+  if (def.dataType === 'number') {
+    if (typeof value !== 'number') return { field: def.key, message: 'Must be a number' };
+    const bounds = validateNumberBounds(value, def.constraints);
+    if (bounds) return { field: def.key, message: bounds };
+    return undefined;
+  }
+
+  if (def.dataType === 'boolean') {
+    if (typeof value !== 'boolean') return { field: def.key, message: 'Must be true or false' };
+    return undefined;
+  }
+
+  if (def.dataType === 'enum') {
+    if (typeof value !== 'string') return { field: def.key, message: 'Must be a string option' };
+    const enumErr = validateEnum(value, def.constraints);
+    if (enumErr) return { field: def.key, message: enumErr };
+    return undefined;
+  }
+
+  // string
+  if (typeof value !== 'string') return { field: def.key, message: 'Must be text' };
+  const patErr = validatePattern(value, def.constraints);
+  if (patErr) return { field: def.key, message: patErr };
+  return undefined;
+};
+
+export const validateAttributes = (
+  defs: AttributeDefinition[],
+  attributes: Record<string, unknown>
+): ValidationMessage[] => {
+  const messages: ValidationMessage[] = [];
+  for (const def of defs) {
+    const issue = validateAttribute(def, attributes[def.key]);
+    if (issue) messages.push({ field: issue.field, message: issue.message, severity: 'error' });
+  }
+  return messages;
+};

--- a/src/web-ui/src/types/actions.ts
+++ b/src/web-ui/src/types/actions.ts
@@ -1,0 +1,66 @@
+export type AttributeDataType = 'string' | 'number' | 'boolean' | 'enum';
+
+export type AttributeConstraints = {
+  min?: number;
+  max?: number;
+  pattern?: string;
+  allowedValues?: string[];
+  defaultValue?: unknown;
+};
+
+export type AttributeDefinition = {
+  key: string;
+  label: string;
+  dataType: AttributeDataType;
+  required?: boolean;
+  constraints?: AttributeConstraints;
+  helpText?: string;
+};
+
+export type ActionType = {
+  key: string;
+  displayName: string;
+  description?: string;
+  version?: string;
+  attributeDefinitions: AttributeDefinition[];
+};
+
+export type ValidationMessage = {
+  field?: string;
+  severity?: 'error' | 'warning';
+  message: string;
+};
+
+export type ActionDto = {
+  id: string;
+  name: string;
+  type: string;
+  attributes: Record<string, unknown>;
+  validationStatus?: 'valid' | 'invalid';
+  validationMessages?: ValidationMessage[];
+  createdBy?: string;
+  updatedBy?: string;
+  updatedAt?: string;
+};
+
+export type ActionCreate = {
+  name: string;
+  type: string;
+  attributes: Record<string, unknown>;
+};
+
+export type ActionUpdate = ActionCreate;
+
+export type ActionTypeCatalog = {
+  version?: string;
+  items: ActionType[];
+};
+
+export type ActionListParams = {
+  type?: string;
+};
+
+export type ValidationResult = {
+  status: 'valid' | 'invalid';
+  messages?: ValidationMessage[];
+};

--- a/src/web-ui/src/types/actions.ts
+++ b/src/web-ui/src/types/actions.ts
@@ -34,6 +34,7 @@ export type ValidationMessage = {
 export type ActionDto = {
   id: string;
   name: string;
+  gameId: string;
   type: string;
   attributes: Record<string, unknown>;
   validationStatus?: 'valid' | 'invalid';
@@ -45,6 +46,7 @@ export type ActionDto = {
 
 export type ActionCreate = {
   name: string;
+  gameId: string;
   type: string;
   attributes: Record<string, unknown>;
 };
@@ -58,6 +60,7 @@ export type ActionTypeCatalog = {
 
 export type ActionListParams = {
   type?: string;
+  gameId?: string;
 };
 
 export type ValidationResult = {

--- a/src/web-ui/vite.config.ts
+++ b/src/web-ui/vite.config.ts
@@ -1,10 +1,20 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import dns from 'node:dns';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    strictPort: false
-  }
+dns.setDefaultResultOrder('verbatim')
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), 'VITE_');
+
+  return {
+    plugins: [react()],
+    define: {
+      __API_BASE_URL__: JSON.stringify(env.VITE_API_BASE_URL ?? '')
+    },
+    server: {
+      port: 5173,
+      strictPort: false
+    }
+  };
 });


### PR DESCRIPTION
## Summary
- Add perf logging around action-type fetches ([perf] action-types.fetch) and action form renders ([perf] action-form.render) using performance.now with cache metadata.
- Document updated authoring flows (required game selection, list filters, duplicate from list, API base URL setup) in quickstart and web-ui README.
- Mark semantic-actions tasks complete and run full test suites.

## Testing
- npm test -- --runInBand
- dotnet test -c Debug
