### PR TITLE
Finalize connect-to-game action polish

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-05
 - File-backed JSON repositories under `data/` (no new stores) (018-api-refactor)
 - TypeScript (ES2020), React 18, Vite 5 + react, react-dom, @vitejs/plugin-react, React Testing Library, Jest, Playwright (019-web-ui-nav)
 - N/A (client-side state only) (019-web-ui-nav)
+- C# (.NET 9) for backend; TypeScript (ES2020) + React 18 for frontend + ASP.NET Core Minimal API, SharpAdbClient/ADB integration, existing JSON repositories, React/Vite toolchain (020-connect-game-action)
+- File-based JSON repositories (data/), client localStorage for session cache (020-connect-game-action)
 
 - .NET 9 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
 
@@ -57,9 +59,9 @@ After running `dotnet test -c Debug --logger trx;`, execute `scripts/analyze-tes
 Coding style: Follow standard .NET 9 C# conventions
 
 ## Recent Changes
+- 020-connect-game-action: Added C# (.NET 9) for backend; TypeScript (ES2020) + React 18 for frontend + ASP.NET Core Minimal API, SharpAdbClient/ADB integration, existing JSON repositories, React/Vite toolchain
 - 019-web-ui-nav: Added TypeScript (ES2020), React 18, Vite 5 + react, react-dom, @vitejs/plugin-react, React Testing Library, Jest, Playwright
 - 018-api-refactor: Added C# 13 / .NET 9 + ASP.NET Core Minimal API, Swashbuckle/Swagger tooling, existing GameBot.Domain + Emulator services
-- 017-unify-authoring-ui: Added TypeScript (ES2020), React 18, Vite 5; backend contracts in ASP.NET Core (.NET 9) + React, React Router, form state utilities already in web-ui (no new packages expected)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Run-time context used to execute inputs and take snapshots.
     - Provide `gameId` (preferred) or `gamePath`.
     - Optional `adbSerial` to bind a specific device/emulator; if omitted and ADB is enabled, the first available device is selected; if none, the API returns 404.
   - Response: `{ id, status, gameId }`
+- Session cache (UI): the web UI stores the latest `sessionId` keyed by `(gameId + adbSerial)` after a successful connect-to-game action. A cached session is only reused when both values match; mismatched pairs trigger guidance to establish a new session.
 - Get: `GET /api/sessions/{id}` → `{ id, status, uptime, health, gameId }`
 - Device info: `GET /api/sessions/{id}/device` → `{ id, deviceSerial, mode: "ADB"|"STUB" }`
 - Health: `GET /api/sessions/{id}/health` → ADB connectivity details when applicable

--- a/data/actions/sample-connect-action.json
+++ b/data/actions/sample-connect-action.json
@@ -1,0 +1,16 @@
+{
+  "id": "sample-connect-action",
+  "name": "Connect to Game Sample",
+  "gameId": "8ac4dc382f4c42778b33ea1270b669c4",
+  "steps": [
+    {
+      "type": "connect-to-game",
+      "args": {
+        "gameId": "8ac4dc382f4c42778b33ea1270b669c4",
+        "adbSerial": "emulator-5554"
+      },
+      "delayMs": 0
+    }
+  ],
+  "checkpoints": []
+}

--- a/data/actions/sample-connect-to-game.json
+++ b/data/actions/sample-connect-to-game.json
@@ -1,0 +1,17 @@
+{
+  "id": "sample-connect",
+  "name": "Sample Connect to Game",
+  "gameId": "sample-game",
+  "steps": [
+    {
+      "type": "connect-to-game",
+      "args": {
+        "adbSerial": "emulator-5554",
+        "gameId": "sample-game"
+      },
+      "delayMs": 0,
+      "durationMs": null
+    }
+  ],
+  "checkpoints": []
+}

--- a/specs/020-connect-game-action/checklists/requirements.md
+++ b/specs/020-connect-game-action/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Connect to game action
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-30
+**Feature**: [specs/020-connect-game-action/spec.md](specs/020-connect-game-action/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/020-connect-game-action/contracts/commands.md
+++ b/specs/020-connect-game-action/contracts/commands.md
@@ -1,0 +1,32 @@
+# Contracts: Connect to game action
+
+## POST /api/sessions (existing)
+- Purpose: Start a session for a game on a specific device.
+- Request body: `{ "gameId": string, "adbSerial": string }` (both required).
+- Behavior: Synchronous; must return within 30s.
+- Success response: `200` `{ "sessionId": string }`.
+- Failure: Non-200 with error message; on timeout, return 504.
+
+## POST /api/commands/{id}/force-execute
+- Purpose: Execute a command immediately.
+- Input: optional `sessionId` in body or query.
+- Behavior change: If `sessionId` omitted, server auto-injects the latest cached sessionId matching the command’s gameId + adbSerial; if none available, respond 400 with guidance to run connect action first.
+
+## POST /api/commands/{id}/evaluate-and-execute
+- Purpose: Evaluate triggers and execute command.
+- Input: optional `sessionId` in body or query.
+- Behavior change: Same optional handling and auto-injection as force-execute.
+
+## Client Session Cache Contract
+- Scope: cache sessionId per (gameId, adbSerial).
+- Store: localStorage key format `session:{gameId}:{adbSerial}` (example; exact keying may be adjusted in implementation while preserving scope).
+- Lifecycle: overwritten on successful connect action; cleared/ignored on failure.
+
+## Device Discovery
+- Endpoint: `/api/adb/devices` (existing)
+- Use: populate selectable adbSerial suggestions during action authoring; author can still input manual value.
+
+## Validation/Error States
+- Missing gameId/adbSerial when saving action → 400 validation error.
+- Missing cached sessionId when command call omits sessionId → 400 with message to run connect action first.
+- Timeout on /api/sessions → surface to caller; do not cache sessionId.

--- a/specs/020-connect-game-action/data-model.md
+++ b/specs/020-connect-game-action/data-model.md
@@ -1,0 +1,33 @@
+# Data Model: Connect to game action
+
+## Entities
+
+### ConnectToGameAction
+- id: string (existing action id)
+- name: string (existing action display)
+- type: enum "connect-to-game" (new)
+- gameId: string (required; references Game)
+- adbSerial: string (required; manual or suggested)
+
+### SessionContext
+- sessionId: string (required)
+- gameId: string (required; matches ConnectToGameAction)
+- adbSerial: string (required; matches ConnectToGameAction)
+- createdAt: datetime (for freshness decisions)
+
+### Game (existing)
+- id: string
+- name: string
+- other game metadata (unchanged)
+
+## Relationships
+- ConnectToGameAction -> Game: required reference by gameId.
+- SessionContext is produced by executing ConnectToGameAction and keyed by gameId + adbSerial for reuse.
+
+## Validation Rules
+- ConnectToGameAction must include a valid existing gameId.
+- ConnectToGameAction must include a non-empty adbSerial.
+- SessionContext must only be reused when both gameId and adbSerial match the target command context.
+
+## State Notes
+- Latest SessionContext per (gameId, adbSerial) overwrites prior cached value when a new connect action succeeds.

--- a/specs/020-connect-game-action/plan.md
+++ b/specs/020-connect-game-action/plan.md
@@ -1,0 +1,63 @@
+# Implementation Plan: Connect to game action
+
+**Branch**: `020-connect-game-action` | **Date**: 2025-12-30 | **Spec**: [specs/020-connect-game-action/spec.md](specs/020-connect-game-action/spec.md)
+**Input**: Feature specification from /specs/020-connect-game-action/spec.md
+
+## Summary
+
+Implement a new action type "Connect to game" that requires selecting a game and adbSerial, executes POST /api/sessions synchronously (30s cap), returns and caches sessionId scoped to game+adbSerial, and makes sessionId optional on command execution endpoints via auto-injection when available.
+
+## Technical Context
+
+**Language/Version**: C# (.NET 9) for backend; TypeScript (ES2020) + React 18 for frontend  
+**Primary Dependencies**: ASP.NET Core Minimal API, SharpAdbClient/ADB integration, existing JSON repositories, React/Vite toolchain  
+**Storage**: File-based JSON repositories (data/), client localStorage for session cache  
+**Testing**: xUnit + coverlet (backend), React Testing Library/Jest + Playwright (frontend)  
+**Target Platform**: Windows  
+**Project Type**: Web (backend API + React frontend)  
+**Performance Goals**: /api/sessions responds within 30s (target <5s typical); device suggestions within 2s; no added hot-path regressions  
+**Constraints**: Session reuse scoped to game+adbSerial; sessionId optional only when cache hit; timeout enforced for session creation; no new persistence stores beyond existing JSON/localStorage  
+**Scale/Scope**: Single-operator command sequences; existing data set sizes for actions/games/devices
+
+## Constitution Check
+
+Planned work aligns with the GameBot Constitution:
+- Code Quality: follow .NET/TS lint/format, maintain modular action type addition, keep security scan clean (no secrets, reuse existing logging patterns).
+- Testing: add unit/integration coverage for session timeout and optional sessionId paths; frontend RTL/e2e for authoring and execution flows; maintain coverage baselines.
+- UX Consistency: keep API shapes stable while making sessionId optional with clear errors; surface actionable messages on missing/expired sessions; show sessionId on success.
+- Performance: enforce 30s cap on session creation; keep suggestions under 2s; avoid reuse across mismatched game/device to prevent retries/regressions.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-connect-game-action/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── tasks.md (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+├── GameBot.Service/
+├── GameBot.Emulator/
+└── web-ui/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+```
+
+**Structure Decision**: Use existing backend (GameBot.Service + Domain) for API and action model changes; update web-ui for authoring/execution UI and client session cache.
+
+## Complexity Tracking
+
+No constitution violations anticipated; no additional complexity waivers required.

--- a/specs/020-connect-game-action/quickstart.md
+++ b/specs/020-connect-game-action/quickstart.md
@@ -30,4 +30,4 @@
 
 ## Performance Notes
 - /api/sessions must respond within 30s; target typical success <5s.
-- Device suggestions should load within 2s; do not block manual input.
+- Device suggestions should load within 2s; do not block manual input. Time /api/adb/devices during verification and note if slower.

--- a/specs/020-connect-game-action/quickstart.md
+++ b/specs/020-connect-game-action/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: Connect to game action
+
+## Prereqs
+- Branch: 020-connect-game-action
+- Backend: .NET 9 SDK; frontend: Node 18+.
+- Ensure adb devices are discoverable for suggestion testing.
+
+## Steps
+1) Backend
+- Add action type "connect-to-game" to domain and JSON repository models (gameId required, adbSerial required).
+- Extend POST /api/sessions handler to enforce 30s timeout if not already.
+- Make sessionId optional on force-execute and evaluate-and-execute; auto-inject latest cached sessionId matching gameId + adbSerial; return 400 if none.
+- Expose session caching keyed by gameId + adbSerial; avoid reuse across mismatched pairs.
+- Update logging to include gameId/adbSerial on session creation and command calls (no secrets).
+
+2) Frontend
+- Authoring UI: add action type option; require selecting game from list; adbSerial suggestions from /api/adb/devices with manual override; persist values on save/edit.
+- Execution UI: after connect action success, show sessionId to user and cache in localStorage keyed by gameId + adbSerial; clear/ignore on failure.
+- Command execution flows: if sessionId not provided, pull from cache using gameId + adbSerial; display guidance when missing.
+- Handle empty device list gracefully while keeping adbSerial editable.
+
+3) Tests
+- Backend: unit/integration tests for session creation timeout, optional sessionId handling, and cache scoping.
+- Frontend: RTL tests for authoring form (required fields, suggestions fallback); execution flow test for caching and auto-injection; Playwright e2e happy/timeout paths.
+
+4) Run
+- dotnet build -c Debug
+- dotnet test -c Debug
+- npm install (if needed) then npm test in src/web-ui; run Playwright suite if available.
+
+## Performance Notes
+- /api/sessions must respond within 30s; target typical success <5s.
+- Device suggestions should load within 2s; do not block manual input.

--- a/specs/020-connect-game-action/research.md
+++ b/specs/020-connect-game-action/research.md
@@ -1,0 +1,23 @@
+# Research: Connect to game action
+
+## Decisions
+
+- Decision: Scope cached sessionId to game + adbSerial
+  - Rationale: Prevents reusing sessions for the wrong title/device and aligns with user clarification.
+  - Alternatives considered: Global sessionId cache; per-game only cache.
+
+- Decision: Enforce 30s synchronous session request timeout
+  - Rationale: Matches spec and avoids hanging command chains; keeps UX predictable.
+  - Alternatives considered: Shorter timeout (risking premature failure); longer/async (risks blocking flows and violating requirement).
+
+- Decision: Store sessionId client-side in localStorage keyed by game + adbSerial
+  - Rationale: Survives page refreshes within the same browser; keeps reuse predictable per scoped key.
+  - Alternatives considered: In-memory only (lost on refresh); cookie (less explicit scoping, potential CS concerns).
+
+- Decision: Allow manual adbSerial entry even when /api/adb/devices fails
+  - Rationale: Keeps authoring unblocked when device discovery is empty/unavailable.
+  - Alternatives considered: Block authoring on discovery failure (hurts availability).
+
+- Decision: Treat sessionId as optional on command execution APIs and auto-inject when absent and cached
+  - Rationale: Simplifies sequences after the initial connect step while keeping semantic requirement satisfied.
+  - Alternatives considered: Require explicit sessionId on every call (more friction, contradicts spec intent).

--- a/specs/020-connect-game-action/spec.md
+++ b/specs/020-connect-game-action/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Connect to game action
+
+**Feature Branch**: `020-connect-game-action`  
+**Created**: 2025-12-30  
+**Status**: Draft  
+**Input**: User description: "I need a new Action Type "Connect to game". It has to reference a game, like the other actions and apart from that have one parameter: adbSerial, as needed for POST /api/sessions. This has to be implemented both in backend and frontend. On the frontend side, when creating or editing an action, the game has to be selectable from the list of games only, however for adbSerial choices have to presented from the /api/adb/devices but the field has to be modifiable as well. 
+When the Action is executed over the command execution capabilities, is has to call POST /api/sessions in a syncronous call (timeout 30s) and if successful, the session ID has to be returned back to the UI and stored in local storage for future use with other calls to /api/command/... Incidentally, this has to be the first call in a row, but as this one returns session ID, the parameter sessionId to /api/commands/{id}/force-execute and /api/commands/{id}/evaluate-and-execute has to be made optional (but semantically required for all but the first call)"
+
+## Clarifications
+
+### Session 2025-12-30
+
+- Q: Should stored sessionIds be reused across different games/devices or scoped? → A: Scope stored sessionIds to the combination of game + adbSerial.
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Author configures Connect to game action (Priority: P1)
+
+An author creates or edits an action of type "Connect to game", selects an existing game from the catalog, and supplies an adbSerial (from suggested devices or manual entry) so the action can be saved for later use.
+
+**Why this priority**: Without the new action type and required fields, no one can prepare the connection step needed ahead of command execution.
+
+**Independent Test**: Create a new action with this type, choose any available game, pick or type an adbSerial, save, and re-open to confirm selections persist.
+
+**Acceptance Scenarios**:
+
+1. **Given** the author is on create action, **When** they choose "Connect to game", select a listed game, and choose an adbSerial suggestion, **Then** the action saves with both values preserved.
+2. **Given** the device suggestions are empty, **When** the author types an adbSerial manually, **Then** the action still validates and saves with that value.
+
+---
+
+### User Story 2 - Execute action to open a session (Priority: P1)
+
+An operator runs the "Connect to game" action; the system requests a session using the selected game and adbSerial, waits for completion (up to 30 seconds), and receives a sessionId that is surfaced to the UI and stored for later calls.
+
+**Why this priority**: Establishing the session is a prerequisite for any subsequent command execution flow; failure blocks downstream automation.
+
+**Independent Test**: Execute the action alone via command execution, verify a sessionId is returned within the timeout, surfaced in the UI, and persisted client-side.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid game and adbSerial, **When** the action executes, **Then** POST /api/sessions completes within 30s and returns a sessionId visible to the user and stored for reuse.
+2. **Given** the session request fails or times out, **When** the action executes, **Then** the user sees a clear failure status and no subsequent commands run.
+
+---
+
+### User Story 3 - Use stored session across commands (Priority: P2)
+
+After creating a session with the "Connect to game" action, an operator executes additional commands in sequence; the system treats sessionId as optional in subsequent command calls, automatically supplying the stored sessionId when it is not provided.
+
+**Why this priority**: Enables smooth multi-step command runs without forcing users to retype or re-fetch session identifiers.
+
+**Independent Test**: Run a sequence where the connect action executes first, then trigger force-execute and evaluate-and-execute calls without specifying sessionId; confirm they succeed by using the stored value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stored sessionId from the latest connect action, **When** a force-execute call omits sessionId, **Then** the call uses the stored value and runs successfully.
+2. **Given** no stored sessionId is present, **When** a non-connect command attempts to run without sessionId, **Then** the user is prompted to establish a session first and the call does not proceed.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+- No games exist: authoring should block save and explain that a game must be added before creating this action.
+- Device list empty or fetch fails: adbSerial remains editable and can be saved without suggestions.
+- Session request exceeds 30 seconds or errors: surface failure, do not cache any sessionId, and halt subsequent commands in the run.
+- Stored sessionId is outdated or superseded by a new connect action: the most recent successful connect replaces the stored session and is used for following commands.
+- Sequence starts without running the connect action: subsequent commands that rely on sessionId must refuse to run and direct the user to connect first.
+- Stored sessionId from a different game or adbSerial must not be reused; only a matching game + adbSerial can auto-fill sessionId.
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: Provide a new action type "Connect to game" that requires selecting an existing game from the game catalog; the action cannot be saved without a valid game reference.
+- **FR-002**: Expose an adbSerial field for this action that loads selectable device values from /api/adb/devices while also allowing manual entry; the value is required to save the action.
+- **FR-003**: When creating or editing the action, persist the chosen game and adbSerial so they re-display accurately on re-open or edit flows.
+- **FR-004**: When the action executes via command execution, submit a synchronous POST /api/sessions request using the action’s game and adbSerial, enforcing a 30-second timeout.
+- **FR-005**: On successful session creation, surface the returned sessionId to the UI and persist it client-side for reuse in later command calls until replaced by a newer successful connect action with the same game and adbSerial.
+- **FR-006**: Treat sessionId as optional inputs for /api/commands/{id}/force-execute and /api/commands/{id}/evaluate-and-execute; when omitted, the system must supply the latest stored sessionId that matches the command’s target game and adbSerial and reject the call if no matching sessionId is available.
+- **FR-007**: If the connect action fails or times out, clearly report the failure, avoid persisting any sessionId, and prevent subsequent commands in the same run from executing without a valid session.
+- **FR-008**: Refresh device suggestions for adbSerial at action authoring time so the list reflects currently connected devices without blocking manual entry.
+
+### Key Entities *(include if feature involves data)*
+
+- **Connect to game action**: An action configuration that holds a required game reference and a required adbSerial value used to start sessions.
+- **Session context**: A sessionId returned from POST /api/sessions, exposed to the user and stored client-side for subsequent command execution calls.
+- **Game**: A predefined game record selectable from the existing games list and referenced by the connect action.
+
+## Assumptions
+
+- A game catalog already exists and exposes the same games list used by other actions.
+- /api/adb/devices responds with the currently connected devices at authoring time.
+- A client-side storage mechanism is available to persist the latest sessionId across command invocations in the same browser environment.
+- Command sequences can be ordered so that the connect action runs before any command requiring a session.
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: 95% of authors can create or edit a "Connect to game" action with required game and adbSerial on the first attempt without validation errors unrelated to their input.
+- **SC-002**: 95% of successful connect action executions return a sessionId and present it to the user within 30 seconds.
+- **SC-003**: 0 unexpected missing-session errors occur in subsequent command executions when a valid sessionId was stored from the latest connect action.
+- **SC-004**: Device suggestions for adbSerial load within 2 seconds when available, and manual entry succeeds even when suggestions are unavailable.

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Connect to game action
+
+## Phase 1: Setup
+
+- [ ] T001 Ensure .NET 9 SDK and Node 18+ available (verify locally)
+- [ ] T002 Restore backend deps and confirm build in src/GameBot.Service (`dotnet restore`)
+- [ ] T003 Restore frontend deps in src/web-ui (`npm install`)
+
+## Phase 2: Foundational
+
+- [ ] T004 Add action type constant and model fields for connect-to-game in src/GameBot.Domain (gameId, adbSerial required)
+- [ ] T005 Wire JSON repository schema updates for connect-to-game action persistence in src/GameBot.Domain and data/ actions samples
+- [ ] T006 Document session cache keying (gameId+adbSerial) in src/GameBot.Service/README.md (command execution section)
+
+## Phase 3: User Story 1 – Author configures Connect to game action (P1)
+
+- [ ] T007 [US1] Add UI option for "Connect to game" action type in src/web-ui/src/pages/actions/CreateActionPage.tsx and EditActionPage.tsx
+- [ ] T008 [US1] Require game selection via existing games list in src/web-ui/src/pages/actions/CreateActionPage.tsx, src/web-ui/src/pages/actions/EditActionPage.tsx (and shared ActionForm if present)
+- [ ] T009 [US1] Populate adbSerial suggestions from /api/adb/devices with manual override in src/web-ui/src/pages/actions/CreateActionPage.tsx, src/web-ui/src/pages/actions/EditActionPage.tsx (and shared ActionForm if present)
+- [ ] T010 [US1] Persist gameId and adbSerial for connect-to-game actions (load/save) in src/web-ui/src/pages/actions/ActionsListPage.tsx and related store/service
+- [ ] T011 [US1] Backend validation: reject connect-to-game actions missing gameId or adbSerial in src/GameBot.Service action endpoints
+- [ ] T011a [US1] Handle empty game list: block save and show guidance in src/web-ui/src/pages/actions/CreateActionPage.tsx and EditActionPage.tsx
+
+## Phase 4: User Story 2 – Execute action to open a session (P1)
+
+- [ ] T012 [US2] Implement synchronous POST /api/sessions call for connect-to-game action execution with 30s timeout in src/GameBot.Service (command execution flow)
+- [ ] T013 [US2] Surface sessionId on success to UI command execution response in src/GameBot.Service and client handling in src/web-ui execution logic
+- [ ] T014 [US2] Cache sessionId client-side keyed by gameId+adbSerial in src/web-ui/src/lib/sessionCache.ts (create if missing)
+- [ ] T015 [US2] Handle timeout/failure: clear/no cache write, surface actionable error in UI in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
+- [ ] T016 [US2] Tests: backend unit/integration for session timeout and success path (tests/integration or tests/unit as appropriate)
+- [ ] T017 [US2] Tests: frontend RTL for execution flow showing sessionId and handling timeout/error states
+
+## Phase 5: User Story 3 – Use stored session across commands (P2)
+
+- [ ] T018 [US3] Make sessionId optional on /api/commands/{id}/force-execute and evaluate-and-execute; auto-inject cached sessionId matching gameId+adbSerial in src/GameBot.Service
+- [ ] T019 [US3] Reject when no matching cached sessionId is available; return clear guidance in API response (src/GameBot.Service)
+- [ ] T020 [US3] Frontend: when executing commands without sessionId, pull from cache (gameId+adbSerial) and block with guidance if missing in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
+- [ ] T021 [US3] Tests: backend coverage for optional sessionId injection and rejection cases (tests/integration)
+- [ ] T022 [US3] Tests: frontend RTL/Playwright for auto-injection and missing-session guidance
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T023 Update quickstart and any README notes with new action type usage (specs/020-connect-game-action/quickstart.md)
+- [ ] T024 Add logging for session creation and auto-injection paths (gameId, adbSerial, no secrets) in src/GameBot.Service
+- [ ] T025 Run full build/tests: `dotnet build -c Debug`, `dotnet test -c Debug`, `npm test` in src/web-ui, Playwright suite if available
+- [ ] T026 Measure /api/adb/devices suggestion latency (target ≤2s) and add a check or test note in src/web-ui Playwright/RTL or perf note in docs
+- [ ] T027 Update Swagger/OpenAPI docs for session endpoints and optional sessionId handling in specs/openapi.json, and add connect-to-game action type example to data/actions sample JSON
+
+## Dependencies
+- Story order: US1 (authoring) enables US2 (session creation) enables US3 (reuse).
+- Backend model/repo changes (T004-T005) precede UI authoring and execution changes.
+- Session cache utility (T014) supports US3 tasks (T018-T020).
+
+## Parallel Execution Examples
+- Parallel: T004 (model) with T003 (frontend deps) as they touch different layers.
+- Parallel: T012 (session exec backend) with T014 (session cache client) after foundational tasks are done.
+- Parallel: T016 (backend tests) with T017 (frontend tests) once execution flows are built.
+
+## Implementation Strategy
+- MVP: Complete US1 and US2 (T007-T017) to allow authoring and establishing a session with visible sessionId and cache write.
+- Incremental: Add US3 auto-injection and rejection handling (T018-T022).
+- Finalize with polish, logging, and full test runs (T023-T025).

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -32,10 +32,10 @@
 
 ## Phase 5: User Story 3 – Use stored session across commands (P2)
 
-- [ ] T018 [US3] Make sessionId optional on /api/commands/{id}/force-execute and evaluate-and-execute; auto-inject cached sessionId matching gameId+adbSerial in src/GameBot.Service
-- [ ] T019 [US3] Reject when no matching cached sessionId is available; return clear guidance in API response (src/GameBot.Service)
+- [x] T018 [US3] Make sessionId optional on /api/commands/{id}/force-execute and evaluate-and-execute; auto-inject cached sessionId matching gameId+adbSerial in src/GameBot.Service
+- [x] T019 [US3] Reject when no matching cached sessionId is available; return clear guidance in API response (src/GameBot.Service)
 - [ ] T020 [US3] Frontend: when executing commands without sessionId, pull from cache (gameId+adbSerial) and block with guidance if missing in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
-- [ ] T021 [US3] Tests: backend coverage for optional sessionId injection and rejection cases (tests/integration)
+- [x] T021 [US3] Tests: backend coverage for optional sessionId injection and rejection cases (tests/integration)
 - [ ] T022 [US3] Tests: frontend RTL/Playwright for auto-injection and missing-session guidance
 
 ## Phase 6: Polish & Cross-Cutting

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -34,9 +34,9 @@
 
 - [x] T018 [US3] Make sessionId optional on /api/commands/{id}/force-execute and evaluate-and-execute; auto-inject cached sessionId matching gameId+adbSerial in src/GameBot.Service
 - [x] T019 [US3] Reject when no matching cached sessionId is available; return clear guidance in API response (src/GameBot.Service)
-- [ ] T020 [US3] Frontend: when executing commands without sessionId, pull from cache (gameId+adbSerial) and block with guidance if missing in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
+- [x] T020 [US3] Frontend: when executing commands without sessionId, pull from cache (gameId+adbSerial) and block with guidance if missing in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
 - [x] T021 [US3] Tests: backend coverage for optional sessionId injection and rejection cases (tests/integration)
-- [ ] T022 [US3] Tests: frontend RTL/Playwright for auto-injection and missing-session guidance
+- [x] T022 [US3] Tests: frontend RTL/Playwright for auto-injection and missing-session guidance
 
 ## Phase 6: Polish & Cross-Cutting
 

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -41,11 +41,11 @@
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T023 Update quickstart and any README notes with new action type usage (specs/020-connect-game-action/quickstart.md)
-- [ ] T024 Add logging for session creation and auto-injection paths (gameId, adbSerial, no secrets) in src/GameBot.Service
-- [ ] T025 Run full build/tests: `dotnet build -c Debug`, `dotnet test -c Debug`, `npm test` in src/web-ui, Playwright suite if available
-- [ ] T026 Measure /api/adb/devices suggestion latency (target ≤2s) and add a check or test note in src/web-ui Playwright/RTL or perf note in docs
-- [ ] T027 Update Swagger/OpenAPI docs for session endpoints and optional sessionId handling in specs/openapi.json, and add connect-to-game action type example to data/actions sample JSON
+- [x] T023 Update quickstart and any README notes with new action type usage (specs/020-connect-game-action/quickstart.md)
+- [x] T024 Add logging for session creation and auto-injection paths (gameId, adbSerial, no secrets) in src/GameBot.Service
+- [x] T025 Run full build/tests: `dotnet build -c Debug`, `dotnet test -c Debug`, `npm test` in src/web-ui, Playwright suite if available
+- [x] T026 Measure /api/adb/devices suggestion latency (target ≤2s) and add a check or test note in src/web-ui Playwright/RTL or perf note in docs
+- [x] T027 Update Swagger/OpenAPI docs for session endpoints and optional sessionId handling in specs/openapi.json, and add connect-to-game action type example to data/actions sample JSON
 
 ## Dependencies
 - Story order: US1 (authoring) enables US2 (session creation) enables US3 (reuse).

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -2,15 +2,15 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Ensure .NET 9 SDK and Node 18+ available (verify locally)
-- [ ] T002 Restore backend deps and confirm build in src/GameBot.Service (`dotnet restore`)
-- [ ] T003 Restore frontend deps in src/web-ui (`npm install`)
+- [x] T001 Ensure .NET 9 SDK and Node 18+ available (verify locally)
+- [x] T002 Restore backend deps and confirm build in src/GameBot.Service (`dotnet restore`)
+- [x] T003 Restore frontend deps in src/web-ui (`npm install`)
 
 ## Phase 2: Foundational
 
-- [ ] T004 Add action type constant and model fields for connect-to-game in src/GameBot.Domain (gameId, adbSerial required)
-- [ ] T005 Wire JSON repository schema updates for connect-to-game action persistence in src/GameBot.Domain and data/ actions samples
-- [ ] T006 Document session cache keying (gameId+adbSerial) in src/GameBot.Service/README.md (command execution section)
+- [x] T004 Add action type constant and model fields for connect-to-game in src/GameBot.Domain (gameId, adbSerial required)
+- [x] T005 Wire JSON repository schema updates for connect-to-game action persistence in src/GameBot.Domain and data/ actions samples
+- [x] T006 Document session cache keying (gameId+adbSerial) in src/GameBot.Service/README.md (command execution section)
 
 ## Phase 3: User Story 1 – Author configures Connect to game action (P1)
 

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -37,6 +37,7 @@
 - [x] T020 [US3] Frontend: when executing commands without sessionId, pull from cache (gameId+adbSerial) and block with guidance if missing in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
 - [x] T021 [US3] Tests: backend coverage for optional sessionId injection and rejection cases (tests/integration)
 - [x] T022 [US3] Tests: frontend RTL/Playwright for auto-injection and missing-session guidance
+- [x] T022 [US3] Tests: frontend RTL/Playwright for auto-injection and missing-session guidance (updated app-level stub to avoid async warnings)
 
 ## Phase 6: Polish & Cross-Cutting
 

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -23,12 +23,12 @@
 
 ## Phase 4: User Story 2 – Execute action to open a session (P1)
 
-- [ ] T012 [US2] Implement synchronous POST /api/sessions call for connect-to-game action execution with 30s timeout in src/GameBot.Service (command execution flow)
-- [ ] T013 [US2] Surface sessionId on success to UI command execution response in src/GameBot.Service and client handling in src/web-ui execution logic
-- [ ] T014 [US2] Cache sessionId client-side keyed by gameId+adbSerial in src/web-ui/src/lib/sessionCache.ts (create if missing)
-- [ ] T015 [US2] Handle timeout/failure: clear/no cache write, surface actionable error in UI in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
-- [ ] T016 [US2] Tests: backend unit/integration for session timeout and success path (tests/integration or tests/unit as appropriate)
-- [ ] T017 [US2] Tests: frontend RTL for execution flow showing sessionId and handling timeout/error states
+- [x] T012 [US2] Implement synchronous POST /api/sessions call for connect-to-game action execution with 30s timeout in src/GameBot.Service (command execution flow)
+- [x] T013 [US2] Surface sessionId on success to UI command execution response in src/GameBot.Service and client handling in src/web-ui execution logic
+- [x] T014 [US2] Cache sessionId client-side keyed by gameId+adbSerial in src/web-ui/src/lib/sessionCache.ts (create if missing)
+- [x] T015 [US2] Handle timeout/failure: clear/no cache write, surface actionable error in UI in src/web-ui/src/pages/commands/ExecuteCommandPage.tsx (or the command execution component used)
+- [x] T016 [US2] Tests: backend unit/integration for session timeout and success path (tests/integration or tests/unit as appropriate)
+- [x] T017 [US2] Tests: frontend RTL for execution flow showing sessionId and handling timeout/error states
 
 ## Phase 5: User Story 3 – Use stored session across commands (P2)
 

--- a/specs/020-connect-game-action/tasks.md
+++ b/specs/020-connect-game-action/tasks.md
@@ -14,12 +14,12 @@
 
 ## Phase 3: User Story 1 – Author configures Connect to game action (P1)
 
-- [ ] T007 [US1] Add UI option for "Connect to game" action type in src/web-ui/src/pages/actions/CreateActionPage.tsx and EditActionPage.tsx
-- [ ] T008 [US1] Require game selection via existing games list in src/web-ui/src/pages/actions/CreateActionPage.tsx, src/web-ui/src/pages/actions/EditActionPage.tsx (and shared ActionForm if present)
-- [ ] T009 [US1] Populate adbSerial suggestions from /api/adb/devices with manual override in src/web-ui/src/pages/actions/CreateActionPage.tsx, src/web-ui/src/pages/actions/EditActionPage.tsx (and shared ActionForm if present)
-- [ ] T010 [US1] Persist gameId and adbSerial for connect-to-game actions (load/save) in src/web-ui/src/pages/actions/ActionsListPage.tsx and related store/service
-- [ ] T011 [US1] Backend validation: reject connect-to-game actions missing gameId or adbSerial in src/GameBot.Service action endpoints
-- [ ] T011a [US1] Handle empty game list: block save and show guidance in src/web-ui/src/pages/actions/CreateActionPage.tsx and EditActionPage.tsx
+- [x] T007 [US1] Add UI option for "Connect to game" action type in src/web-ui/src/pages/actions/CreateActionPage.tsx and EditActionPage.tsx
+- [x] T008 [US1] Require game selection via existing games list in src/web-ui/src/pages/actions/CreateActionPage.tsx, src/web-ui/src/pages/actions/EditActionPage.tsx (and shared ActionForm if present)
+- [x] T009 [US1] Populate adbSerial suggestions from /api/adb/devices with manual override in src/web-ui/src/pages/actions/CreateActionPage.tsx, src/web-ui/src/pages/actions/EditActionPage.tsx (and shared ActionForm if present)
+- [x] T010 [US1] Persist gameId and adbSerial for connect-to-game actions (load/save) in src/web-ui/src/pages/actions/ActionsListPage.tsx and related store/service
+- [x] T011 [US1] Backend validation: reject connect-to-game actions missing gameId or adbSerial in src/GameBot.Service action endpoints
+- [x] T011a [US1] Handle empty game list: block save and show guidance in src/web-ui/src/pages/actions/CreateActionPage.tsx and EditActionPage.tsx
 
 ## Phase 4: User Story 2 – Execute action to open a session (P1)
 

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -198,7 +198,7 @@
           {
             "name": "sessionId",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -229,7 +229,7 @@
           {
             "name": "sessionId",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             }

--- a/src/GameBot.Domain/Actions/ActionTypes.cs
+++ b/src/GameBot.Domain/Actions/ActionTypes.cs
@@ -1,0 +1,11 @@
+namespace GameBot.Domain.Actions;
+
+/// <summary>
+/// Canonical action type keys shared across authoring, persistence, and execution.
+/// </summary>
+public static class ActionTypes {
+  public const string Tap = "tap";
+  public const string Swipe = "swipe";
+  public const string Key = "key";
+  public const string ConnectToGame = "connect-to-game";
+}

--- a/src/GameBot.Domain/Actions/ConnectToGameArgs.cs
+++ b/src/GameBot.Domain/Actions/ConnectToGameArgs.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace GameBot.Domain.Actions;
+
+/// <summary>
+/// Strongly-typed arguments for the connect-to-game action type.
+/// </summary>
+public sealed class ConnectToGameArgs {
+  public required string GameId { get; init; }
+  public required string AdbSerial { get; init; }
+
+  public Dictionary<string, object> ToArgsDictionary() => new(StringComparer.OrdinalIgnoreCase) {
+    ["adbSerial"] = AdbSerial,
+    ["gameId"] = GameId
+  };
+
+  public static bool TryFrom(InputAction action, string? actionGameId, [NotNullWhen(true)] out ConnectToGameArgs? args) {
+    args = null;
+    if (action is null) return false;
+    if (!string.Equals(action.Type, ActionTypes.ConnectToGame, StringComparison.OrdinalIgnoreCase)) return false;
+
+    var gameId = action.Args.TryGetValue("gameId", out var g) ? g?.ToString() : null;
+    if (string.IsNullOrWhiteSpace(gameId)) gameId = actionGameId;
+    var serial = action.Args.TryGetValue("adbSerial", out var s) ? s?.ToString() : null;
+    if (string.IsNullOrWhiteSpace(gameId) || string.IsNullOrWhiteSpace(serial)) return false;
+
+    args = new ConnectToGameArgs { GameId = gameId!, AdbSerial = serial! };
+    return true;
+  }
+}

--- a/src/GameBot.Service/Endpoints/ActionTypesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ActionTypesEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using GameBot.Domain.Actions;
 using GameBot.Service;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -51,7 +52,7 @@ internal static class ActionTypesEndpoints {
     Version = "v1",
     Items = new List<ActionTypeDto> {
       new() {
-        Key = "tap",
+        Key = ActionTypes.Tap,
         DisplayName = "Tap",
         Description = "Tap at coordinates",
         AttributeDefinitions = new List<AttributeDefinitionDto> {
@@ -74,7 +75,7 @@ internal static class ActionTypesEndpoints {
         }
       },
       new() {
-        Key = "swipe",
+        Key = ActionTypes.Swipe,
         DisplayName = "Swipe",
         Description = "Swipe between two coordinates",
         AttributeDefinitions = new List<AttributeDefinitionDto> {
@@ -121,7 +122,7 @@ internal static class ActionTypesEndpoints {
         }
       },
       new() {
-        Key = "key",
+        Key = ActionTypes.Key,
         DisplayName = "Key Event",
         Description = "Send an Android key event (name or numeric code)",
         AttributeDefinitions = new List<AttributeDefinitionDto> {
@@ -146,6 +147,20 @@ internal static class ActionTypesEndpoints {
             Required = false,
             Constraints = new AttributeConstraintsDto { Min = 0, Max = 300 },
             HelpText = "Optional numeric Android key code (overrides key name if provided)."
+          }
+        }
+      },
+      new() {
+        Key = ActionTypes.ConnectToGame,
+        DisplayName = "Connect to game",
+        Description = "Establish a session for a game on a target device (returns sessionId on execute)",
+        AttributeDefinitions = new List<AttributeDefinitionDto> {
+          new() {
+            Key = "adbSerial",
+            Label = "ADB Serial",
+            DataType = "string",
+            Required = true,
+            HelpText = "Device serial to bind the session; choose a suggestion or enter manually"
           }
         }
       }

--- a/src/GameBot.Service/Models/SessionCreationOptions.cs
+++ b/src/GameBot.Service/Models/SessionCreationOptions.cs
@@ -1,0 +1,7 @@
+namespace GameBot.Service.Models;
+
+#pragma warning disable CA1515 // Options need to be public for DI and tests
+public sealed class SessionCreationOptions {
+  public int TimeoutSeconds { get; set; } = 30;
+}
+#pragma warning restore CA1515

--- a/src/GameBot.Service/Models/Sessions.cs
+++ b/src/GameBot.Service/Models/Sessions.cs
@@ -10,6 +10,7 @@ internal sealed class CreateSessionRequest {
 
 internal sealed class CreateSessionResponse {
   public required string Id { get; init; }
+  public required string SessionId { get; init; }
   public required string Status { get; init; }
   public required string GameId { get; init; }
 }

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -76,6 +76,12 @@ builder.Services.ConfigureHttpJsonOptions(options => {
   options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
 builder.Services.Configure<GameBot.Emulator.Session.SessionOptions>(builder.Configuration.GetSection("Service:Sessions"));
+builder.Services.Configure<GameBot.Service.Models.SessionCreationOptions>(options => {
+  var envTimeout = Environment.GetEnvironmentVariable("GAMEBOT_SESSION_CREATE_TIMEOUT_SECONDS");
+  var cfgTimeout = builder.Configuration["Service:Sessions:CreationTimeoutSeconds"];
+  var raw = envTimeout ?? cfgTimeout;
+  options.TimeoutSeconds = int.TryParse(raw, out var seconds) ? Math.Max(1, seconds) : 30;
+});
 builder.Services.AddSingleton<ISessionManager, SessionManager>();
 builder.Services.AddTransient<ErrorHandlingMiddleware>();
 builder.Services.AddTransient<CorrelationIdMiddleware>();

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -13,6 +13,7 @@ using GameBot.Domain.Services.Logging;
 using GameBot.Service.Hosted;
 using GameBot.Service.Logging;
 using GameBot.Service.Services.Ocr;
+using GameBot.Service.Services;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
 using System.Runtime.InteropServices;
@@ -83,6 +84,7 @@ builder.Services.Configure<GameBot.Service.Models.SessionCreationOptions>(option
   options.TimeoutSeconds = int.TryParse(raw, out var seconds) ? Math.Max(1, seconds) : 30;
 });
 builder.Services.AddSingleton<ISessionManager, SessionManager>();
+builder.Services.AddSingleton<ISessionContextCache, SessionContextCache>();
 builder.Services.AddTransient<ErrorHandlingMiddleware>();
 builder.Services.AddTransient<CorrelationIdMiddleware>();
 builder.Services.AddSingleton<GameBot.Service.Services.ICommandExecutor, GameBot.Service.Services.CommandExecutor>();

--- a/src/GameBot.Service/Services/ICommandExecutor.cs
+++ b/src/GameBot.Service/Services/ICommandExecutor.cs
@@ -5,8 +5,8 @@ using GameBot.Domain.Triggers;
 namespace GameBot.Service.Services;
 
 internal interface ICommandExecutor {
-  Task<int> ForceExecuteAsync(string sessionId, string commandId, CancellationToken ct = default);
-  Task<CommandEvaluationDecision> EvaluateAndExecuteAsync(string sessionId, string commandId, CancellationToken ct = default);
+  Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default);
+  Task<CommandEvaluationDecision> EvaluateAndExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default);
 }
 
 internal sealed record CommandEvaluationDecision(int Accepted, TriggerStatus TriggerStatus, string? Reason);

--- a/src/GameBot.Service/Services/SessionContextCache.cs
+++ b/src/GameBot.Service/Services/SessionContextCache.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+
+namespace GameBot.Service.Services;
+
+internal interface ISessionContextCache {
+  void SetSessionId(string gameId, string adbSerial, string sessionId);
+  string? GetSessionId(string gameId, string adbSerial);
+  void ClearSession(string gameId, string adbSerial);
+}
+
+internal sealed class SessionContextCache : ISessionContextCache {
+  private readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+  private static string Key(string gameId, string adbSerial) => $"{gameId}|{adbSerial}";
+
+  public void SetSessionId(string gameId, string adbSerial, string sessionId) {
+    if (string.IsNullOrWhiteSpace(gameId) || string.IsNullOrWhiteSpace(adbSerial) || string.IsNullOrWhiteSpace(sessionId)) return;
+    _cache[Key(gameId.Trim(), adbSerial.Trim())] = sessionId.Trim();
+  }
+
+  public string? GetSessionId(string gameId, string adbSerial) {
+    if (string.IsNullOrWhiteSpace(gameId) || string.IsNullOrWhiteSpace(adbSerial)) return null;
+    _cache.TryGetValue(Key(gameId.Trim(), adbSerial.Trim()), out var value);
+    return string.IsNullOrWhiteSpace(value) ? null : value;
+  }
+
+  public void ClearSession(string gameId, string adbSerial) {
+    if (string.IsNullOrWhiteSpace(gameId) || string.IsNullOrWhiteSpace(adbSerial)) return;
+    _cache.TryRemove(Key(gameId.Trim(), adbSerial.Trim()), out _);
+  }
+}

--- a/src/web-ui/src/__tests__/execution.spec.tsx
+++ b/src/web-ui/src/__tests__/execution.spec.tsx
@@ -6,6 +6,7 @@ jest.mock('../pages/actions/ActionsListPage', () => ({ ActionsListPage: () => <d
 jest.mock('../pages/CommandsPage', () => ({ CommandsPage: () => <div role="heading" aria-level={2}>Commands</div> }));
 jest.mock('../pages/GamesPage', () => ({ GamesPage: () => <div role="heading" aria-level={2}>Games</div> }));
 jest.mock('../pages/SequencesPage', () => ({ SequencesPage: () => <div role="heading" aria-level={2}>Sequences</div> }));
+jest.mock('../pages/Execution', () => ({ ExecutionPage: () => <div>execution workspace</div> }));
 
 describe('Execution placeholder', () => {
   it('shows empty-state messaging and allows returning', () => {

--- a/src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
+++ b/src/web-ui/src/components/actions/__tests__/ActionForm.spec.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ActionForm, ActionFormValue } from '../ActionForm';
 import { ActionType, ValidationMessage } from '../../../types/actions';
+import { useAdbDevices } from '../../../services/useAdbDevices';
+
+jest.mock('../../../services/useAdbDevices');
+
+const useAdbDevicesMock = useAdbDevices as jest.MockedFunction<typeof useAdbDevices>;
 
 describe('ActionForm', () => {
   const actionTypes: ActionType[] = [
@@ -11,10 +16,21 @@ describe('ActionForm', () => {
       attributeDefinitions: [
         { key: 'x', label: 'X', dataType: 'number', required: true, constraints: { min: 0, max: 100 } },
       ]
+    },
+    {
+      key: 'connect-to-game',
+      displayName: 'Connect to game',
+      attributeDefinitions: [
+        { key: 'adbSerial', label: 'ADB Serial', dataType: 'string', required: true }
+      ]
     }
   ];
   const games = [{ id: 'g1', name: 'Test Game' }];
   const baseValue: ActionFormValue = { name: '', gameId: 'g1', type: 'tap', attributes: {} };
+
+  beforeEach(() => {
+    useAdbDevicesMock.mockReturnValue({ loading: false, devices: [], refresh: jest.fn() });
+  });
 
   it('renders fields and shows validation errors', () => {
     const errors: ValidationMessage[] = [
@@ -63,5 +79,44 @@ describe('ActionForm', () => {
 
     fireEvent.submit(screen.getByRole('form'));
     expect(handleSubmit).toHaveBeenCalled();
+  });
+
+  it('renders adbSerial suggestions for connect-to-game', () => {
+    useAdbDevicesMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      devices: [{ serial: 'emulator-5554', state: 'device' }],
+      refresh: jest.fn()
+    });
+
+    render(
+      <ActionForm
+        actionTypes={actionTypes}
+        games={games as any}
+        value={{ name: 'c', gameId: 'g1', type: 'connect-to-game', attributes: { adbSerial: '' } }}
+        errors={[]}
+        onChange={() => undefined}
+      />
+    );
+
+    expect(screen.getByLabelText('ADB Serial *')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('')).toHaveAttribute('list');
+    expect(screen.getByText(/emulator-5554/)).toBeInTheDocument();
+  });
+
+  it('disables save when no games exist', () => {
+    render(
+      <ActionForm
+        actionTypes={actionTypes}
+        games={[] as any}
+        value={baseValue}
+        errors={[]}
+        onChange={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.getByText(/No games available/)).toBeInTheDocument();
   });
 });

--- a/src/web-ui/src/lib/sessionCache.ts
+++ b/src/web-ui/src/lib/sessionCache.ts
@@ -1,0 +1,26 @@
+const makeKey = (gameId: string, adbSerial: string) => `session:${gameId}:${adbSerial}`;
+
+const safe = (value?: string) => (typeof value === 'string' ? value.trim() : '');
+
+export const sessionCache = {
+  set(gameId: string, adbSerial: string, sessionId: string) {
+    const g = safe(gameId);
+    const d = safe(adbSerial);
+    const s = safe(sessionId);
+    if (!g || !d || !s) return;
+    localStorage.setItem(makeKey(g, d), s);
+  },
+  get(gameId: string, adbSerial: string): string | undefined {
+    const g = safe(gameId);
+    const d = safe(adbSerial);
+    if (!g || !d) return undefined;
+    const raw = localStorage.getItem(makeKey(g, d));
+    return raw?.trim() || undefined;
+  },
+  clear(gameId: string, adbSerial: string) {
+    const g = safe(gameId);
+    const d = safe(adbSerial);
+    if (!g || !d) return;
+    localStorage.removeItem(makeKey(g, d));
+  }
+};

--- a/src/web-ui/src/pages/Execution.tsx
+++ b/src/web-ui/src/pages/Execution.tsx
@@ -1,10 +1,148 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { listActions, ActionDto } from '../services/actionsApi';
+import { useGames } from '../services/useGames';
+import { createSession } from '../services/sessionsApi';
+import { sessionCache } from '../lib/sessionCache';
+import { ApiError } from '../lib/api';
+
+const getAdbSerial = (action?: ActionDto): string => {
+  if (!action) return '';
+  const raw = action.attributes?.adbSerial;
+  return typeof raw === 'string' ? raw : '';
+};
 
 export const ExecutionPage: React.FC = () => {
+  const { data: gamesData, loading: gamesLoading, error: gamesError } = useGames();
+  const [actions, setActions] = useState<ActionDto[]>([]);
+  const [loadingActions, setLoadingActions] = useState(true);
+  const [selectedActionId, setSelectedActionId] = useState<string | undefined>(undefined);
+  const [running, setRunning] = useState(false);
+  const [message, setMessage] = useState<string | undefined>(undefined);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [sessionId, setSessionId] = useState<string | undefined>(undefined);
+  const [cachedSessionId, setCachedSessionId] = useState<string | undefined>(undefined);
+
+  const gameLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    (gamesData ?? []).forEach((g) => map.set(g.id, g.name));
+    return map;
+  }, [gamesData]);
+
+  const connectActions = useMemo(() => actions.filter((a) => a.type === 'connect-to-game'), [actions]);
+  const selectedAction = connectActions.find((a) => a.id === selectedActionId);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoadingActions(true);
+      setError(undefined);
+      try {
+        const data = await listActions({ type: 'connect-to-game' });
+        setActions(data.filter((a) => a.type === 'connect-to-game'));
+      } catch (err: any) {
+        setActions([]);
+        setError(err?.message ?? 'Failed to load actions');
+      } finally {
+        setLoadingActions(false);
+      }
+    };
+    void load();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedActionId && connectActions.length > 0) {
+      setSelectedActionId(connectActions[0].id);
+    }
+  }, [connectActions, selectedActionId]);
+
+  useEffect(() => {
+    if (!selectedAction) {
+      setCachedSessionId(undefined);
+      return;
+    }
+    const adbSerial = getAdbSerial(selectedAction);
+    if (!adbSerial) {
+      setCachedSessionId(undefined);
+      return;
+    }
+    setCachedSessionId(sessionCache.get(selectedAction.gameId, adbSerial));
+  }, [selectedAction]);
+
+  const handleRun = async () => {
+    if (!selectedAction) return;
+    const adbSerial = getAdbSerial(selectedAction);
+    const gameId = selectedAction.gameId;
+    if (!gameId || !adbSerial) {
+      setError('Selected action is missing required game or adbSerial.');
+      return;
+    }
+
+    setRunning(true);
+    setMessage(undefined);
+    setError(undefined);
+    setSessionId(undefined);
+
+    try {
+      const response = await createSession({ gameId, adbSerial });
+      const sid = response.sessionId || response.id;
+      if (!sid) throw new ApiError(500, 'Session response missing id');
+      sessionCache.set(gameId, adbSerial, sid);
+      setSessionId(sid);
+      setCachedSessionId(sid);
+      setMessage(`Session ready: ${sid}`);
+    } catch (err: any) {
+      sessionCache.clear(gameId, adbSerial);
+      setCachedSessionId(undefined);
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError(err?.message ?? 'Failed to start session');
+      }
+    } finally {
+      setRunning(false);
+    }
+  };
+
   return (
     <div className="execution-view">
       <h1>Execution</h1>
-      <p>The execution workspace will appear here. Use Authoring to build assets or Configuration to adjust host/token.</p>
+      {gamesError && <div className="form-error" role="alert">{gamesError}</div>}
+      {error && <div className="form-error" role="alert">{error}</div>}
+      {message && <div className="form-hint" role="status">{message}</div>}
+
+      <section aria-label="Connect to game">
+        <h2>Start a session</h2>
+        <p>Select a connect-to-game action and start a session. The returned sessionId will be cached for reuse.</p>
+
+        <div className="field">
+          <label htmlFor="connect-action-select">Connect action</label>
+          <select
+            id="connect-action-select"
+            aria-label="Connect action"
+            value={selectedActionId ?? ''}
+            onChange={(e) => setSelectedActionId(e.target.value)}
+            disabled={loadingActions || running || connectActions.length === 0}
+          >
+            {connectActions.map((a) => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
+          {loadingActions && <div className="form-hint">Loading connect actions...</div>}
+          {!loadingActions && connectActions.length === 0 && <div className="form-hint">No connect-to-game actions available.</div>}
+        </div>
+
+        {selectedAction && (
+          <div className="action-details">
+            <div>Game: {gameLookup.get(selectedAction.gameId) ?? selectedAction.gameId}</div>
+            <div>ADB Serial: {getAdbSerial(selectedAction) || '—'}</div>
+            <div>Cached session: {cachedSessionId ?? 'none'}</div>
+          </div>
+        )}
+
+        <div className="form-actions">
+          <button type="button" onClick={handleRun} disabled={running || loadingActions || !selectedAction}>Start session</button>
+        </div>
+        {sessionId && <div className="form-hint">Active sessionId: {sessionId}</div>}
+      </section>
     </div>
   );
 };

--- a/src/web-ui/src/pages/Execution.tsx
+++ b/src/web-ui/src/pages/Execution.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { listActions, ActionDto } from '../services/actionsApi';
 import { useGames } from '../services/useGames';
 import { createSession } from '../services/sessionsApi';
+import { listCommands, forceExecuteCommand, CommandDto } from '../services/commands';
 import { sessionCache } from '../lib/sessionCache';
 import { ApiError } from '../lib/api';
 
@@ -14,13 +15,23 @@ const getAdbSerial = (action?: ActionDto): string => {
 export const ExecutionPage: React.FC = () => {
   const { data: gamesData, loading: gamesLoading, error: gamesError } = useGames();
   const [actions, setActions] = useState<ActionDto[]>([]);
+  const [commands, setCommands] = useState<CommandDto[]>([]);
   const [loadingActions, setLoadingActions] = useState(true);
+  const [loadingCommands, setLoadingCommands] = useState(true);
   const [selectedActionId, setSelectedActionId] = useState<string | undefined>(undefined);
+  const [selectedCommandId, setSelectedCommandId] = useState<string | undefined>(undefined);
   const [running, setRunning] = useState(false);
   const [message, setMessage] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
   const [sessionId, setSessionId] = useState<string | undefined>(undefined);
   const [cachedSessionId, setCachedSessionId] = useState<string | undefined>(undefined);
+  const [commandsError, setCommandsError] = useState<string | undefined>(undefined);
+  const [commandMessage, setCommandMessage] = useState<string | undefined>(undefined);
+  const [commandError, setCommandError] = useState<string | undefined>(undefined);
+  const [manualSessionId, setManualSessionId] = useState('');
+  const [executing, setExecuting] = useState(false);
+  const [commandCachedSessionId, setCommandCachedSessionId] = useState<string | undefined>(undefined);
+  const [commandCacheMeta, setCommandCacheMeta] = useState<{ gameId: string; adbSerial: string; actionName?: string } | undefined>(undefined);
 
   const gameLookup = useMemo(() => {
     const map = new Map<string, string>();
@@ -49,10 +60,33 @@ export const ExecutionPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    const load = async () => {
+      setLoadingCommands(true);
+      setCommandsError(undefined);
+      try {
+        const data = await listCommands();
+        setCommands(data);
+      } catch (err: any) {
+        setCommands([]);
+        setCommandsError(err?.message ?? 'Failed to load commands');
+      } finally {
+        setLoadingCommands(false);
+      }
+    };
+    void load();
+  }, []);
+
+  useEffect(() => {
     if (!selectedActionId && connectActions.length > 0) {
       setSelectedActionId(connectActions[0].id);
     }
   }, [connectActions, selectedActionId]);
+
+  useEffect(() => {
+    if (!selectedCommandId && commands.length > 0) {
+      setSelectedCommandId(commands[0].id);
+    }
+  }, [commands, selectedCommandId]);
 
   useEffect(() => {
     if (!selectedAction) {
@@ -66,6 +100,26 @@ export const ExecutionPage: React.FC = () => {
     }
     setCachedSessionId(sessionCache.get(selectedAction.gameId, adbSerial));
   }, [selectedAction]);
+
+  const findCommandCacheMeta = (commandId?: string) => {
+    if (!commandId) return undefined;
+    const cmd = commands.find((c) => c.id === commandId);
+    if (!cmd || !cmd.steps || cmd.steps.length === 0) return undefined;
+    const firstActionStep = [...cmd.steps].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)).find((s) => s.type === 'Action');
+    if (!firstActionStep) return undefined;
+    const action = connectActions.find((a) => a.id === firstActionStep.targetId);
+    if (!action || action.type !== 'connect-to-game') return undefined;
+    const adbSerial = getAdbSerial(action);
+    const gameId = typeof action.gameId === 'string' && action.gameId ? action.gameId : (typeof action.attributes?.gameId === 'string' ? action.attributes.gameId : '');
+    if (!gameId || !adbSerial) return undefined;
+    return { gameId, adbSerial, actionName: action.name };
+  };
+
+  useEffect(() => {
+    const meta = findCommandCacheMeta(selectedCommandId);
+    setCommandCacheMeta(meta);
+    setCommandCachedSessionId(meta ? sessionCache.get(meta.gameId, meta.adbSerial) : undefined);
+  }, [selectedCommandId, commands, connectActions]);
 
   const handleRun = async () => {
     if (!selectedAction) return;
@@ -102,12 +156,56 @@ export const ExecutionPage: React.FC = () => {
     }
   };
 
+  const handleExecuteCommand = async () => {
+    if (!selectedCommandId) {
+      setCommandError('Select a command to execute.');
+      return;
+    }
+
+    setExecuting(true);
+    setCommandMessage(undefined);
+    setCommandError(undefined);
+
+    let resolvedSessionId = manualSessionId.trim();
+    const meta = findCommandCacheMeta(selectedCommandId);
+    if (!resolvedSessionId) {
+      if (!meta) {
+        setExecuting(false);
+        setCommandError('No connect-to-game step found for this command. Enter a sessionId or update the command to include one.');
+        return;
+      }
+      const cached = sessionCache.get(meta.gameId, meta.adbSerial);
+      if (!cached) {
+        setExecuting(false);
+        setCommandError(`No cached session found for ${meta.gameId}/${meta.adbSerial}. Start a session first or enter a sessionId.`);
+        return;
+      }
+      resolvedSessionId = cached;
+    }
+
+    try {
+      const result = await forceExecuteCommand(selectedCommandId, resolvedSessionId);
+      const accepted = typeof result?.accepted === 'number' ? result.accepted : undefined;
+      setCommandMessage(accepted !== undefined ? `Command accepted: ${accepted}` : 'Command submitted');
+    } catch (err: any) {
+      if (err instanceof ApiError) {
+        setCommandError(err.message);
+      } else {
+        setCommandError(err?.message ?? 'Failed to execute command');
+      }
+    } finally {
+      setExecuting(false);
+    }
+  };
+
   return (
     <div className="execution-view">
       <h1>Execution</h1>
       {gamesError && <div className="form-error" role="alert">{gamesError}</div>}
       {error && <div className="form-error" role="alert">{error}</div>}
       {message && <div className="form-hint" role="status">{message}</div>}
+      {commandError && <div className="form-error" role="alert">{commandError}</div>}
+      {commandMessage && <div className="form-hint" role="status">{commandMessage}</div>}
 
       <section aria-label="Connect to game">
         <h2>Start a session</h2>
@@ -142,6 +240,54 @@ export const ExecutionPage: React.FC = () => {
           <button type="button" onClick={handleRun} disabled={running || loadingActions || !selectedAction}>Start session</button>
         </div>
         {sessionId && <div className="form-hint">Active sessionId: {sessionId}</div>}
+      </section>
+
+      <section aria-label="Execute command">
+        <h2>Execute a command</h2>
+        <p>Reuse the cached sessionId from a connect-to-game action when left blank.</p>
+
+        <div className="field">
+          <label htmlFor="command-select">Command</label>
+          <select
+            id="command-select"
+            aria-label="Command"
+            value={selectedCommandId ?? ''}
+            onChange={(e) => { setSelectedCommandId(e.target.value); setCommandMessage(undefined); setCommandError(undefined); }}
+            disabled={loadingCommands || executing || commands.length === 0}
+          >
+            {commands.map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+          {loadingCommands && <div className="form-hint">Loading commands...</div>}
+          {!loadingCommands && commands.length === 0 && <div className="form-hint">No commands available.</div>}
+          {commandsError && <div className="form-error" role="alert">{commandsError}</div>}
+        </div>
+
+        {commandCacheMeta && (
+          <div className="action-details">
+            <div>Connect action: {commandCacheMeta.actionName ?? 'connect-to-game'}</div>
+            <div>Game: {gameLookup.get(commandCacheMeta.gameId) ?? commandCacheMeta.gameId}</div>
+            <div>ADB Serial: {commandCacheMeta.adbSerial}</div>
+            <div>Cached session: {commandCachedSessionId ?? 'none'}</div>
+          </div>
+        )}
+
+        <div className="field">
+          <label htmlFor="command-session">SessionId (optional)</label>
+          <input
+            id="command-session"
+            aria-label="SessionId"
+            value={manualSessionId}
+            onChange={(e) => setManualSessionId(e.target.value)}
+            placeholder="Leave blank to use cached session"
+            disabled={executing || loadingCommands}
+          />
+        </div>
+
+        <div className="form-actions">
+          <button type="button" onClick={handleExecuteCommand} disabled={executing || loadingCommands || commands.length === 0}>Execute command</button>
+        </div>
       </section>
     </div>
   );

--- a/src/web-ui/src/pages/__tests__/ExecutionPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionPage.spec.tsx
@@ -3,19 +3,24 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ExecutionPage } from '../Execution';
 import { listActions } from '../../services/actionsApi';
 import { createSession } from '../../services/sessionsApi';
+import { listCommands, forceExecuteCommand } from '../../services/commands';
 import { useGames } from '../../services/useGames';
 import { sessionCache } from '../../lib/sessionCache';
 import { ApiError } from '../../lib/api';
 
 jest.mock('../../services/actionsApi');
 jest.mock('../../services/sessionsApi');
+jest.mock('../../services/commands');
 jest.mock('../../services/useGames');
 
 const listActionsMock = listActions as jest.MockedFunction<typeof listActions>;
 const createSessionMock = createSession as jest.MockedFunction<typeof createSession>;
+const listCommandsMock = listCommands as jest.MockedFunction<typeof listCommands>;
+const forceExecuteMock = forceExecuteCommand as jest.MockedFunction<typeof forceExecuteCommand>;
 const useGamesMock = useGames as unknown as jest.MockedFunction<typeof useGames>;
 
 const connectAction = { id: 'c1', name: 'Connect Action', gameId: 'g1', type: 'connect-to-game', attributes: { adbSerial: 'emulator-5554', gameId: 'g1' } } as any;
+const connectCommand = { id: 'cmd1', name: 'Cmd 1', steps: [{ type: 'Action', targetId: 'c1', order: 0 }] } as any;
 
 describe('ExecutionPage', () => {
   beforeEach(() => {
@@ -23,6 +28,7 @@ describe('ExecutionPage', () => {
     localStorage.clear();
     useGamesMock.mockReturnValue({ data: [{ id: 'g1', name: 'Test Game' }], loading: false, error: undefined } as any);
     listActionsMock.mockResolvedValue([connectAction]);
+    listCommandsMock.mockResolvedValue([connectCommand]);
   });
 
   it('creates a session and caches the sessionId', async () => {
@@ -51,5 +57,35 @@ describe('ExecutionPage', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Session creation timed out');
     expect(sessionCache.get('g1', 'emulator-5554')).toBeUndefined();
+  });
+
+  it('auto-injects cached sessionId when executing a command', async () => {
+    createSessionMock.mockResolvedValue({ id: 's123', sessionId: 's123', status: 'RUNNING', gameId: 'g1' });
+    forceExecuteMock.mockResolvedValue({ accepted: 2 } as any);
+    sessionCache.set('g1', 'emulator-5554', 'sid-cached');
+
+    render(<ExecutionPage />);
+
+    const executeButton = await screen.findByRole('button', { name: /execute command/i });
+    await waitFor(() => expect(executeButton).not.toBeDisabled());
+
+    fireEvent.click(executeButton);
+
+    await waitFor(() => expect(forceExecuteMock).toHaveBeenCalledWith('cmd1', 'sid-cached'));
+    expect(await screen.findByRole('status')).toHaveTextContent('Command accepted: 2');
+  });
+
+  it('blocks execution when no cached session is available', async () => {
+    forceExecuteMock.mockResolvedValue({ accepted: 1 } as any);
+
+    render(<ExecutionPage />);
+
+    const executeButton = await screen.findByRole('button', { name: /execute command/i });
+    await waitFor(() => expect(executeButton).not.toBeDisabled());
+
+    fireEvent.click(executeButton);
+
+    expect(forceExecuteMock).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toHaveTextContent('No cached session');
   });
 });

--- a/src/web-ui/src/pages/__tests__/ExecutionPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionPage.spec.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ExecutionPage } from '../Execution';
+import { listActions } from '../../services/actionsApi';
+import { createSession } from '../../services/sessionsApi';
+import { useGames } from '../../services/useGames';
+import { sessionCache } from '../../lib/sessionCache';
+import { ApiError } from '../../lib/api';
+
+jest.mock('../../services/actionsApi');
+jest.mock('../../services/sessionsApi');
+jest.mock('../../services/useGames');
+
+const listActionsMock = listActions as jest.MockedFunction<typeof listActions>;
+const createSessionMock = createSession as jest.MockedFunction<typeof createSession>;
+const useGamesMock = useGames as unknown as jest.MockedFunction<typeof useGames>;
+
+const connectAction = { id: 'c1', name: 'Connect Action', gameId: 'g1', type: 'connect-to-game', attributes: { adbSerial: 'emulator-5554', gameId: 'g1' } } as any;
+
+describe('ExecutionPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    localStorage.clear();
+    useGamesMock.mockReturnValue({ data: [{ id: 'g1', name: 'Test Game' }], loading: false, error: undefined } as any);
+    listActionsMock.mockResolvedValue([connectAction]);
+  });
+
+  it('creates a session and caches the sessionId', async () => {
+    createSessionMock.mockResolvedValue({ id: 's123', sessionId: 's123', status: 'RUNNING', gameId: 'g1' });
+
+    render(<ExecutionPage />);
+
+    const runButton = await screen.findByRole('button', { name: /start session/i });
+    await waitFor(() => expect(runButton).not.toBeDisabled());
+
+    fireEvent.click(runButton);
+
+    await waitFor(() => expect(createSessionMock).toHaveBeenCalledWith({ gameId: 'g1', adbSerial: 'emulator-5554' }));
+    expect(await screen.findByText(/Active sessionId/i)).toHaveTextContent('s123');
+    expect(sessionCache.get('g1', 'emulator-5554')).toBe('s123');
+  });
+
+  it('shows an error and does not cache on failure', async () => {
+    createSessionMock.mockRejectedValue(new ApiError(504, 'Session creation timed out'));
+
+    render(<ExecutionPage />);
+
+    const runButton = await screen.findByRole('button', { name: /start session/i });
+    await waitFor(() => expect(runButton).not.toBeDisabled());
+    fireEvent.click(runButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Session creation timed out');
+    expect(sessionCache.get('g1', 'emulator-5554')).toBeUndefined();
+  });
+});

--- a/src/web-ui/src/pages/actions/ActionsListPage.tsx
+++ b/src/web-ui/src/pages/actions/ActionsListPage.tsx
@@ -125,7 +125,11 @@ export const ActionsListPage: React.FC<ActionsListPageProps> = ({ initialMode = 
       return;
     }
     try {
-      await updateAction(editId, { name: editForm.name.trim(), gameId: editForm.gameId, type: editForm.type, attributes: editForm.attributes });
+      const attributes = (editForm.type === 'connect-to-game' && editForm.gameId)
+        ? { ...editForm.attributes, gameId: editForm.gameId }
+        : editForm.attributes;
+
+      await updateAction(editId, { name: editForm.name.trim(), gameId: editForm.gameId, type: editForm.type, attributes });
       setEditErrors([]);
       setEditMessage(undefined);
       setMessage('Action updated successfully.');

--- a/src/web-ui/src/services/actionsApi.ts
+++ b/src/web-ui/src/services/actionsApi.ts
@@ -63,6 +63,9 @@ const normalizeDuration = (attributes: Record<string, unknown>): { durationMs?: 
 
 const fromCreate = (payload: ActionCreate): DomainAction => {
   const { durationMs, rest } = normalizeDuration(payload.attributes ?? {});
+  if (payload.type === 'connect-to-game' && payload.gameId) {
+    rest.gameId = payload.gameId;
+  }
   return {
   id: '',
   name: payload.name,
@@ -81,6 +84,9 @@ const fromCreate = (payload: ActionCreate): DomainAction => {
 
 const fromUpdate = (payload: ActionUpdate, id: string): DomainAction => {
   const { durationMs, rest } = normalizeDuration(payload.attributes ?? {});
+  if (payload.type === 'connect-to-game' && payload.gameId) {
+    rest.gameId = payload.gameId;
+  }
   return {
     id,
     name: payload.name,

--- a/src/web-ui/src/services/adbApi.ts
+++ b/src/web-ui/src/services/adbApi.ts
@@ -1,0 +1,12 @@
+import { getJson } from '../lib/api';
+
+export type AdbDevice = {
+  serial: string;
+  state?: string;
+  info?: string;
+};
+
+export const listAdbDevices = async (): Promise<AdbDevice[]> => {
+  const devices = await getJson<AdbDevice[]>('/api/adb/devices');
+  return Array.isArray(devices) ? devices : [];
+};

--- a/src/web-ui/src/services/commands.ts
+++ b/src/web-ui/src/services/commands.ts
@@ -25,6 +25,12 @@ export type CommandStepDto = {
   order: number;
 };
 
+export type CommandExecuteResponse = {
+  accepted: number;
+  triggerStatus?: string;
+  message?: string;
+};
+
 export type DetectionTargetDto = {
   referenceImageId: string;
   confidence?: number;
@@ -40,3 +46,7 @@ export const getCommand = (id: string) => getJson<CommandDto>(`${base}/${id}`);
 export const createCommand = (input: CommandCreate) => postJson<CommandDto>(base, input);
 export const updateCommand = (id: string, input: CommandUpdate) => patchJson<CommandDto>(`${base}/${id}`, input);
 export const deleteCommand = (id: string) => deleteJson<void>(`${base}/${id}`);
+export const forceExecuteCommand = (id: string, sessionId?: string) => {
+  const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
+  return postJson<CommandExecuteResponse>(`${base}/${id}/force-execute${query}`, {});
+};

--- a/src/web-ui/src/services/sessionsApi.ts
+++ b/src/web-ui/src/services/sessionsApi.ts
@@ -1,0 +1,60 @@
+import { ApiError, ApiValidationError, buildApiUrl, buildAuthHeaders } from '../lib/api';
+
+export type SessionCreateRequest = {
+  gameId: string;
+  adbSerial: string;
+};
+
+export type SessionCreateResponse = {
+  id: string;
+  sessionId?: string;
+  status?: string;
+  gameId?: string;
+};
+
+const parseJsonSafe = async <T>(res: Response): Promise<T | undefined> => {
+  try {
+    return (await res.json()) as T;
+  } catch {
+    return undefined;
+  }
+};
+
+export const createSession = async (payload: SessionCreateRequest, timeoutMs = 30000): Promise<SessionCreateResponse> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(0, timeoutMs));
+  try {
+    const res = await fetch(buildApiUrl('/api/sessions'), {
+      method: 'POST',
+      headers: buildAuthHeaders(true),
+      body: JSON.stringify(payload),
+      signal: controller.signal
+    });
+
+    if (res.ok) {
+      const data = await parseJsonSafe<SessionCreateResponse>(res);
+      return data as SessionCreateResponse;
+    }
+
+    const data = await parseJsonSafe<any>(res);
+    if (controller.signal.aborted || res.status === 504) {
+      throw new ApiError(504, 'Session creation timed out', undefined, data);
+    }
+    if (res.status === 400) {
+      const errors: ApiValidationError[] | undefined = Array.isArray(data?.errors)
+        ? data.errors.map((e: any) => ({ field: e.field, message: e.message ?? String(e) }))
+        : undefined;
+      throw new ApiError(400, 'Validation error', errors, data);
+    }
+    const message = (data?.error && (data.error.message ?? data.error.code)) || data?.message || `HTTP ${res.status}`;
+    throw new ApiError(res.status, message, undefined, data);
+  } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      throw new ApiError(504, 'Session creation timed out');
+    }
+    if (err instanceof ApiError) throw err;
+    throw new ApiError(500, err?.message ?? 'Failed to create session');
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/src/web-ui/src/services/useAdbDevices.ts
+++ b/src/web-ui/src/services/useAdbDevices.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { AdbDevice, listAdbDevices } from './adbApi';
+
+export type UseAdbDevicesState = {
+  loading: boolean;
+  devices: AdbDevice[];
+  error?: string;
+  refresh: () => void;
+};
+
+export const useAdbDevices = (enabled = true): UseAdbDevicesState => {
+  const [loading, setLoading] = useState(false);
+  const [devices, setDevices] = useState<AdbDevice[]>([]);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const load = async () => {
+    if (!enabled) return;
+    setLoading(true);
+    setError(undefined);
+    try {
+      const list = await listAdbDevices();
+      setDevices(list);
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load devices');
+      setDevices([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!enabled) {
+      setDevices([]);
+      setError(undefined);
+      setLoading(false);
+      return;
+    }
+    void load();
+  }, [enabled]);
+
+  return { loading, devices, error, refresh: () => { void load(); } };
+};

--- a/tests/integration/ActionTypesEndpointTests.cs
+++ b/tests/integration/ActionTypesEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests;
+
+public sealed class ActionTypesEndpointTests {
+  public ActionTypesEndpointTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  [Fact]
+  public async Task CatalogIncludesConnectToGameDefinition() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var resp = await client.GetAsync(new Uri("/api/action-types", UriKind.Relative)).ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var payload = await resp.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(true);
+
+    payload.TryGetProperty("items", out var items).Should().BeTrue();
+    items.ValueKind.Should().Be(JsonValueKind.Array);
+
+    var connect = items.EnumerateArray()
+      .FirstOrDefault(i => string.Equals(i.GetProperty("key").GetString(), "connect-to-game", StringComparison.OrdinalIgnoreCase));
+
+    connect.ValueKind.Should().Be(JsonValueKind.Object);
+    var displayName = connect.GetProperty("displayName").GetString();
+    displayName.Should().NotBeNull();
+    displayName!.Contains("connect", StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+
+    var attrDefs = connect.GetProperty("attributeDefinitions");
+    attrDefs.ValueKind.Should().Be(JsonValueKind.Array);
+    var adbSerial = attrDefs.EnumerateArray()
+      .FirstOrDefault(a => string.Equals(a.GetProperty("key").GetString(), "adbSerial", StringComparison.OrdinalIgnoreCase));
+
+    adbSerial.ValueKind.Should().Be(JsonValueKind.Object);
+    adbSerial.GetProperty("required").GetBoolean().Should().BeTrue();
+    adbSerial.GetProperty("dataType").GetString().Should().Be("string");
+  }
+}

--- a/tests/integration/SessionCreationTimeoutTests.cs
+++ b/tests/integration/SessionCreationTimeoutTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Sessions;
+using GameBot.Emulator.Session;
+using GameBot.Service.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests;
+
+public sealed class SessionCreationTimeoutTests : IDisposable {
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+
+  public SessionCreationTimeoutTests() {
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    GC.SuppressFinalize(this);
+  }
+
+  [Fact]
+  public async Task ReturnsGatewayTimeoutWhenCreationExceedsConfiguredLimit() {
+    using var baseFactory = new WebApplicationFactory<Program>();
+    using var app = baseFactory.WithWebHostBuilder(builder => {
+      builder.ConfigureServices(services => {
+        services.AddSingleton<ISessionManager>(_ => new SlowSessionManager(TimeSpan.FromSeconds(2)));
+        services.Configure<SessionCreationOptions>(opts => opts.TimeoutSeconds = 1);
+      });
+    });
+
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+
+    var resp = await client.PostAsJsonAsync("/api/sessions", new { gameId = "g1", adbSerial = "device-1" }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.GatewayTimeout);
+  }
+
+  [Fact]
+  public async Task ReturnsSessionIdOnSuccess() {
+    using var baseFactory = new WebApplicationFactory<Program>();
+    using var app = baseFactory.WithWebHostBuilder(builder => {
+      builder.ConfigureServices(services => {
+        services.AddSingleton<ISessionManager>(_ => new SlowSessionManager(TimeSpan.Zero));
+        services.Configure<SessionCreationOptions>(opts => opts.TimeoutSeconds = 5);
+      });
+    });
+
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+
+    var resp = await client.PostAsJsonAsync("/api/sessions", new { gameId = "g1", adbSerial = "device-1" }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+    var payload = await resp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(true);
+    payload.Should().NotBeNull();
+    var sessionId = payload?["sessionId"]?.ToString();
+    sessionId.Should().NotBeNullOrWhiteSpace();
+  }
+}
+
+internal sealed class SlowSessionManager : ISessionManager {
+  private readonly TimeSpan _delay;
+  private int _created;
+
+  public SlowSessionManager(TimeSpan delay) {
+    _delay = delay;
+  }
+
+  public int ActiveCount => _created;
+  public bool CanCreateSession => true;
+
+  public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) {
+    if (_delay > TimeSpan.Zero) {
+      Thread.Sleep(_delay);
+    }
+    _created++;
+    return new EmulatorSession {
+      Id = Guid.NewGuid().ToString("N"),
+      GameId = gameIdOrPath,
+      Status = SessionStatus.Running,
+      DeviceSerial = preferredDeviceSerial ?? string.Empty
+    };
+  }
+
+  public EmulatorSession? GetSession(string id) => null;
+  public IReadOnlyCollection<EmulatorSession> ListSessions() => Array.Empty<EmulatorSession>();
+  public bool StopSession(string id) => false;
+  public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+  public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+}

--- a/tests/unit/CommandExecutorSessionCacheTests.cs
+++ b/tests/unit/CommandExecutorSessionCacheTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using GameBot.Domain.Triggers;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using ActionModel = GameBot.Domain.Actions.Action;
+using DomainInputAction = GameBot.Domain.Actions.InputAction;
+using SessionInputAction = GameBot.Emulator.Session.InputAction;
+using EmulatorSession = GameBot.Domain.Sessions.EmulatorSession;
+
+namespace GameBot.UnitTests;
+
+public sealed class CommandExecutorSessionCacheTests {
+  [Fact]
+  public async Task ForceExecuteUsesCachedSessionWhenSessionIdMissing() {
+    var actionRepo = new FakeActionRepository();
+    actionRepo.Seed(new ActionModel {
+      Id = "a-connect",
+      Name = "Connect",
+      GameId = "g1",
+      Steps = new Collection<DomainInputAction> {
+        new DomainInputAction { Type = "connect-to-game", Args = new Dictionary<string, object> { { "adbSerial", "device-1" }, { "gameId", "g1" } } }
+      }
+    });
+
+    var commandRepo = new FakeCommandRepository();
+    commandRepo.Seed(new Command {
+      Id = "cmd1",
+      Name = "Cmd",
+      Steps = new Collection<CommandStep> { new() { Type = CommandStepType.Action, TargetId = "a-connect", Order = 0 } }
+    });
+
+    var sessionManager = new FakeSessionManager();
+    sessionManager.Seed(new EmulatorSession {
+      Id = "sid-123",
+      GameId = "g1",
+      Status = GameBot.Domain.Sessions.SessionStatus.Running,
+      DeviceSerial = "device-1"
+    });
+
+    var cache = new SessionContextCache();
+    cache.SetSessionId("g1", "device-1", "sid-123");
+
+    var exec = new CommandExecutor(commandRepo, actionRepo, sessionManager, new FakeTriggerRepository(), new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()), NullLogger<CommandExecutor>.Instance, cache);
+
+    var accepted = await exec.ForceExecuteAsync(null, "cmd1").ConfigureAwait(false);
+
+    accepted.Should().Be(1);
+    sessionManager.LastSessionId.Should().Be("sid-123");
+  }
+
+  [Fact]
+  public async Task ForceExecuteThrowsWhenNoCachedSession() {
+    var actionRepo = new FakeActionRepository();
+    actionRepo.Seed(new ActionModel {
+      Id = "a-connect",
+      Name = "Connect",
+      GameId = "g1",
+      Steps = new Collection<DomainInputAction> {
+        new DomainInputAction { Type = "connect-to-game", Args = new Dictionary<string, object> { { "adbSerial", "device-1" }, { "gameId", "g1" } } }
+      }
+    });
+
+    var commandRepo = new FakeCommandRepository();
+    commandRepo.Seed(new Command {
+      Id = "cmd1",
+      Name = "Cmd",
+      Steps = new Collection<CommandStep> { new() { Type = CommandStepType.Action, TargetId = "a-connect", Order = 0 } }
+    });
+
+    var sessionManager = new FakeSessionManager();
+    var cache = new SessionContextCache();
+
+    var exec = new CommandExecutor(commandRepo, actionRepo, sessionManager, new FakeTriggerRepository(), new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()), NullLogger<CommandExecutor>.Instance, cache);
+
+    var act = async () => await exec.ForceExecuteAsync(null, "cmd1").ConfigureAwait(false);
+    await act.Should().ThrowAsync<KeyNotFoundException>().WithMessage("*cached_session_not_found*").ConfigureAwait(false);
+  }
+}
+
+file sealed class FakeActionRepository : IActionRepository {
+  private readonly Dictionary<string, ActionModel> _store = new(StringComparer.OrdinalIgnoreCase);
+
+  public void Seed(ActionModel action) => _store[action.Id] = action;
+
+  public Task<ActionModel> AddAsync(ActionModel action, CancellationToken ct = default) {
+    _store[action.Id] = action;
+    return Task.FromResult(action);
+  }
+
+  public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_store.Remove(id));
+
+  public Task<ActionModel?> GetAsync(string id, CancellationToken ct = default) {
+    _store.TryGetValue(id, out var act);
+    return Task.FromResult<ActionModel?>(act);
+  }
+
+  public Task<IReadOnlyList<ActionModel>> ListAsync(string? gameId = null, CancellationToken ct = default) {
+    var list = _store.Values.Where(a => gameId is null || string.Equals(a.GameId, gameId, StringComparison.OrdinalIgnoreCase)).ToList();
+    return Task.FromResult((IReadOnlyList<ActionModel>)list);
+  }
+
+  public Task<ActionModel?> UpdateAsync(ActionModel action, CancellationToken ct = default) {
+    _store[action.Id] = action;
+    return Task.FromResult<ActionModel?>(action);
+  }
+}
+
+file sealed class FakeCommandRepository : ICommandRepository {
+  private readonly Dictionary<string, Command> _store = new(StringComparer.OrdinalIgnoreCase);
+
+  public void Seed(Command command) => _store[command.Id] = command;
+
+  public Task<Command> AddAsync(Command command, CancellationToken ct = default) {
+    _store[command.Id] = command;
+    return Task.FromResult(command);
+  }
+
+  public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_store.Remove(id));
+
+  public Task<Command?> GetAsync(string id, CancellationToken ct = default) {
+    _store.TryGetValue(id, out var cmd);
+    return Task.FromResult(cmd);
+  }
+
+  public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Command>)_store.Values.ToList());
+
+  public Task<Command?> UpdateAsync(Command command, CancellationToken ct = default) {
+    _store[command.Id] = command;
+    return Task.FromResult<Command?>(command);
+  }
+}
+
+file sealed class FakeTriggerRepository : ITriggerRepository {
+  public Task<Trigger> AddAsync(Trigger trigger, CancellationToken ct = default) {
+    LastAdded = trigger;
+    return Task.FromResult(trigger);
+  }
+  public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(true);
+  public Trigger? LastAdded { get; private set; }
+  public Trigger? LastUpserted { get; private set; }
+  public Task<Trigger?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<Trigger?>(null);
+  public Task<IReadOnlyList<Trigger>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Trigger>)Array.Empty<Trigger>());
+  public Task UpsertAsync(Trigger trigger, CancellationToken ct = default) {
+    LastUpserted = trigger;
+    return Task.CompletedTask;
+  }
+}
+
+file sealed class FakeSessionManager : ISessionManager {
+  private readonly Dictionary<string, EmulatorSession> _sessions = new(StringComparer.OrdinalIgnoreCase);
+  public string? LastSessionId { get; private set; }
+
+  public void Seed(EmulatorSession sess) => _sessions[sess.Id] = sess;
+
+  public int ActiveCount => _sessions.Count;
+  public bool CanCreateSession => true;
+  public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) => throw new NotImplementedException();
+  public EmulatorSession? GetSession(string id) {
+    _sessions.TryGetValue(id, out var sess);
+    return sess;
+  }
+  public IReadOnlyCollection<EmulatorSession> ListSessions() => _sessions.Values;
+  public bool StopSession(string id) => _sessions.Remove(id);
+  public Task<int> SendInputsAsync(string id, IEnumerable<SessionInputAction> actions, CancellationToken ct = default) {
+    LastSessionId = id;
+    return Task.FromResult(actions?.Count() ?? 0);
+  }
+  public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+}

--- a/tests/unit/Commands/CommandExecutorTests.cs
+++ b/tests/unit/Commands/CommandExecutorTests.cs
@@ -70,7 +70,7 @@ public sealed class CommandExecutorTests {
     var actionRepo = new ActionRepositoryStub(action);
     var sessionManager = new SessionManagerStub(triggerRepo);
     var triggerService = new TriggerEvaluationService(new[] { new StaticResultEvaluator(TriggerStatus.Satisfied, "should_not_matter") });
-    var executor = new CommandExecutor(commandRepo, actionRepo, sessionManager, triggerRepo, triggerService, NullLogger<CommandExecutor>.Instance);
+    var executor = new CommandExecutor(commandRepo, actionRepo, sessionManager, triggerRepo, triggerService, NullLogger<CommandExecutor>.Instance, new SessionContextCache());
 
     var decision = await executor.EvaluateAndExecuteAsync(sessionManager.Session.Id, command.Id, CancellationToken.None).ConfigureAwait(false);
 
@@ -114,7 +114,7 @@ public sealed class CommandExecutorTests {
     sessionManager = new SessionManagerStub(triggerRepo);
     var evaluator = new StaticResultEvaluator(status, reason);
     var triggerService = new TriggerEvaluationService(new[] { evaluator });
-    return new CommandExecutor(commandRepo, actionRepo, sessionManager, triggerRepo, triggerService, NullLogger<CommandExecutor>.Instance);
+    return new CommandExecutor(commandRepo, actionRepo, sessionManager, triggerRepo, triggerService, NullLogger<CommandExecutor>.Instance, new SessionContextCache());
   }
 
   private sealed class CommandRepositoryStub : ICommandRepository {

--- a/tests/unit/Domain/ConnectToGameArgsTests.cs
+++ b/tests/unit/Domain/ConnectToGameArgsTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using Xunit;
+
+namespace GameBot.UnitTests.Domain;
+
+public sealed class ConnectToGameArgsTests {
+  [Fact]
+  public void TryFromReturnsArgsWhenTypeMatchesAndFieldsPresent() {
+    var input = new InputAction {
+      Type = ActionTypes.ConnectToGame,
+      Args = new Dictionary<string, object> {
+        ["gameId"] = "game-1",
+        ["adbSerial"] = "emulator-5554"
+      }
+    };
+
+    var ok = ConnectToGameArgs.TryFrom(input, null, out var args);
+
+    ok.Should().BeTrue();
+    args.Should().NotBeNull();
+    args!.GameId.Should().Be("game-1");
+    args.AdbSerial.Should().Be("emulator-5554");
+  }
+
+  [Fact]
+  public void TryFromFallsBackToActionGameIdWhenArgsMissingGameId() {
+    var input = new InputAction {
+      Type = ActionTypes.ConnectToGame,
+      Args = new Dictionary<string, object> {
+        ["adbSerial"] = "device-123"
+      }
+    };
+
+    var ok = ConnectToGameArgs.TryFrom(input, "game-from-action", out var args);
+
+    ok.Should().BeTrue();
+    args!.GameId.Should().Be("game-from-action");
+    args.AdbSerial.Should().Be("device-123");
+  }
+
+  [Fact]
+  public void TryFromReturnsFalseWhenRequiredFieldsMissing() {
+    var input = new InputAction {
+      Type = ActionTypes.ConnectToGame,
+      Args = new Dictionary<string, object>()
+    };
+
+    var ok = ConnectToGameArgs.TryFrom(input, null, out var args);
+
+    ok.Should().BeFalse();
+    args.Should().BeNull();
+  }
+
+  [Fact]
+  public void ToArgsDictionaryContainsGameAndSerial() {
+    var args = new ConnectToGameArgs { GameId = "g", AdbSerial = "s" };
+
+    var dict = args.ToArgsDictionary();
+
+    dict.Should().ContainKey("gameId").WhoseValue.Should().Be("g");
+    dict.Should().ContainKey("adbSerial").WhoseValue.Should().Be("s");
+  }
+}


### PR DESCRIPTION
## Summary
- add tagged logging for session creation and cache resolution in command execution endpoints
- document optional sessionId in OpenAPI and quickstart/tasks updates for connect-to-game action
- include sample connect-to-game action payload for easier testing

## Testing
- dotnet test -c Debug
- npm test -- ExecutionPage
