### PR TITLE
Execution-log feature: persistence, hierarchy, retention, and full test coverage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-05
 - Checked-in repository version files for override/counter/marker state; existing installer/runtime persisted properties under user scope (`%LocalAppData%`) (026-installer-semver-upgrade)
 - C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (authoring UI) + ASP.NET Core Minimal API, `GameBot.Domain` command/action repositories, `CommandExecutor`, existing detection pipeline (`IReferenceImageStore`, `IScreenSource`, `ITemplateMatcher`), existing web-ui authoring APIs. (027-add-primitive-tap-action)
 - Existing file-backed JSON command repository under `data/commands`; no new persistence store. (027-add-primitive-tap-action)
+- C# 13 / .NET 9 (service/domain), TypeScript ES2020 / React 18 (future consumer only) + ASP.NET Core Minimal API, existing `GameBot.Domain` command/sequence services, file-backed repositories under `data/`, existing config/logging policy infrastructure. (028-execution-log)
+- File-backed JSON execution-log repository under `data/execution-logs` with retention-driven cleanup; retention configuration persisted in existing config store. (028-execution-log)
 
 - .NET 9 + ASP.NET Core Minimal API; SharpAdbClient (ADB integration); System.Drawing/Imaging or Windows Graphics Capture for snapshots (001-android-emulator-service)
 
@@ -71,9 +73,9 @@ After running `dotnet test -c Debug --logger trx;`, execute `scripts/analyze-tes
 Coding style: Follow standard .NET 9 C# conventions
 
 ## Recent Changes
+- 028-execution-log: Added C# 13 / .NET 9 (service/domain), TypeScript ES2020 / React 18 (future consumer only) + ASP.NET Core Minimal API, existing `GameBot.Domain` command/sequence services, file-backed repositories under `data/`, existing config/logging policy infrastructure.
 - 027-add-primitive-tap-action: Added C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (authoring UI) + ASP.NET Core Minimal API, `GameBot.Domain` command/action repositories, `CommandExecutor`, existing detection pipeline (`IReferenceImageStore`, `IScreenSource`, `ITemplateMatcher`), existing web-ui authoring APIs.
 - 026-installer-semver-upgrade: Added C# / .NET 9, PowerShell 5.1+, WiX authoring (XML) + `WixToolset.Sdk` (v6), ASP.NET Core minimal API host configuration pipeline, existing JSON config/file repositories, PowerShell build scripts
-- 025-standalone-windows-installer: Added C# 13 / .NET 9, PowerShell 5.1+, WiX authoring (XML) + `WixToolset.Sdk` (v4), existing `GameBot.Service` publish output, existing web UI build output
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,12 @@ _ReSharper.Caches/
 
 data.old/ 
 tools/
+!tools/
+tools/*
+!tools/coverage/
+tools/coverage/*
+!tools/coverage/execution-log-coverage-20260227.json
+!tools/coverage/execution-log-perf-20260227.json
 
 # PR helper files (do not commit)
 PR_BODY.md

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ Thumbs.db
 [Dd]esktop.ini
 $RECYCLE.BIN/
 **/.DS_Store
+*.tmp
+*.swp
 
 # Secrets / local env
 .env

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -61,6 +61,21 @@ Redaction: Any key containing `TOKEN`, `SECRET`, `PASSWORD`, or `KEY` (case-inse
   - Default: `(<app-base>)/data` when not set; or `Service:Storage:Root` if provided.
   - Example (PowerShell): `$env:GAMEBOT_DATA_DIR = "C:\\src\\GameBot\\data"`
 
+### Execution log storage paths (explicit)
+
+Execution log files are persisted under the resolved storage root (from `Service:Storage:Root` or `GAMEBOT_DATA_DIR`; fallback: `<app-base>/data`).
+
+- Execution entries: `<storage-root>/execution-logs/*.json`
+- Retention policy file: `<storage-root>/config/execution-log-policy.json`
+
+Examples:
+- If `$env:GAMEBOT_DATA_DIR = "C:\\src\\GameBot\\data"`:
+  - `C:\\src\\GameBot\\data\\execution-logs\\*.json`
+  - `C:\\src\\GameBot\\data\\config\\execution-log-policy.json`
+- If no overrides are set and the service runs from `src/GameBot.Service/bin/Debug/net9.0`:
+  - `src/GameBot.Service/bin/Debug/net9.0/data/execution-logs/*.json`
+  - `src/GameBot.Service/bin/Debug/net9.0/data/config/execution-log-policy.json`
+
 - GAMEBOT_DYNAMIC_PORT
   - Purpose: Bind service to a dynamically assigned port instead of a fixed one to avoid conflicts in tests/CI.
   - Used in: `Program.cs`

--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Notes:
 - Storage root for file repositories:
   - Environment: `GAMEBOT_DATA_DIR`
   - Config: `Service:Storage:Root` (default: `<app>/data` under the running process)
+  - Execution-log file paths: see `ENVIRONMENT.md` → [Execution log storage paths (explicit)](ENVIRONMENT.md#execution-log-storage-paths-explicit)
 - Session settings (Options): `Service:Sessions`
   - `MaxConcurrentSessions` (default 3)
   - `IdleTimeoutSeconds` (default 1800)

--- a/docs/perf-checklist.md
+++ b/docs/perf-checklist.md
@@ -33,3 +33,19 @@ Reporting
 	- `create_p95_ms=1.91`, `create_avg_ms=1.35`
 	- `update_p95_ms=2.19`, `update_avg_ms=1.56`
 - Assessment: command create/update p95 remains well under the `< 200 ms` target in local validation.
+
+## Execution Log API Latency Sample (2026-02-27)
+
+- Measurement target:
+	- Write path: `PUT /api/execution-logs/retention`
+	- Query path: `GET /api/execution-logs?pageSize=50`
+- Method:
+	- 25 sequential iterations per endpoint against local debug service (`http://localhost:5081`).
+	- Per-request elapsed time measured with `System.Diagnostics.Stopwatch` in PowerShell.
+- Results:
+	- Write: `p95=4.44 ms`, `avg=10.68 ms`
+	- Query: `p95=6.31 ms`, `avg=4.51 ms`
+- Evidence artifact:
+	- `tools/coverage/execution-log-perf-20260227.json`
+- Assessment:
+	- Both write and query p95 latencies are comfortably below the `< 200 ms` target.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -49,3 +49,21 @@
 	- Create command with PrimitiveTap: `p95=1.91 ms`, `avg=1.35 ms`
 	- Update command with PrimitiveTap: `p95=2.19 ms`, `avg=1.56 ms`
 - Result: command API latency remains comfortably below the plan target (`< 200 ms p95`).
+
+## Execution Log Feature Validation (2026-02-27)
+
+- **Build validation**: `dotnet build -c Debug` succeeded after implementation wiring and analyzer remediation.
+- **Test validation**: `dotnet test -c Debug --logger trx` succeeded with `299/299` passing tests.
+- **Required failure analysis**: `scripts/analyze-test-results.ps1` reported `All tests passed across 3 TRX file(s)` after clearing stale TRX files.
+- **Contract validation**: Swagger example coverage includes execution-log routes, including `PUT /api/execution-logs/retention` request/response examples.
+- **Privacy check**: Execution log persistence path enforces redaction/masking through `ExecutionLogSanitizer` before repository writes.
+- **Security scans**:
+	- `.NET dependency vulnerability scan`: `dotnet list GameBot.sln package --vulnerable --include-transitive` reported no vulnerable packages.
+	- Repository secret-signature scan (`git grep` over common API key/private-key patterns) returned no matches.
+- **Coverage evidence (touched area)**:
+	- `src/GameBot.Service/Services/CommandExecutor.cs`: `85.71%` statement coverage (`runTests` coverage mode).
+	- `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs`: `85.32%` statement coverage (`runTests` coverage mode).
+	- Coverage artifact recorded at `tools/coverage/execution-log-coverage-20260227.json`.
+- **Performance evidence (p95 write/query)**:
+	- `PUT /api/execution-logs/retention` (25 iterations): `p95=4.44 ms`, `avg=10.68 ms`.
+	- `GET /api/execution-logs?pageSize=50` (25 iterations): `p95=6.31 ms`, `avg=4.51 ms`.

--- a/specs/028-execution-log/checklists/requirements.md
+++ b/specs/028-execution-log/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Persisted Execution Log
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1 passed all checklist items.
+- Relative-link suggestion is captured as route-style path strings in assumptions and FR-006 (host/port agnostic).
+- Specification is ready for `/speckit.plan`.

--- a/specs/028-execution-log/contracts/execution-log.openapi.yaml
+++ b/specs/028-execution-log/contracts/execution-log.openapi.yaml
@@ -1,0 +1,293 @@
+openapi: 3.0.3
+info:
+  title: GameBot Execution Log API
+  version: 0.1.0
+  description: Backend contracts for persisted command and sequence execution logs.
+paths:
+  /api/execution-logs:
+    get:
+      summary: List execution log entries
+      parameters:
+        - in: query
+          name: fromUtc
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: toUtc
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: finalStatus
+          schema:
+            type: string
+            enum: [success, failure]
+        - in: query
+          name: objectType
+          schema:
+            type: string
+            enum: [command, sequence]
+        - in: query
+          name: objectId
+          schema:
+            type: string
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+        - in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Paged execution log result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionLogListResponse'
+  /api/execution-logs/{id}:
+    get:
+      summary: Get execution log entry detail
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionLogEntry'
+        '404':
+          description: Entry not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/execution-logs/retention:
+    get:
+      summary: Get execution log retention policy
+      responses:
+        '200':
+          description: Current retention policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionLogRetentionPolicy'
+    put:
+      summary: Update execution log retention policy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecutionLogRetentionPolicyPatch'
+      responses:
+        '200':
+          description: Updated policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionLogRetentionPolicy'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    ExecutionLogListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExecutionLogEntry'
+        nextCursor:
+          type: string
+          nullable: true
+
+    ExecutionLogEntry:
+      type: object
+      required:
+        - id
+        - timestampUtc
+        - executionType
+        - finalStatus
+        - objectRef
+        - navigation
+        - hierarchy
+        - summary
+        - details
+        - stepOutcomes
+      properties:
+        id:
+          type: string
+        timestampUtc:
+          type: string
+          format: date-time
+        executionType:
+          type: string
+          enum: [command, sequence]
+        finalStatus:
+          type: string
+          enum: [success, failure]
+        objectRef:
+          $ref: '#/components/schemas/ExecutionObjectReference'
+        navigation:
+          $ref: '#/components/schemas/ExecutionNavigationContext'
+        hierarchy:
+          $ref: '#/components/schemas/ExecutionHierarchyContext'
+        summary:
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExecutionDetailItem'
+        stepOutcomes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExecutionStepOutcome'
+
+    ExecutionObjectReference:
+      type: object
+      required: [objectType, objectId, displayNameSnapshot]
+      properties:
+        objectType:
+          type: string
+          enum: [command, sequence]
+        objectId:
+          type: string
+        displayNameSnapshot:
+          type: string
+        versionSnapshot:
+          type: string
+          nullable: true
+
+    ExecutionNavigationContext:
+      type: object
+      required: [directPath, pathKind]
+      properties:
+        directPath:
+          type: string
+          description: Relative route to directly executed object.
+          pattern: '^/'
+        parentPath:
+          type: string
+          nullable: true
+          description: Relative route to parent sequence context, when nested.
+          pattern: '^/'
+        pathKind:
+          type: string
+          enum: [relative-route]
+
+    ExecutionHierarchyContext:
+      type: object
+      required: [rootExecutionId, depth]
+      properties:
+        rootExecutionId:
+          type: string
+        parentExecutionId:
+          type: string
+          nullable: true
+        depth:
+          type: integer
+          minimum: 0
+        sequenceIndex:
+          type: integer
+          nullable: true
+          minimum: 0
+
+    ExecutionStepOutcome:
+      type: object
+      required: [stepOrder, stepType, outcome]
+      properties:
+        stepOrder:
+          type: integer
+          minimum: 0
+        stepType:
+          type: string
+        outcome:
+          type: string
+          enum: [executed, not_executed]
+        reasonCode:
+          type: string
+          nullable: true
+        reasonText:
+          type: string
+          nullable: true
+
+    ExecutionDetailItem:
+      type: object
+      required: [kind, message, sensitivity]
+      properties:
+        kind:
+          type: string
+        message:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
+              - type: integer
+              - type: boolean
+        sensitivity:
+          type: string
+          enum: [normal, masked, redacted]
+
+    ExecutionLogRetentionPolicy:
+      type: object
+      required: [enabled, retentionDays, cleanupIntervalMinutes, updatedAtUtc]
+      properties:
+        enabled:
+          type: boolean
+        retentionDays:
+          type: integer
+          minimum: 1
+        cleanupIntervalMinutes:
+          type: integer
+          minimum: 1
+        updatedAtUtc:
+          type: string
+          format: date-time
+
+    ExecutionLogRetentionPolicyPatch:
+      type: object
+      required: [enabled]
+      properties:
+        enabled:
+          type: boolean
+        retentionDays:
+          type: integer
+          minimum: 1
+        cleanupIntervalMinutes:
+          type: integer
+          minimum: 1
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            hint:
+              type: string
+              nullable: true

--- a/specs/028-execution-log/contracts/execution-log.openapi.yaml
+++ b/specs/028-execution-log/contracts/execution-log.openapi.yaml
@@ -3,10 +3,17 @@ info:
   title: GameBot Execution Log API
   version: 0.1.0
   description: Backend contracts for persisted command and sequence execution logs.
+  x-feature-id: 028-execution-log
+  x-last-validated-utc: '2026-02-28T08:30:00Z'
+tags:
+  - name: ExecutionLogs
+    description: Query persisted execution outcomes and manage retention policy.
 paths:
   /api/execution-logs:
     get:
       summary: List execution log entries
+      operationId: ListExecutionLogs
+      tags: [ExecutionLogs]
       parameters:
         - in: query
           name: fromUtc
@@ -53,6 +60,8 @@ paths:
   /api/execution-logs/{id}:
     get:
       summary: Get execution log entry detail
+      operationId: GetExecutionLog
+      tags: [ExecutionLogs]
       parameters:
         - in: path
           name: id
@@ -75,6 +84,8 @@ paths:
   /api/execution-logs/retention:
     get:
       summary: Get execution log retention policy
+      operationId: GetExecutionLogRetentionPolicy
+      tags: [ExecutionLogs]
       responses:
         '200':
           description: Current retention policy
@@ -84,6 +95,8 @@ paths:
                 $ref: '#/components/schemas/ExecutionLogRetentionPolicy'
     put:
       summary: Update execution log retention policy
+      operationId: UpdateExecutionLogRetentionPolicy
+      tags: [ExecutionLogs]
       requestBody:
         required: true
         content:

--- a/specs/028-execution-log/data-model.md
+++ b/specs/028-execution-log/data-model.md
@@ -1,0 +1,114 @@
+# Data Model
+
+## Entities
+
+### ExecutionLogEntry
+- `id`: string (unique immutable identifier)
+- `timestampUtc`: datetime (required; execution event time)
+- `executionType`: enum [`command`, `sequence`] (required)
+- `finalStatus`: enum [`success`, `failure`] (required)
+- `objectRef`: `ExecutionObjectReference` (required)
+- `navigation`: `ExecutionNavigationContext` (required)
+- `hierarchy`: `ExecutionHierarchyContext` (required)
+- `summary`: string (required; concise user-facing text)
+- `details`: array of `ExecutionDetailItem` (required; may be empty)
+- `stepOutcomes`: array of `ExecutionStepOutcome` (required; may be empty)
+- `retentionExpiresUtc`: datetime (required)
+
+Validation rules:
+- `summary` MUST be concise and non-empty.
+- `finalStatus` MUST be `success` or `failure`.
+- Sensitive values MUST be masked/redacted in `details` before persistence.
+
+### ExecutionObjectReference
+- `objectType`: enum [`command`, `sequence`] (required)
+- `objectId`: string (required)
+- `displayNameSnapshot`: string (required)
+- `versionSnapshot`: string? (optional, if available)
+
+Validation rules:
+- `objectId` + `timestampUtc` MUST be sufficient for user identification.
+- Snapshot values are immutable once persisted.
+
+### ExecutionNavigationContext
+- `directPath`: string (required; relative route to directly executed object)
+- `parentPath`: string? (optional; relative route to parent sequence when nested)
+- `pathKind`: enum [`relative-route`] (required)
+
+Validation rules:
+- Paths MUST be relative and MUST NOT include scheme/host/port.
+- For nested execution, `parentPath` SHOULD be present.
+
+### ExecutionHierarchyContext
+- `rootExecutionId`: string (required)
+- `parentExecutionId`: string? (optional for top-level)
+- `depth`: integer (required, >= 0)
+- `sequenceIndex`: integer? (optional, order within parent sequence)
+
+Validation rules:
+- `depth = 0` implies no parent.
+- Child entries MUST reference existing parent/root identifiers in same persisted set.
+
+### ExecutionStepOutcome
+- `stepOrder`: integer (required, >= 0)
+- `stepType`: string (required; e.g., action/command/primitiveTap)
+- `outcome`: enum [`executed`, `not_executed`] (required)
+- `reasonCode`: string? (optional, machine-friendly)
+- `reasonText`: string? (optional, user-facing)
+
+Validation rules:
+- `outcome=not_executed` SHOULD include `reasonText`.
+
+### ExecutionDetailItem
+- `kind`: string (required; e.g., `detection`, `tap`, `sequence`)
+- `message`: string (required; user-facing concise statement)
+- `attributes`: map<string, primitive> (optional; masked values only)
+- `sensitivity`: enum [`normal`, `masked`, `redacted`] (required)
+
+Validation rules:
+- `message` MUST not expose raw sensitive data.
+- `attributes` values MUST already be sanitized.
+
+### ExecutionRetentionPolicy
+- `enabled`: boolean (required)
+- `retentionDays`: integer (required when enabled, > 0)
+- `cleanupIntervalMinutes`: integer (required, > 0)
+- `updatedAtUtc`: datetime (required)
+
+Validation rules:
+- Policy changes apply to subsequent cleanup cycles.
+
+## Relationships
+- One `ExecutionLogEntry` has one `ExecutionObjectReference`.
+- One `ExecutionLogEntry` has one `ExecutionNavigationContext`.
+- One `ExecutionLogEntry` has one `ExecutionHierarchyContext`.
+- One `ExecutionLogEntry` has many `ExecutionStepOutcome` and many `ExecutionDetailItem`.
+- `ExecutionRetentionPolicy` governs expiration and cleanup for all `ExecutionLogEntry` records.
+
+## State Transitions
+
+### ExecutionLogEntry.finalStatus
+- Start: pending in-memory execution context
+- End: `success` when execution completes as intended
+- End: `failure` when execution fails or terminally cannot proceed
+
+### ExecutionStepOutcome.outcome
+- Start: step evaluated
+- End: `executed` when step action was performed
+- End: `not_executed` when step was skipped/blocked (for example detection below threshold)
+
+### Retention lifecycle
+- On write: compute `retentionExpiresUtc` from active policy
+- During cleanup cycle: entries with `retentionExpiresUtc <= now` become purge candidates
+- On purge: entry removed from durable storage
+
+## Query Model
+- List endpoint supports filters by:
+  - time range (`fromUtc`, `toUtc`)
+  - `finalStatus`
+  - `objectType`
+  - `objectId`
+- Pagination fields:
+  - `pageSize`
+  - `cursor` (opaque continuation token)
+- Default ordering: newest first by `timestampUtc`

--- a/specs/028-execution-log/plan.md
+++ b/specs/028-execution-log/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Persisted Execution Log
+
+**Branch**: `028-execution-log` | **Date**: 2026-02-27 | **Spec**: [specs/028-execution-log/spec.md](specs/028-execution-log/spec.md)
+**Input**: Feature specification from `/specs/028-execution-log/spec.md`
+
+## Summary
+
+Introduce durable backend execution logging for command and sequence runs with end-user oriented entries that capture timestamp, identifiable object reference, hierarchy context, final status (`success`/`failure`), per-step outcome (`executed`/`not_executed`), concise outcome detail, masked sensitive values, and relative navigation context for future web UI linking. The feature adds persistence, retrieval contracts, and configurable retention policy without requiring immediate UI implementation.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9 (service/domain), TypeScript ES2020 / React 18 (future consumer only)
+
+**Primary Dependencies**: ASP.NET Core Minimal API, existing `GameBot.Domain` command/sequence services, file-backed repositories under `data/`, existing config/logging policy infrastructure.
+
+**Storage**: File-backed JSON execution-log repository under `data/execution-logs` with retention-driven cleanup; retention configuration persisted in existing config store.
+
+**Testing**: xUnit unit tests for event-to-log mapping and masking rules, integration tests for execution endpoint logging and retrieval endpoints, contract tests for new API shapes; touched-area coverage >=80% line and >=70% branch.
+
+**Target Platform**: Windows development/runtime baseline.
+
+**Project Type**: Web application backend API with future web-ui consumption.
+
+**Performance Goals**:
+- Additional logging overhead per command/sequence execution p95 < 25 ms.
+- Log query endpoint p95 < 300 ms for default page size with typical local dataset.
+- Cleanup execution (retention purge) should not block command execution request path.
+
+**Constraints**:
+- Preserve existing command/sequence execution behavior and response compatibility.
+- Keep end-user log entries concise and avoid developer-only trace jargon.
+- Store only masked/redacted sensitive values.
+- Use relative navigation paths only (host/port agnostic).
+- Keep retention period configurable.
+
+**Scale/Scope**:
+- Execution coverage: all command and sequence execution attempts, including skipped/not executed steps.
+- Data volume target: up to 100k retained log entries per environment with paged retrieval.
+- Scope limited to backend persistence + retrieval readiness; web-ui rendering deferred.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Phase 0 Gate Review
+
+- Code Quality: PASS — planned implementation reuses existing endpoint/service/repository patterns, introduces focused domain entities, and avoids new external dependencies.
+- Testing: PASS — unit/integration/contract tests planned with deterministic fixtures and touched-area coverage targets meeting constitution thresholds.
+- UX Consistency: PASS — logs and API responses remain actionable, stable, and user-oriented; sensitive data masking is explicit.
+- Performance: PASS — measurable latency budgets and non-blocking cleanup strategy are defined.
+- Performance measurement approach: capture p95 write/query timings during verification and record evidence in feature docs.
+
+### Post-Phase 1 Design Re-check
+
+- Code Quality: PASS — data model and contracts preserve cohesive boundaries (service layer owns log write orchestration; domain services expose execution context signals; repository persists snapshots; endpoints read/query).
+- Testing: PASS — artifacts define testable status/outcome semantics, hierarchy linking, and masking behavior with deterministic acceptance checks.
+- UX Consistency: PASS — contract fields explicitly support object identification, relative navigation context, and concise user-facing outcome summaries.
+- Performance: PASS — design uses append-oriented writes and paginated reads; retention cleanup is decoupled from execution path.
+
+## Phase 0: Research Output
+
+`research.md` resolves:
+- Canonical execution log schema for command/sequence + step outcomes.
+- Relative navigation path strategy for nested objects.
+- Retention and cleanup policy configuration approach.
+- Sensitive-value masking/redaction policy and default behavior.
+- Retrieval/query contract shape for backend-only phase.
+
+## Phase 1: Design & Contracts Output
+
+- `data-model.md`: execution log domain entities, validation rules, and lifecycle/cleanup states.
+- `contracts/execution-log.openapi.yaml`: create-by-execution, list/filter, detail retrieval, and retention configuration contract additions.
+- `quickstart.md`: backend verification flow for successful run, skipped run, hierarchy linking, masking, and retention config.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/028-execution-log/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── execution-log.openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   ├── Commands/                    # Existing command/sequence domain models
+│   ├── Services/                    # Execution context signals consumed by service layer
+│   └── Logging/                     # Existing logging policy models/services
+└── GameBot.Service/
+    ├── Endpoints/                   # Commands/Sequences/ExecutionLog endpoints
+    ├── Models/                      # DTOs for execution log query/response
+    └── Services/                    # Execution log persistence and masking service
+
+tests/
+├── unit/                            # Mapping, masking, retention rule tests
+├── integration/                     # Execution + persistence + query flows
+└── contract/                        # API contract shape and backward compatibility
+```
+
+**Structure Decision**: Extend existing `GameBot.Domain` and `GameBot.Service` modules with an execution-log slice; no new top-level project or storage technology.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/028-execution-log/quickstart.md
+++ b/specs/028-execution-log/quickstart.md
@@ -75,7 +75,9 @@ Expected:
 ## 8) Run automated tests
 ```powershell
 Set-Location C:/src/GameBot
-dotnet test -c Debug
+Get-ChildItem -Path tests -Filter *.trx -Recurse | Remove-Item -Force
+dotnet test -c Debug --logger trx
+./scripts/analyze-test-results.ps1
 ```
 
 Focus areas:

--- a/specs/028-execution-log/quickstart.md
+++ b/specs/028-execution-log/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart
+
+## 1) Build and run the service
+```powershell
+Set-Location C:/src/GameBot
+dotnet build -c Debug
+dotnet run -c Debug --project src/GameBot.Service
+```
+
+## 2) Trigger a command execution that succeeds
+```powershell
+$commandId = "<existing-command-id>"
+$sessionId = "<active-session-id>"
+Invoke-RestMethod -Method Post -Uri "http://localhost:5081/api/commands/$commandId/force-execute?sessionId=$sessionId"
+```
+
+Expected:
+- Execution is accepted.
+- A persisted execution log entry is created with `finalStatus=success`.
+
+## 3) Trigger a command/step path that does not execute
+```powershell
+$commandId = "<command-id-with-detection-threshold-failure>"
+$sessionId = "<active-session-id>"
+Invoke-RestMethod -Method Post -Uri "http://localhost:5081/api/commands/$commandId/force-execute?sessionId=$sessionId"
+```
+
+Expected:
+- Persisted entry includes step outcome `not_executed`.
+- Entry includes user-facing reason (for example threshold not met).
+
+## 4) Query recent execution logs
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5081/api/execution-logs?pageSize=20"
+```
+
+Expected:
+- Items include timestamp, object identity, hierarchy context, `finalStatus`, step outcomes, and relative navigation context.
+- Nested entries include both direct object path and parent hierarchy path.
+
+## 5) Filter for failures of a specific object
+```powershell
+$objectId = "<command-or-sequence-id>"
+Invoke-RestMethod -Method Get -Uri "http://localhost:5081/api/execution-logs?finalStatus=failure&objectId=$objectId&pageSize=20"
+```
+
+Expected:
+- Returned rows are limited to matching failed executions.
+
+## 6) Inspect one log entry
+```powershell
+$logId = "<execution-log-id>"
+Invoke-RestMethod -Method Get -Uri "http://localhost:5081/api/execution-logs/$logId"
+```
+
+Expected:
+- Detail includes sanitized `details` payload, hierarchy links, and route-style relative navigation paths.
+
+## 7) Update retention policy (configurable period)
+```powershell
+$body = @'
+{
+  "enabled": true,
+  "retentionDays": 60,
+  "cleanupIntervalMinutes": 30
+}
+'@
+Invoke-RestMethod -Method Put -Uri "http://localhost:5081/api/execution-logs/retention" -ContentType "application/json" -Body $body
+```
+
+Expected:
+- Policy update is persisted.
+- Future cleanup cycles enforce the new retention duration.
+
+## 8) Run automated tests
+```powershell
+Set-Location C:/src/GameBot
+dotnet test -c Debug
+```
+
+Focus areas:
+- Execution-to-log mapping for command and sequence runs.
+- Hierarchy linkage and relative navigation context.
+- `success/failure` plus `executed/not_executed` semantics.
+- Sensitive value masking/redaction before persistence.
+- Retention configuration and cleanup behavior.

--- a/specs/028-execution-log/research.md
+++ b/specs/028-execution-log/research.md
@@ -1,0 +1,50 @@
+# Research
+
+## Decision 1: Persist execution logs as append-oriented JSON records with repository abstraction
+- Decision: Use a dedicated execution log repository backed by JSON files under `data/execution-logs`, following existing file-repository patterns.
+- Rationale: Aligns with current architecture, keeps operational model simple, and avoids introducing new storage dependencies.
+- Alternatives considered:
+  - Reusing existing command/sequence files (rejected: mixes runtime telemetry with authoring data).
+  - New database dependency (rejected: out of scope and operationally heavier).
+
+## Decision 2: Capture command and sequence runs as correlated log entries with parent-child linkage
+- Decision: Write one top-level entry per command/sequence execution plus step-level outcome details, preserving parent-child references for nested runs.
+- Rationale: Supports both high-level success/failure review and hierarchy-aware troubleshooting from persisted data.
+- Alternatives considered:
+  - Flat, uncorrelated entries only (rejected: weak sequence diagnostics).
+  - Aggregate-only sequence result (rejected: loses failing-node visibility).
+
+## Decision 3: Keep final status separate from step execution outcome
+- Decision: Use final status values `success|failure` and separate per-step outcome flag `executed|not_executed`.
+- Rationale: Preserves user-requested status semantics while clearly representing skipped/blocked steps.
+- Alternatives considered:
+  - Three-state status including `not_executed` (rejected per clarification).
+  - Encode skip only in reason text (rejected: ambiguous for filtering/tests).
+
+## Decision 4: Represent navigation context as host-agnostic relative routes
+- Decision: Persist relative paths for direct object navigation and parent hierarchy context (for nested executions).
+- Rationale: Works across environments without binding host/port and supports future web-ui deep links.
+- Alternatives considered:
+  - Absolute URLs (rejected: environment-coupled and brittle).
+  - IDs only with no route hints (rejected: poorer UX and slower troubleshooting).
+
+## Decision 5: Make retention configurable with asynchronous cleanup
+- Decision: Expose configurable retention duration and perform expiry cleanup outside the execution request critical path.
+- Rationale: Meets configurability requirement and avoids latency regressions in command execution.
+- Alternatives considered:
+  - Fixed retention period (rejected by clarification).
+  - Cleanup only at read-time (rejected: stale data growth and unpredictable query cost).
+
+## Decision 6: Apply sensitive-value masking/redaction before persistence
+- Decision: Execution details are normalized and masked/redacted before writing to durable storage.
+- Rationale: Protects sensitive values while keeping enough context for user troubleshooting.
+- Alternatives considered:
+  - Store raw details (rejected: privacy risk).
+  - Remove all parameter details (rejected: insufficient diagnostics).
+
+## Decision 7: Introduce retrieval endpoints with filtering and pagination
+- Decision: Add list/detail endpoints for execution logs, with filters on status, object type/id, and time range; include pagination.
+- Rationale: Enables immediate backend consumption and future web-ui integration while controlling query cost.
+- Alternatives considered:
+  - No retrieval API yet (rejected: limits validation and near-term usability).
+  - Bulk-only export endpoint (rejected: poor interactive diagnostics).

--- a/specs/028-execution-log/spec.md
+++ b/specs/028-execution-log/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Persisted Execution Log
+
+**Feature Branch**: `[028-execution-log]`  
+**Created**: 2026-02-27  
+**Status**: Draft  
+**Input**: User description: "execution log. I want to have a persisted execution log of each command and sequence execution in order to be able to check what failed and what succeeded. The log must contain the following information: Timestamp, Object being executed (also the hierarchy, i.e. if a command was a standalone or part of sequence) and status: success/failure. Object should be identifiable, so that the end user can find what execution object actually failed or succeeded, maybe a link to open it in the authoring UI (watch out for hierarchy) would be helpful. The link should be relative, of course, as we cannot bind to a specific host/port, make a suggestion, how to achieve this. If an object is parametrized (like a primitive tap), make sure you log, what actually happened, e.g. Detected an image ABC at location (x,y) with Confidence a, then Tap at location (x,y). Also necessary information available now in traces should be noted, for example if command execution was not performed due to detection not being able to find anything above threshold. The log should be consise and informative and it should be oriented on the end users, not the developers. Later I'd like to have it displayed in the web-ui, but for now it's enough if it's stored on the backend."
+
+## Clarifications
+
+### Session 2026-02-27
+
+- Q: How should steps that were intentionally not executed (for example detection below threshold) be represented in status semantics? → A: Keep final status as `success`/`failure` and add a separate step outcome flag (`executed`/`not_executed`).
+- Q: What log retention period should be used? → A: Keep period configurable.
+- Q: For nested executions, should entries carry child-only link, parent-only link, or both? → A: Include both child link and parent hierarchy context in the same entry.
+- Q: How should sensitive parameter values be handled in execution logs? → A: Log user-facing details with sensitive values masked or redacted.
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Review execution outcomes (Priority: P1)
+
+As an end user, I can review persisted execution log entries for commands and sequences so I can quickly see what succeeded, what failed, and when.
+
+**Why this priority**: This is the core outcome: users need a durable execution history to diagnose failures after runs complete.
+
+**Independent Test**: Can be fully tested by running one successful command and one failing command, then verifying persisted entries contain timestamp, execution object, hierarchy context, and final status.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command execution completes successfully, **When** the log is persisted, **Then** an entry records execution time, object identity, hierarchy context, and status `success`.
+2. **Given** a sequence execution fails, **When** the log is persisted, **Then** the sequence and impacted command entries record failure status and user-readable failure reason.
+
+---
+
+### User Story 2 - Trace sequence hierarchy (Priority: P2)
+
+As an end user, I can see whether a command executed standalone or as part of a sequence, including parent-child relationship details, so I can understand where a failure happened.
+
+**Why this priority**: Hierarchy context is necessary to troubleshoot sequence runs where multiple commands execute in order.
+
+**Independent Test**: Can be tested by running the same command once standalone and once inside a sequence, then validating logs clearly differentiate both contexts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command runs inside a sequence, **When** its log entry is written, **Then** the entry includes parent sequence identity and relative position in hierarchy.
+2. **Given** a command runs standalone, **When** its log entry is written, **Then** the entry indicates no parent sequence and remains uniquely identifiable.
+
+---
+
+### User Story 3 - Understand what actually happened (Priority: P3)
+
+As an end user, I can read concise, outcome-focused execution details for parameterized actions and skipped operations so I know why a step succeeded, failed, or did not execute.
+
+**Why this priority**: Clear, concise activity details reduce support burden and help users self-diagnose without developer-only traces.
+
+**Independent Test**: Can be tested by executing a parameterized action with successful detection and another with detection below threshold, then confirming both outcomes are captured in user-friendly detail.
+
+**Acceptance Scenarios**:
+
+1. **Given** detection succeeds and a tap executes, **When** logging occurs, **Then** the log includes concise details such as detected reference, detected location, confidence value, and executed tap location.
+2. **Given** detection does not meet threshold, **When** the command is skipped or fails, **Then** the log includes that execution did not proceed and explains the threshold condition in user-facing language.
+
+---
+
+### Edge Cases
+
+- Multiple executions occur in the same second; each entry still remains uniquely identifiable and ordered.
+- A sequence starts but is interrupted mid-run; completed and non-completed child items are distinguishable.
+- The referenced object (command/sequence) is later renamed or deleted; historical log entries remain understandable and still reference the original identity captured at execution time.
+- An execution detail payload is unusually long; log output remains concise and truncates or summarizes non-essential detail while retaining critical outcome data.
+- Relative authoring path cannot be resolved for a historical object; entry keeps object identifiers and marks navigation path as unavailable.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST persist an execution log entry for every command execution attempt and every sequence execution attempt.
+- **FR-002**: Each execution log entry MUST include execution timestamp, final execution status (`success` or `failure`), and object identity sufficient for end users to determine exactly what was executed.
+- **FR-003**: Each execution log entry MUST indicate hierarchy context, including whether execution was standalone or part of a sequence, and when nested MUST identify parent sequence context.
+- **FR-004**: Log entries for parameterized or multi-step actions MUST include concise, user-facing outcome details describing what occurred (for example detection result, confidence, resolved coordinates, and follow-up action taken).
+- **FR-005**: When execution does not proceed as expected (for example detection below threshold), the log MUST record that execution step as not performed and include the reason in end-user language.
+- **FR-006**: Each log entry MUST include a stable, relative authoring navigation path suggestion so a future web UI can open the directly executed object without requiring host or port binding.
+- **FR-007**: For hierarchical executions, the system MUST preserve parent-child execution relationships and execution order so users can reconstruct the sequence run and identify the exact failed node.
+- **FR-008**: Persisted log content MUST be concise and informative for end users, avoiding developer-only trace jargon while preserving actionable failure/success context.
+- **FR-009**: Log entries MUST remain readable and actionable even if underlying objects are later modified, renamed, or removed.
+- **FR-010**: The backend MUST store execution logs durably so they can be retrieved later by user-facing features.
+- **FR-011**: Each logged execution step MUST include an outcome flag (`executed` or `not_executed`) distinct from final status to clearly represent skipped or blocked steps.
+- **FR-012**: The log retention period MUST be configurable so deployments can choose how long execution logs are kept before automated cleanup.
+- **FR-013**: For nested execution contexts, each relevant log entry MUST capture both the child object navigation path and parent hierarchy context so users can open the direct object and still understand where it ran.
+- **FR-014**: Execution log details MUST mask or redact sensitive values while preserving enough context for end users to understand execution outcomes.
+- **FR-015**: Log summaries MUST be limited to 240 characters, and each execution entry MUST include no more than 10 detail items unless a final item explicitly states additional details were truncated.
+- **FR-016**: Historical log entries MUST remain actionable after referenced object rename or deletion by preserving immutable object identifier and display-name snapshot captured at execution time.
+
+### Key Entities *(include if feature involves data)*
+
+- **Execution Log Entry**: A persisted record of one execution attempt containing timestamp, status, object identity, hierarchy metadata, user-facing outcome summary, and optional relative authoring path.
+- **Execution Object Reference**: Identifies the executed object (command or sequence) using stable identifiers and display name snapshot captured at execution time.
+- **Execution Hierarchy Link**: Relationship metadata connecting a child command execution to a parent sequence execution and ordering context.
+- **Execution Navigation Context**: Combined navigation data that includes a direct child object path and parent sequence hierarchy context for nested executions.
+- **Execution Outcome Detail**: Concise, structured narrative of what happened during execution (e.g., detection found/not found, confidence values, coordinates used, skipped action reason).
+- **Step Outcome Flag**: A per-step marker with values `executed` or `not_executed` that explains whether the step was actually performed regardless of final execution status.
+- **Retention Policy**: A configurable rule defining how long execution log records are retained before expiration.
+- **Sensitive Data Handling Rule**: A policy defining which execution detail fields require masking or redaction before persistence.
+
+## Assumptions
+
+- Existing backend execution signals already provide enough event data to derive user-oriented summaries without introducing developer-only debugging fields.
+- Relative navigation paths are stored as route-like strings (for example, `/authoring/commands/{id}` and `/authoring/sequences/{id}`) so any hosting environment can resolve them.
+- If both sequence and child command are relevant, entries include child path and parent reference; a UI can decide whether to open child directly or sequence context first.
+- Initial scope is backend persistence and retrieval readiness only; no new UI behavior is required in this feature.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of command and sequence execution attempts produce a persisted execution log entry.
+- **SC-002**: In validation runs, users can identify the exact failed or successful execution object from log data alone in at least 95% of reviewed entries.
+- **SC-003**: In validation runs involving sequence executions, users can determine where in the hierarchy a failure occurred in at least 95% of cases.
+- **SC-004**: For parameterized actions and skipped detections, at least 95% of sampled log entries contain sufficient outcome detail for a user to explain what happened without consulting developer traces.
+- **SC-005**: At least 95% of sampled execution entries comply with summary/detail conciseness bounds (summary <= 240 characters, <= 10 detail items with truncation marker when exceeded).
+- **SC-006**: Operators can change retention duration through configuration and observe that newly expired entries are cleaned up according to the configured policy.
+- **SC-007**: In privacy validation samples, no persisted execution log entry exposes unmasked sensitive values while still allowing users to determine what succeeded, failed, or was not executed.

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: Persisted Execution Log
+
+**Input**: Design documents from `/specs/028-execution-log/`
+**Prerequisites**: `plan.md` (required), `spec.md` (required for user stories), `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: Tests are REQUIRED for executable logic per the Constitution.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare execution-log scaffolding, contract references, and fixtures.
+
+- [ ] T001 Add execution log route constant in src/GameBot.Service/ApiRoutes.cs
+- [ ] T002 [P] Add execution-log sample payload fixtures in tests/TestAssets/execution-logs/
+- [ ] T003 [P] Add execution-log sample data folder placeholder in data/execution-logs/.gitkeep
+- [ ] T004 [P] Align contract artifact metadata for execution logs in specs/028-execution-log/contracts/execution-log.openapi.yaml
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build core domain/service/repository plumbing required before user story work.
+
+**⚠️ CRITICAL**: No user story work begins until this phase is complete.
+
+- [ ] T005 Create execution log domain entities and value objects in src/GameBot.Domain/Logging/ExecutionLogModels.cs
+- [ ] T006 [P] Add retention policy domain model in src/GameBot.Domain/Logging/ExecutionLogRetentionPolicy.cs
+- [ ] T007 Create execution log repository interface in src/GameBot.Domain/Logging/IExecutionLogRepository.cs
+- [ ] T008 Implement file-backed execution log repository in src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
+- [ ] T009 [P] Add execution log DTOs for list/detail responses in src/GameBot.Service/Models/ExecutionLogs.cs
+- [ ] T010 [P] Implement execution log masking/sanitization helper in src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
+- [ ] T011 Implement execution log write/query service in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [ ] T012 Wire execution-log dependencies and storage paths in src/GameBot.Service/Program.cs
+
+**Checkpoint**: Foundation ready; user stories can be implemented independently.
+
+---
+
+## Phase 3: User Story 1 - Review execution outcomes (Priority: P1)
+
+**Goal**: Persist and retrieve command/sequence execution outcomes with timestamp, identifiable object, and final status.
+
+**Independent Test**: Run one successful command and one failing execution, then verify persisted and queryable entries contain timestamp, object identity, hierarchy context, and final status.
+
+### Tests for User Story 1
+
+- [ ] T013 [P] [US1] Add unit tests for execution entry mapping and required fields in tests/unit/ExecutionLogs/ExecutionLogEntryMappingTests.cs
+- [ ] T014 [P] [US1] Add integration tests for command execution log persistence in tests/integration/ExecutionLogs/CommandExecutionLoggingIntegrationTests.cs
+- [ ] T015 [P] [US1] Add integration tests for sequence execution log persistence in tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
+- [ ] T016 [P] [US1] Add contract tests for execution-log list/detail endpoints in tests/contract/OpenApiContractTests.cs
+- [ ] T017 [P] [US1] Add integration test for historical log actionability after object rename/delete in tests/integration/ExecutionLogs/ExecutionLogObjectSnapshotIntegrationTests.cs
+
+### Implementation for User Story 1
+
+- [ ] T018 [US1] Add execution-log endpoints (list/detail) in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+- [ ] T019 [US1] Map execution-log endpoints in service startup in src/GameBot.Service/Program.cs
+- [ ] T020 [US1] Persist command execution results to execution log in src/GameBot.Service/Services/CommandExecutor.cs
+- [ ] T021 [US1] Persist sequence execution results to execution log in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [ ] T022 [US1] Capture immutable object identity snapshots for logs in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [ ] T023 [US1] Implement paged list/detail query logic in src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
+
+**Checkpoint**: User Story 1 is independently functional and testable.
+
+---
+
+## Phase 4: User Story 2 - Trace sequence hierarchy (Priority: P2)
+
+**Goal**: Preserve parent-child execution context and dual navigation (direct object + parent hierarchy path).
+
+**Independent Test**: Execute the same command standalone and within a sequence, then verify logs differentiate both contexts and include direct + parent navigation context when nested.
+
+### Tests for User Story 2
+
+- [ ] T024 [P] [US2] Add unit tests for hierarchy context construction in tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
+- [ ] T025 [P] [US2] Add integration tests for nested sequence parent-child linkage in tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
+- [ ] T026 [P] [US2] Add integration tests for direct and parent navigation path persistence in tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
+
+### Implementation for User Story 2
+
+- [ ] T027 [US2] Add hierarchy context builder for root/parent/depth/order fields in src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs
+- [ ] T028 [US2] Add navigation context builder for directPath and parentPath in src/GameBot.Service/Services/ExecutionLog/ExecutionNavigationBuilder.cs
+- [ ] T029 [US2] Apply hierarchy + navigation builders during command logging in src/GameBot.Service/Services/CommandExecutor.cs
+- [ ] T030 [US2] Apply hierarchy + navigation builders for nested sequence logging in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [ ] T031 [US2] Extend execution-log response mapping for hierarchy and navigation fields in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+
+**Checkpoint**: User Stories 1 and 2 are independently functional and testable.
+
+---
+
+## Phase 5: User Story 3 - Understand what actually happened (Priority: P3)
+
+**Goal**: Log concise step-level outcome details, support `executed/not_executed`, mask sensitive values, and make retention configurable.
+
+**Independent Test**: Execute parameterized flow with one detected-and-executed step and one detection-below-threshold step, then verify user-facing details, masked values, and `executed/not_executed` outcomes are persisted; update retention config and verify policy persistence/cleanup behavior.
+
+### Tests for User Story 3
+
+- [ ] T032 [P] [US3] Add unit tests for detail masking/redaction rules in tests/unit/ExecutionLogs/ExecutionLogSanitizerTests.cs
+- [ ] T033 [P] [US3] Add integration tests for executed/not_executed step outcomes in tests/integration/ExecutionLogs/ExecutionStepOutcomeIntegrationTests.cs
+- [ ] T034 [P] [US3] Add integration tests for retention policy update and cleanup in tests/integration/ExecutionLogs/ExecutionLogRetentionIntegrationTests.cs
+- [ ] T035 [P] [US3] Add contract tests for retention endpoints in tests/contract/OpenApiContractTests.cs
+- [ ] T036 [P] [US3] Add integration tests for summary/detail conciseness bounds and truncation marker in tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
+
+### Implementation for User Story 3
+
+- [ ] T037 [US3] Capture concise outcome detail records (detection/tap/skip reasons) in src/GameBot.Service/Services/CommandExecutor.cs
+- [ ] T038 [US3] Normalize step outcomes to executed/not_executed in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [ ] T039 [US3] Enforce masking/redaction prior to persistence in src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
+- [ ] T040 [US3] Enforce summary/detail conciseness bounds and truncation marker in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [ ] T041 [US3] Add retention policy repository and persistence in src/GameBot.Domain/Logging/ExecutionLogRetentionPolicyRepository.cs
+- [ ] T042 [US3] Add retention get/update endpoints in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+- [ ] T043 [US3] Add asynchronous retention cleanup worker in src/GameBot.Service/Hosted/ExecutionLogRetentionCleanupService.cs
+- [ ] T044 [US3] Register retention cleanup hosted service in src/GameBot.Service/Program.cs
+
+**Checkpoint**: All user stories are independently functional and testable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate quality gates, documentation, and performance/operational evidence.
+
+- [ ] T045 [P] Update execution-log usage and validation steps in specs/028-execution-log/quickstart.md
+- [ ] T046 [P] Add implementation validation evidence and privacy checks in docs/validation.md
+- [ ] T047 Run .NET format verification for touched code via GameBot.sln
+- [ ] T048 Run static analysis build (warnings reviewed/justified) via GameBot.sln
+- [ ] T049 Run backend tests and analyze results with scripts/analyze-test-results.ps1
+- [ ] T050 Collect touched-area coverage report (>=80% line, >=70% branch) in tools/coverage/
+- [ ] T051 Run security/secret scan and record results in docs/validation.md
+- [ ] T052 Execute p95 write/query performance measurement and record results in docs/perf-checklist.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: no dependencies, starts immediately.
+- **Phase 2 (Foundational)**: depends on Phase 1 and blocks all user stories.
+- **Phase 3-5 (User Stories)**: depend on Phase 2 completion; stories can run in parallel if staffed.
+- **Phase 6 (Polish)**: depends on completion of desired user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: starts after foundational phase; no dependency on other stories.
+- **US2 (P2)**: starts after foundational phase and depends on US1 write-path tasks T020-T021; hierarchy/navigation tasks proceed once baseline persistence flow is in place.
+- **US3 (P3)**: starts after foundational phase; can run in parallel with US2, but should land after US1 baseline persistence flow.
+
+### Within Each User Story
+
+- Tests are written first and verified failing before implementation.
+- Domain/repository changes precede endpoint mapping for that story.
+- Endpoint/service integration completes before story checkpoint validation.
+
+### Suggested Story Completion Order
+
+1. Phase 1 → Phase 2
+2. MVP: Phase 3 (US1)
+3. Phase 4 (US2) and Phase 5 (US3)
+4. Phase 6 polish and full verification
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1
+
+- Run T013, T014, T015, T016, and T017 in parallel (separate test files/layers).
+- Run T018 and T022 in parallel (endpoint file vs service file) before integrating with T019/T020/T021/T023.
+
+### User Story 2
+
+- Run T024, T025, and T026 in parallel (unit + distinct integration files).
+- Run T027 and T028 in parallel (separate builder files).
+
+### User Story 3
+
+- Run T032, T033, T034, T035, and T036 in parallel (separate test files/layers).
+- Run T041 and T043 in parallel (repository vs hosted service) before wiring in T044.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Deliver Phase 3 (US1) fully.
+3. Validate US1 independent test criteria.
+4. Optionally release backend-only MVP for log persistence/retrieval.
+
+### Incremental Delivery
+
+1. Ship US1 for durable execution outcome visibility.
+2. Ship US2 for hierarchy-aware diagnostics and navigation context.
+3. Ship US3 for detailed user-facing outcomes, masking, conciseness bounds, and retention controls.
+4. Complete polish/verification including lint/format/static analysis, coverage, security scan, and performance evidence.
+
+### Parallel Team Strategy
+
+1. One engineer owns domain/repository and retention worker tasks.
+2. One engineer owns endpoint/contracts and API mapping tasks.
+3. One engineer owns test suites (unit/integration/contract) in parallel with implementation.

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -72,17 +72,17 @@
 
 ### Tests for User Story 2
 
-- [ ] T024 [P] [US2] Add unit tests for hierarchy context construction in tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
+- [X] T024 [P] [US2] Add unit tests for hierarchy context construction in tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
 - [ ] T025 [P] [US2] Add integration tests for nested sequence parent-child linkage in tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
 - [ ] T026 [P] [US2] Add integration tests for direct and parent navigation path persistence in tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
 
 ### Implementation for User Story 2
 
-- [ ] T027 [US2] Add hierarchy context builder for root/parent/depth/order fields in src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs
-- [ ] T028 [US2] Add navigation context builder for directPath and parentPath in src/GameBot.Service/Services/ExecutionLog/ExecutionNavigationBuilder.cs
-- [ ] T029 [US2] Apply hierarchy + navigation builders during command logging in src/GameBot.Service/Services/CommandExecutor.cs
-- [ ] T030 [US2] Apply hierarchy + navigation builders for nested sequence logging in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
-- [ ] T031 [US2] Extend execution-log response mapping for hierarchy and navigation fields in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+- [X] T027 [US2] Add hierarchy context builder for root/parent/depth/order fields in src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs
+- [X] T028 [US2] Add navigation context builder for directPath and parentPath in src/GameBot.Service/Services/ExecutionLog/ExecutionNavigationBuilder.cs
+- [X] T029 [US2] Apply hierarchy + navigation builders during command logging in src/GameBot.Service/Services/CommandExecutor.cs
+- [X] T030 [US2] Apply hierarchy + navigation builders for nested sequence logging in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [X] T031 [US2] Extend execution-log response mapping for hierarchy and navigation fields in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
 
 **Checkpoint**: User Stories 1 and 2 are independently functional and testable.
 

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -12,9 +12,9 @@
 **Purpose**: Prepare execution-log scaffolding, contract references, and fixtures.
 
 - [X] T001 Add execution log route constant in src/GameBot.Service/ApiRoutes.cs
-- [ ] T002 [P] Add execution-log sample payload fixtures in tests/TestAssets/execution-logs/
-- [ ] T003 [P] Add execution-log sample data folder placeholder in data/execution-logs/.gitkeep
-- [ ] T004 [P] Align contract artifact metadata for execution logs in specs/028-execution-log/contracts/execution-log.openapi.yaml
+- [X] T002 [P] Add execution-log sample payload fixtures in tests/TestAssets/execution-logs/
+- [X] T003 [P] Add execution-log sample data folder placeholder in data/execution-logs/.gitkeep
+- [X] T004 [P] Align contract artifact metadata for execution logs in specs/028-execution-log/contracts/execution-log.openapi.yaml
 
 ---
 
@@ -121,14 +121,14 @@
 
 **Purpose**: Validate quality gates, documentation, and performance/operational evidence.
 
-- [ ] T045 [P] Update execution-log usage and validation steps in specs/028-execution-log/quickstart.md
-- [ ] T046 [P] Add implementation validation evidence and privacy checks in docs/validation.md
+- [X] T045 [P] Update execution-log usage and validation steps in specs/028-execution-log/quickstart.md
+- [X] T046 [P] Add implementation validation evidence and privacy checks in docs/validation.md
 - [ ] T047 Run .NET format verification for touched code via GameBot.sln
-- [ ] T048 Run static analysis build (warnings reviewed/justified) via GameBot.sln
-- [ ] T049 Run backend tests and analyze results with scripts/analyze-test-results.ps1
-- [ ] T050 Collect touched-area coverage report (>=80% line, >=70% branch) in tools/coverage/
-- [ ] T051 Run security/secret scan and record results in docs/validation.md
-- [ ] T052 Execute p95 write/query performance measurement and record results in docs/perf-checklist.md
+- [X] T048 Run static analysis build (warnings reviewed/justified) via GameBot.sln
+- [X] T049 Run backend tests and analyze results with scripts/analyze-test-results.ps1
+- [X] T050 Collect touched-area coverage report (>=80% line, >=70% branch) in tools/coverage/
+- [X] T051 Run security/secret scan and record results in docs/validation.md
+- [X] T052 Execute p95 write/query performance measurement and record results in docs/perf-checklist.md
 
 ---
 

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -11,7 +11,7 @@
 
 **Purpose**: Prepare execution-log scaffolding, contract references, and fixtures.
 
-- [ ] T001 Add execution log route constant in src/GameBot.Service/ApiRoutes.cs
+- [X] T001 Add execution log route constant in src/GameBot.Service/ApiRoutes.cs
 - [ ] T002 [P] Add execution-log sample payload fixtures in tests/TestAssets/execution-logs/
 - [ ] T003 [P] Add execution-log sample data folder placeholder in data/execution-logs/.gitkeep
 - [ ] T004 [P] Align contract artifact metadata for execution logs in specs/028-execution-log/contracts/execution-log.openapi.yaml
@@ -24,14 +24,14 @@
 
 **⚠️ CRITICAL**: No user story work begins until this phase is complete.
 
-- [ ] T005 Create execution log domain entities and value objects in src/GameBot.Domain/Logging/ExecutionLogModels.cs
-- [ ] T006 [P] Add retention policy domain model in src/GameBot.Domain/Logging/ExecutionLogRetentionPolicy.cs
-- [ ] T007 Create execution log repository interface in src/GameBot.Domain/Logging/IExecutionLogRepository.cs
-- [ ] T008 Implement file-backed execution log repository in src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
-- [ ] T009 [P] Add execution log DTOs for list/detail responses in src/GameBot.Service/Models/ExecutionLogs.cs
-- [ ] T010 [P] Implement execution log masking/sanitization helper in src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
-- [ ] T011 Implement execution log write/query service in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
-- [ ] T012 Wire execution-log dependencies and storage paths in src/GameBot.Service/Program.cs
+- [X] T005 Create execution log domain entities and value objects in src/GameBot.Domain/Logging/ExecutionLogModels.cs
+- [X] T006 [P] Add retention policy domain model in src/GameBot.Domain/Logging/ExecutionLogRetentionPolicy.cs
+- [X] T007 Create execution log repository interface in src/GameBot.Domain/Logging/IExecutionLogRepository.cs
+- [X] T008 Implement file-backed execution log repository in src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
+- [X] T009 [P] Add execution log DTOs for list/detail responses in src/GameBot.Service/Models/ExecutionLogs.cs
+- [X] T010 [P] Implement execution log masking/sanitization helper in src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
+- [X] T011 Implement execution log write/query service in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [X] T012 Wire execution-log dependencies and storage paths in src/GameBot.Service/Program.cs
 
 **Checkpoint**: Foundation ready; user stories can be implemented independently.
 
@@ -53,12 +53,12 @@
 
 ### Implementation for User Story 1
 
-- [ ] T018 [US1] Add execution-log endpoints (list/detail) in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
-- [ ] T019 [US1] Map execution-log endpoints in service startup in src/GameBot.Service/Program.cs
-- [ ] T020 [US1] Persist command execution results to execution log in src/GameBot.Service/Services/CommandExecutor.cs
-- [ ] T021 [US1] Persist sequence execution results to execution log in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
-- [ ] T022 [US1] Capture immutable object identity snapshots for logs in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
-- [ ] T023 [US1] Implement paged list/detail query logic in src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
+- [X] T018 [US1] Add execution-log endpoints (list/detail) in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+- [X] T019 [US1] Map execution-log endpoints in service startup in src/GameBot.Service/Program.cs
+- [X] T020 [US1] Persist command execution results to execution log in src/GameBot.Service/Services/CommandExecutor.cs
+- [X] T021 [US1] Persist sequence execution results to execution log in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [X] T022 [US1] Capture immutable object identity snapshots for logs in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [X] T023 [US1] Implement paged list/detail query logic in src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
 
 **Checkpoint**: User Story 1 is independently functional and testable.
 
@@ -104,14 +104,14 @@
 
 ### Implementation for User Story 3
 
-- [ ] T037 [US3] Capture concise outcome detail records (detection/tap/skip reasons) in src/GameBot.Service/Services/CommandExecutor.cs
-- [ ] T038 [US3] Normalize step outcomes to executed/not_executed in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
-- [ ] T039 [US3] Enforce masking/redaction prior to persistence in src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
-- [ ] T040 [US3] Enforce summary/detail conciseness bounds and truncation marker in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
-- [ ] T041 [US3] Add retention policy repository and persistence in src/GameBot.Domain/Logging/ExecutionLogRetentionPolicyRepository.cs
-- [ ] T042 [US3] Add retention get/update endpoints in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
-- [ ] T043 [US3] Add asynchronous retention cleanup worker in src/GameBot.Service/Hosted/ExecutionLogRetentionCleanupService.cs
-- [ ] T044 [US3] Register retention cleanup hosted service in src/GameBot.Service/Program.cs
+- [X] T037 [US3] Capture concise outcome detail records (detection/tap/skip reasons) in src/GameBot.Service/Services/CommandExecutor.cs
+- [X] T038 [US3] Normalize step outcomes to executed/not_executed in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [X] T039 [US3] Enforce masking/redaction prior to persistence in src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
+- [X] T040 [US3] Enforce summary/detail conciseness bounds and truncation marker in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [X] T041 [US3] Add retention policy repository and persistence in src/GameBot.Domain/Logging/ExecutionLogRetentionPolicyRepository.cs
+- [X] T042 [US3] Add retention get/update endpoints in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+- [X] T043 [US3] Add asynchronous retention cleanup worker in src/GameBot.Service/Hosted/ExecutionLogRetentionCleanupService.cs
+- [X] T044 [US3] Register retention cleanup hosted service in src/GameBot.Service/Program.cs
 
 **Checkpoint**: All user stories are independently functional and testable.
 

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -45,11 +45,11 @@
 
 ### Tests for User Story 1
 
-- [ ] T013 [P] [US1] Add unit tests for execution entry mapping and required fields in tests/unit/ExecutionLogs/ExecutionLogEntryMappingTests.cs
-- [ ] T014 [P] [US1] Add integration tests for command execution log persistence in tests/integration/ExecutionLogs/CommandExecutionLoggingIntegrationTests.cs
-- [ ] T015 [P] [US1] Add integration tests for sequence execution log persistence in tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
-- [ ] T016 [P] [US1] Add contract tests for execution-log list/detail endpoints in tests/contract/OpenApiContractTests.cs
-- [ ] T017 [P] [US1] Add integration test for historical log actionability after object rename/delete in tests/integration/ExecutionLogs/ExecutionLogObjectSnapshotIntegrationTests.cs
+- [X] T013 [P] [US1] Add unit tests for execution entry mapping and required fields in tests/unit/ExecutionLogs/ExecutionLogEntryMappingTests.cs
+- [X] T014 [P] [US1] Add integration tests for command execution log persistence in tests/integration/ExecutionLogs/CommandExecutionLoggingIntegrationTests.cs
+- [X] T015 [P] [US1] Add integration tests for sequence execution log persistence in tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
+- [X] T016 [P] [US1] Add contract tests for execution-log list/detail endpoints in tests/contract/OpenApiContractTests.cs
+- [X] T017 [P] [US1] Add integration test for historical log actionability after object rename/delete in tests/integration/ExecutionLogs/ExecutionLogObjectSnapshotIntegrationTests.cs
 
 ### Implementation for User Story 1
 

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -73,8 +73,8 @@
 ### Tests for User Story 2
 
 - [X] T024 [P] [US2] Add unit tests for hierarchy context construction in tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
-- [ ] T025 [P] [US2] Add integration tests for nested sequence parent-child linkage in tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
-- [ ] T026 [P] [US2] Add integration tests for direct and parent navigation path persistence in tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
+- [X] T025 [P] [US2] Add integration tests for nested sequence parent-child linkage in tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
+- [X] T026 [P] [US2] Add integration tests for direct and parent navigation path persistence in tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
 
 ### Implementation for User Story 2
 

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -123,7 +123,7 @@
 
 - [X] T045 [P] Update execution-log usage and validation steps in specs/028-execution-log/quickstart.md
 - [X] T046 [P] Add implementation validation evidence and privacy checks in docs/validation.md
-- [ ] T047 Run .NET format verification for touched code via GameBot.sln
+- [x] T047 Run .NET format verification for touched code via GameBot.sln
 - [X] T048 Run static analysis build (warnings reviewed/justified) via GameBot.sln
 - [X] T049 Run backend tests and analyze results with scripts/analyze-test-results.ps1
 - [X] T050 Collect touched-area coverage report (>=80% line, >=70% branch) in tools/coverage/

--- a/specs/028-execution-log/tasks.md
+++ b/specs/028-execution-log/tasks.md
@@ -96,11 +96,11 @@
 
 ### Tests for User Story 3
 
-- [ ] T032 [P] [US3] Add unit tests for detail masking/redaction rules in tests/unit/ExecutionLogs/ExecutionLogSanitizerTests.cs
-- [ ] T033 [P] [US3] Add integration tests for executed/not_executed step outcomes in tests/integration/ExecutionLogs/ExecutionStepOutcomeIntegrationTests.cs
-- [ ] T034 [P] [US3] Add integration tests for retention policy update and cleanup in tests/integration/ExecutionLogs/ExecutionLogRetentionIntegrationTests.cs
-- [ ] T035 [P] [US3] Add contract tests for retention endpoints in tests/contract/OpenApiContractTests.cs
-- [ ] T036 [P] [US3] Add integration tests for summary/detail conciseness bounds and truncation marker in tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
+- [X] T032 [P] [US3] Add unit tests for detail masking/redaction rules in tests/unit/ExecutionLogs/ExecutionLogSanitizerTests.cs
+- [X] T033 [P] [US3] Add integration tests for executed/not_executed step outcomes in tests/integration/ExecutionLogs/ExecutionStepOutcomeIntegrationTests.cs
+- [X] T034 [P] [US3] Add integration tests for retention policy update and cleanup in tests/integration/ExecutionLogs/ExecutionLogRetentionIntegrationTests.cs
+- [X] T035 [P] [US3] Add contract tests for retention endpoints in tests/contract/OpenApiContractTests.cs
+- [X] T036 [P] [US3] Add integration tests for summary/detail conciseness bounds and truncation marker in tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
 
 ### Implementation for User Story 3
 

--- a/src/GameBot.Domain/Logging/ExecutionLogModels.cs
+++ b/src/GameBot.Domain/Logging/ExecutionLogModels.cs
@@ -1,0 +1,59 @@
+namespace GameBot.Domain.Logging;
+
+public sealed record ExecutionObjectReference(
+  string ObjectType,
+  string ObjectId,
+  string DisplayNameSnapshot,
+  string? VersionSnapshot = null);
+
+public sealed record ExecutionNavigationContext(
+  string DirectPath,
+  string? ParentPath,
+  string PathKind = "relative-route");
+
+public sealed record ExecutionHierarchyContext(
+  string RootExecutionId,
+  string? ParentExecutionId,
+  int Depth,
+  int? SequenceIndex);
+
+public sealed record ExecutionStepOutcome(
+  int StepOrder,
+  string StepType,
+  string Outcome,
+  string? ReasonCode,
+  string? ReasonText);
+
+public sealed record ExecutionDetailItem(
+  string Kind,
+  string Message,
+  Dictionary<string, object?>? Attributes,
+  string Sensitivity);
+
+public sealed class ExecutionLogEntry
+{
+  public string Id { get; init; } = Guid.NewGuid().ToString("N");
+  public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
+  public string ExecutionType { get; init; } = "command";
+  public string FinalStatus { get; init; } = "success";
+  public required ExecutionObjectReference ObjectRef { get; init; }
+  public required ExecutionNavigationContext Navigation { get; init; }
+  public required ExecutionHierarchyContext Hierarchy { get; init; }
+  public string Summary { get; init; } = string.Empty;
+  public IReadOnlyList<ExecutionDetailItem> Details { get; init; } = Array.Empty<ExecutionDetailItem>();
+  public IReadOnlyList<ExecutionStepOutcome> StepOutcomes { get; init; } = Array.Empty<ExecutionStepOutcome>();
+  public DateTimeOffset RetentionExpiresUtc { get; init; }
+}
+
+public sealed class ExecutionLogQuery
+{
+  public DateTimeOffset? FromUtc { get; init; }
+  public DateTimeOffset? ToUtc { get; init; }
+  public string? FinalStatus { get; init; }
+  public string? ObjectType { get; init; }
+  public string? ObjectId { get; init; }
+  public int PageSize { get; init; } = 50;
+  public string? Cursor { get; init; }
+}
+
+public sealed record ExecutionLogPage(IReadOnlyList<ExecutionLogEntry> Items, string? NextCursor);

--- a/src/GameBot.Domain/Logging/ExecutionLogRetentionPolicy.cs
+++ b/src/GameBot.Domain/Logging/ExecutionLogRetentionPolicy.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace GameBot.Domain.Logging;
+
+public sealed class ExecutionLogRetentionPolicy
+{
+  public bool Enabled { get; init; } = true;
+  public int RetentionDays { get; init; } = 60;
+  public int CleanupIntervalMinutes { get; init; } = 30;
+  public DateTimeOffset UpdatedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+
+  [JsonIgnore]
+  public static ExecutionLogRetentionPolicy Default => new();
+}

--- a/src/GameBot.Domain/Logging/ExecutionLogRetentionPolicyRepository.cs
+++ b/src/GameBot.Domain/Logging/ExecutionLogRetentionPolicyRepository.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+
+namespace GameBot.Domain.Logging;
+
+public interface IExecutionLogRetentionPolicyRepository
+{
+  Task<ExecutionLogRetentionPolicy> GetAsync(CancellationToken ct = default);
+  Task<ExecutionLogRetentionPolicy> SaveAsync(ExecutionLogRetentionPolicy policy, CancellationToken ct = default);
+}
+
+public sealed class ExecutionLogRetentionPolicyRepository : IExecutionLogRetentionPolicyRepository, IDisposable
+{
+  private readonly string _filePath;
+  private readonly SemaphoreSlim _mutex = new(1, 1);
+  private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+  {
+    WriteIndented = true
+  };
+
+  public ExecutionLogRetentionPolicyRepository(string storageRoot)
+  {
+    var configDir = Path.Combine(storageRoot, "config");
+    Directory.CreateDirectory(configDir);
+    _filePath = Path.Combine(configDir, "execution-log-policy.json");
+  }
+
+  public async Task<ExecutionLogRetentionPolicy> GetAsync(CancellationToken ct = default)
+  {
+    await _mutex.WaitAsync(ct).ConfigureAwait(false);
+    try
+    {
+      if (!File.Exists(_filePath))
+      {
+        return ExecutionLogRetentionPolicy.Default;
+      }
+
+      using var fs = File.OpenRead(_filePath);
+      var item = await JsonSerializer.DeserializeAsync<ExecutionLogRetentionPolicy>(fs, JsonOptions, ct).ConfigureAwait(false);
+      return item ?? ExecutionLogRetentionPolicy.Default;
+    }
+    catch
+    {
+      return ExecutionLogRetentionPolicy.Default;
+    }
+    finally
+    {
+      _mutex.Release();
+    }
+  }
+
+  public async Task<ExecutionLogRetentionPolicy> SaveAsync(ExecutionLogRetentionPolicy policy, CancellationToken ct = default)
+  {
+    ArgumentNullException.ThrowIfNull(policy);
+    await _mutex.WaitAsync(ct).ConfigureAwait(false);
+    try
+    {
+      var persisted = new ExecutionLogRetentionPolicy
+      {
+        Enabled = policy.Enabled,
+        RetentionDays = Math.Max(1, policy.RetentionDays),
+        CleanupIntervalMinutes = Math.Max(1, policy.CleanupIntervalMinutes),
+        UpdatedAtUtc = DateTimeOffset.UtcNow
+      };
+      using var fs = File.Create(_filePath);
+      await JsonSerializer.SerializeAsync(fs, persisted, JsonOptions, ct).ConfigureAwait(false);
+      return persisted;
+    }
+    finally
+    {
+      _mutex.Release();
+    }
+  }
+
+  public void Dispose()
+  {
+    _mutex.Dispose();
+  }
+}

--- a/src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
+++ b/src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace GameBot.Domain.Logging;
+
+public sealed class FileExecutionLogRepository : IExecutionLogRepository, IDisposable
+{
+  private readonly string _dir;
+  private readonly SemaphoreSlim _mutex = new(1, 1);
+  private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+  {
+    WriteIndented = true
+  };
+
+  public FileExecutionLogRepository(string storageRoot)
+  {
+    _dir = Path.Combine(storageRoot, "execution-logs");
+    Directory.CreateDirectory(_dir);
+  }
+
+  public async Task AddAsync(ExecutionLogEntry entry, CancellationToken ct = default)
+  {
+    ArgumentNullException.ThrowIfNull(entry);
+    var path = Path.Combine(_dir, entry.Id + ".json");
+    await _mutex.WaitAsync(ct).ConfigureAwait(false);
+    try
+    {
+      using var fs = File.Create(path);
+      await JsonSerializer.SerializeAsync(fs, entry, JsonOptions, ct).ConfigureAwait(false);
+    }
+    finally
+    {
+      _mutex.Release();
+    }
+  }
+
+  public async Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default)
+  {
+    if (string.IsNullOrWhiteSpace(id)) return null;
+    var path = Path.Combine(_dir, id + ".json");
+    if (!File.Exists(path)) return null;
+    using var fs = File.OpenRead(path);
+    return await JsonSerializer.DeserializeAsync<ExecutionLogEntry>(fs, JsonOptions, ct).ConfigureAwait(false);
+  }
+
+  public async Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default)
+  {
+    query ??= new ExecutionLogQuery();
+    var pageSize = Math.Clamp(query.PageSize <= 0 ? 50 : query.PageSize, 1, 200);
+
+    var entries = new List<ExecutionLogEntry>();
+    foreach (var file in Directory.EnumerateFiles(_dir, "*.json"))
+    {
+      ct.ThrowIfCancellationRequested();
+      using var fs = File.OpenRead(file);
+      var item = await JsonSerializer.DeserializeAsync<ExecutionLogEntry>(fs, JsonOptions, ct).ConfigureAwait(false);
+      if (item is null) continue;
+      if (query.FromUtc.HasValue && item.TimestampUtc < query.FromUtc.Value) continue;
+      if (query.ToUtc.HasValue && item.TimestampUtc > query.ToUtc.Value) continue;
+      if (!string.IsNullOrWhiteSpace(query.FinalStatus) && !string.Equals(item.FinalStatus, query.FinalStatus, StringComparison.OrdinalIgnoreCase)) continue;
+      if (!string.IsNullOrWhiteSpace(query.ObjectType) && !string.Equals(item.ObjectRef.ObjectType, query.ObjectType, StringComparison.OrdinalIgnoreCase)) continue;
+      if (!string.IsNullOrWhiteSpace(query.ObjectId) && !string.Equals(item.ObjectRef.ObjectId, query.ObjectId, StringComparison.OrdinalIgnoreCase)) continue;
+      entries.Add(item);
+    }
+
+    var ordered = entries.OrderByDescending(e => e.TimestampUtc).ThenByDescending(e => e.Id).ToList();
+
+    var startIndex = 0;
+    if (!string.IsNullOrWhiteSpace(query.Cursor))
+    {
+      if (int.TryParse(query.Cursor, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed >= 0)
+      {
+        startIndex = parsed;
+      }
+    }
+
+    if (startIndex >= ordered.Count)
+    {
+      return new ExecutionLogPage(Array.Empty<ExecutionLogEntry>(), null);
+    }
+
+    var items = ordered.Skip(startIndex).Take(pageSize).ToList();
+    var nextIndex = startIndex + items.Count;
+    var nextCursor = nextIndex < ordered.Count ? nextIndex.ToString(CultureInfo.InvariantCulture) : null;
+
+    return new ExecutionLogPage(items, nextCursor);
+  }
+
+  public async Task<int> DeleteExpiredAsync(DateTimeOffset nowUtc, CancellationToken ct = default)
+  {
+    var deleted = 0;
+    foreach (var file in Directory.EnumerateFiles(_dir, "*.json"))
+    {
+      ct.ThrowIfCancellationRequested();
+      try
+      {
+        var text = await File.ReadAllTextAsync(file, ct).ConfigureAwait(false);
+        var entry = JsonSerializer.Deserialize<ExecutionLogEntry>(text, JsonOptions);
+        if (entry is null) continue;
+        if (entry.RetentionExpiresUtc <= nowUtc)
+        {
+          File.Delete(file);
+          deleted++;
+        }
+      }
+      catch
+      {
+      }
+    }
+
+    return deleted;
+  }
+
+  public void Dispose()
+  {
+    _mutex.Dispose();
+  }
+}

--- a/src/GameBot.Domain/Logging/IExecutionLogRepository.cs
+++ b/src/GameBot.Domain/Logging/IExecutionLogRepository.cs
@@ -1,0 +1,9 @@
+namespace GameBot.Domain.Logging;
+
+public interface IExecutionLogRepository
+{
+  Task AddAsync(ExecutionLogEntry entry, CancellationToken ct = default);
+  Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default);
+  Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default);
+  Task<int> DeleteExpiredAsync(DateTimeOffset nowUtc, CancellationToken ct = default);
+}

--- a/src/GameBot.Service/ApiRoutes.cs
+++ b/src/GameBot.Service/ApiRoutes.cs
@@ -18,6 +18,7 @@ internal static class ApiRoutes
     internal const string EmulatorScreenshot = Emulator + "/screenshot";
     internal const string ImageDetect = Images + "/detect";
     internal const string Metrics = Base + "/metrics";
+    internal const string ExecutionLogs = Base + "/execution-logs";
     internal const string Adb = Base + "/adb";
     internal const string Ocr = Base + "/ocr";
 }

--- a/src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
@@ -1,0 +1,127 @@
+using GameBot.Domain.Logging;
+using GameBot.Service.Models;
+using GameBot.Service.Services.ExecutionLog;
+
+namespace GameBot.Service.Endpoints;
+
+internal static class ExecutionLogsEndpoints
+{
+  public static IEndpointRouteBuilder MapExecutionLogEndpoints(this IEndpointRouteBuilder app)
+  {
+    var group = app.MapGroup(ApiRoutes.ExecutionLogs).WithTags("ExecutionLogs");
+
+    group.MapGet("", async (
+      DateTimeOffset? fromUtc,
+      DateTimeOffset? toUtc,
+      string? finalStatus,
+      string? objectType,
+      string? objectId,
+      int? pageSize,
+      string? cursor,
+      IExecutionLogService svc,
+      CancellationToken ct) =>
+    {
+      var page = await svc.QueryAsync(new ExecutionLogQuery
+      {
+        FromUtc = fromUtc,
+        ToUtc = toUtc,
+        FinalStatus = finalStatus,
+        ObjectType = objectType,
+        ObjectId = objectId,
+        PageSize = pageSize ?? 50,
+        Cursor = cursor
+      }, ct).ConfigureAwait(false);
+
+      return Results.Ok(new ExecutionLogListResponseDto
+      {
+        Items = page.Items.Select(ToDto).ToArray(),
+        NextCursor = page.NextCursor
+      });
+    }).WithName("ListExecutionLogs");
+
+    group.MapGet("/{id}", async (string id, IExecutionLogService svc, CancellationToken ct) =>
+    {
+      var item = await svc.GetAsync(id, ct).ConfigureAwait(false);
+      if (item is null)
+      {
+        return Results.NotFound(new
+        {
+          error = new { code = "not_found", message = "Execution log entry not found", hint = (string?)null }
+        });
+      }
+
+      return Results.Ok(ToDto(item));
+    }).WithName("GetExecutionLog");
+
+    group.MapGet("/retention", async (IExecutionLogService svc, CancellationToken ct) =>
+    {
+      var policy = await svc.GetRetentionAsync(ct).ConfigureAwait(false);
+      return Results.Ok(new ExecutionLogRetentionPolicyDto
+      {
+        Enabled = policy.Enabled,
+        RetentionDays = policy.RetentionDays,
+        CleanupIntervalMinutes = policy.CleanupIntervalMinutes,
+        UpdatedAtUtc = policy.UpdatedAtUtc
+      });
+    }).WithName("GetExecutionLogRetentionPolicy");
+
+    group.MapPut("/retention", async (ExecutionLogRetentionPolicyPatchDto patch, IExecutionLogService svc, CancellationToken ct) =>
+    {
+      var updated = await svc.UpdateRetentionAsync(patch.Enabled, patch.RetentionDays, patch.CleanupIntervalMinutes, ct).ConfigureAwait(false);
+      return Results.Ok(new ExecutionLogRetentionPolicyDto
+      {
+        Enabled = updated.Enabled,
+        RetentionDays = updated.RetentionDays,
+        CleanupIntervalMinutes = updated.CleanupIntervalMinutes,
+        UpdatedAtUtc = updated.UpdatedAtUtc
+      });
+    }).WithName("UpdateExecutionLogRetentionPolicy");
+
+    return app;
+  }
+
+  private static ExecutionLogEntryDto ToDto(ExecutionLogEntry entry)
+    => new()
+    {
+      Id = entry.Id,
+      TimestampUtc = entry.TimestampUtc,
+      ExecutionType = entry.ExecutionType,
+      FinalStatus = entry.FinalStatus,
+      ObjectRef = new ExecutionObjectReferenceDto
+      {
+        ObjectType = entry.ObjectRef.ObjectType,
+        ObjectId = entry.ObjectRef.ObjectId,
+        DisplayNameSnapshot = entry.ObjectRef.DisplayNameSnapshot,
+        VersionSnapshot = entry.ObjectRef.VersionSnapshot
+      },
+      Navigation = new ExecutionNavigationContextDto
+      {
+        DirectPath = entry.Navigation.DirectPath,
+        ParentPath = entry.Navigation.ParentPath,
+        PathKind = entry.Navigation.PathKind
+      },
+      Hierarchy = new ExecutionHierarchyContextDto
+      {
+        RootExecutionId = entry.Hierarchy.RootExecutionId,
+        ParentExecutionId = entry.Hierarchy.ParentExecutionId,
+        Depth = entry.Hierarchy.Depth,
+        SequenceIndex = entry.Hierarchy.SequenceIndex
+      },
+      Summary = entry.Summary,
+      Details = entry.Details.Select(d => new ExecutionDetailItemDto
+      {
+        Kind = d.Kind,
+        Message = d.Message,
+        Attributes = d.Attributes,
+        Sensitivity = d.Sensitivity
+      }).ToArray(),
+      StepOutcomes = entry.StepOutcomes.Select(s => new ExecutionStepOutcomeDto
+      {
+        StepOrder = s.StepOrder,
+        StepType = s.StepType,
+        Outcome = s.Outcome,
+        ReasonCode = s.ReasonCode,
+        ReasonText = s.ReasonText
+      }).ToArray()
+    };
+}

--- a/src/GameBot.Service/Hosted/ExecutionLogRetentionCleanupService.cs
+++ b/src/GameBot.Service/Hosted/ExecutionLogRetentionCleanupService.cs
@@ -1,0 +1,53 @@
+using GameBot.Service.Services.ExecutionLog;
+
+namespace GameBot.Service.Hosted;
+
+internal sealed partial class ExecutionLogRetentionCleanupService : BackgroundService
+{
+  private readonly IServiceProvider _serviceProvider;
+  private readonly ILogger<ExecutionLogRetentionCleanupService> _logger;
+
+  public ExecutionLogRetentionCleanupService(IServiceProvider serviceProvider, ILogger<ExecutionLogRetentionCleanupService> logger)
+  {
+    _serviceProvider = serviceProvider;
+    _logger = logger;
+  }
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    while (!stoppingToken.IsCancellationRequested)
+    {
+      try
+      {
+        using var scope = _serviceProvider.CreateScope();
+        var svc = scope.ServiceProvider.GetRequiredService<IExecutionLogService>();
+        var policy = await svc.GetRetentionAsync(stoppingToken).ConfigureAwait(false);
+        var deleted = await svc.CleanupExpiredAsync(stoppingToken).ConfigureAwait(false);
+        if (deleted > 0)
+        {
+          Log.CleanupRemoved(_logger, deleted);
+        }
+
+        await Task.Delay(TimeSpan.FromMinutes(Math.Max(1, policy.CleanupIntervalMinutes)), stoppingToken).ConfigureAwait(false);
+      }
+      catch (OperationCanceledException)
+      {
+        break;
+      }
+      catch (Exception ex)
+      {
+        Log.CleanupFailed(_logger, ex);
+        await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken).ConfigureAwait(false);
+      }
+    }
+  }
+
+  private static partial class Log
+  {
+    [LoggerMessage(EventId = 7100, Level = LogLevel.Information, Message = "Execution log cleanup removed {Count} expired entries.")]
+    public static partial void CleanupRemoved(ILogger logger, int count);
+
+    [LoggerMessage(EventId = 7101, Level = LogLevel.Warning, Message = "Execution log cleanup cycle failed.")]
+    public static partial void CleanupFailed(ILogger logger, Exception ex);
+  }
+}

--- a/src/GameBot.Service/Models/ExecutionLogs.cs
+++ b/src/GameBot.Service/Models/ExecutionLogs.cs
@@ -1,0 +1,87 @@
+namespace GameBot.Service.Models;
+
+internal sealed class ExecutionLogQueryDto
+{
+  public DateTimeOffset? FromUtc { get; init; }
+  public DateTimeOffset? ToUtc { get; init; }
+  public string? FinalStatus { get; init; }
+  public string? ObjectType { get; init; }
+  public string? ObjectId { get; init; }
+  public int? PageSize { get; init; }
+  public string? Cursor { get; init; }
+}
+
+internal sealed class ExecutionObjectReferenceDto
+{
+  public required string ObjectType { get; init; }
+  public required string ObjectId { get; init; }
+  public required string DisplayNameSnapshot { get; init; }
+  public string? VersionSnapshot { get; init; }
+}
+
+internal sealed class ExecutionNavigationContextDto
+{
+  public required string DirectPath { get; init; }
+  public string? ParentPath { get; init; }
+  public required string PathKind { get; init; }
+}
+
+internal sealed class ExecutionHierarchyContextDto
+{
+  public required string RootExecutionId { get; init; }
+  public string? ParentExecutionId { get; init; }
+  public int Depth { get; init; }
+  public int? SequenceIndex { get; init; }
+}
+
+internal sealed class ExecutionStepOutcomeDto
+{
+  public int StepOrder { get; init; }
+  public required string StepType { get; init; }
+  public required string Outcome { get; init; }
+  public string? ReasonCode { get; init; }
+  public string? ReasonText { get; init; }
+}
+
+internal sealed class ExecutionDetailItemDto
+{
+  public required string Kind { get; init; }
+  public required string Message { get; init; }
+  public Dictionary<string, object?>? Attributes { get; init; }
+  public required string Sensitivity { get; init; }
+}
+
+internal sealed class ExecutionLogEntryDto
+{
+  public required string Id { get; init; }
+  public DateTimeOffset TimestampUtc { get; init; }
+  public required string ExecutionType { get; init; }
+  public required string FinalStatus { get; init; }
+  public required ExecutionObjectReferenceDto ObjectRef { get; init; }
+  public required ExecutionNavigationContextDto Navigation { get; init; }
+  public required ExecutionHierarchyContextDto Hierarchy { get; init; }
+  public required string Summary { get; init; }
+  public required IReadOnlyList<ExecutionDetailItemDto> Details { get; init; }
+  public required IReadOnlyList<ExecutionStepOutcomeDto> StepOutcomes { get; init; }
+}
+
+internal sealed class ExecutionLogListResponseDto
+{
+  public required IReadOnlyList<ExecutionLogEntryDto> Items { get; init; }
+  public string? NextCursor { get; init; }
+}
+
+internal sealed class ExecutionLogRetentionPolicyDto
+{
+  public bool Enabled { get; init; }
+  public int RetentionDays { get; init; }
+  public int CleanupIntervalMinutes { get; init; }
+  public DateTimeOffset UpdatedAtUtc { get; init; }
+}
+
+internal sealed class ExecutionLogRetentionPolicyPatchDto
+{
+  public bool Enabled { get; init; }
+  public int? RetentionDays { get; init; }
+  public int? CleanupIntervalMinutes { get; init; }
+}

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -696,8 +696,10 @@ sequences.MapPost("{id}/execute", async (
     sequenceName,
     status,
     $"Sequence '{sequenceName}' {status} with {res.Steps.Count} executed commands.",
-    parentExecutionId: null,
-    depth: 0,
+    new GameBot.Service.Services.ExecutionLog.ExecutionLogContext
+    {
+      Depth = 0
+    },
     details: new[] {
       new GameBot.Domain.Logging.ExecutionDetailItem(
         "sequence",

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -107,6 +107,9 @@ builder.Services.AddSingleton<ITriggerRepository>(_ => new FileTriggerRepository
 builder.Services.AddSingleton<IActionRepository>(_ => new FileActionRepository(storageRoot));
 builder.Services.AddSingleton<ICommandRepository>(_ => new FileCommandRepository(storageRoot));
 builder.Services.AddSingleton<ISequenceRepository>(_ => new FileSequenceRepository(storageRoot));
+builder.Services.AddSingleton<IExecutionLogRepository>(_ => new FileExecutionLogRepository(storageRoot));
+builder.Services.AddSingleton<IExecutionLogRetentionPolicyRepository>(_ => new ExecutionLogRetentionPolicyRepository(storageRoot));
+builder.Services.AddSingleton<GameBot.Service.Services.ExecutionLog.IExecutionLogService, GameBot.Service.Services.ExecutionLog.ExecutionLogService>();
 builder.Services.AddSingleton<SemanticVersionComparer>();
 builder.Services.AddSingleton<VersionSourceLoader>();
 builder.Services.AddSingleton<VersionResolutionService>();
@@ -201,6 +204,7 @@ GameBot.Service.Services.DynamicLogFilters.HttpMinLevel = httpMinLevelEnv?.Trim(
 builder.Services.AddSingleton<GameBot.Service.Hosted.ITriggerEvaluationMetrics, GameBot.Service.Hosted.TriggerEvaluationMetrics>();
 builder.Services.AddHostedService<GameBot.Service.Hosted.ConfigSnapshotStartupInitializer>();
 builder.Services.AddHostedService<LoggingPolicyStartupInitializer>();
+builder.Services.AddHostedService<GameBot.Service.Hosted.ExecutionLogRetentionCleanupService>();
 
 // Bind detection options (threshold, max results, timeout, overlap)
 builder.Services.Configure<DetectionOptions>(builder.Configuration.GetSection(DetectionOptions.SectionName));
@@ -339,6 +343,7 @@ app.MapMetricsEndpoints();
 app.MapConfigEndpoints();
 app.MapConfigLoggingEndpoints();
 app.MapCoverageEndpoints();
+app.MapExecutionLogEndpoints();
 
 app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequestModel request, VersionSourceLoader loader) =>
 {
@@ -614,6 +619,8 @@ sequences.MapDelete("{id}", async (ISequenceRepository repo, string id) =>
 sequences.MapPost("{id}/execute", async (
   GameBot.Domain.Services.SequenceRunner runner,
   TriggerEvaluationService evalSvc,
+  GameBot.Service.Services.ExecutionLog.IExecutionLogService executionLogService,
+  ISequenceRepository sequenceRepository,
   string id,
   CancellationToken ct) =>
 {
@@ -681,6 +688,24 @@ sequences.MapPost("{id}/execute", async (
     },
     ct: ct
   ).ConfigureAwait(false);
+  var sequence = await sequenceRepository.GetAsync(id).ConfigureAwait(false);
+  var sequenceName = sequence?.Name ?? id;
+  var status = string.Equals(res.Status, "Completed", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
+  await executionLogService.LogSequenceExecutionAsync(
+    id,
+    sequenceName,
+    status,
+    $"Sequence '{sequenceName}' {status} with {res.Steps.Count} executed commands.",
+    parentExecutionId: null,
+    depth: 0,
+    details: new[] {
+      new GameBot.Domain.Logging.ExecutionDetailItem(
+        "sequence",
+        $"Executed commands: {string.Join(",", res.Steps.Select(s => s.CommandId).Take(10))}",
+        new Dictionary<string, object?> { ["executedCount"] = res.Steps.Count },
+        "normal")
+    },
+    ct).ConfigureAwait(false);
   return Results.Ok(res);
 }).WithName("ExecuteSequence").WithTags("Sequences");
 

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -47,8 +47,7 @@ var loggingGate = new LoggingPolicyGate();
 // Console logging with timestamps + scopes; ensure no duplicate console providers
 builder.Logging.ClearProviders();
 builder.Logging.SetMinimumLevel(LogLevel.Trace);
-builder.Services.Configure<LoggerFilterOptions>(options =>
-{
+builder.Services.Configure<LoggerFilterOptions>(options => {
   options.Rules.Clear();
   options.MinLevel = LogLevel.Trace;
 });
@@ -67,10 +66,8 @@ var corsOrigins = (builder.Configuration["Service:Cors:Origins"]
                   ?? Environment.GetEnvironmentVariable("GAMEBOT_CORS_ORIGINS")
                   ?? "http://localhost:5173")
                   .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-builder.Services.AddCors(options =>
-{
-  options.AddPolicy("WebUiCors", policy =>
-  {
+builder.Services.AddCors(options => {
+  options.AddPolicy("WebUiCors", policy => {
     if (corsOrigins.Length > 0)
       policy.WithOrigins(corsOrigins).AllowAnyHeader().AllowAnyMethod().WithExposedHeaders("X-Capture-Id");
     else
@@ -116,13 +113,11 @@ builder.Services.AddSingleton<VersionResolutionService>();
 builder.Services.AddSingleton<GameBot.Domain.Services.SequenceRunner>();
 builder.Services.AddSingleton(loggingGate);
 builder.Services.AddSingleton<ILoggingPolicyApplier>(sp => sp.GetRequiredService<LoggingPolicyGate>());
-builder.Services.AddSingleton<ILoggingPolicyRepository>(sp =>
-{
+builder.Services.AddSingleton<ILoggingPolicyRepository>(sp => {
   var logger = sp.GetRequiredService<ILogger<LoggingPolicyRepository>>();
   return new LoggingPolicyRepository(storageRoot, () => LoggingPolicySnapshot.CreateDefault(loggingComponentCatalog, LogLevel.Warning, "system-seed"), logger);
 });
-builder.Services.AddSingleton(sp =>
-{
+builder.Services.AddSingleton(sp => {
   var repo = sp.GetRequiredService<ILoggingPolicyRepository>();
   var logger = sp.GetRequiredService<ILogger<RuntimeLoggingPolicyService>>();
   var applier = sp.GetRequiredService<ILoggingPolicyApplier>();
@@ -251,12 +246,10 @@ var hasInstalledWebUi = Directory.Exists(installedWebUiRoot) && File.Exists(Path
   var arch = RuntimeInformation.ProcessArchitecture.ToString();
   var buildInfo = CvRuntime.GetOpenCvBuildInformation();
   string firstLine;
-  if (string.IsNullOrEmpty(buildInfo))
-  {
+  if (string.IsNullOrEmpty(buildInfo)) {
     firstLine = "unavailable";
   }
-  else
-  {
+  else {
     var span = buildInfo.AsSpan();
     var idx = span.IndexOfAny('\r', '\n');
     firstLine = idx >= 0 ? new string(span.Slice(0, idx)) : buildInfo;
@@ -345,10 +338,8 @@ app.MapConfigLoggingEndpoints();
 app.MapCoverageEndpoints();
 app.MapExecutionLogEndpoints();
 
-app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequestModel request, VersionSourceLoader loader) =>
-{
-  if (!Enum.TryParse<BuildContext>(request.BuildContext, ignoreCase: true, out var buildContext))
-  {
+app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequestModel request, VersionSourceLoader loader) => {
+  if (!Enum.TryParse<BuildContext>(request.BuildContext, ignoreCase: true, out var buildContext)) {
     return Results.BadRequest(new { code = "invalid_build_context", message = "buildContext must be one of: ci, local." });
   }
 
@@ -358,35 +349,29 @@ app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequest
   CiBuildCounter? fileCounter = null;
   var notes = new List<string>();
 
-  if (!string.IsNullOrWhiteSpace(versioningDirectory))
-  {
-    try
-    {
+  if (!string.IsNullOrWhiteSpace(versioningDirectory)) {
+    try {
       fileOverride = loader.LoadOverrideFromDirectory(versioningDirectory);
       fileMarker = loader.LoadReleaseLineMarkerFromDirectory(versioningDirectory);
       fileCounter = loader.LoadCiBuildCounterFromDirectory(versioningDirectory);
       notes.Add("source:versioning-files");
     }
-    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
-    {
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException) {
       return Results.BadRequest(new { code = "invalid_versioning_sources", message = ex.Message });
     }
   }
-  else
-  {
+  else {
     notes.Add("source:request-only");
   }
 
   var requestOverride = request.Override;
-  var effectiveOverride = new VersionOverride
-  {
+  var effectiveOverride = new VersionOverride {
     Major = requestOverride?.Major ?? request.Major ?? fileOverride?.Major,
     Minor = requestOverride?.Minor ?? request.Minor ?? fileOverride?.Minor,
     Patch = requestOverride?.Patch ?? request.Patch ?? fileOverride?.Patch
   };
 
-  if (effectiveOverride.Major is not null || effectiveOverride.Minor is not null || effectiveOverride.Patch is not null)
-  {
+  if (effectiveOverride.Major is not null || effectiveOverride.Minor is not null || effectiveOverride.Patch is not null) {
     notes.Add("source:override");
   }
 
@@ -394,31 +379,26 @@ app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequest
   var previousSequence = fileMarker?.Sequence;
   var requestedSequence = requestMarker?.Sequence ?? request.ReleaseLineSequence ?? fileMarker?.Sequence;
   var transitionDetected = VersionResolutionService.HasReleaseLineTransition(previousSequence, requestedSequence);
-  if (transitionDetected)
-  {
+  if (transitionDetected) {
     notes.Add("source:release-line-transition");
   }
 
   var requestCounter = request.CiBuildCounter?.LastBuild ?? request.LastCiBuild;
   var effectiveLastBuild = requestCounter ?? fileCounter?.LastBuild ?? 0;
-  if (requestCounter.HasValue)
-  {
+  if (requestCounter.HasValue) {
     notes.Add("source:counter-request");
   }
-  else if (fileCounter is not null)
-  {
+  else if (fileCounter is not null) {
     notes.Add("source:counter-file");
   }
 
-  var resolutionInput = new VersionResolutionInput
-  {
+  var resolutionInput = new VersionResolutionInput {
     BaselineVersion = new SemanticVersion(1, 0, 0, Math.Max(0, effectiveLastBuild)),
     Override = effectiveOverride,
     ReleaseLineTransitionDetected = transitionDetected,
     PreviousReleaseLineSequence = previousSequence,
     CurrentReleaseLineSequence = requestedSequence,
-    CiBuildCounter = new CiBuildCounter
-    {
+    CiBuildCounter = new CiBuildCounter {
       LastBuild = Math.Max(0, effectiveLastBuild),
       UpdatedAtUtc = DateTimeOffset.UtcNow,
       UpdatedBy = string.Equals(buildContext, BuildContext.Ci) ? "ci" : "local"
@@ -429,10 +409,8 @@ app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequest
   var resolved = VersionResolutionService.Resolve(resolutionInput);
   var responseNotes = resolved.Notes.Concat(notes).Distinct(StringComparer.Ordinal).ToArray();
 
-  return Results.Ok(new GameBot.Service.Models.VersionResolveResultModel
-  {
-    Version = new GameBot.Service.Models.SemanticVersionModel
-    {
+  return Results.Ok(new GameBot.Service.Models.VersionResolveResultModel {
+    Version = new GameBot.Service.Models.SemanticVersionModel {
       Major = resolved.Version.Major,
       Minor = resolved.Version.Minor,
       Patch = resolved.Version.Patch,
@@ -448,8 +426,7 @@ app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequest
 .WithTags("Versioning")
 .WithName("ResolveVersion");
 
-app.MapPost("/installer/compare", (GameBot.Service.Models.InstallCompareRequestModel request, SemanticVersionComparer comparer) =>
-{
+app.MapPost("/installer/compare", (GameBot.Service.Models.InstallCompareRequestModel request, SemanticVersionComparer comparer) => {
   var installed = new SemanticVersion(
     request.InstalledVersion.Major,
     request.InstalledVersion.Minor,
@@ -462,28 +439,23 @@ app.MapPost("/installer/compare", (GameBot.Service.Models.InstallCompareRequestM
     request.CandidateVersion.Build);
 
   var compare = comparer.Compare(candidate, installed);
-  if (compare < 0)
-  {
-    return Results.Ok(new GameBot.Service.Models.InstallCompareResultModel
-    {
+  if (compare < 0) {
+    return Results.Ok(new GameBot.Service.Models.InstallCompareResultModel {
       Outcome = "downgrade",
       Reason = "Candidate version is lower than installed version.",
       PreserveProperties = false
     });
   }
 
-  if (compare > 0)
-  {
-    return Results.Ok(new GameBot.Service.Models.InstallCompareResultModel
-    {
+  if (compare > 0) {
+    return Results.Ok(new GameBot.Service.Models.InstallCompareResultModel {
       Outcome = "upgrade",
       Reason = "Candidate version is higher than installed version.",
       PreserveProperties = true
     });
   }
 
-  return Results.Ok(new GameBot.Service.Models.InstallCompareResultModel
-  {
+  return Results.Ok(new GameBot.Service.Models.InstallCompareResultModel {
     Outcome = "sameBuild",
     Reason = "Candidate version equals installed version.",
     PreserveProperties = false
@@ -493,30 +465,24 @@ app.MapPost("/installer/compare", (GameBot.Service.Models.InstallCompareRequestM
 .WithTags("Installer")
 .WithName("CompareInstallerVersion");
 
-app.MapPost("/installer/same-build/decision", (GameBot.Service.Models.SameBuildDecisionRequestModel request) =>
-{
-  if (string.Equals(request.Mode, "unattended", StringComparison.OrdinalIgnoreCase))
-  {
-    return Results.Ok(new GameBot.Service.Models.SameBuildDecisionResultModel
-    {
+app.MapPost("/installer/same-build/decision", (GameBot.Service.Models.SameBuildDecisionRequestModel request) => {
+  if (string.Equals(request.Mode, "unattended", StringComparison.OrdinalIgnoreCase)) {
+    return Results.Ok(new GameBot.Service.Models.SameBuildDecisionResultModel {
       Action = "skip",
       MutatesState = false,
       StatusCode = 4090
     });
   }
 
-  if (string.Equals(request.InteractiveChoice, "reinstall", StringComparison.OrdinalIgnoreCase))
-  {
-    return Results.Ok(new GameBot.Service.Models.SameBuildDecisionResultModel
-    {
+  if (string.Equals(request.InteractiveChoice, "reinstall", StringComparison.OrdinalIgnoreCase)) {
+    return Results.Ok(new GameBot.Service.Models.SameBuildDecisionResultModel {
       Action = "reinstall",
       MutatesState = true,
       StatusCode = 0
     });
   }
 
-  return Results.Ok(new GameBot.Service.Models.SameBuildDecisionResultModel
-  {
+  return Results.Ok(new GameBot.Service.Models.SameBuildDecisionResultModel {
     Action = "cancel",
     MutatesState = false,
     StatusCode = 0
@@ -529,23 +495,18 @@ app.MapPost("/installer/same-build/decision", (GameBot.Service.Models.SameBuildD
 // Sequences endpoints
 var sequences = app.MapGroup(ApiRoutes.Sequences).WithTags("Sequences");
 
-sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo) =>
-{
+sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo) => {
   using var doc = await System.Text.Json.JsonDocument.ParseAsync(http.Body).ConfigureAwait(false);
   var root = doc.RootElement;
   // Authoring shape: { name: string, steps?: string[] }
-  if (root.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == System.Text.Json.JsonValueKind.String && !root.TryGetProperty("blocks", out _))
-  {
+  if (root.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == System.Text.Json.JsonValueKind.String && !root.TryGetProperty("blocks", out _)) {
     var name = nameProp.GetString()!.Trim();
     var seq = new GameBot.Domain.Commands.CommandSequence { Id = string.Empty, Name = name, CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow };
-    if (root.TryGetProperty("steps", out var stepsProp) && stepsProp.ValueKind == System.Text.Json.JsonValueKind.Array)
-    {
+    if (root.TryGetProperty("steps", out var stepsProp) && stepsProp.ValueKind == System.Text.Json.JsonValueKind.Array) {
       var order = 0;
       var steps = new List<GameBot.Domain.Commands.SequenceStep>();
-      foreach (var el in stepsProp.EnumerateArray())
-      {
-        if (el.ValueKind == System.Text.Json.JsonValueKind.String)
-        {
+      foreach (var el in stepsProp.EnumerateArray()) {
+        if (el.ValueKind == System.Text.Json.JsonValueKind.String) {
           steps.Add(new GameBot.Domain.Commands.SequenceStep { Order = order++, CommandId = el.GetString()! });
         }
       }
@@ -565,32 +526,26 @@ sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo) =>
   return Results.Created($"{ApiRoutes.Sequences}/{createdDomain.Id}", createdDomain);
 }).Accepts<System.Text.Json.JsonElement>("application/json").WithName("CreateSequence");
 
-sequences.MapGet("{id}", async (ISequenceRepository repo, string id) =>
-{
+sequences.MapGet("{id}", async (ISequenceRepository repo, string id) => {
   var found = await repo.GetAsync(id).ConfigureAwait(false);
   if (found is null) return Results.NotFound();
   return Results.Ok(new { id = found.Id, name = found.Name, steps = found.Steps.Select(s => s.CommandId).ToArray() });
 }).WithName("GetSequence");
 
-sequences.MapPut("{id}", async (HttpRequest http, ISequenceRepository repo, string id) =>
-{
+sequences.MapPut("{id}", async (HttpRequest http, ISequenceRepository repo, string id) => {
   var existing = await repo.GetAsync(id).ConfigureAwait(false);
   if (existing is null) return Results.NotFound();
   using var doc = await System.Text.Json.JsonDocument.ParseAsync(http.Body).ConfigureAwait(false);
   var root = doc.RootElement;
-  if (root.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == System.Text.Json.JsonValueKind.String)
-  {
+  if (root.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == System.Text.Json.JsonValueKind.String) {
     var name = nameProp.GetString()!.Trim();
     if (!string.IsNullOrWhiteSpace(name)) existing.Name = name;
   }
-  if (root.TryGetProperty("steps", out var stepsProp) && stepsProp.ValueKind == System.Text.Json.JsonValueKind.Array)
-  {
+  if (root.TryGetProperty("steps", out var stepsProp) && stepsProp.ValueKind == System.Text.Json.JsonValueKind.Array) {
     var order = 0;
     var steps = new List<GameBot.Domain.Commands.SequenceStep>();
-    foreach (var el in stepsProp.EnumerateArray())
-    {
-      if (el.ValueKind == System.Text.Json.JsonValueKind.String)
-      {
+    foreach (var el in stepsProp.EnumerateArray()) {
+      if (el.ValueKind == System.Text.Json.JsonValueKind.String) {
         steps.Add(new GameBot.Domain.Commands.SequenceStep { Order = order++, CommandId = el.GetString()! });
       }
     }
@@ -601,15 +556,13 @@ sequences.MapPut("{id}", async (HttpRequest http, ISequenceRepository repo, stri
   return Results.Ok(new { id = saved.Id, name = saved.Name, steps = saved.Steps.Select(s => s.CommandId).ToArray() });
 }).WithName("UpdateSequence");
 
-sequences.MapGet("", async (ISequenceRepository repo) =>
-{
+sequences.MapGet("", async (ISequenceRepository repo) => {
   var list = await repo.ListAsync().ConfigureAwait(false);
   var resp = list.Select(s => new { id = s.Id, name = s.Name, steps = s.Steps.Select(x => x.CommandId).ToArray() });
   return Results.Ok(resp);
 }).WithName("ListSequences");
 
-sequences.MapDelete("{id}", async (ISequenceRepository repo, string id) =>
-{
+sequences.MapDelete("{id}", async (ISequenceRepository repo, string id) => {
   var existing = await repo.GetAsync(id).ConfigureAwait(false);
   if (existing is null) return Results.NotFound(new { error = new { code = "not_found", message = "Sequence not found", hint = (string?)null } });
   var ok = await repo.DeleteAsync(id).ConfigureAwait(false);
@@ -622,94 +575,84 @@ sequences.MapPost("{id}/execute", async (
   GameBot.Service.Services.ExecutionLog.IExecutionLogService executionLogService,
   ISequenceRepository sequenceRepository,
   string id,
-  CancellationToken ct) =>
-{
-  // Minimal stub: delegate is a no-op; command execution integration will be added in later phases
-  var res = await runner.ExecuteAsync(
-    id,
-    _ => Task.CompletedTask,
-    gateEvaluator: (step, token) =>
-    {
-      // Temporary evaluator for integration tests:
-      // TargetId "always" => gate passes; "never" => gate fails
-      if (step.Gate == null) return Task.FromResult(true);
-      var tid = step.Gate.TargetId ?? string.Empty;
-      if (string.Equals(tid, "always", StringComparison.OrdinalIgnoreCase)) return Task.FromResult(true);
-      if (string.Equals(tid, "never", StringComparison.OrdinalIgnoreCase)) return Task.FromResult(false);
-      // Default: pass
-      return Task.FromResult(true);
-    },
-    conditionEvaluator: (cond, token) =>
-    {
-      // Map Blocks.Condition to a transient Trigger and evaluate via TriggerEvaluationService
-      if (string.Equals(cond.Source, "image", StringComparison.OrdinalIgnoreCase))
-      {
-        var region = cond.Region is null ? new GameBot.Domain.Triggers.Region { X = 0, Y = 0, Width = 1, Height = 1 }
-                                         : new GameBot.Domain.Triggers.Region { X = cond.Region.X, Y = cond.Region.Y, Width = cond.Region.Width, Height = cond.Region.Height };
-        var trig = new GameBot.Domain.Triggers.Trigger
-        {
-          Id = "inline-image",
-          Type = GameBot.Domain.Triggers.TriggerType.ImageMatch,
-          Enabled = true,
-          Params = new GameBot.Domain.Triggers.ImageMatchParams
-          {
-            ReferenceImageId = cond.TargetId,
-            Region = region,
-            SimilarityThreshold = cond.ConfidenceThreshold ?? 0.85
-          }
-        };
-        var r = evalSvc.Evaluate(trig, DateTimeOffset.UtcNow);
-        return Task.FromResult(r.Status == GameBot.Domain.Triggers.TriggerStatus.Satisfied);
-      }
-      if (string.Equals(cond.Source, "text", StringComparison.OrdinalIgnoreCase))
-      {
-        var region = cond.Region is null ? new GameBot.Domain.Triggers.Region { X = 0, Y = 0, Width = 1, Height = 1 }
-                                         : new GameBot.Domain.Triggers.Region { X = cond.Region.X, Y = cond.Region.Y, Width = cond.Region.Width, Height = cond.Region.Height };
-        var mode = string.Equals(cond.Mode, "Absent", StringComparison.OrdinalIgnoreCase) ? "not-found" : "found";
-        var trig = new GameBot.Domain.Triggers.Trigger
-        {
-          Id = "inline-text",
-          Type = GameBot.Domain.Triggers.TriggerType.TextMatch,
-          Enabled = true,
-          Params = new GameBot.Domain.Triggers.TextMatchParams
-          {
-            Target = cond.TargetId,
-            Region = region,
-            ConfidenceThreshold = cond.ConfidenceThreshold ?? 0.80,
-            Mode = mode,
-            Language = cond.Language
-          }
-        };
-        var r = evalSvc.Evaluate(trig, DateTimeOffset.UtcNow);
-        return Task.FromResult(r.Status == GameBot.Domain.Triggers.TriggerStatus.Satisfied);
-      }
-      // Unsupported source
-      return Task.FromResult(false);
-    },
-    ct: ct
-  ).ConfigureAwait(false);
-  var sequence = await sequenceRepository.GetAsync(id).ConfigureAwait(false);
-  var sequenceName = sequence?.Name ?? id;
-  var status = string.Equals(res.Status, "Completed", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
-  await executionLogService.LogSequenceExecutionAsync(
-    id,
-    sequenceName,
-    status,
-    $"Sequence '{sequenceName}' {status} with {res.Steps.Count} executed commands.",
-    new GameBot.Service.Services.ExecutionLog.ExecutionLogContext
-    {
-      Depth = 0
-    },
-    details: new[] {
+  CancellationToken ct) => {
+    // Minimal stub: delegate is a no-op; command execution integration will be added in later phases
+    var res = await runner.ExecuteAsync(
+      id,
+      _ => Task.CompletedTask,
+      gateEvaluator: (step, token) => {
+        // Temporary evaluator for integration tests:
+        // TargetId "always" => gate passes; "never" => gate fails
+        if (step.Gate == null) return Task.FromResult(true);
+        var tid = step.Gate.TargetId ?? string.Empty;
+        if (string.Equals(tid, "always", StringComparison.OrdinalIgnoreCase)) return Task.FromResult(true);
+        if (string.Equals(tid, "never", StringComparison.OrdinalIgnoreCase)) return Task.FromResult(false);
+        // Default: pass
+        return Task.FromResult(true);
+      },
+      conditionEvaluator: (cond, token) => {
+        // Map Blocks.Condition to a transient Trigger and evaluate via TriggerEvaluationService
+        if (string.Equals(cond.Source, "image", StringComparison.OrdinalIgnoreCase)) {
+          var region = cond.Region is null ? new GameBot.Domain.Triggers.Region { X = 0, Y = 0, Width = 1, Height = 1 }
+                                           : new GameBot.Domain.Triggers.Region { X = cond.Region.X, Y = cond.Region.Y, Width = cond.Region.Width, Height = cond.Region.Height };
+          var trig = new GameBot.Domain.Triggers.Trigger {
+            Id = "inline-image",
+            Type = GameBot.Domain.Triggers.TriggerType.ImageMatch,
+            Enabled = true,
+            Params = new GameBot.Domain.Triggers.ImageMatchParams {
+              ReferenceImageId = cond.TargetId,
+              Region = region,
+              SimilarityThreshold = cond.ConfidenceThreshold ?? 0.85
+            }
+          };
+          var r = evalSvc.Evaluate(trig, DateTimeOffset.UtcNow);
+          return Task.FromResult(r.Status == GameBot.Domain.Triggers.TriggerStatus.Satisfied);
+        }
+        if (string.Equals(cond.Source, "text", StringComparison.OrdinalIgnoreCase)) {
+          var region = cond.Region is null ? new GameBot.Domain.Triggers.Region { X = 0, Y = 0, Width = 1, Height = 1 }
+                                           : new GameBot.Domain.Triggers.Region { X = cond.Region.X, Y = cond.Region.Y, Width = cond.Region.Width, Height = cond.Region.Height };
+          var mode = string.Equals(cond.Mode, "Absent", StringComparison.OrdinalIgnoreCase) ? "not-found" : "found";
+          var trig = new GameBot.Domain.Triggers.Trigger {
+            Id = "inline-text",
+            Type = GameBot.Domain.Triggers.TriggerType.TextMatch,
+            Enabled = true,
+            Params = new GameBot.Domain.Triggers.TextMatchParams {
+              Target = cond.TargetId,
+              Region = region,
+              ConfidenceThreshold = cond.ConfidenceThreshold ?? 0.80,
+              Mode = mode,
+              Language = cond.Language
+            }
+          };
+          var r = evalSvc.Evaluate(trig, DateTimeOffset.UtcNow);
+          return Task.FromResult(r.Status == GameBot.Domain.Triggers.TriggerStatus.Satisfied);
+        }
+        // Unsupported source
+        return Task.FromResult(false);
+      },
+      ct: ct
+    ).ConfigureAwait(false);
+    var sequence = await sequenceRepository.GetAsync(id).ConfigureAwait(false);
+    var sequenceName = sequence?.Name ?? id;
+    var status = string.Equals(res.Status, "Completed", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
+    await executionLogService.LogSequenceExecutionAsync(
+      id,
+      sequenceName,
+      status,
+      $"Sequence '{sequenceName}' {status} with {res.Steps.Count} executed commands.",
+      new GameBot.Service.Services.ExecutionLog.ExecutionLogContext {
+        Depth = 0
+      },
+      details: new[] {
       new GameBot.Domain.Logging.ExecutionDetailItem(
         "sequence",
         $"Executed commands: {string.Join(",", res.Steps.Select(s => s.CommandId).Take(10))}",
         new Dictionary<string, object?> { ["executedCount"] = res.Steps.Count },
         "normal")
-    },
-    ct).ConfigureAwait(false);
-  return Results.Ok(res);
-}).WithName("ExecuteSequence").WithTags("Sequences");
+      },
+      ct).ConfigureAwait(false);
+    return Results.Ok(res);
+  }).WithName("ExecuteSequence").WithTags("Sequences");
 
 // Legacy guard rails: respond with guidance instead of serving old roots
 MapLegacyGuard("/actions", ApiRoutes.Actions);
@@ -741,8 +684,7 @@ if (hasInstalledWebUi) {
 
 app.Run();
 
-void MapLegacyGuard(string legacyRoot, string canonicalRoot)
-{
+void MapLegacyGuard(string legacyRoot, string canonicalRoot) {
   app.MapMethods(legacyRoot, new[] { HttpMethods.Get, HttpMethods.Post, HttpMethods.Put, HttpMethods.Patch, HttpMethods.Delete },
     (HttpContext ctx) => Results.Json(
       new { error = new { code = "legacy_route", message = "Use the canonical API base path.", hint = canonicalRoot } },
@@ -756,32 +698,26 @@ void MapLegacyGuard(string legacyRoot, string canonicalRoot)
     .ExcludeFromDescription();
 }
 
-static string? ReadInstallerNetworkValue(string name)
-{
-  if (!OperatingSystem.IsWindows())
-  {
+static string? ReadInstallerNetworkValue(string name) {
+  if (!OperatingSystem.IsWindows()) {
     return null;
   }
 
   const string subKey = @"Software\GameBot\Network";
 
   var currentUser = Registry.GetValue($@"HKEY_CURRENT_USER\{subKey}", name, null)?.ToString();
-  if (!string.IsNullOrWhiteSpace(currentUser))
-  {
+  if (!string.IsNullOrWhiteSpace(currentUser)) {
     return currentUser;
   }
 
   return null;
 }
 
-static string? TryFindVersioningDirectory()
-{
+static string? TryFindVersioningDirectory() {
   var directory = new DirectoryInfo(AppContext.BaseDirectory);
-  while (directory is not null)
-  {
+  while (directory is not null) {
     var candidate = Path.Combine(directory.FullName, "installer", "versioning");
-    if (Directory.Exists(candidate))
-    {
+    if (Directory.Exists(candidate)) {
       return candidate;
     }
 
@@ -791,112 +727,86 @@ static string? TryFindVersioningDirectory()
   return null;
 }
 
-static List<string> ValidateSequence(GameBot.Domain.Commands.CommandSequence seq)
-{
+static List<string> ValidateSequence(GameBot.Domain.Commands.CommandSequence seq) {
   var errs = new List<string>();
   // Validate blocks if present
-  if (seq.Blocks is { Count: > 0 })
-  {
-    foreach (var b in seq.Blocks)
-    {
+  if (seq.Blocks is { Count: > 0 }) {
+    foreach (var b in seq.Blocks) {
       ValidateBlock(b, errs, isTopLevel: true);
     }
   }
   return errs;
 }
 
-static void ValidateBlock(object blockObj, List<string> errs, bool isTopLevel)
-{
-  if (blockObj is System.Text.Json.JsonElement je && je.ValueKind == System.Text.Json.JsonValueKind.Object)
-  {
+static void ValidateBlock(object blockObj, List<string> errs, bool isTopLevel) {
+  if (blockObj is System.Text.Json.JsonElement je && je.ValueKind == System.Text.Json.JsonValueKind.Object) {
     string? type = null;
-    if (je.TryGetProperty("type", out var tProp) && tProp.ValueKind == System.Text.Json.JsonValueKind.String)
-    {
+    if (je.TryGetProperty("type", out var tProp) && tProp.ValueKind == System.Text.Json.JsonValueKind.String) {
       type = tProp.GetString();
     }
-    if (string.IsNullOrWhiteSpace(type))
-    {
+    if (string.IsNullOrWhiteSpace(type)) {
       errs.Add("Block missing required 'type'.");
       return;
     }
     var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "repeatCount", "repeatUntil", "while", "ifElse" };
-    if (!allowed.Contains(type))
-    {
+    if (!allowed.Contains(type)) {
       errs.Add($"Unsupported block type '{type}'.");
       return;
     }
 
     // Common: steps array for all but else-only
-    if (je.TryGetProperty("steps", out var stepsProp) && stepsProp.ValueKind == System.Text.Json.JsonValueKind.Array)
-    {
-      foreach (var item in stepsProp.EnumerateArray())
-      {
+    if (je.TryGetProperty("steps", out var stepsProp) && stepsProp.ValueKind == System.Text.Json.JsonValueKind.Array) {
+      foreach (var item in stepsProp.EnumerateArray()) {
         // item can be a Step (object without 'type') or a nested Block (object with 'type')
-        if (item.ValueKind == System.Text.Json.JsonValueKind.Object && item.TryGetProperty("type", out var nestedType))
-        {
+        if (item.ValueKind == System.Text.Json.JsonValueKind.Object && item.TryGetProperty("type", out var nestedType)) {
           ValidateBlock(item, errs, isTopLevel: false);
         }
       }
     }
 
-    if (type.Equals("ifElse", StringComparison.OrdinalIgnoreCase))
-    {
-      if (!je.TryGetProperty("condition", out var cond) || cond.ValueKind != System.Text.Json.JsonValueKind.Object)
-      {
+    if (type.Equals("ifElse", StringComparison.OrdinalIgnoreCase)) {
+      if (!je.TryGetProperty("condition", out var cond) || cond.ValueKind != System.Text.Json.JsonValueKind.Object) {
         errs.Add("ifElse block requires 'condition'.");
       }
       // Validate elseSteps only for ifElse
-      if (je.TryGetProperty("elseSteps", out var elseProp) && elseProp.ValueKind == System.Text.Json.JsonValueKind.Array)
-      {
-        foreach (var item in elseProp.EnumerateArray())
-        {
-          if (item.ValueKind == System.Text.Json.JsonValueKind.Object && item.TryGetProperty("type", out var nestedType))
-          {
+      if (je.TryGetProperty("elseSteps", out var elseProp) && elseProp.ValueKind == System.Text.Json.JsonValueKind.Array) {
+        foreach (var item in elseProp.EnumerateArray()) {
+          if (item.ValueKind == System.Text.Json.JsonValueKind.Object && item.TryGetProperty("type", out var nestedType)) {
             ValidateBlock(item, errs, isTopLevel: false);
           }
         }
       }
     }
-    else if (type.Equals("repeatUntil", StringComparison.OrdinalIgnoreCase) || type.Equals("while", StringComparison.OrdinalIgnoreCase))
-    {
-      if (!je.TryGetProperty("condition", out var cond) || cond.ValueKind != System.Text.Json.JsonValueKind.Object)
-      {
+    else if (type.Equals("repeatUntil", StringComparison.OrdinalIgnoreCase) || type.Equals("while", StringComparison.OrdinalIgnoreCase)) {
+      if (!je.TryGetProperty("condition", out var cond) || cond.ValueKind != System.Text.Json.JsonValueKind.Object) {
         errs.Add($"{type} block requires 'condition'.");
       }
       var hasTimeout = je.TryGetProperty("timeoutMs", out var to) && to.ValueKind == System.Text.Json.JsonValueKind.Number && to.GetInt32() >= 0;
       var hasMaxIter = je.TryGetProperty("maxIterations", out var mi) && mi.ValueKind == System.Text.Json.JsonValueKind.Number && mi.GetInt32() >= 1;
-      if (!hasTimeout && !hasMaxIter)
-      {
+      if (!hasTimeout && !hasMaxIter) {
         errs.Add($"{type} block must set 'timeoutMs' or 'maxIterations'.");
       }
-      if (je.TryGetProperty("cadenceMs", out var cadence) && cadence.ValueKind == System.Text.Json.JsonValueKind.Number)
-      {
+      if (je.TryGetProperty("cadenceMs", out var cadence) && cadence.ValueKind == System.Text.Json.JsonValueKind.Number) {
         var c = cadence.GetInt32();
-        if (c < 50 || c > 5000)
-        {
+        if (c < 50 || c > 5000) {
           errs.Add($"{type} cadenceMs out of bounds (50-5000): {c}.");
         }
       }
     }
-    else if (type.Equals("repeatCount", StringComparison.OrdinalIgnoreCase))
-    {
-      if (!je.TryGetProperty("maxIterations", out var mi) || mi.ValueKind != System.Text.Json.JsonValueKind.Number || mi.GetInt32() < 0)
-      {
+    else if (type.Equals("repeatCount", StringComparison.OrdinalIgnoreCase)) {
+      if (!je.TryGetProperty("maxIterations", out var mi) || mi.ValueKind != System.Text.Json.JsonValueKind.Number || mi.GetInt32() < 0) {
         errs.Add("repeatCount requires non-negative 'maxIterations'.");
       }
-      if (je.TryGetProperty("cadenceMs", out var cadence) && cadence.ValueKind == System.Text.Json.JsonValueKind.Number)
-      {
+      if (je.TryGetProperty("cadenceMs", out var cadence) && cadence.ValueKind == System.Text.Json.JsonValueKind.Number) {
         var c = cadence.GetInt32();
-        if (c != 0 && (c < 50 || c > 5000))
-        {
+        if (c != 0 && (c < 50 || c > 5000)) {
           errs.Add($"repeatCount cadenceMs must be 0 or within 50-5000: {c}.");
         }
       }
     }
 
     // If a non-ifElse block provides elseSteps, flag as error (T015)
-    if (!type.Equals("ifElse", StringComparison.OrdinalIgnoreCase) && je.TryGetProperty("elseSteps", out var elseAny) && elseAny.ValueKind == System.Text.Json.JsonValueKind.Array)
-    {
+    if (!type.Equals("ifElse", StringComparison.OrdinalIgnoreCase) && je.TryGetProperty("elseSteps", out var elseAny) && elseAny.ValueKind == System.Text.Json.JsonValueKind.Array) {
       errs.Add($"'elseSteps' is only valid for ifElse blocks, not '{type}'.");
     }
   }

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -1,10 +1,12 @@
 using GameBot.Domain.Actions;
 using GameBot.Domain.Commands;
+using GameBot.Domain.Logging;
 using GameBot.Domain.Services;
 using GameBot.Domain.Triggers;
 using GameBot.Emulator.Session;
 using Microsoft.Extensions.Logging;
 using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
 using System.Globalization;
 
 namespace GameBot.Service.Services;
@@ -20,8 +22,9 @@ internal sealed class CommandExecutor : ICommandExecutor {
   private readonly GameBot.Domain.Triggers.Evaluators.IScreenSource? _screen;
   private readonly GameBot.Domain.Vision.ITemplateMatcher? _matcher;
   private readonly ISessionContextCache _sessionCache;
+  private readonly IExecutionLogService? _executionLogService;
 
-  public CommandExecutor(ICommandRepository commands, IActionRepository actions, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache) {
+  public CommandExecutor(ICommandRepository commands, IActionRepository actions, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, IExecutionLogService? executionLogService = null) {
     _commands = commands;
     _actions = actions;
     _sessions = sessions;
@@ -32,10 +35,11 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _screen = screen;
     _matcher = matcher;
     _sessionCache = sessionCache;
+    _executionLogService = executionLogService;
   }
 
   // Fallback constructor for environments without detection services registered (non-Windows or tests)
-  public CommandExecutor(ICommandRepository commands, IActionRepository actions, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, ISessionContextCache sessionCache) {
+  public CommandExecutor(ICommandRepository commands, IActionRepository actions, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, ISessionContextCache sessionCache, IExecutionLogService? executionLogService = null) {
     _commands = commands;
     _actions = actions;
     _sessions = sessions;
@@ -46,6 +50,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _screen = null;
     _matcher = null;
     _sessionCache = sessionCache;
+    _executionLogService = executionLogService;
   }
 
   public async Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default) {
@@ -62,6 +67,12 @@ internal sealed class CommandExecutor : ICommandExecutor {
     var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     var stepOutcomes = new List<PrimitiveTapStepOutcome>();
     var accepted = await ExecuteCommandRecursiveAsync(resolvedSessionId, commandId, visited, stepOutcomes, ct).ConfigureAwait(false);
+    if (_executionLogService is not null) {
+      var cmd = await _commands.GetAsync(commandId, ct).ConfigureAwait(false);
+      var cmdName = cmd?.Name ?? commandId;
+      var status = stepOutcomes.Any(o => !string.Equals(o.Status, "executed", StringComparison.OrdinalIgnoreCase)) ? "failure" : "success";
+      await _executionLogService.LogCommandExecutionAsync(commandId, cmdName, status, stepOutcomes, null, 0, ct).ConfigureAwait(false);
+    }
     return new CommandForceExecutionResult(accepted, stepOutcomes);
   }
 
@@ -81,6 +92,9 @@ internal sealed class CommandExecutor : ICommandExecutor {
 
     if (string.IsNullOrWhiteSpace(cmd.TriggerId)) {
       // No trigger configured: do not execute. Return pending/unsatisfied.
+      if (_executionLogService is not null) {
+        await _executionLogService.LogCommandExecutionAsync(commandId, cmd.Name, "failure", Array.Empty<PrimitiveTapStepOutcome>(), null, 0, ct).ConfigureAwait(false);
+      }
       return new CommandEvaluationExecutionResult(0, TriggerStatus.Pending, "no_trigger_configured", Array.Empty<PrimitiveTapStepOutcome>());
     }
 
@@ -101,6 +115,9 @@ internal sealed class CommandExecutor : ICommandExecutor {
 
     await _triggers.UpsertAsync(trigger, ct).ConfigureAwait(false);
     Log.TriggerSkipped(_logger, commandId, trigger.Id, res.Status, res.Reason);
+    if (_executionLogService is not null) {
+      await _executionLogService.LogCommandExecutionAsync(commandId, cmd.Name, "failure", Array.Empty<PrimitiveTapStepOutcome>(), null, 0, ct).ConfigureAwait(false);
+    }
     return new CommandEvaluationExecutionResult(0, res.Status, res.Reason, Array.Empty<PrimitiveTapStepOutcome>());
   }
 

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -156,7 +156,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
         // If the command includes a detection target, attempt to resolve coordinates for tap actions
         if (cmd.Detection is not null && OperatingSystem.IsWindows()) {
           try {
-            #nullable disable
+#nullable disable
             var detection = cmd.Detection!;
             var screenSrc = _screen;
             var images = _images;
@@ -176,20 +176,20 @@ internal sealed class CommandExecutor : ICommandExecutor {
               if (matcher is null) { Log.DetectionSkip(_logger, "matcher_unavailable"); }
               else {
                 var adapter = new GameBot.Domain.Services.ActionExecutionAdapter(matcher);
-              foreach (var inp in inputs) {
-                var ok = adapter.TryApplyDetectionCoordinates(
-                  new GameBot.Domain.Actions.InputAction { Type = inp.Type, Args = inp.Args, DelayMs = inp.DelayMs, DurationMs = inp.DurationMs },
-                  detection,
-                  screenMat,
-                  templateMat,
-                  detection.Confidence,
-                  out var err);
-                if (!ok && err is not null) { Log.DetectionSkip(_logger, err); }
-              }
+                foreach (var inp in inputs) {
+                  var ok = adapter.TryApplyDetectionCoordinates(
+                    new GameBot.Domain.Actions.InputAction { Type = inp.Type, Args = inp.Args, DelayMs = inp.DelayMs, DurationMs = inp.DurationMs },
+                    detection,
+                    screenMat,
+                    templateMat,
+                    detection.Confidence,
+                    out var err);
+                  if (!ok && err is not null) { Log.DetectionSkip(_logger, err); }
+                }
               }
               screenMat.Dispose();
               templateMat.Dispose();
-              #nullable restore
+#nullable restore
             }
           }
           catch (Exception ex) {

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -71,7 +71,13 @@ internal sealed class CommandExecutor : ICommandExecutor {
       var cmd = await _commands.GetAsync(commandId, ct).ConfigureAwait(false);
       var cmdName = cmd?.Name ?? commandId;
       var status = stepOutcomes.Any(o => !string.Equals(o.Status, "executed", StringComparison.OrdinalIgnoreCase)) ? "failure" : "success";
-      await _executionLogService.LogCommandExecutionAsync(commandId, cmdName, status, stepOutcomes, null, 0, ct).ConfigureAwait(false);
+      await _executionLogService.LogCommandExecutionAsync(
+        commandId,
+        cmdName,
+        status,
+        stepOutcomes,
+        new ExecutionLogContext { Depth = 0 },
+        ct).ConfigureAwait(false);
     }
     return new CommandForceExecutionResult(accepted, stepOutcomes);
   }
@@ -93,7 +99,13 @@ internal sealed class CommandExecutor : ICommandExecutor {
     if (string.IsNullOrWhiteSpace(cmd.TriggerId)) {
       // No trigger configured: do not execute. Return pending/unsatisfied.
       if (_executionLogService is not null) {
-        await _executionLogService.LogCommandExecutionAsync(commandId, cmd.Name, "failure", Array.Empty<PrimitiveTapStepOutcome>(), null, 0, ct).ConfigureAwait(false);
+        await _executionLogService.LogCommandExecutionAsync(
+          commandId,
+          cmd.Name,
+          "failure",
+          Array.Empty<PrimitiveTapStepOutcome>(),
+          new ExecutionLogContext { Depth = 0 },
+          ct).ConfigureAwait(false);
       }
       return new CommandEvaluationExecutionResult(0, TriggerStatus.Pending, "no_trigger_configured", Array.Empty<PrimitiveTapStepOutcome>());
     }
@@ -116,7 +128,13 @@ internal sealed class CommandExecutor : ICommandExecutor {
     await _triggers.UpsertAsync(trigger, ct).ConfigureAwait(false);
     Log.TriggerSkipped(_logger, commandId, trigger.Id, res.Status, res.Reason);
     if (_executionLogService is not null) {
-      await _executionLogService.LogCommandExecutionAsync(commandId, cmd.Name, "failure", Array.Empty<PrimitiveTapStepOutcome>(), null, 0, ct).ConfigureAwait(false);
+      await _executionLogService.LogCommandExecutionAsync(
+        commandId,
+        cmd.Name,
+        "failure",
+        Array.Empty<PrimitiveTapStepOutcome>(),
+        new ExecutionLogContext { Depth = 0 },
+        ct).ConfigureAwait(false);
     }
     return new CommandEvaluationExecutionResult(0, res.Status, res.Reason, Array.Empty<PrimitiveTapStepOutcome>());
   }

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs
@@ -2,10 +2,8 @@ using GameBot.Domain.Logging;
 
 namespace GameBot.Service.Services.ExecutionLog;
 
-internal static class ExecutionHierarchyBuilder
-{
-  public static ExecutionHierarchyContext Build(ExecutionLogContext? context)
-  {
+internal static class ExecutionHierarchyBuilder {
+  public static ExecutionHierarchyContext Build(ExecutionLogContext? context) {
     var parentExecutionId = NullIfWhiteSpace(context?.ParentExecutionId);
     var rootExecutionId = NullIfWhiteSpace(context?.RootExecutionId)
                           ?? parentExecutionId

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs
@@ -1,0 +1,23 @@
+using GameBot.Domain.Logging;
+
+namespace GameBot.Service.Services.ExecutionLog;
+
+internal static class ExecutionHierarchyBuilder
+{
+  public static ExecutionHierarchyContext Build(ExecutionLogContext? context)
+  {
+    var parentExecutionId = NullIfWhiteSpace(context?.ParentExecutionId);
+    var rootExecutionId = NullIfWhiteSpace(context?.RootExecutionId)
+                          ?? parentExecutionId
+                          ?? Guid.NewGuid().ToString("N");
+
+    return new ExecutionHierarchyContext(
+      rootExecutionId,
+      parentExecutionId,
+      Math.Max(0, context?.Depth ?? 0),
+      context?.SequenceIndex);
+  }
+
+  private static string? NullIfWhiteSpace(string? value)
+    => string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs
@@ -1,0 +1,11 @@
+namespace GameBot.Service.Services.ExecutionLog;
+
+internal sealed class ExecutionLogContext
+{
+  public string? ParentExecutionId { get; init; }
+  public string? RootExecutionId { get; init; }
+  public int Depth { get; init; }
+  public int? SequenceIndex { get; init; }
+  public string? ParentObjectType { get; init; }
+  public string? ParentObjectId { get; init; }
+}

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs
@@ -1,7 +1,6 @@
 namespace GameBot.Service.Services.ExecutionLog;
 
-internal sealed class ExecutionLogContext
-{
+internal sealed class ExecutionLogContext {
   public string? ParentExecutionId { get; init; }
   public string? RootExecutionId { get; init; }
   public int Depth { get; init; }

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
@@ -1,0 +1,41 @@
+using System.Text.RegularExpressions;
+using GameBot.Domain.Logging;
+
+namespace GameBot.Service.Services.ExecutionLog;
+
+internal static class ExecutionLogSanitizer
+{
+  private static readonly Regex SecretKeyRegex = new("(token|password|secret|apikey|api_key|authorization)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+  public static IReadOnlyList<ExecutionDetailItem> SanitizeDetails(IReadOnlyList<ExecutionDetailItem> details)
+  {
+    if (details.Count == 0) return details;
+
+    var sanitized = new List<ExecutionDetailItem>(details.Count);
+    foreach (var detail in details)
+    {
+      var attributes = detail.Attributes is null
+        ? null
+        : detail.Attributes.ToDictionary(
+          kvp => kvp.Key,
+          kvp => MaskIfSensitive(kvp.Key, kvp.Value));
+
+      var sensitivity = attributes is null || attributes.Count == 0
+        ? detail.Sensitivity
+        : attributes.Values.Any(v => string.Equals(v as string, "[REDACTED]", StringComparison.Ordinal))
+          ? "redacted"
+          : detail.Sensitivity;
+
+      sanitized.Add(new ExecutionDetailItem(detail.Kind, detail.Message, attributes, sensitivity));
+    }
+
+    return sanitized;
+  }
+
+  private static object? MaskIfSensitive(string key, object? value)
+  {
+    if (value is null) return null;
+    if (!SecretKeyRegex.IsMatch(key)) return value;
+    return "[REDACTED]";
+  }
+}

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogSanitizer.cs
@@ -3,17 +3,14 @@ using GameBot.Domain.Logging;
 
 namespace GameBot.Service.Services.ExecutionLog;
 
-internal static class ExecutionLogSanitizer
-{
+internal static class ExecutionLogSanitizer {
   private static readonly Regex SecretKeyRegex = new("(token|password|secret|apikey|api_key|authorization)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-  public static IReadOnlyList<ExecutionDetailItem> SanitizeDetails(IReadOnlyList<ExecutionDetailItem> details)
-  {
+  public static IReadOnlyList<ExecutionDetailItem> SanitizeDetails(IReadOnlyList<ExecutionDetailItem> details) {
     if (details.Count == 0) return details;
 
     var sanitized = new List<ExecutionDetailItem>(details.Count);
-    foreach (var detail in details)
-    {
+    foreach (var detail in details) {
       var attributes = detail.Attributes is null
         ? null
         : detail.Attributes.ToDictionary(
@@ -32,8 +29,7 @@ internal static class ExecutionLogSanitizer
     return sanitized;
   }
 
-  private static object? MaskIfSensitive(string key, object? value)
-  {
+  private static object? MaskIfSensitive(string key, object? value) {
     if (value is null) return null;
     if (!SecretKeyRegex.IsMatch(key)) return value;
     return "[REDACTED]";

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -3,8 +3,7 @@ using GameBot.Service.Services;
 
 namespace GameBot.Service.Services.ExecutionLog;
 
-internal interface IExecutionLogService
-{
+internal interface IExecutionLogService {
   Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, string? parentExecutionId, int depth, CancellationToken ct = default);
   Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, ExecutionLogContext context, CancellationToken ct = default);
   Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, string? parentExecutionId, int depth, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default);
@@ -16,15 +15,13 @@ internal interface IExecutionLogService
   Task<int> CleanupExpiredAsync(CancellationToken ct = default);
 }
 
-internal sealed class ExecutionLogService : IExecutionLogService
-{
+internal sealed class ExecutionLogService : IExecutionLogService {
   private readonly IExecutionLogRepository _repository;
   private readonly IExecutionLogRetentionPolicyRepository _retentionRepository;
 
   public ExecutionLogService(
     IExecutionLogRepository repository,
-    IExecutionLogRetentionPolicyRepository retentionRepository)
-  {
+    IExecutionLogRetentionPolicyRepository retentionRepository) {
     _repository = repository;
     _retentionRepository = retentionRepository;
   }
@@ -35,15 +32,13 @@ internal sealed class ExecutionLogService : IExecutionLogService
       commandName,
       finalStatus,
       primitiveOutcomes,
-      new ExecutionLogContext
-      {
+      new ExecutionLogContext {
         ParentExecutionId = parentExecutionId,
         Depth = depth
       },
       ct).ConfigureAwait(false);
 
-  public async Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, ExecutionLogContext context, CancellationToken ct = default)
-  {
+  public async Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, ExecutionLogContext context, CancellationToken ct = default) {
     var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
     var now = DateTimeOffset.UtcNow;
 
@@ -57,28 +52,23 @@ internal sealed class ExecutionLogService : IExecutionLogService
       .ToList();
 
     var details = new List<ExecutionDetailItem>();
-    foreach (var outcome in primitiveOutcomes)
-    {
-      if (string.Equals(outcome.Status, "executed", StringComparison.OrdinalIgnoreCase) && outcome.ResolvedPoint is not null)
-      {
+    foreach (var outcome in primitiveOutcomes) {
+      if (string.Equals(outcome.Status, "executed", StringComparison.OrdinalIgnoreCase) && outcome.ResolvedPoint is not null) {
         details.Add(new ExecutionDetailItem(
           "tap",
           $"Tap executed at ({outcome.ResolvedPoint.X},{outcome.ResolvedPoint.Y}).",
-          new Dictionary<string, object?>
-          {
+          new Dictionary<string, object?> {
             ["x"] = outcome.ResolvedPoint.X,
             ["y"] = outcome.ResolvedPoint.Y,
             ["confidence"] = outcome.DetectionConfidence
           },
           "normal"));
       }
-      else
-      {
+      else {
         details.Add(new ExecutionDetailItem(
           "step",
           $"Step {outcome.StepOrder} was not executed: {outcome.Reason ?? outcome.Status}",
-          new Dictionary<string, object?>
-          {
+          new Dictionary<string, object?> {
             ["reasonCode"] = outcome.Status,
             ["reason"] = outcome.Reason
           },
@@ -86,8 +76,7 @@ internal sealed class ExecutionLogService : IExecutionLogService
       }
     }
 
-    var entry = new ExecutionLogEntry
-    {
+    var entry = new ExecutionLogEntry {
       TimestampUtc = now,
       ExecutionType = "command",
       FinalStatus = NormalizeStatus(finalStatus),
@@ -109,21 +98,18 @@ internal sealed class ExecutionLogService : IExecutionLogService
       sequenceName,
       finalStatus,
       summary,
-      new ExecutionLogContext
-      {
+      new ExecutionLogContext {
         ParentExecutionId = parentExecutionId,
         Depth = depth
       },
       details,
       ct).ConfigureAwait(false);
 
-  public async Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default)
-  {
+  public async Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default) {
     var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
     var now = DateTimeOffset.UtcNow;
 
-    var entry = new ExecutionLogEntry
-    {
+    var entry = new ExecutionLogEntry {
       TimestampUtc = now,
       ExecutionType = "sequence",
       FinalStatus = NormalizeStatus(finalStatus),
@@ -148,11 +134,9 @@ internal sealed class ExecutionLogService : IExecutionLogService
   public Task<ExecutionLogRetentionPolicy> GetRetentionAsync(CancellationToken ct = default)
     => _retentionRepository.GetAsync(ct);
 
-  public async Task<ExecutionLogRetentionPolicy> UpdateRetentionAsync(bool enabled, int? retentionDays, int? cleanupIntervalMinutes, CancellationToken ct = default)
-  {
+  public async Task<ExecutionLogRetentionPolicy> UpdateRetentionAsync(bool enabled, int? retentionDays, int? cleanupIntervalMinutes, CancellationToken ct = default) {
     var current = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
-    var updated = new ExecutionLogRetentionPolicy
-    {
+    var updated = new ExecutionLogRetentionPolicy {
       Enabled = enabled,
       RetentionDays = retentionDays ?? current.RetentionDays,
       CleanupIntervalMinutes = cleanupIntervalMinutes ?? current.CleanupIntervalMinutes,
@@ -161,8 +145,7 @@ internal sealed class ExecutionLogService : IExecutionLogService
     return await _retentionRepository.SaveAsync(updated, ct).ConfigureAwait(false);
   }
 
-  public async Task<int> CleanupExpiredAsync(CancellationToken ct = default)
-  {
+  public async Task<int> CleanupExpiredAsync(CancellationToken ct = default) {
     var policy = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
     if (!policy.Enabled) return 0;
     return await _repository.DeleteExpiredAsync(DateTimeOffset.UtcNow, ct).ConfigureAwait(false);
@@ -171,14 +154,12 @@ internal sealed class ExecutionLogService : IExecutionLogService
   private static string NormalizeStatus(string status)
     => string.Equals(status, "success", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
 
-  private static string TrimSummary(string summary)
-  {
+  private static string TrimSummary(string summary) {
     var text = string.IsNullOrWhiteSpace(summary) ? "Execution completed." : summary.Trim();
     return text.Length <= 240 ? text : text[..240];
   }
 
-  private static IReadOnlyList<ExecutionDetailItem> TrimDetails(IReadOnlyList<ExecutionDetailItem> details)
-  {
+  private static IReadOnlyList<ExecutionDetailItem> TrimDetails(IReadOnlyList<ExecutionDetailItem> details) {
     if (details.Count <= 10) return details;
     var trimmed = details.Take(9).ToList();
     trimmed.Add(new ExecutionDetailItem("meta", "Additional details were truncated.", null, "normal"));

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -1,0 +1,158 @@
+using GameBot.Domain.Logging;
+using GameBot.Service.Services;
+
+namespace GameBot.Service.Services.ExecutionLog;
+
+internal interface IExecutionLogService
+{
+  Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, string? parentExecutionId, int depth, CancellationToken ct = default);
+  Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, string? parentExecutionId, int depth, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default);
+  Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default);
+  Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default);
+  Task<ExecutionLogRetentionPolicy> GetRetentionAsync(CancellationToken ct = default);
+  Task<ExecutionLogRetentionPolicy> UpdateRetentionAsync(bool enabled, int? retentionDays, int? cleanupIntervalMinutes, CancellationToken ct = default);
+  Task<int> CleanupExpiredAsync(CancellationToken ct = default);
+}
+
+internal sealed class ExecutionLogService : IExecutionLogService
+{
+  private readonly IExecutionLogRepository _repository;
+  private readonly IExecutionLogRetentionPolicyRepository _retentionRepository;
+
+  public ExecutionLogService(IExecutionLogRepository repository, IExecutionLogRetentionPolicyRepository retentionRepository)
+  {
+    _repository = repository;
+    _retentionRepository = retentionRepository;
+  }
+
+  public async Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, string? parentExecutionId, int depth, CancellationToken ct = default)
+  {
+    var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
+    var now = DateTimeOffset.UtcNow;
+    var rootExecutionId = parentExecutionId ?? Guid.NewGuid().ToString("N");
+
+    var stepOutcomes = primitiveOutcomes
+      .Select(o => new ExecutionStepOutcome(
+        o.StepOrder,
+        "primitiveTap",
+        string.Equals(o.Status, "executed", StringComparison.OrdinalIgnoreCase) ? "executed" : "not_executed",
+        o.Status,
+        o.Reason))
+      .ToList();
+
+    var details = new List<ExecutionDetailItem>();
+    foreach (var outcome in primitiveOutcomes)
+    {
+      if (string.Equals(outcome.Status, "executed", StringComparison.OrdinalIgnoreCase) && outcome.ResolvedPoint is not null)
+      {
+        details.Add(new ExecutionDetailItem(
+          "tap",
+          $"Tap executed at ({outcome.ResolvedPoint.X},{outcome.ResolvedPoint.Y}).",
+          new Dictionary<string, object?>
+          {
+            ["x"] = outcome.ResolvedPoint.X,
+            ["y"] = outcome.ResolvedPoint.Y,
+            ["confidence"] = outcome.DetectionConfidence
+          },
+          "normal"));
+      }
+      else
+      {
+        details.Add(new ExecutionDetailItem(
+          "step",
+          $"Step {outcome.StepOrder} was not executed: {outcome.Reason ?? outcome.Status}",
+          new Dictionary<string, object?>
+          {
+            ["reasonCode"] = outcome.Status,
+            ["reason"] = outcome.Reason
+          },
+          "normal"));
+      }
+    }
+
+    var entry = new ExecutionLogEntry
+    {
+      TimestampUtc = now,
+      ExecutionType = "command",
+      FinalStatus = NormalizeStatus(finalStatus),
+      ObjectRef = new ExecutionObjectReference("command", commandId, commandName),
+      Navigation = new ExecutionNavigationContext($"/authoring/commands/{commandId}", parentExecutionId is null ? null : $"/authoring/sequences/{parentExecutionId}"),
+      Hierarchy = new ExecutionHierarchyContext(rootExecutionId, parentExecutionId, Math.Max(0, depth), null),
+      Summary = TrimSummary($"Command '{commandName}' {NormalizeStatus(finalStatus)} with {stepOutcomes.Count} tracked step outcomes."),
+      Details = TrimDetails(ExecutionLogSanitizer.SanitizeDetails(details)),
+      StepOutcomes = stepOutcomes,
+      RetentionExpiresUtc = retention.Enabled ? now.AddDays(Math.Max(1, retention.RetentionDays)) : DateTimeOffset.MaxValue
+    };
+
+    await _repository.AddAsync(entry, ct).ConfigureAwait(false);
+  }
+
+  public async Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, string? parentExecutionId, int depth, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default)
+  {
+    var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
+    var now = DateTimeOffset.UtcNow;
+    var rootExecutionId = parentExecutionId ?? Guid.NewGuid().ToString("N");
+
+    var entry = new ExecutionLogEntry
+    {
+      TimestampUtc = now,
+      ExecutionType = "sequence",
+      FinalStatus = NormalizeStatus(finalStatus),
+      ObjectRef = new ExecutionObjectReference("sequence", sequenceId, sequenceName),
+      Navigation = new ExecutionNavigationContext($"/authoring/sequences/{sequenceId}", null),
+      Hierarchy = new ExecutionHierarchyContext(rootExecutionId, parentExecutionId, Math.Max(0, depth), null),
+      Summary = TrimSummary(summary),
+      Details = TrimDetails(ExecutionLogSanitizer.SanitizeDetails(details?.ToList() ?? new List<ExecutionDetailItem>())),
+      StepOutcomes = Array.Empty<ExecutionStepOutcome>(),
+      RetentionExpiresUtc = retention.Enabled ? now.AddDays(Math.Max(1, retention.RetentionDays)) : DateTimeOffset.MaxValue
+    };
+
+    await _repository.AddAsync(entry, ct).ConfigureAwait(false);
+  }
+
+  public Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default)
+    => _repository.QueryAsync(query, ct);
+
+  public Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default)
+    => _repository.GetAsync(id, ct);
+
+  public Task<ExecutionLogRetentionPolicy> GetRetentionAsync(CancellationToken ct = default)
+    => _retentionRepository.GetAsync(ct);
+
+  public async Task<ExecutionLogRetentionPolicy> UpdateRetentionAsync(bool enabled, int? retentionDays, int? cleanupIntervalMinutes, CancellationToken ct = default)
+  {
+    var current = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
+    var updated = new ExecutionLogRetentionPolicy
+    {
+      Enabled = enabled,
+      RetentionDays = retentionDays ?? current.RetentionDays,
+      CleanupIntervalMinutes = cleanupIntervalMinutes ?? current.CleanupIntervalMinutes,
+      UpdatedAtUtc = DateTimeOffset.UtcNow
+    };
+    return await _retentionRepository.SaveAsync(updated, ct).ConfigureAwait(false);
+  }
+
+  public async Task<int> CleanupExpiredAsync(CancellationToken ct = default)
+  {
+    var policy = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
+    if (!policy.Enabled) return 0;
+    return await _repository.DeleteExpiredAsync(DateTimeOffset.UtcNow, ct).ConfigureAwait(false);
+  }
+
+  private static string NormalizeStatus(string status)
+    => string.Equals(status, "success", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
+
+  private static string TrimSummary(string summary)
+  {
+    var text = string.IsNullOrWhiteSpace(summary) ? "Execution completed." : summary.Trim();
+    return text.Length <= 240 ? text : text[..240];
+  }
+
+  private static IReadOnlyList<ExecutionDetailItem> TrimDetails(IReadOnlyList<ExecutionDetailItem> details)
+  {
+    if (details.Count <= 10) return details;
+    var trimmed = details.Take(9).ToList();
+    trimmed.Add(new ExecutionDetailItem("meta", "Additional details were truncated.", null, "normal"));
+    return trimmed;
+  }
+}

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -6,7 +6,9 @@ namespace GameBot.Service.Services.ExecutionLog;
 internal interface IExecutionLogService
 {
   Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, string? parentExecutionId, int depth, CancellationToken ct = default);
+  Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, ExecutionLogContext context, CancellationToken ct = default);
   Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, string? parentExecutionId, int depth, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default);
+  Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default);
   Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default);
   Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default);
   Task<ExecutionLogRetentionPolicy> GetRetentionAsync(CancellationToken ct = default);
@@ -19,17 +21,31 @@ internal sealed class ExecutionLogService : IExecutionLogService
   private readonly IExecutionLogRepository _repository;
   private readonly IExecutionLogRetentionPolicyRepository _retentionRepository;
 
-  public ExecutionLogService(IExecutionLogRepository repository, IExecutionLogRetentionPolicyRepository retentionRepository)
+  public ExecutionLogService(
+    IExecutionLogRepository repository,
+    IExecutionLogRetentionPolicyRepository retentionRepository)
   {
     _repository = repository;
     _retentionRepository = retentionRepository;
   }
 
   public async Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, string? parentExecutionId, int depth, CancellationToken ct = default)
+    => await LogCommandExecutionAsync(
+      commandId,
+      commandName,
+      finalStatus,
+      primitiveOutcomes,
+      new ExecutionLogContext
+      {
+        ParentExecutionId = parentExecutionId,
+        Depth = depth
+      },
+      ct).ConfigureAwait(false);
+
+  public async Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, ExecutionLogContext context, CancellationToken ct = default)
   {
     var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
     var now = DateTimeOffset.UtcNow;
-    var rootExecutionId = parentExecutionId ?? Guid.NewGuid().ToString("N");
 
     var stepOutcomes = primitiveOutcomes
       .Select(o => new ExecutionStepOutcome(
@@ -76,8 +92,8 @@ internal sealed class ExecutionLogService : IExecutionLogService
       ExecutionType = "command",
       FinalStatus = NormalizeStatus(finalStatus),
       ObjectRef = new ExecutionObjectReference("command", commandId, commandName),
-      Navigation = new ExecutionNavigationContext($"/authoring/commands/{commandId}", parentExecutionId is null ? null : $"/authoring/sequences/{parentExecutionId}"),
-      Hierarchy = new ExecutionHierarchyContext(rootExecutionId, parentExecutionId, Math.Max(0, depth), null),
+      Navigation = ExecutionNavigationBuilder.Build("command", commandId, context),
+      Hierarchy = ExecutionHierarchyBuilder.Build(context),
       Summary = TrimSummary($"Command '{commandName}' {NormalizeStatus(finalStatus)} with {stepOutcomes.Count} tracked step outcomes."),
       Details = TrimDetails(ExecutionLogSanitizer.SanitizeDetails(details)),
       StepOutcomes = stepOutcomes,
@@ -88,10 +104,23 @@ internal sealed class ExecutionLogService : IExecutionLogService
   }
 
   public async Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, string? parentExecutionId, int depth, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default)
+    => await LogSequenceExecutionAsync(
+      sequenceId,
+      sequenceName,
+      finalStatus,
+      summary,
+      new ExecutionLogContext
+      {
+        ParentExecutionId = parentExecutionId,
+        Depth = depth
+      },
+      details,
+      ct).ConfigureAwait(false);
+
+  public async Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default)
   {
     var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
     var now = DateTimeOffset.UtcNow;
-    var rootExecutionId = parentExecutionId ?? Guid.NewGuid().ToString("N");
 
     var entry = new ExecutionLogEntry
     {
@@ -99,8 +128,8 @@ internal sealed class ExecutionLogService : IExecutionLogService
       ExecutionType = "sequence",
       FinalStatus = NormalizeStatus(finalStatus),
       ObjectRef = new ExecutionObjectReference("sequence", sequenceId, sequenceName),
-      Navigation = new ExecutionNavigationContext($"/authoring/sequences/{sequenceId}", null),
-      Hierarchy = new ExecutionHierarchyContext(rootExecutionId, parentExecutionId, Math.Max(0, depth), null),
+      Navigation = ExecutionNavigationBuilder.Build("sequence", sequenceId, context),
+      Hierarchy = ExecutionHierarchyBuilder.Build(context),
       Summary = TrimSummary(summary),
       Details = TrimDetails(ExecutionLogSanitizer.SanitizeDetails(details?.ToList() ?? new List<ExecutionDetailItem>())),
       StepOutcomes = Array.Empty<ExecutionStepOutcome>(),

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionNavigationBuilder.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionNavigationBuilder.cs
@@ -2,24 +2,19 @@ using GameBot.Domain.Logging;
 
 namespace GameBot.Service.Services.ExecutionLog;
 
-internal static class ExecutionNavigationBuilder
-{
-  public static ExecutionNavigationContext Build(string objectType, string objectId, ExecutionLogContext? context)
-  {
+internal static class ExecutionNavigationBuilder {
+  public static ExecutionNavigationContext Build(string objectType, string objectId, ExecutionLogContext? context) {
     var directPath = BuildPath(objectType, objectId) ?? "/authoring/unknown";
     var parentPath = BuildPath(context?.ParentObjectType, context?.ParentObjectId);
     return new ExecutionNavigationContext(directPath, parentPath);
   }
 
-  private static string? BuildPath(string? objectType, string? objectId)
-  {
-    if (string.IsNullOrWhiteSpace(objectType) || string.IsNullOrWhiteSpace(objectId))
-    {
+  private static string? BuildPath(string? objectType, string? objectId) {
+    if (string.IsNullOrWhiteSpace(objectType) || string.IsNullOrWhiteSpace(objectId)) {
       return null;
     }
 
-    return objectType.Trim().ToLowerInvariant() switch
-    {
+    return objectType.Trim().ToLowerInvariant() switch {
       "command" => $"/authoring/commands/{objectId}",
       "sequence" => $"/authoring/sequences/{objectId}",
       _ => $"/authoring/{objectType.ToLowerInvariant()}/{objectId}"

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionNavigationBuilder.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionNavigationBuilder.cs
@@ -1,0 +1,28 @@
+using GameBot.Domain.Logging;
+
+namespace GameBot.Service.Services.ExecutionLog;
+
+internal static class ExecutionNavigationBuilder
+{
+  public static ExecutionNavigationContext Build(string objectType, string objectId, ExecutionLogContext? context)
+  {
+    var directPath = BuildPath(objectType, objectId) ?? "/authoring/unknown";
+    var parentPath = BuildPath(context?.ParentObjectType, context?.ParentObjectId);
+    return new ExecutionNavigationContext(directPath, parentPath);
+  }
+
+  private static string? BuildPath(string? objectType, string? objectId)
+  {
+    if (string.IsNullOrWhiteSpace(objectType) || string.IsNullOrWhiteSpace(objectId))
+    {
+      return null;
+    }
+
+    return objectType.Trim().ToLowerInvariant() switch
+    {
+      "command" => $"/authoring/commands/{objectId}",
+      "sequence" => $"/authoring/sequences/{objectId}",
+      _ => $"/authoring/{objectType.ToLowerInvariant()}/{objectId}"
+    };
+  }
+}

--- a/src/GameBot.Service/Swagger/SwaggerConfig.cs
+++ b/src/GameBot.Service/Swagger/SwaggerConfig.cs
@@ -166,6 +166,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ApplyTriggerExamples(operation, path, method, context);
     ApplyGameExamples(operation, path, method, context);
     ApplyImageExamples(operation, path, method, context);
+    ApplyExecutionLogExamples(operation, path, method, context);
     ApplyInstallerExamples(operation, path, method, context);
   }
 
@@ -492,6 +493,31 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   }
 
+  private static void ApplyExecutionLogExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
+  {
+    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ExecutionLogs))
+    {
+      operation.Summary ??= "List execution logs";
+      SetResponseExample(operation, "200", ExecutionLogListResponse(), context, typeof(GameBot.Service.Models.ExecutionLogListResponseDto));
+    }
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.ExecutionLogs + "/", StringComparison.OrdinalIgnoreCase) && !path.EndsWith("/retention", StringComparison.OrdinalIgnoreCase))
+    {
+      operation.Summary ??= "Get an execution log entry";
+      SetResponseExample(operation, "200", ExecutionLogEntryResponse(), context, typeof(GameBot.Service.Models.ExecutionLogEntryDto));
+    }
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ExecutionLogs + "/retention"))
+    {
+      operation.Summary ??= "Get execution log retention policy";
+      SetResponseExample(operation, "200", ExecutionLogRetentionResponse(), context, typeof(GameBot.Service.Models.ExecutionLogRetentionPolicyDto));
+    }
+    else if (IsMethod(method, HttpMethods.Put) && IsPath(path, ApiRoutes.ExecutionLogs + "/retention"))
+    {
+      operation.Summary ??= "Update execution log retention policy";
+      SetRequestExample(operation, ExecutionLogRetentionUpdateRequest(), context, typeof(GameBot.Service.Models.ExecutionLogRetentionPolicyPatchDto));
+      SetResponseExample(operation, "200", ExecutionLogRetentionResponse(), context, typeof(GameBot.Service.Models.ExecutionLogRetentionPolicyDto));
+    }
+  }
+
   private static string NormalizePath(string? relativePath)
   {
     if (string.IsNullOrWhiteSpace(relativePath)) return string.Empty;
@@ -616,6 +642,84 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     {
       new OpenApiString("minor:auto-transition"),
       new OpenApiString("build:ci-authoritative")
+    }
+  };
+
+  private static OpenApiObject ExecutionLogRetentionUpdateRequest() => new OpenApiObject
+  {
+    ["enabled"] = new OpenApiBoolean(true),
+    ["retentionDays"] = new OpenApiInteger(30),
+    ["cleanupIntervalMinutes"] = new OpenApiInteger(60)
+  };
+
+  private static OpenApiObject ExecutionLogRetentionResponse() => new OpenApiObject
+  {
+    ["enabled"] = new OpenApiBoolean(true),
+    ["retentionDays"] = new OpenApiInteger(30),
+    ["cleanupIntervalMinutes"] = new OpenApiInteger(60),
+    ["updatedAtUtc"] = new OpenApiString("2026-01-01T00:00:00Z")
+  };
+
+  private static OpenApiObject ExecutionLogListResponse() => new OpenApiObject
+  {
+    ["items"] = new OpenApiArray
+    {
+      ExecutionLogEntryResponse()
+    },
+    ["nextCursor"] = new OpenApiString("2026-01-01T00:00:00.0000000+00:00|exe_0001")
+  };
+
+  private static OpenApiObject ExecutionLogEntryResponse() => new OpenApiObject
+  {
+    ["id"] = new OpenApiString("exe_0001"),
+    ["timestampUtc"] = new OpenApiString("2026-01-01T00:00:00Z"),
+    ["executionType"] = new OpenApiString("command"),
+    ["finalStatus"] = new OpenApiString("success"),
+    ["objectRef"] = new OpenApiObject
+    {
+      ["objectType"] = new OpenApiString("command"),
+      ["objectId"] = new OpenApiString("cmd-farm"),
+      ["displayNameSnapshot"] = new OpenApiString("Farm Run"),
+      ["versionSnapshot"] = new OpenApiString("2026.01")
+    },
+    ["navigation"] = new OpenApiObject
+    {
+      ["directPath"] = new OpenApiString("/api/commands/cmd-farm"),
+      ["parentPath"] = new OpenApiString("/api/sequences/seq-daily"),
+      ["pathKind"] = new OpenApiString("command")
+    },
+    ["hierarchy"] = new OpenApiObject
+    {
+      ["rootExecutionId"] = new OpenApiString("exe_root_0001"),
+      ["parentExecutionId"] = new OpenApiString("exe_parent_0001"),
+      ["depth"] = new OpenApiInteger(1),
+      ["sequenceIndex"] = new OpenApiInteger(2)
+    },
+    ["summary"] = new OpenApiString("Command executed successfully"),
+    ["details"] = new OpenApiArray
+    {
+      new OpenApiObject
+      {
+        ["kind"] = new OpenApiString("execution"),
+        ["message"] = new OpenApiString("Trigger matched and command dispatched."),
+        ["attributes"] = new OpenApiObject
+        {
+          ["triggerMatched"] = new OpenApiBoolean(true),
+          ["durationMs"] = new OpenApiInteger(812)
+        },
+        ["sensitivity"] = new OpenApiString("public")
+      }
+    },
+    ["stepOutcomes"] = new OpenApiArray
+    {
+      new OpenApiObject
+      {
+        ["stepOrder"] = new OpenApiInteger(1),
+        ["stepType"] = new OpenApiString("tap"),
+        ["outcome"] = new OpenApiString("executed"),
+        ["reasonCode"] = new OpenApiString("none"),
+        ["reasonText"] = new OpenApiString("Step executed normally")
+      }
     }
   };
 

--- a/src/GameBot.Service/Swagger/SwaggerConfig.cs
+++ b/src/GameBot.Service/Swagger/SwaggerConfig.cs
@@ -13,8 +13,7 @@ using GameBot.Service.Endpoints;
 
 namespace GameBot.Service.Swagger;
 
-internal static class SwaggerConfig
-{
+internal static class SwaggerConfig {
   private static readonly string[] ActionsTags = ["Actions"];
   private static readonly string[] CommandsTags = ["Commands"];
   private static readonly string[] GamesTags = ["Games"];
@@ -26,30 +25,24 @@ internal static class SwaggerConfig
   private static readonly string[] MetricsTags = ["Metrics"];
   private static readonly string[] EmulatorsTags = ["Emulators"];
 
-  public static IServiceCollection AddSwaggerDocs(this IServiceCollection services)
-  {
-    services.AddSwaggerGen(options =>
-    {
-      options.SwaggerDoc("v1", new OpenApiInfo
-      {
+  public static IServiceCollection AddSwaggerDocs(this IServiceCollection services) {
+    services.AddSwaggerGen(options => {
+      options.SwaggerDoc("v1", new OpenApiInfo {
         Title = "GameBot API",
         Version = "v1",
         Description = "Canonical GameBot endpoints under /api",
       });
 
-      options.TagActionsBy(api =>
-      {
+      options.TagActionsBy(api => {
         var tags = api.ActionDescriptor.EndpointMetadata.OfType<TagsAttribute>()
                       .SelectMany(t => t.Tags)
                       .ToList();
-        if (tags.Count > 0)
-        {
+        if (tags.Count > 0) {
           return tags;
         }
 
         var derived = DeriveTags(api.RelativePath);
-        if (derived.Length > 0)
-        {
+        if (derived.Length > 0) {
           return derived;
         }
 
@@ -62,77 +55,63 @@ internal static class SwaggerConfig
     return services;
   }
 
-  private static string[] DeriveTags(string? relativePath)
-  {
-    if (string.IsNullOrWhiteSpace(relativePath))
-    {
+  private static string[] DeriveTags(string? relativePath) {
+    if (string.IsNullOrWhiteSpace(relativePath)) {
       return Array.Empty<string>();
     }
 
     var path = "/" + relativePath.TrimStart('/');
 
     if (path.StartsWith(ApiRoutes.Actions, StringComparison.OrdinalIgnoreCase) ||
-        path.StartsWith(ApiRoutes.ActionTypes, StringComparison.OrdinalIgnoreCase))
-    {
+        path.StartsWith(ApiRoutes.ActionTypes, StringComparison.OrdinalIgnoreCase)) {
       return ActionsTags;
     }
 
-    if (path.StartsWith(ApiRoutes.Commands, StringComparison.OrdinalIgnoreCase))
-    {
+    if (path.StartsWith(ApiRoutes.Commands, StringComparison.OrdinalIgnoreCase)) {
       return CommandsTags;
     }
 
-    if (path.StartsWith(ApiRoutes.Games, StringComparison.OrdinalIgnoreCase))
-    {
+    if (path.StartsWith(ApiRoutes.Games, StringComparison.OrdinalIgnoreCase)) {
       return GamesTags;
     }
 
-    if (path.StartsWith(ApiRoutes.Sequences, StringComparison.OrdinalIgnoreCase))
-    {
+    if (path.StartsWith(ApiRoutes.Sequences, StringComparison.OrdinalIgnoreCase)) {
       return SequencesTags;
     }
 
-    if (path.StartsWith(ApiRoutes.Sessions, StringComparison.OrdinalIgnoreCase))
-    {
+    if (path.StartsWith(ApiRoutes.Sessions, StringComparison.OrdinalIgnoreCase)) {
       return SessionsTags;
     }
 
     if (path.StartsWith(ApiRoutes.ConfigLogging, StringComparison.OrdinalIgnoreCase) ||
-        path.StartsWith(ApiRoutes.Config, StringComparison.OrdinalIgnoreCase))
-    {
+        path.StartsWith(ApiRoutes.Config, StringComparison.OrdinalIgnoreCase)) {
       return ConfigurationTags;
     }
 
-    if (path.StartsWith(ApiRoutes.Triggers, StringComparison.OrdinalIgnoreCase))
-    {
+    if (path.StartsWith(ApiRoutes.Triggers, StringComparison.OrdinalIgnoreCase)) {
       return TriggersTags;
     }
 
     if (path.StartsWith(ApiRoutes.Images, StringComparison.OrdinalIgnoreCase) ||
-        path.StartsWith(ApiRoutes.ImageDetect, StringComparison.OrdinalIgnoreCase))
-    {
+        path.StartsWith(ApiRoutes.ImageDetect, StringComparison.OrdinalIgnoreCase)) {
       return ImagesTags;
     }
 
-    if (path.StartsWith(ApiRoutes.Metrics, StringComparison.OrdinalIgnoreCase))
-    {
+    if (path.StartsWith(ApiRoutes.Metrics, StringComparison.OrdinalIgnoreCase)) {
       return MetricsTags;
     }
 
     if (path.StartsWith(ApiRoutes.Adb, StringComparison.OrdinalIgnoreCase) ||
-        path.StartsWith(ApiRoutes.Ocr, StringComparison.OrdinalIgnoreCase))
-    {
+        path.StartsWith(ApiRoutes.Ocr, StringComparison.OrdinalIgnoreCase)) {
       return EmulatorsTags;
     }
 
     return Array.Empty<string>();
   }
 
-  public static IApplicationBuilder UseSwaggerDocs(this IApplicationBuilder app)
-  {
+  public static IApplicationBuilder UseSwaggerDocs(this IApplicationBuilder app) {
     app.UseSwagger();
-    app.UseSwaggerUI(options =>
-    {
+    app.UseSwaggerUI(options => {
       options.SwaggerEndpoint("/swagger/v1/swagger.json", "GameBot API v1");
       options.DisplayRequestDuration();
       options.DocExpansion(Swashbuckle.AspNetCore.SwaggerUI.DocExpansion.List);
@@ -141,16 +120,13 @@ internal static class SwaggerConfig
   }
 }
 
-internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
-{
-  public void Apply(OpenApiOperation operation, OperationFilterContext context)
-  {
+internal sealed class SwaggerExamplesOperationFilter : IOperationFilter {
+  public void Apply(OpenApiOperation operation, OperationFilterContext context) {
     var path = NormalizePath(context.ApiDescription.RelativePath);
     var isApiRoute = path.StartsWith(ApiRoutes.Base, StringComparison.OrdinalIgnoreCase);
     var isInstallerRoute = path.StartsWith("/installer", StringComparison.OrdinalIgnoreCase);
     var isVersioningRoute = path.StartsWith("/versioning", StringComparison.OrdinalIgnoreCase);
-    if (!isApiRoute && !isInstallerRoute && !isVersioningRoute)
-    {
+    if (!isApiRoute && !isInstallerRoute && !isVersioningRoute) {
       return;
     }
 
@@ -170,374 +146,303 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ApplyInstallerExamples(operation, path, method, context);
   }
 
-  private static void ApplyInstallerExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Post) && IsPath(path, "/installer/compare"))
-    {
+  private static void ApplyInstallerExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, "/installer/compare")) {
       operation.Summary ??= "Compare installed and candidate installer versions";
       SetRequestExample(operation, InstallerCompareRequest(), context);
       SetResponseExample(operation, "200", InstallerCompareResponse(), context);
     }
-    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, "/installer/same-build/decision"))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, "/installer/same-build/decision")) {
       operation.Summary ??= "Resolve same-build install decision";
       SetRequestExample(operation, SameBuildDecisionRequest(), context);
       SetResponseExample(operation, "200", SameBuildDecisionResponse(), context);
     }
-    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, "/versioning/resolve"))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, "/versioning/resolve")) {
       operation.Summary ??= "Resolve semantic installer version from source inputs";
       SetRequestExample(operation, VersionResolveRequest(), context);
       SetResponseExample(operation, "200", VersionResolveResponse(), context);
     }
   }
 
-  private static void ApplyActionExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Actions))
-    {
+  private static void ApplyActionExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Actions)) {
       operation.Summary ??= "Create an action";
       SetRequestExample(operation, ActionCreateRequest(), context, typeof(GameBot.Service.Models.CreateActionRequest));
       SetResponseExample(operation, "201", ActionCreateResponse(), context, typeof(GameBot.Service.Models.ActionResponse));
     }
-    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Actions))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Actions)) {
       operation.Summary ??= "List actions";
       SetResponseExample(operation, "200", ActionListResponse(), context, typeof(IEnumerable<GameBot.Service.Models.ActionResponse>));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Actions + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Actions + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get an action";
       SetResponseExample(operation, "200", ActionCreateResponse(), context, typeof(GameBot.Service.Models.ActionResponse));
     }
-    else if ((IsMethod(method, HttpMethods.Patch) || IsMethod(method, HttpMethods.Put)) && path.StartsWith(ApiRoutes.Actions + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if ((IsMethod(method, HttpMethods.Patch) || IsMethod(method, HttpMethods.Put)) && path.StartsWith(ApiRoutes.Actions + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Update an action";
       SetRequestExample(operation, ActionUpdateRequest(), context, typeof(ActionUpdateSchema));
       SetResponseExample(operation, "200", ActionCreateResponse(), context, typeof(GameBot.Service.Models.ActionResponse));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/duplicate", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/duplicate", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Duplicate an action";
       SetResponseExample(operation, "201", ActionCreateResponse(), context, typeof(GameBot.Service.Models.ActionResponse));
     }
   }
 
-  private static void ApplyActionTypesExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ActionTypes))
-    {
+  private static void ApplyActionTypesExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ActionTypes)) {
       operation.Summary ??= "List available action types";
       SetResponseExample(operation, "200", ActionTypesResponse(), context, typeof(ActionTypeCatalogDto));
     }
   }
 
-  private static void ApplyCommandExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Commands))
-    {
+  private static void ApplyCommandExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Commands)) {
       operation.Summary ??= "Create a command";
       SetRequestExample(operation, CommandCreateRequest(), context, typeof(CommandCreateSchema));
       SetResponseExample(operation, "201", CommandCreateResponse(), context, typeof(GameBot.Service.Models.CommandResponse));
     }
-    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Commands))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Commands)) {
       operation.Summary ??= "List commands";
       SetResponseExample(operation, "200", CommandListResponse(), context, typeof(IEnumerable<GameBot.Service.Models.CommandResponse>));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Commands + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Commands + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get a command";
       SetResponseExample(operation, "200", CommandCreateResponse(), context, typeof(GameBot.Service.Models.CommandResponse));
     }
-    else if (IsMethod(method, HttpMethods.Patch) && path.StartsWith(ApiRoutes.Commands + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Patch) && path.StartsWith(ApiRoutes.Commands + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Update a command";
       SetRequestExample(operation, CommandUpdateRequest(), context, typeof(GameBot.Service.Models.UpdateCommandRequest));
       SetResponseExample(operation, "200", CommandCreateResponse(), context, typeof(GameBot.Service.Models.CommandResponse));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/force-execute", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/force-execute", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Force execute a command";
       SetResponseExample(operation, "202", SessionInputsResponse(), context, typeof(SessionAcceptedSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/evaluate-and-execute", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/evaluate-and-execute", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Evaluate trigger then execute";
       SetResponseExample(operation, "202", CommandEvaluateResponse(), context, typeof(CommandEvaluateResponseSchema));
     }
   }
 
-  private static void ApplySequenceExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Sequences))
-    {
+  private static void ApplySequenceExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Sequences)) {
       operation.Summary ??= "Create a sequence";
       SetRequestExample(operation, SequenceCreateRequest(), context, typeof(SequenceRequestSchema));
       SetResponseExample(operation, "201", SequenceCreateResponse(), context, typeof(SequenceResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Sequences))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Sequences)) {
       operation.Summary ??= "List sequences";
       SetResponseExample(operation, "200", SequenceListResponse(), context, typeof(IEnumerable<SequenceResponseSchema>));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sequences + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sequences + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get a sequence";
       SetResponseExample(operation, "200", SequenceCreateResponse(), context, typeof(SequenceResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Sequences + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Sequences + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Update a sequence";
       SetRequestExample(operation, SequenceCreateRequest(), context, typeof(SequenceRequestSchema));
       SetResponseExample(operation, "200", SequenceCreateResponse(), context, typeof(SequenceResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/execute", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains("/execute", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Execute a sequence";
       SetResponseExample(operation, "200", SequenceExecuteResponse(), context, typeof(GameBot.Domain.Services.SequenceExecutionResult));
     }
   }
 
-  private static void ApplySessionExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Sessions))
-    {
+  private static void ApplySessionExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Sessions)) {
       operation.Summary ??= "Create a session";
       SetRequestExample(operation, SessionCreateRequest(), context, typeof(GameBot.Service.Models.CreateSessionRequest));
       SetResponseExample(operation, "201", SessionCreateResponse(), context, typeof(GameBot.Service.Models.CreateSessionResponse));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.Contains(ApiRoutes.Sessions + "/running", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.Contains(ApiRoutes.Sessions + "/running", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "List running sessions";
       SetResponseExample(operation, "200", RunningSessionsResponse(), context, typeof(GameBot.Service.Models.RunningSessionsResponse));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/start", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/start", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Start a session";
       SetRequestExample(operation, SessionStartRequest(), context, typeof(GameBot.Service.Models.StartSessionRequest));
       SetResponseExample(operation, "200", SessionStartResponse(), context, typeof(GameBot.Service.Models.StartSessionResponse));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/stop", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/stop", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Stop a session";
       SetRequestExample(operation, SessionStopRequest(), context, typeof(GameBot.Service.Models.StopSessionRequest));
       SetResponseExample(operation, "200", SessionStopResponse(), context, typeof(GameBot.Service.Models.StopSessionResponse));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/{id}/inputs", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/{id}/inputs", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Send inputs to a session";
       SetRequestExample(operation, SessionInputsRequest(), context, typeof(GameBot.Service.Models.InputActionsRequest));
       SetResponseExample(operation, "202", SessionInputsResponse(), context, typeof(SessionAcceptedSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/{id}/execute-action", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Sessions + "/{id}/execute-action", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Execute an action against a session";
       SetResponseExample(operation, "202", SessionInputsResponse(), context, typeof(SessionAcceptedSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.Contains(ApiRoutes.Sessions + "/{id}/snapshot", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.Contains(ApiRoutes.Sessions + "/{id}/snapshot", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Fetch a session snapshot";
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sessions + "/" , StringComparison.OrdinalIgnoreCase) && path.EndsWith("/device" , StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sessions + "/", StringComparison.OrdinalIgnoreCase) && path.EndsWith("/device", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get session device";
       SetResponseExample(operation, "200", SessionDeviceResponse(), context, typeof(SessionDeviceSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sessions + "/" , StringComparison.OrdinalIgnoreCase) && path.EndsWith("/health" , StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sessions + "/", StringComparison.OrdinalIgnoreCase) && path.EndsWith("/health", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get session health";
       SetResponseExample(operation, "200", SessionHealthResponse(), context, typeof(SessionHealthSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sessions + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Sessions + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get a session";
       SetResponseExample(operation, "200", SessionGetResponse(), context, typeof(SessionDetailSchema));
     }
-    else if (IsMethod(method, HttpMethods.Delete) && path.StartsWith(ApiRoutes.Sessions + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Delete) && path.StartsWith(ApiRoutes.Sessions + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Stop a session";
       SetResponseExample(operation, "202", SessionStopResponse(), context, typeof(SessionStopSchema));
     }
   }
 
-  private static void ApplyConfigurationExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Config))
-    {
+  private static void ApplyConfigurationExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Config)) {
       operation.Summary ??= "Get configuration snapshot";
       SetResponseExample(operation, "200", ConfigurationSnapshotResponse(), context, typeof(ConfigurationSnapshotSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Config + "/refresh", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Config + "/refresh", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Refresh configuration snapshot";
       SetResponseExample(operation, "200", ConfigurationSnapshotResponse(), context, typeof(ConfigurationSnapshotSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ConfigLogging))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ConfigLogging)) {
       operation.Summary ??= "Get runtime logging policy";
       SetResponseExample(operation, "200", LoggingPolicyResponse(), context, typeof(LoggingPolicySchema));
     }
-    else if (IsMethod(method, HttpMethods.Put) && path.Contains(ApiRoutes.ConfigLogging + "/components/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Put) && path.Contains(ApiRoutes.ConfigLogging + "/components/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Update logging component policy";
       SetRequestExample(operation, LoggingPolicyUpdateRequest(), context, typeof(GameBot.Service.Models.Logging.LoggingComponentPatchDto));
       SetResponseExample(operation, "200", LoggingPolicyResponse(), context, typeof(LoggingPolicySchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.ConfigLogging + "/reset", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.ConfigLogging + "/reset", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Reset logging policy";
       SetRequestExample(operation, LoggingPolicyResetRequest(), context, typeof(LoggingPolicyResetRequestSchema));
       SetResponseExample(operation, "200", LoggingPolicyResponse(), context, typeof(LoggingPolicySchema));
     }
   }
 
-  private static void ApplyTriggerExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Triggers))
-    {
+  private static void ApplyTriggerExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Triggers)) {
       operation.Summary ??= "Create a trigger";
       SetRequestExample(operation, TriggerCreateRequest(), context, typeof(TriggerAuthoringSchema));
       SetResponseExample(operation, "201", TriggerCreateResponse(), context, typeof(TriggerResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Triggers))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Triggers)) {
       operation.Summary ??= "List triggers";
       SetResponseExample(operation, "200", TriggerListResponse(), context, typeof(IEnumerable<TriggerResponseSchema>));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Triggers + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Triggers + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get a trigger";
       SetResponseExample(operation, "200", TriggerCreateResponse(), context, typeof(TriggerResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Triggers + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Triggers + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Update a trigger";
       SetRequestExample(operation, TriggerCreateRequest(), context, typeof(TriggerAuthoringSchema));
       SetResponseExample(operation, "200", TriggerCreateResponse(), context, typeof(TriggerResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Triggers + "/{id}/test", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && path.Contains(ApiRoutes.Triggers + "/{id}/test", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Evaluate a trigger";
       SetResponseExample(operation, "200", TriggerTestResponse(), context, typeof(TriggerTestResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.ImageDetect))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.ImageDetect)) {
       operation.Summary ??= "Detect reference image matches";
       SetRequestExample(operation, ImageDetectRequest(), context, typeof(GameBot.Service.Endpoints.Dto.DetectRequest));
       SetResponseExample(operation, "200", ImageDetectResponse(), context, typeof(GameBot.Service.Endpoints.Dto.DetectResponse));
     }
   }
 
-  private static void ApplyGameExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Games))
-    {
+  private static void ApplyGameExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Games)) {
       operation.Summary ??= "Create a game";
       SetRequestExample(operation, GameCreateRequest(), context, typeof(GameCreateSchema));
       SetResponseExample(operation, "201", GameCreateResponse(), context, typeof(GameResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Games))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Games)) {
       operation.Summary ??= "List games";
       SetResponseExample(operation, "200", GameListResponse(), context, typeof(IEnumerable<GameResponseSchema>));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Games + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Games + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get a game";
       SetResponseExample(operation, "200", GameCreateResponse(), context, typeof(GameResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Games + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Games + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Update a game";
       SetRequestExample(operation, GameUpdateRequest(), context, typeof(GameCreateSchema));
       SetResponseExample(operation, "200", GameCreateResponse(), context, typeof(GameResponseSchema));
     }
   }
 
-  private static void ApplyImageExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Images))
-    {
+  private static void ApplyImageExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.Images)) {
       operation.Summary ??= "List image references";
       SetResponseExample(operation, "200", ImageReferenceListResponse(), context, typeof(IEnumerable<ImageReferenceListItemSchema>));
     }
-    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Images))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.Images)) {
       operation.Summary ??= "Upload an image reference";
       SetRequestExample(operation, ImageUploadRequest(), context, typeof(GameBot.Service.Endpoints.ImageReferencesEndpoints.UploadImageRequest));
       SetResponseExample(operation, "201", ImageUploadResponse(), context, typeof(ImageUploadResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.ImageCrop))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.ImageCrop)) {
       operation.Summary ??= "Crop and save an emulator screenshot";
       SetRequestExample(operation, ImageCropRequest(), context);
       SetResponseExample(operation, "201", ImageCropResponse(), context);
     }
-    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Images + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Put) && path.StartsWith(ApiRoutes.Images + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Overwrite an image reference";
       SetRequestExample(operation, ImageOverwriteRequest(), context, typeof(GameBot.Service.Endpoints.ImageReferencesEndpoints.OverwriteImageRequest));
       SetResponseExample(operation, "200", ImageOverwriteResponse(), context, typeof(ImageOverwriteResponseSchema));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Images + "/", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.Images + "/", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get an image reference";
       SetResponseExample(operation, "200", ImageReferenceResponse(), context, typeof(ImageReferenceSchema));
     }
-    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.ImageDetect))
-    {
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.ImageDetect)) {
       operation.Summary ??= "Detect reference image matches";
       SetRequestExample(operation, ImageDetectRequest(), context, typeof(GameBot.Service.Endpoints.Dto.DetectRequest));
       SetResponseExample(operation, "200", ImageDetectResponse(), context, typeof(GameBot.Service.Endpoints.Dto.DetectResponse));
     }
   }
 
-  private static void ApplyExecutionLogExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context)
-  {
-    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ExecutionLogs))
-    {
+  private static void ApplyExecutionLogExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ExecutionLogs)) {
       operation.Summary ??= "List execution logs";
       SetResponseExample(operation, "200", ExecutionLogListResponse(), context, typeof(GameBot.Service.Models.ExecutionLogListResponseDto));
     }
-    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.ExecutionLogs + "/", StringComparison.OrdinalIgnoreCase) && !path.EndsWith("/retention", StringComparison.OrdinalIgnoreCase))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && path.StartsWith(ApiRoutes.ExecutionLogs + "/", StringComparison.OrdinalIgnoreCase) && !path.EndsWith("/retention", StringComparison.OrdinalIgnoreCase)) {
       operation.Summary ??= "Get an execution log entry";
       SetResponseExample(operation, "200", ExecutionLogEntryResponse(), context, typeof(GameBot.Service.Models.ExecutionLogEntryDto));
     }
-    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ExecutionLogs + "/retention"))
-    {
+    else if (IsMethod(method, HttpMethods.Get) && IsPath(path, ApiRoutes.ExecutionLogs + "/retention")) {
       operation.Summary ??= "Get execution log retention policy";
       SetResponseExample(operation, "200", ExecutionLogRetentionResponse(), context, typeof(GameBot.Service.Models.ExecutionLogRetentionPolicyDto));
     }
-    else if (IsMethod(method, HttpMethods.Put) && IsPath(path, ApiRoutes.ExecutionLogs + "/retention"))
-    {
+    else if (IsMethod(method, HttpMethods.Put) && IsPath(path, ApiRoutes.ExecutionLogs + "/retention")) {
       operation.Summary ??= "Update execution log retention policy";
       SetRequestExample(operation, ExecutionLogRetentionUpdateRequest(), context, typeof(GameBot.Service.Models.ExecutionLogRetentionPolicyPatchDto));
       SetResponseExample(operation, "200", ExecutionLogRetentionResponse(), context, typeof(GameBot.Service.Models.ExecutionLogRetentionPolicyDto));
     }
   }
 
-  private static string NormalizePath(string? relativePath)
-  {
+  private static string NormalizePath(string? relativePath) {
     if (string.IsNullOrWhiteSpace(relativePath)) return string.Empty;
     var trimmed = relativePath.TrimStart('/');
     return "/" + trimmed;
   }
 
-  private static bool IsPath(string actual, string expected)
-  {
+  private static bool IsPath(string actual, string expected) {
     static string Normalize(string path) => path.EndsWith('/') ? path.TrimEnd('/') : path;
     return string.Equals(Normalize(actual), Normalize(expected), StringComparison.OrdinalIgnoreCase);
   }
 
   private static bool IsMethod(string method, string expected) => string.Equals(method, expected, StringComparison.OrdinalIgnoreCase);
 
-  private static void SetRequestExample(OpenApiOperation operation, IOpenApiAny example, OperationFilterContext context, Type? schemaType = null)
-  {
+  private static void SetRequestExample(OpenApiOperation operation, IOpenApiAny example, OperationFilterContext context, Type? schemaType = null) {
     operation.RequestBody ??= new OpenApiRequestBody { Content = new Dictionary<string, OpenApiMediaType>() };
-    if (!operation.RequestBody.Content.TryGetValue("application/json", out var media))
-    {
+    if (!operation.RequestBody.Content.TryGetValue("application/json", out var media)) {
       media = new OpenApiMediaType();
       operation.RequestBody.Content["application/json"] = media;
     }
@@ -545,17 +450,14 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     media.Schema ??= GenerateSchema(context, schemaType);
   }
 
-  private static void SetResponseExample(OpenApiOperation operation, string statusCode, IOpenApiAny example, OperationFilterContext context, Type? schemaType = null)
-  {
-    if (!operation.Responses.TryGetValue(statusCode, out var response))
-    {
+  private static void SetResponseExample(OpenApiOperation operation, string statusCode, IOpenApiAny example, OperationFilterContext context, Type? schemaType = null) {
+    if (!operation.Responses.TryGetValue(statusCode, out var response)) {
       response = new OpenApiResponse { Description = statusCode.Length > 0 && statusCode[0] == '2' ? "Success" : "Response" };
       operation.Responses[statusCode] = response;
     }
 
     response.Content ??= new Dictionary<string, OpenApiMediaType>();
-    if (!response.Content.TryGetValue("application/json", out var media))
-    {
+    if (!response.Content.TryGetValue("application/json", out var media)) {
       media = new OpenApiMediaType();
       response.Content["application/json"] = media;
     }
@@ -563,23 +465,19 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     media.Schema ??= GenerateSchema(context, schemaType);
   }
 
-  private static OpenApiSchema GenerateSchema(OperationFilterContext context, Type? schemaType)
-  {
+  private static OpenApiSchema GenerateSchema(OperationFilterContext context, Type? schemaType) {
     var type = schemaType ?? typeof(object);
     return context.SchemaGenerator.GenerateSchema(type, context.SchemaRepository);
   }
 
-  private static OpenApiObject InstallerCompareRequest() => new OpenApiObject
-  {
-    ["installedVersion"] = new OpenApiObject
-    {
+  private static OpenApiObject InstallerCompareRequest() => new OpenApiObject {
+    ["installedVersion"] = new OpenApiObject {
       ["major"] = new OpenApiInteger(1),
       ["minor"] = new OpenApiInteger(0),
       ["patch"] = new OpenApiInteger(0),
       ["build"] = new OpenApiInteger(9)
     },
-    ["candidateVersion"] = new OpenApiObject
-    {
+    ["candidateVersion"] = new OpenApiObject {
       ["major"] = new OpenApiInteger(1),
       ["minor"] = new OpenApiInteger(0),
       ["patch"] = new OpenApiInteger(0),
@@ -587,49 +485,40 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject InstallerCompareResponse() => new OpenApiObject
-  {
+  private static OpenApiObject InstallerCompareResponse() => new OpenApiObject {
     ["outcome"] = new OpenApiString("upgrade"),
     ["reason"] = new OpenApiString("Candidate version is higher than installed version."),
     ["preserveProperties"] = new OpenApiBoolean(true)
   };
 
-  private static OpenApiObject SameBuildDecisionRequest() => new OpenApiObject
-  {
+  private static OpenApiObject SameBuildDecisionRequest() => new OpenApiObject {
     ["mode"] = new OpenApiString("interactive"),
     ["interactiveChoice"] = new OpenApiString("reinstall")
   };
 
-  private static OpenApiObject SameBuildDecisionResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SameBuildDecisionResponse() => new OpenApiObject {
     ["action"] = new OpenApiString("reinstall"),
     ["mutatesState"] = new OpenApiBoolean(true),
     ["statusCode"] = new OpenApiInteger(0)
   };
 
-  private static OpenApiObject VersionResolveRequest() => new OpenApiObject
-  {
+  private static OpenApiObject VersionResolveRequest() => new OpenApiObject {
     ["buildContext"] = new OpenApiString("ci"),
-    ["override"] = new OpenApiObject
-    {
+    ["override"] = new OpenApiObject {
       ["major"] = new OpenApiInteger(1),
       ["minor"] = new OpenApiInteger(2)
     },
-    ["releaseLineMarker"] = new OpenApiObject
-    {
+    ["releaseLineMarker"] = new OpenApiObject {
       ["releaseLineId"] = new OpenApiString("main"),
       ["sequence"] = new OpenApiInteger(4)
     },
-    ["ciBuildCounter"] = new OpenApiObject
-    {
+    ["ciBuildCounter"] = new OpenApiObject {
       ["lastBuild"] = new OpenApiInteger(18)
     }
   };
 
-  private static OpenApiObject VersionResolveResponse() => new OpenApiObject
-  {
-    ["version"] = new OpenApiObject
-    {
+  private static OpenApiObject VersionResolveResponse() => new OpenApiObject {
+    ["version"] = new OpenApiObject {
       ["major"] = new OpenApiInteger(1),
       ["minor"] = new OpenApiInteger(2),
       ["patch"] = new OpenApiInteger(0),
@@ -645,23 +534,20 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject ExecutionLogRetentionUpdateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject ExecutionLogRetentionUpdateRequest() => new OpenApiObject {
     ["enabled"] = new OpenApiBoolean(true),
     ["retentionDays"] = new OpenApiInteger(30),
     ["cleanupIntervalMinutes"] = new OpenApiInteger(60)
   };
 
-  private static OpenApiObject ExecutionLogRetentionResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ExecutionLogRetentionResponse() => new OpenApiObject {
     ["enabled"] = new OpenApiBoolean(true),
     ["retentionDays"] = new OpenApiInteger(30),
     ["cleanupIntervalMinutes"] = new OpenApiInteger(60),
     ["updatedAtUtc"] = new OpenApiString("2026-01-01T00:00:00Z")
   };
 
-  private static OpenApiObject ExecutionLogListResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ExecutionLogListResponse() => new OpenApiObject {
     ["items"] = new OpenApiArray
     {
       ExecutionLogEntryResponse()
@@ -669,27 +555,23 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ["nextCursor"] = new OpenApiString("2026-01-01T00:00:00.0000000+00:00|exe_0001")
   };
 
-  private static OpenApiObject ExecutionLogEntryResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ExecutionLogEntryResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("exe_0001"),
     ["timestampUtc"] = new OpenApiString("2026-01-01T00:00:00Z"),
     ["executionType"] = new OpenApiString("command"),
     ["finalStatus"] = new OpenApiString("success"),
-    ["objectRef"] = new OpenApiObject
-    {
+    ["objectRef"] = new OpenApiObject {
       ["objectType"] = new OpenApiString("command"),
       ["objectId"] = new OpenApiString("cmd-farm"),
       ["displayNameSnapshot"] = new OpenApiString("Farm Run"),
       ["versionSnapshot"] = new OpenApiString("2026.01")
     },
-    ["navigation"] = new OpenApiObject
-    {
+    ["navigation"] = new OpenApiObject {
       ["directPath"] = new OpenApiString("/api/commands/cmd-farm"),
       ["parentPath"] = new OpenApiString("/api/sequences/seq-daily"),
       ["pathKind"] = new OpenApiString("command")
     },
-    ["hierarchy"] = new OpenApiObject
-    {
+    ["hierarchy"] = new OpenApiObject {
       ["rootExecutionId"] = new OpenApiString("exe_root_0001"),
       ["parentExecutionId"] = new OpenApiString("exe_parent_0001"),
       ["depth"] = new OpenApiInteger(1),
@@ -723,8 +605,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject ActionCreateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject ActionCreateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Collect coins"),
     ["gameId"] = new OpenApiString("game-123"),
     ["steps"] = new OpenApiArray
@@ -744,8 +625,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ["checkpoints"] = new OpenApiArray { new OpenApiString("after-start"), new OpenApiString("before-exit") }
   };
 
-  private static OpenApiObject ActionCreateResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ActionCreateResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("action-abc"),
     ["name"] = new OpenApiString("Collect coins"),
     ["gameId"] = new OpenApiString("game-123"),
@@ -771,8 +651,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ActionCreateResponse()
   };
 
-  private static OpenApiObject SequenceCreateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject SequenceCreateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Morning routine"),
     ["steps"] = new OpenApiArray
     {
@@ -781,8 +660,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject ActionTypesResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ActionTypesResponse() => new OpenApiObject {
     ["version"] = new OpenApiString("v1"),
     ["items"] = new OpenApiArray
     {
@@ -849,8 +727,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject SequenceCreateResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SequenceCreateResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("sequence-xyz"),
     ["name"] = new OpenApiString("Morning routine"),
     ["steps"] = new OpenApiArray
@@ -865,28 +742,24 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     SequenceCreateResponse()
   };
 
-  private static OpenApiObject SessionCreateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject SessionCreateRequest() => new OpenApiObject {
     ["gameId"] = new OpenApiString("game-123"),
     ["adbSerial"] = new OpenApiString("emulator-5554")
   };
 
-  private static OpenApiObject SessionCreateResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SessionCreateResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("session-123"),
     ["status"] = new OpenApiString("PENDING"),
     ["gameId"] = new OpenApiString("game-123")
   };
 
-  private static OpenApiObject SessionStartRequest() => new OpenApiObject
-  {
+  private static OpenApiObject SessionStartRequest() => new OpenApiObject {
     ["gameId"] = new OpenApiString("game-123"),
     ["emulatorId"] = new OpenApiString("emulator-5554"),
     ["options"] = new OpenApiObject { ["idleTimeoutSeconds"] = new OpenApiInteger(30) }
   };
 
-  private static OpenApiObject RunningSessionExample() => new OpenApiObject
-  {
+  private static OpenApiObject RunningSessionExample() => new OpenApiObject {
     ["sessionId"] = new OpenApiString("session-abc"),
     ["gameId"] = new OpenApiString("game-123"),
     ["emulatorId"] = new OpenApiString("emulator-5554"),
@@ -895,8 +768,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ["status"] = new OpenApiString("running")
   };
 
-  private static OpenApiObject SessionStartResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SessionStartResponse() => new OpenApiObject {
     ["sessionId"] = new OpenApiString("session-abc"),
     ["runningSessions"] = new OpenApiArray
     {
@@ -913,21 +785,18 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject RunningSessionsResponse() => new OpenApiObject
-  {
+  private static OpenApiObject RunningSessionsResponse() => new OpenApiObject {
     ["sessions"] = new OpenApiArray
     {
       RunningSessionExample()
     }
   };
 
-  private static OpenApiObject SessionStopRequest() => new OpenApiObject
-  {
+  private static OpenApiObject SessionStopRequest() => new OpenApiObject {
     ["sessionId"] = new OpenApiString("session-abc")
   };
 
-  private static OpenApiObject SessionInputsRequest() => new OpenApiObject
-  {
+  private static OpenApiObject SessionInputsRequest() => new OpenApiObject {
     ["actions"] = new OpenApiArray
     {
       new OpenApiObject
@@ -944,25 +813,21 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject SessionInputsResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SessionInputsResponse() => new OpenApiObject {
     ["accepted"] = new OpenApiInteger(1)
   };
 
-  private static OpenApiObject ConfigurationSnapshotResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ConfigurationSnapshotResponse() => new OpenApiObject {
     ["generatedAtUtc"] = new OpenApiString("2025-12-28T12:00:00Z"),
     ["serviceVersion"] = new OpenApiString("1.0.0"),
     ["refreshCount"] = new OpenApiInteger(1),
-    ["parameters"] = new OpenApiObject
-    {
+    ["parameters"] = new OpenApiObject {
       ["GAMEBOT_DATA_DIR"] = new OpenApiObject { ["name"] = new OpenApiString("GAMEBOT_DATA_DIR"), ["source"] = new OpenApiString("Default"), ["value"] = new OpenApiString("C:/data"), ["isSecret"] = new OpenApiBoolean(false) },
       ["Service__Auth__Token"] = new OpenApiObject { ["name"] = new OpenApiString("Service__Auth__Token"), ["source"] = new OpenApiString("File"), ["value"] = new OpenApiString("***"), ["isSecret"] = new OpenApiBoolean(true) }
     }
   };
 
-  private static OpenApiObject LoggingPolicyResponse() => new OpenApiObject
-  {
+  private static OpenApiObject LoggingPolicyResponse() => new OpenApiObject {
     ["updatedAtUtc"] = new OpenApiString("2025-12-28T12:00:00Z"),
     ["components"] = new OpenApiArray
     {
@@ -976,23 +841,19 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject LoggingPolicyUpdateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject LoggingPolicyUpdateRequest() => new OpenApiObject {
     ["level"] = new OpenApiString("Information"),
     ["enabled"] = new OpenApiBoolean(true),
     ["notes"] = new OpenApiString("Temporary override for debugging")
   };
 
-  private static OpenApiObject LoggingPolicyResetRequest() => new OpenApiObject
-  {
+  private static OpenApiObject LoggingPolicyResetRequest() => new OpenApiObject {
     ["reason"] = new OpenApiString("Revert to defaults")
   };
 
-  private static OpenApiObject TriggerCreateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject TriggerCreateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Start screen ready"),
-    ["criteria"] = new OpenApiObject
-    {
+    ["criteria"] = new OpenApiObject {
       ["type"] = new OpenApiString("image-match"),
       ["referenceImageId"] = new OpenApiString("start-screen"),
       ["region"] = new OpenApiObject { ["x"] = new OpenApiDouble(0.1), ["y"] = new OpenApiDouble(0.1), ["width"] = new OpenApiDouble(0.5), ["height"] = new OpenApiDouble(0.5) },
@@ -1001,12 +862,10 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ["actions"] = new OpenApiArray { new OpenApiString("action-abc") }
   };
 
-  private static OpenApiObject TriggerCreateResponse() => new OpenApiObject
-  {
+  private static OpenApiObject TriggerCreateResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("trigger-123"),
     ["name"] = new OpenApiString("Start screen ready"),
-    ["criteria"] = new OpenApiObject
-    {
+    ["criteria"] = new OpenApiObject {
       ["type"] = new OpenApiString("image-match"),
       ["referenceImageId"] = new OpenApiString("start-screen"),
       ["region"] = new OpenApiObject { ["x"] = new OpenApiDouble(0.1), ["y"] = new OpenApiDouble(0.1), ["width"] = new OpenApiDouble(0.5), ["height"] = new OpenApiDouble(0.5) },
@@ -1022,23 +881,20 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     TriggerCreateResponse()
   };
 
-  private static OpenApiObject TriggerTestResponse() => new OpenApiObject
-  {
+  private static OpenApiObject TriggerTestResponse() => new OpenApiObject {
     ["status"] = new OpenApiString("Satisfied"),
     ["evaluatedAt"] = new OpenApiString("2025-12-28T12:00:00Z"),
     ["reason"] = new OpenApiString("Image match exceeded threshold")
   };
 
-  private static OpenApiObject ImageDetectRequest() => new OpenApiObject
-  {
+  private static OpenApiObject ImageDetectRequest() => new OpenApiObject {
     ["referenceImageId"] = new OpenApiString("start-screen"),
     ["threshold"] = new OpenApiDouble(0.85),
     ["maxResults"] = new OpenApiInteger(3),
     ["overlap"] = new OpenApiDouble(0.1)
   };
 
-  private static OpenApiObject ImageDetectResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ImageDetectResponse() => new OpenApiObject {
     ["limitsHit"] = new OpenApiBoolean(false),
     ["matches"] = new OpenApiArray
     {
@@ -1056,13 +912,11 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject ImageCropRequest() => new OpenApiObject
-  {
+  private static OpenApiObject ImageCropRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("battle-start"),
     ["overwrite"] = new OpenApiBoolean(false),
     ["sourceCaptureId"] = new OpenApiString("cap_123"),
-    ["bounds"] = new OpenApiObject
-    {
+    ["bounds"] = new OpenApiObject {
       ["x"] = new OpenApiInteger(120),
       ["y"] = new OpenApiInteger(200),
       ["width"] = new OpenApiInteger(64),
@@ -1070,13 +924,11 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject ImageCropResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ImageCropResponse() => new OpenApiObject {
     ["name"] = new OpenApiString("battle-start"),
     ["fileName"] = new OpenApiString("battle-start.png"),
     ["storagePath"] = new OpenApiString("data/images/battle-start.png"),
-    ["bounds"] = new OpenApiObject
-    {
+    ["bounds"] = new OpenApiObject {
       ["x"] = new OpenApiInteger(120),
       ["y"] = new OpenApiInteger(200),
       ["width"] = new OpenApiInteger(64),
@@ -1084,8 +936,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject ActionUpdateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject ActionUpdateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Collect coins v2"),
     ["gameId"] = new OpenApiString("game-123"),
     ["steps"] = new OpenApiArray
@@ -1101,14 +952,12 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ["checkpoints"] = new OpenApiArray { new OpenApiString("after-start") }
   };
 
-  private static OpenApiObject CommandCreateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject CommandCreateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Warmup"),
     ["actions"] = new OpenApiArray { new OpenApiString("action-abc"), new OpenApiString("action-def") }
   };
 
-  private static OpenApiObject CommandUpdateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject CommandUpdateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Warmup v2"),
     ["triggerId"] = new OpenApiString("trigger-1"),
     ["steps"] = new OpenApiArray
@@ -1118,8 +967,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject CommandCreateResponse() => new OpenApiObject
-  {
+  private static OpenApiObject CommandCreateResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("command-123"),
     ["name"] = new OpenApiString("Warmup"),
     ["triggerId"] = new OpenApiString("trigger-1"),
@@ -1131,15 +979,13 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
 
   private static OpenApiArray CommandListResponse() => new OpenApiArray { CommandCreateResponse() };
 
-  private static OpenApiObject CommandEvaluateResponse() => new OpenApiObject
-  {
+  private static OpenApiObject CommandEvaluateResponse() => new OpenApiObject {
     ["accepted"] = new OpenApiBoolean(true),
     ["triggerStatus"] = new OpenApiString("Satisfied"),
     ["message"] = new OpenApiString("Trigger satisfied; executed")
   };
 
-  private static OpenApiObject SequenceExecuteResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SequenceExecuteResponse() => new OpenApiObject {
     ["sequenceId"] = new OpenApiString("sequence-xyz"),
     ["status"] = new OpenApiString("Succeeded"),
     ["startedAt"] = new OpenApiString("2025-12-28T12:00:00Z"),
@@ -1158,8 +1004,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     }
   };
 
-  private static OpenApiObject SessionGetResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SessionGetResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("session-123"),
     ["status"] = new OpenApiString("RUNNING"),
     ["uptime"] = new OpenApiInteger(42),
@@ -1167,39 +1012,33 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     ["gameId"] = new OpenApiString("game-123")
   };
 
-  private static OpenApiObject SessionDeviceResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SessionDeviceResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("session-123"),
     ["deviceSerial"] = new OpenApiString("emulator-5554"),
     ["mode"] = new OpenApiString("ADB")
   };
 
-  private static OpenApiObject SessionHealthResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SessionHealthResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("session-123"),
     ["mode"] = new OpenApiString("ADB"),
     ["deviceSerial"] = new OpenApiString("emulator-5554"),
-    ["adb"] = new OpenApiObject
-    {
+    ["adb"] = new OpenApiObject {
       ["ok"] = new OpenApiBoolean(true),
       ["stdout"] = new OpenApiString("device"),
       ["stderr"] = new OpenApiString(string.Empty)
     }
   };
 
-  private static OpenApiObject SessionStopResponse() => new OpenApiObject
-  {
+  private static OpenApiObject SessionStopResponse() => new OpenApiObject {
     ["stopped"] = new OpenApiBoolean(true)
   };
 
-  private static OpenApiObject GameCreateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject GameCreateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Awesome Game"),
     ["metadata"] = new OpenApiObject { ["genre"] = new OpenApiString("arcade"), ["version"] = new OpenApiString("1.0.0") }
   };
 
-  private static OpenApiObject GameCreateResponse() => new OpenApiObject
-  {
+  private static OpenApiObject GameCreateResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("game-123"),
     ["name"] = new OpenApiString("Awesome Game"),
     ["metadata"] = new OpenApiObject { ["genre"] = new OpenApiString("arcade"), ["version"] = new OpenApiString("1.0.0") }
@@ -1207,31 +1046,26 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
 
   private static OpenApiArray GameListResponse() => new OpenApiArray { GameCreateResponse() };
 
-  private static OpenApiObject GameUpdateRequest() => new OpenApiObject
-  {
+  private static OpenApiObject GameUpdateRequest() => new OpenApiObject {
     ["name"] = new OpenApiString("Awesome Game v2"),
     ["description"] = new OpenApiString("Updated description")
   };
 
-  private static OpenApiObject ImageUploadRequest() => new OpenApiObject
-  {
+  private static OpenApiObject ImageUploadRequest() => new OpenApiObject {
     ["id"] = new OpenApiString("start-screen"),
     ["data"] = new OpenApiString("iVBORw0KGgoAAAANSUhEUgAAAAUA")
   };
 
-  private static OpenApiObject ImageUploadResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ImageUploadResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("start-screen"),
     ["overwrite"] = new OpenApiBoolean(false)
   };
 
-  private static OpenApiObject ImageOverwriteRequest() => new OpenApiObject
-  {
+  private static OpenApiObject ImageOverwriteRequest() => new OpenApiObject {
     ["data"] = new OpenApiString("iVBORw0KGgoAAAANSUhEUgAAAAUA")
   };
 
-  private static OpenApiObject ImageOverwriteResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ImageOverwriteResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("start-screen"),
     ["contentType"] = new OpenApiString("image/png"),
     ["sizeBytes"] = new OpenApiInteger(12345),
@@ -1244,40 +1078,34 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter
     new OpenApiObject { ["id"] = new OpenApiString("pause-screen") }
   };
 
-  private static OpenApiObject ImageReferenceResponse() => new OpenApiObject
-  {
+  private static OpenApiObject ImageReferenceResponse() => new OpenApiObject {
     ["id"] = new OpenApiString("start-screen")
   };
 }
 
-internal sealed class ActionUpdateSchema
-{
+internal sealed class ActionUpdateSchema {
   public string? Name { get; set; }
   public string? GameId { get; set; }
   public ICollection<GameBot.Service.Models.InputActionDto>? Steps { get; set; }
   public ICollection<string>? Checkpoints { get; set; }
 }
 
-internal sealed class SequenceRequestSchema
-{
+internal sealed class SequenceRequestSchema {
   public string? Name { get; set; }
   public ICollection<string>? Steps { get; set; }
 }
 
-internal sealed class SequenceResponseSchema
-{
+internal sealed class SequenceResponseSchema {
   public required string Id { get; set; }
   public required string Name { get; set; }
   public ICollection<string> Steps { get; set; } = new List<string>();
 }
 
-internal sealed class SessionAcceptedSchema
-{
+internal sealed class SessionAcceptedSchema {
   public int Accepted { get; set; }
 }
 
-internal sealed class SessionDetailSchema
-{
+internal sealed class SessionDetailSchema {
   public required string Id { get; set; }
   public required string Status { get; set; }
   public long Uptime { get; set; }
@@ -1285,70 +1113,60 @@ internal sealed class SessionDetailSchema
   public string? GameId { get; set; }
 }
 
-internal sealed class SessionDeviceSchema
-{
+internal sealed class SessionDeviceSchema {
   public required string Id { get; set; }
   public string? DeviceSerial { get; set; }
   public string? Mode { get; set; }
 }
 
-internal sealed class SessionHealthSchema
-{
+internal sealed class SessionHealthSchema {
   public required string Id { get; set; }
   public string? Mode { get; set; }
   public string? DeviceSerial { get; set; }
   public SessionHealthAdbSchema? Adb { get; set; }
 }
 
-internal sealed class SessionHealthAdbSchema
-{
+internal sealed class SessionHealthAdbSchema {
   public bool Ok { get; set; }
   public string? Stdout { get; set; }
   public string? Stderr { get; set; }
 }
 
-internal sealed class SessionStopSchema
-{
+internal sealed class SessionStopSchema {
   public string? Status { get; set; }
 }
 
-internal sealed class ConfigurationSnapshotSchema
-{
+internal sealed class ConfigurationSnapshotSchema {
   public DateTimeOffset GeneratedAtUtc { get; set; }
   public string? ServiceVersion { get; set; }
   public int RefreshCount { get; set; }
   public IDictionary<string, ConfigParameterSchema>? Parameters { get; set; }
 }
 
-internal sealed class ConfigParameterSchema
-{
+internal sealed class ConfigParameterSchema {
   public string? Name { get; set; }
   public string? Source { get; set; }
   public string? Value { get; set; }
   public bool IsSecret { get; set; }
 }
 
-internal sealed class LoggingPolicySchema
-{
+internal sealed class LoggingPolicySchema {
   public DateTimeOffset UpdatedAtUtc { get; set; }
   public ICollection<LoggingComponentSchema> Components { get; set; } = new List<LoggingComponentSchema>();
 }
 
-internal sealed class LoggingComponentSchema
-{
+internal sealed class LoggingComponentSchema {
   public string? Name { get; set; }
   public string? Level { get; set; }
   public bool Enabled { get; set; }
   public string? Notes { get; set; }
 }
 
-internal sealed class LoggingPolicyResetRequestSchema
-{
+internal sealed class LoggingPolicyResetRequestSchema {
   public string? Reason { get; set; }
 }
 
-internal sealed class TriggerAuthoringSchema
-{
+internal sealed class TriggerAuthoringSchema {
   public string? Name { get; set; }
   public TriggerCriteriaSchema? Criteria { get; set; }
   public ICollection<string>? Actions { get; set; }
@@ -1356,24 +1174,21 @@ internal sealed class TriggerAuthoringSchema
   public string? Sequence { get; set; }
 }
 
-internal sealed class TriggerCriteriaSchema
-{
+internal sealed class TriggerCriteriaSchema {
   public string? Type { get; set; }
   public string? ReferenceImageId { get; set; }
   public RegionSchema? Region { get; set; }
   public double? SimilarityThreshold { get; set; }
 }
 
-internal sealed class RegionSchema
-{
+internal sealed class RegionSchema {
   public double X { get; set; }
   public double Y { get; set; }
   public double Width { get; set; }
   public double Height { get; set; }
 }
 
-internal sealed class TriggerResponseSchema
-{
+internal sealed class TriggerResponseSchema {
   public required string Id { get; set; }
   public string? Name { get; set; }
   public TriggerCriteriaSchema? Criteria { get; set; }
@@ -1382,64 +1197,55 @@ internal sealed class TriggerResponseSchema
   public string? Sequence { get; set; }
 }
 
-internal sealed class TriggerTestResponseSchema
-{
+internal sealed class TriggerTestResponseSchema {
   public string? Status { get; set; }
   public DateTimeOffset EvaluatedAt { get; set; }
   public string? Reason { get; set; }
 }
 
-internal sealed class CommandCreateSchema
-{
+internal sealed class CommandCreateSchema {
   public required string Name { get; set; }
   public string? TriggerId { get; set; }
   public ICollection<string>? Actions { get; set; }
   public ICollection<GameBot.Service.Models.CommandStepDto>? Steps { get; set; }
 }
 
-internal sealed class CommandEvaluateResponseSchema
-{
+internal sealed class CommandEvaluateResponseSchema {
   public bool Accepted { get; set; }
   public string? TriggerStatus { get; set; }
   public string? Message { get; set; }
 }
 
-internal sealed class GameCreateSchema
-{
+internal sealed class GameCreateSchema {
   public required string Name { get; set; }
   public object? Metadata { get; set; }
   public string? Description { get; set; }
 }
 
-internal sealed class GameResponseSchema
-{
+internal sealed class GameResponseSchema {
   public required string Id { get; set; }
   public required string Name { get; set; }
   public object? Metadata { get; set; }
   public string? Description { get; set; }
 }
 
-internal sealed class ImageUploadResponseSchema
-{
+internal sealed class ImageUploadResponseSchema {
   public string? Id { get; set; }
   public bool Overwrite { get; set; }
 }
 
-internal sealed class ImageOverwriteResponseSchema
-{
+internal sealed class ImageOverwriteResponseSchema {
   public string? Id { get; set; }
   public string? ContentType { get; set; }
   public long SizeBytes { get; set; }
   public DateTimeOffset UpdatedAtUtc { get; set; }
 }
 
-internal sealed class ImageReferenceListItemSchema
-{
+internal sealed class ImageReferenceListItemSchema {
   public string? Id { get; set; }
 }
 
-internal sealed class ImageReferenceSchema
-{
+internal sealed class ImageReferenceSchema {
   public string? Id { get; set; }
   public bool? Fallback { get; set; }
 }

--- a/tests/TestAssets/execution-logs/execution-log-entry.sample.json
+++ b/tests/TestAssets/execution-logs/execution-log-entry.sample.json
@@ -1,0 +1,44 @@
+{
+  "id": "exe_0001",
+  "timestampUtc": "2026-01-01T00:00:00Z",
+  "executionType": "command",
+  "finalStatus": "success",
+  "objectRef": {
+    "objectType": "command",
+    "objectId": "cmd-farm",
+    "displayNameSnapshot": "Farm Run",
+    "versionSnapshot": "2026.01"
+  },
+  "navigation": {
+    "directPath": "/api/commands/cmd-farm",
+    "parentPath": "/api/sequences/seq-daily",
+    "pathKind": "command"
+  },
+  "hierarchy": {
+    "rootExecutionId": "exe_root_0001",
+    "parentExecutionId": "exe_parent_0001",
+    "depth": 1,
+    "sequenceIndex": 2
+  },
+  "summary": "Command executed successfully",
+  "details": [
+    {
+      "kind": "execution",
+      "message": "Trigger matched and command dispatched.",
+      "attributes": {
+        "triggerMatched": true,
+        "durationMs": 812
+      },
+      "sensitivity": "public"
+    }
+  ],
+  "stepOutcomes": [
+    {
+      "stepOrder": 1,
+      "stepType": "tap",
+      "outcome": "executed",
+      "reasonCode": "none",
+      "reasonText": "Step executed normally"
+    }
+  ]
+}

--- a/tests/TestAssets/execution-logs/execution-log-list.sample.json
+++ b/tests/TestAssets/execution-logs/execution-log-list.sample.json
@@ -1,0 +1,31 @@
+{
+  "items": [
+    {
+      "id": "exe_0001",
+      "timestampUtc": "2026-01-01T00:00:00Z",
+      "executionType": "command",
+      "finalStatus": "success",
+      "objectRef": {
+        "objectType": "command",
+        "objectId": "cmd-farm",
+        "displayNameSnapshot": "Farm Run",
+        "versionSnapshot": "2026.01"
+      },
+      "navigation": {
+        "directPath": "/api/commands/cmd-farm",
+        "parentPath": "/api/sequences/seq-daily",
+        "pathKind": "command"
+      },
+      "hierarchy": {
+        "rootExecutionId": "exe_root_0001",
+        "parentExecutionId": "exe_parent_0001",
+        "depth": 1,
+        "sequenceIndex": 2
+      },
+      "summary": "Command executed successfully",
+      "details": [],
+      "stepOutcomes": []
+    }
+  ],
+  "nextCursor": "2026-01-01T00:00:00.0000000+00:00|exe_0001"
+}

--- a/tests/TestAssets/execution-logs/execution-log-retention.sample.json
+++ b/tests/TestAssets/execution-logs/execution-log-retention.sample.json
@@ -1,0 +1,6 @@
+{
+  "enabled": true,
+  "retentionDays": 30,
+  "cleanupIntervalMinutes": 60,
+  "updatedAtUtc": "2026-01-01T00:00:00Z"
+}

--- a/tests/contract/OpenApiContractTests.cs
+++ b/tests/contract/OpenApiContractTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
@@ -51,5 +52,26 @@ public sealed class OpenApiContractTests : IDisposable {
     root.ToString().Should().Contain("PrimitiveTap");
 
     root.ToString().Should().Contain("evaluate-and-execute");
+  }
+
+  [Fact]
+  public async Task SwaggerDocumentIncludesExecutionLogRetentionEndpoints()
+  {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    var resp = await client.GetAsync(new Uri("/swagger/v1/swagger.json", UriKind.Relative)).ConfigureAwait(true);
+    resp.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true));
+    var root = doc.RootElement;
+    var paths = root.GetProperty("paths");
+
+    paths.TryGetProperty("/api/execution-logs/retention", out var retentionPath).Should().BeTrue();
+    retentionPath.TryGetProperty("get", out _).Should().BeTrue();
+    retentionPath.TryGetProperty("put", out var putOp).Should().BeTrue();
+
+    putOp.TryGetProperty("requestBody", out var requestBody).Should().BeTrue();
+    requestBody.TryGetProperty("content", out var content).Should().BeTrue();
+    content.TryGetProperty("application/json", out _).Should().BeTrue();
   }
 }

--- a/tests/contract/OpenApiContractTests.cs
+++ b/tests/contract/OpenApiContractTests.cs
@@ -73,4 +73,21 @@ public sealed class OpenApiContractTests : IDisposable {
     requestBody.TryGetProperty("content", out var content).Should().BeTrue();
     content.TryGetProperty("application/json", out _).Should().BeTrue();
   }
+
+  [Fact]
+  public async Task SwaggerDocumentIncludesExecutionLogListAndDetailEndpoints() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    var resp = await client.GetAsync(new Uri("/swagger/v1/swagger.json", UriKind.Relative)).ConfigureAwait(true);
+    resp.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true));
+    var paths = doc.RootElement.GetProperty("paths");
+
+    paths.TryGetProperty("/api/execution-logs", out var listPath).Should().BeTrue();
+    listPath.TryGetProperty("get", out _).Should().BeTrue();
+
+    paths.TryGetProperty("/api/execution-logs/{id}", out var detailPath).Should().BeTrue();
+    detailPath.TryGetProperty("get", out _).Should().BeTrue();
+  }
 }

--- a/tests/contract/OpenApiContractTests.cs
+++ b/tests/contract/OpenApiContractTests.cs
@@ -55,8 +55,7 @@ public sealed class OpenApiContractTests : IDisposable {
   }
 
   [Fact]
-  public async Task SwaggerDocumentIncludesExecutionLogRetentionEndpoints()
-  {
+  public async Task SwaggerDocumentIncludesExecutionLogRetentionEndpoints() {
     using var app = new WebApplicationFactory<Program>();
     var client = app.CreateClient();
     var resp = await client.GetAsync(new Uri("/swagger/v1/swagger.json", UriKind.Relative)).ConfigureAwait(true);

--- a/tests/integration/ExecutionLogs/CommandExecutionLoggingIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/CommandExecutionLoggingIntegrationTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using FluentAssertions;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class CommandExecutionLoggingIntegrationTests {
+  [Fact]
+  public async Task CommandExecutionIsPersistedAndQueryableViaExecutionLogsEndpoint() {
+    var previousAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+    try {
+      using var app = new WebApplicationFactory<Program>();
+      var client = app.CreateClient();
+      client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+      var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+      await logService.LogCommandExecutionAsync(
+        "cmd-us1-persist",
+        "US1 Persisted Command",
+        "success",
+        new[] { new PrimitiveTapStepOutcome(1, "executed", null, new PrimitiveTapResolvedPoint(11, 22), 0.95) },
+        new ExecutionLogContext { Depth = 0 }).ConfigureAwait(false);
+
+      var listResp = await client.GetAsync(new Uri("/api/execution-logs?objectType=command&objectId=cmd-us1-persist&pageSize=1", UriKind.Relative)).ConfigureAwait(false);
+      listResp.EnsureSuccessStatusCode();
+
+      using var listDoc = JsonDocument.Parse(await listResp.Content.ReadAsStringAsync().ConfigureAwait(false));
+      var items = listDoc.RootElement.GetProperty("items");
+      items.GetArrayLength().Should().Be(1);
+
+      var item = items[0];
+      item.GetProperty("executionType").GetString().Should().Be("command");
+      item.GetProperty("finalStatus").GetString().Should().Be("success");
+      item.GetProperty("objectRef").GetProperty("objectId").GetString().Should().Be("cmd-us1-persist");
+
+      var id = item.GetProperty("id").GetString();
+      var detailResp = await client.GetAsync(new Uri($"/api/execution-logs/{id}", UriKind.Relative)).ConfigureAwait(false);
+      detailResp.EnsureSuccessStatusCode();
+
+      using var detailDoc = JsonDocument.Parse(await detailResp.Content.ReadAsStringAsync().ConfigureAwait(false));
+      detailDoc.RootElement.GetProperty("stepOutcomes").GetArrayLength().Should().Be(1);
+      detailDoc.RootElement.GetProperty("navigation").GetProperty("directPath").GetString().Should().Be("/authoring/commands/cmd-us1-persist");
+    }
+    finally {
+      Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", previousAuthToken);
+    }
+  }
+}

--- a/tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class ExecutionHierarchyIntegrationTests
+{
+  [Fact]
+  public async Task NestedSequenceAndCommandPersistParentChildHierarchy()
+  {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+
+    var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+    await logService.LogSequenceExecutionAsync(
+      "seq-parent",
+      "Parent Sequence",
+      "success",
+      "Parent executed",
+      new ExecutionLogContext { Depth = 0 },
+      details: null).ConfigureAwait(false);
+
+    var parent = (await logService.QueryAsync(new ExecutionLogQuery
+    {
+      ObjectType = "sequence",
+      ObjectId = "seq-parent",
+      PageSize = 1
+    }).ConfigureAwait(false)).Items.Single();
+
+    await logService.LogCommandExecutionAsync(
+      "cmd-child",
+      "Child Command",
+      "success",
+      Array.Empty<PrimitiveTapStepOutcome>(),
+      new ExecutionLogContext
+      {
+        ParentExecutionId = parent.Id,
+        RootExecutionId = parent.Hierarchy.RootExecutionId,
+        ParentObjectType = "sequence",
+        ParentObjectId = "seq-parent",
+        Depth = 1,
+        SequenceIndex = 0
+      }).ConfigureAwait(false);
+
+    var child = (await logService.QueryAsync(new ExecutionLogQuery
+    {
+      ObjectType = "command",
+      ObjectId = "cmd-child",
+      PageSize = 1
+    }).ConfigureAwait(false)).Items.Single();
+
+    child.Hierarchy.ParentExecutionId.Should().Be(parent.Id);
+    child.Hierarchy.RootExecutionId.Should().Be(parent.Hierarchy.RootExecutionId);
+    child.Hierarchy.Depth.Should().Be(1);
+    child.Hierarchy.SequenceIndex.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task NestedCommandPersistsDirectAndParentNavigationPaths()
+  {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+
+    var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+    await logService.LogSequenceExecutionAsync(
+      "seq-navigate",
+      "Navigation Parent",
+      "success",
+      "Parent executed",
+      new ExecutionLogContext { Depth = 0 },
+      details: null).ConfigureAwait(false);
+
+    var parent = (await logService.QueryAsync(new ExecutionLogQuery
+    {
+      ObjectType = "sequence",
+      ObjectId = "seq-navigate",
+      PageSize = 1
+    }).ConfigureAwait(false)).Items.Single();
+
+    await logService.LogCommandExecutionAsync(
+      "cmd-navigate",
+      "Navigation Child",
+      "failure",
+      Array.Empty<PrimitiveTapStepOutcome>(),
+      new ExecutionLogContext
+      {
+        ParentExecutionId = parent.Id,
+        RootExecutionId = parent.Hierarchy.RootExecutionId,
+        ParentObjectType = "sequence",
+        ParentObjectId = "seq-navigate",
+        Depth = 1
+      }).ConfigureAwait(false);
+
+    var child = (await logService.QueryAsync(new ExecutionLogQuery
+    {
+      ObjectType = "command",
+      ObjectId = "cmd-navigate",
+      PageSize = 1
+    }).ConfigureAwait(false)).Items.Single();
+
+    child.Navigation.DirectPath.Should().Be("/authoring/commands/cmd-navigate");
+    child.Navigation.ParentPath.Should().Be("/authoring/sequences/seq-navigate");
+    child.Navigation.PathKind.Should().Be("relative-route");
+  }
+}

--- a/tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs
@@ -9,11 +9,9 @@ using Xunit;
 namespace GameBot.IntegrationTests.ExecutionLogs;
 
 [Collection("ConfigIsolation")]
-public sealed class ExecutionHierarchyIntegrationTests
-{
+public sealed class ExecutionHierarchyIntegrationTests {
   [Fact]
-  public async Task NestedSequenceAndCommandPersistParentChildHierarchy()
-  {
+  public async Task NestedSequenceAndCommandPersistParentChildHierarchy() {
     TestEnvironment.PrepareCleanDataDir();
 
     using var app = new WebApplicationFactory<Program>();
@@ -29,8 +27,7 @@ public sealed class ExecutionHierarchyIntegrationTests
       new ExecutionLogContext { Depth = 0 },
       details: null).ConfigureAwait(false);
 
-    var parent = (await logService.QueryAsync(new ExecutionLogQuery
-    {
+    var parent = (await logService.QueryAsync(new ExecutionLogQuery {
       ObjectType = "sequence",
       ObjectId = "seq-parent",
       PageSize = 1
@@ -41,8 +38,7 @@ public sealed class ExecutionHierarchyIntegrationTests
       "Child Command",
       "success",
       Array.Empty<PrimitiveTapStepOutcome>(),
-      new ExecutionLogContext
-      {
+      new ExecutionLogContext {
         ParentExecutionId = parent.Id,
         RootExecutionId = parent.Hierarchy.RootExecutionId,
         ParentObjectType = "sequence",
@@ -51,8 +47,7 @@ public sealed class ExecutionHierarchyIntegrationTests
         SequenceIndex = 0
       }).ConfigureAwait(false);
 
-    var child = (await logService.QueryAsync(new ExecutionLogQuery
-    {
+    var child = (await logService.QueryAsync(new ExecutionLogQuery {
       ObjectType = "command",
       ObjectId = "cmd-child",
       PageSize = 1
@@ -65,8 +60,7 @@ public sealed class ExecutionHierarchyIntegrationTests
   }
 
   [Fact]
-  public async Task NestedCommandPersistsDirectAndParentNavigationPaths()
-  {
+  public async Task NestedCommandPersistsDirectAndParentNavigationPaths() {
     TestEnvironment.PrepareCleanDataDir();
 
     using var app = new WebApplicationFactory<Program>();
@@ -82,8 +76,7 @@ public sealed class ExecutionHierarchyIntegrationTests
       new ExecutionLogContext { Depth = 0 },
       details: null).ConfigureAwait(false);
 
-    var parent = (await logService.QueryAsync(new ExecutionLogQuery
-    {
+    var parent = (await logService.QueryAsync(new ExecutionLogQuery {
       ObjectType = "sequence",
       ObjectId = "seq-navigate",
       PageSize = 1
@@ -94,8 +87,7 @@ public sealed class ExecutionHierarchyIntegrationTests
       "Navigation Child",
       "failure",
       Array.Empty<PrimitiveTapStepOutcome>(),
-      new ExecutionLogContext
-      {
+      new ExecutionLogContext {
         ParentExecutionId = parent.Id,
         RootExecutionId = parent.Hierarchy.RootExecutionId,
         ParentObjectType = "sequence",
@@ -103,8 +95,7 @@ public sealed class ExecutionHierarchyIntegrationTests
         Depth = 1
       }).ConfigureAwait(false);
 
-    var child = (await logService.QueryAsync(new ExecutionLogQuery
-    {
+    var child = (await logService.QueryAsync(new ExecutionLogQuery {
       ObjectType = "command",
       ObjectId = "cmd-navigate",
       PageSize = 1

--- a/tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
@@ -8,11 +8,9 @@ using Xunit;
 namespace GameBot.IntegrationTests.ExecutionLogs;
 
 [Collection("ConfigIsolation")]
-public sealed class ExecutionLogConcisenessIntegrationTests
-{
+public sealed class ExecutionLogConcisenessIntegrationTests {
   [Fact]
-  public async Task SequenceLogTrimsSummaryAndTruncatesDetailsWithMarker()
-  {
+  public async Task SequenceLogTrimsSummaryAndTruncatesDetailsWithMarker() {
     TestEnvironment.PrepareCleanDataDir();
 
     using var app = new WebApplicationFactory<Program>();
@@ -33,8 +31,7 @@ public sealed class ExecutionLogConcisenessIntegrationTests
       new ExecutionLogContext { Depth = 0 },
       details).ConfigureAwait(false);
 
-    var item = (await logService.QueryAsync(new ExecutionLogQuery
-    {
+    var item = (await logService.QueryAsync(new ExecutionLogQuery {
       ObjectType = "sequence",
       ObjectId = "seq-concise",
       PageSize = 1

--- a/tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class ExecutionLogConcisenessIntegrationTests
+{
+  [Fact]
+  public async Task SequenceLogTrimsSummaryAndTruncatesDetailsWithMarker()
+  {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+
+    var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+    var longSummary = new string('x', 500);
+    var details = Enumerable.Range(1, 15)
+      .Select(i => new ExecutionDetailItem("detail", $"detail-{i}", null, "normal"))
+      .ToArray();
+
+    await logService.LogSequenceExecutionAsync(
+      "seq-concise",
+      "Concise Sequence",
+      "success",
+      longSummary,
+      new ExecutionLogContext { Depth = 0 },
+      details).ConfigureAwait(false);
+
+    var item = (await logService.QueryAsync(new ExecutionLogQuery
+    {
+      ObjectType = "sequence",
+      ObjectId = "seq-concise",
+      PageSize = 1
+    }).ConfigureAwait(false)).Items.Single();
+
+    item.Summary.Length.Should().BeLessOrEqualTo(240);
+    item.Details.Should().HaveCount(10);
+    item.Details[9].Kind.Should().Be("meta");
+    item.Details[9].Message.Should().Be("Additional details were truncated.");
+  }
+}

--- a/tests/integration/ExecutionLogs/ExecutionLogObjectSnapshotIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionLogObjectSnapshotIntegrationTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class ExecutionLogObjectSnapshotIntegrationTests {
+  [Fact]
+  public async Task HistoricalLogKeepsOriginalSnapshotAfterCommandRenameAndDelete() {
+    var previousAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+    try {
+      using var app = new WebApplicationFactory<Program>();
+      var client = app.CreateClient();
+      client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+      var commandRepository = app.Services.GetRequiredService<ICommandRepository>();
+      var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+      await commandRepository.AddAsync(new Command {
+        Id = "cmd-snapshot-001",
+        Name = "Original Snapshot Name",
+        Steps = new Collection<CommandStep>()
+      }).ConfigureAwait(false);
+
+      await logService.LogCommandExecutionAsync(
+        "cmd-snapshot-001",
+        "Original Snapshot Name",
+        "success",
+        Array.Empty<PrimitiveTapStepOutcome>(),
+        new ExecutionLogContext { Depth = 0 }).ConfigureAwait(false);
+
+      var command = await commandRepository.GetAsync("cmd-snapshot-001").ConfigureAwait(false);
+      command.Should().NotBeNull();
+      command!.Name = "Renamed Command";
+      await commandRepository.UpdateAsync(command).ConfigureAwait(false);
+      await commandRepository.DeleteAsync("cmd-snapshot-001").ConfigureAwait(false);
+
+      var listResp = await client.GetAsync(new Uri("/api/execution-logs?objectType=command&objectId=cmd-snapshot-001&pageSize=1", UriKind.Relative)).ConfigureAwait(false);
+      listResp.EnsureSuccessStatusCode();
+
+      using var listDoc = JsonDocument.Parse(await listResp.Content.ReadAsStringAsync().ConfigureAwait(false));
+      var item = listDoc.RootElement.GetProperty("items")[0];
+
+      item.GetProperty("objectRef").GetProperty("objectId").GetString().Should().Be("cmd-snapshot-001");
+      item.GetProperty("objectRef").GetProperty("displayNameSnapshot").GetString().Should().Be("Original Snapshot Name");
+      item.GetProperty("navigation").GetProperty("directPath").GetString().Should().Be("/authoring/commands/cmd-snapshot-001");
+
+      var deleted = await commandRepository.GetAsync("cmd-snapshot-001").ConfigureAwait(false);
+      deleted.Should().BeNull();
+    }
+    finally {
+      Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", previousAuthToken);
+    }
+  }
+}

--- a/tests/integration/ExecutionLogs/ExecutionLogRetentionIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionLogRetentionIntegrationTests.cs
@@ -8,11 +8,9 @@ using Xunit;
 namespace GameBot.IntegrationTests.ExecutionLogs;
 
 [Collection("ConfigIsolation")]
-public sealed class ExecutionLogRetentionIntegrationTests
-{
+public sealed class ExecutionLogRetentionIntegrationTests {
   [Fact]
-  public async Task RetentionPolicyUpdatePersistsAndCleanupDeletesExpiredEntries()
-  {
+  public async Task RetentionPolicyUpdatePersistsAndCleanupDeletesExpiredEntries() {
     TestEnvironment.PrepareCleanDataDir();
 
     using var app = new WebApplicationFactory<Program>();
@@ -32,8 +30,7 @@ public sealed class ExecutionLogRetentionIntegrationTests
     persisted.RetentionDays.Should().Be(3);
     persisted.CleanupIntervalMinutes.Should().Be(5);
 
-    var expired = new ExecutionLogEntry
-    {
+    var expired = new ExecutionLogEntry {
       Id = "expired-entry-001",
       TimestampUtc = DateTimeOffset.UtcNow.AddDays(-10),
       ExecutionType = "command",

--- a/tests/integration/ExecutionLogs/ExecutionLogRetentionIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionLogRetentionIntegrationTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class ExecutionLogRetentionIntegrationTests
+{
+  [Fact]
+  public async Task RetentionPolicyUpdatePersistsAndCleanupDeletesExpiredEntries()
+  {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+
+    var logService = app.Services.GetRequiredService<IExecutionLogService>();
+    var policyRepo = app.Services.GetRequiredService<IExecutionLogRetentionPolicyRepository>();
+    var logRepo = app.Services.GetRequiredService<IExecutionLogRepository>();
+
+    var updated = await logService.UpdateRetentionAsync(true, 3, 5).ConfigureAwait(false);
+    updated.Enabled.Should().BeTrue();
+    updated.RetentionDays.Should().Be(3);
+    updated.CleanupIntervalMinutes.Should().Be(5);
+
+    var persisted = await policyRepo.GetAsync().ConfigureAwait(false);
+    persisted.Enabled.Should().BeTrue();
+    persisted.RetentionDays.Should().Be(3);
+    persisted.CleanupIntervalMinutes.Should().Be(5);
+
+    var expired = new ExecutionLogEntry
+    {
+      Id = "expired-entry-001",
+      TimestampUtc = DateTimeOffset.UtcNow.AddDays(-10),
+      ExecutionType = "command",
+      FinalStatus = "failure",
+      ObjectRef = new ExecutionObjectReference("command", "cmd-expired", "Expired"),
+      Navigation = new ExecutionNavigationContext("/authoring/commands/cmd-expired", null),
+      Hierarchy = new ExecutionHierarchyContext("root-expired", null, 0, null),
+      Summary = "expired",
+      Details = Array.Empty<ExecutionDetailItem>(),
+      StepOutcomes = Array.Empty<ExecutionStepOutcome>(),
+      RetentionExpiresUtc = DateTimeOffset.UtcNow.AddMinutes(-5)
+    };
+
+    await logRepo.AddAsync(expired).ConfigureAwait(false);
+
+    var deleted = await logService.CleanupExpiredAsync().ConfigureAwait(false);
+    deleted.Should().BeGreaterThan(0);
+
+    var stillThere = await logRepo.GetAsync("expired-entry-001").ConfigureAwait(false);
+    stillThere.Should().BeNull();
+  }
+}

--- a/tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
@@ -8,11 +8,9 @@ using Xunit;
 namespace GameBot.IntegrationTests.ExecutionLogs;
 
 [Collection("ConfigIsolation")]
-public sealed class ExecutionNavigationIntegrationTests
-{
+public sealed class ExecutionNavigationIntegrationTests {
   [Fact]
-  public async Task StandaloneSequenceHasDirectPathAndNoParentPath()
-  {
+  public async Task StandaloneSequenceHasDirectPathAndNoParentPath() {
     TestEnvironment.PrepareCleanDataDir();
 
     using var app = new WebApplicationFactory<Program>();
@@ -28,8 +26,7 @@ public sealed class ExecutionNavigationIntegrationTests
       new ExecutionLogContext { Depth = 0 },
       details: null).ConfigureAwait(false);
 
-    var sequence = (await logService.QueryAsync(new ExecutionLogQuery
-    {
+    var sequence = (await logService.QueryAsync(new ExecutionLogQuery {
       ObjectType = "sequence",
       ObjectId = "seq-alone",
       PageSize = 1

--- a/tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionNavigationIntegrationTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class ExecutionNavigationIntegrationTests
+{
+  [Fact]
+  public async Task StandaloneSequenceHasDirectPathAndNoParentPath()
+  {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+
+    var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+    await logService.LogSequenceExecutionAsync(
+      "seq-alone",
+      "Standalone Sequence",
+      "success",
+      "Standalone execution",
+      new ExecutionLogContext { Depth = 0 },
+      details: null).ConfigureAwait(false);
+
+    var sequence = (await logService.QueryAsync(new ExecutionLogQuery
+    {
+      ObjectType = "sequence",
+      ObjectId = "seq-alone",
+      PageSize = 1
+    }).ConfigureAwait(false)).Items.Single();
+
+    sequence.Navigation.DirectPath.Should().Be("/authoring/sequences/seq-alone");
+    sequence.Navigation.ParentPath.Should().BeNull();
+  }
+}

--- a/tests/integration/ExecutionLogs/ExecutionStepOutcomeIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionStepOutcomeIntegrationTests.cs
@@ -9,11 +9,9 @@ using Xunit;
 namespace GameBot.IntegrationTests.ExecutionLogs;
 
 [Collection("ConfigIsolation")]
-public sealed class ExecutionStepOutcomeIntegrationTests
-{
+public sealed class ExecutionStepOutcomeIntegrationTests {
   [Fact]
-  public async Task CommandLogNormalizesStepOutcomesToExecutedAndNotExecuted()
-  {
+  public async Task CommandLogNormalizesStepOutcomesToExecutedAndNotExecuted() {
     TestEnvironment.PrepareCleanDataDir();
 
     using var app = new WebApplicationFactory<Program>();
@@ -34,8 +32,7 @@ public sealed class ExecutionStepOutcomeIntegrationTests
       primitiveOutcomes,
       new ExecutionLogContext { Depth = 0 }).ConfigureAwait(false);
 
-    var item = (await logService.QueryAsync(new ExecutionLogQuery
-    {
+    var item = (await logService.QueryAsync(new ExecutionLogQuery {
       ObjectType = "command",
       ObjectId = "cmd-step-outcomes",
       PageSize = 1

--- a/tests/integration/ExecutionLogs/ExecutionStepOutcomeIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/ExecutionStepOutcomeIntegrationTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class ExecutionStepOutcomeIntegrationTests
+{
+  [Fact]
+  public async Task CommandLogNormalizesStepOutcomesToExecutedAndNotExecuted()
+  {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+
+    var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+    var primitiveOutcomes = new[]
+    {
+      new PrimitiveTapStepOutcome(1, "executed", null, new PrimitiveTapResolvedPoint(100, 120), 0.92),
+      new PrimitiveTapStepOutcome(2, "skipped_detection_failed", "threshold_not_met", null, 0.41)
+    };
+
+    await logService.LogCommandExecutionAsync(
+      "cmd-step-outcomes",
+      "Step Outcomes Command",
+      "failure",
+      primitiveOutcomes,
+      new ExecutionLogContext { Depth = 0 }).ConfigureAwait(false);
+
+    var item = (await logService.QueryAsync(new ExecutionLogQuery
+    {
+      ObjectType = "command",
+      ObjectId = "cmd-step-outcomes",
+      PageSize = 1
+    }).ConfigureAwait(false)).Items.Single();
+
+    item.StepOutcomes.Should().HaveCount(2);
+    item.StepOutcomes[0].Outcome.Should().Be("executed");
+    item.StepOutcomes[1].Outcome.Should().Be("not_executed");
+    item.StepOutcomes[1].ReasonText.Should().Be("threshold_not_met");
+  }
+}

--- a/tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class SequenceExecutionLoggingIntegrationTests {
+  [Fact]
+  public async Task SequenceExecutionIsPersistedAndQueryableViaExecutionLogsEndpoint() {
+    var previousAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+    try {
+      using var app = new WebApplicationFactory<Program>();
+      var client = app.CreateClient();
+      client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+      var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+      await logService.LogSequenceExecutionAsync(
+        "seq-us1-persist",
+        "US1 Persisted Sequence",
+        "failure",
+        "Sequence failed while evaluating a step.",
+        new ExecutionLogContext { Depth = 0 },
+        new[] {
+          new ExecutionDetailItem(
+            "sequence",
+            "Executed commands: cmd-a,cmd-b",
+            new Dictionary<string, object?> { ["executedCount"] = 2 },
+            "normal")
+        }).ConfigureAwait(false);
+
+      var listResp = await client.GetAsync(new Uri("/api/execution-logs?objectType=sequence&objectId=seq-us1-persist&pageSize=1", UriKind.Relative)).ConfigureAwait(false);
+      listResp.EnsureSuccessStatusCode();
+
+      using var listDoc = JsonDocument.Parse(await listResp.Content.ReadAsStringAsync().ConfigureAwait(false));
+      var items = listDoc.RootElement.GetProperty("items");
+      items.GetArrayLength().Should().Be(1);
+
+      var item = items[0];
+      item.GetProperty("executionType").GetString().Should().Be("sequence");
+      item.GetProperty("finalStatus").GetString().Should().Be("failure");
+      item.GetProperty("objectRef").GetProperty("displayNameSnapshot").GetString().Should().Be("US1 Persisted Sequence");
+      item.GetProperty("navigation").GetProperty("directPath").GetString().Should().Be("/authoring/sequences/seq-us1-persist");
+    }
+    finally {
+      Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", previousAuthToken);
+    }
+  }
+}

--- a/tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using GameBot.Service.Services.ExecutionLog;
+using Xunit;
+
+namespace GameBot.UnitTests.ExecutionLogs;
+
+public sealed class ExecutionHierarchyContextTests
+{
+  [Fact]
+  public void BuildUsesParentAsRootWhenRootNotProvided()
+  {
+    var context = ExecutionHierarchyBuilder.Build(new ExecutionLogContext
+    {
+      ParentExecutionId = "parent-001",
+      Depth = 2,
+      SequenceIndex = 3
+    });
+
+    context.RootExecutionId.Should().Be("parent-001");
+    context.ParentExecutionId.Should().Be("parent-001");
+    context.Depth.Should().Be(2);
+    context.SequenceIndex.Should().Be(3);
+  }
+
+  [Fact]
+  public void BuildPrefersExplicitRootExecutionIdWhenProvided()
+  {
+    var context = ExecutionHierarchyBuilder.Build(new ExecutionLogContext
+    {
+      RootExecutionId = "root-123",
+      ParentExecutionId = "parent-002",
+      Depth = -5
+    });
+
+    context.RootExecutionId.Should().Be("root-123");
+    context.ParentExecutionId.Should().Be("parent-002");
+    context.Depth.Should().Be(0);
+  }
+
+  [Fact]
+  public void BuildGeneratesRootWhenNoContextProvided()
+  {
+    var context = ExecutionHierarchyBuilder.Build(null);
+
+    context.RootExecutionId.Should().NotBeNullOrWhiteSpace();
+    context.ParentExecutionId.Should().BeNull();
+    context.Depth.Should().Be(0);
+  }
+
+  [Fact]
+  public void NavigationBuilderCreatesDirectAndParentPathsForNestedCommand()
+  {
+    var context = ExecutionNavigationBuilder.Build("command", "cmd-001", new ExecutionLogContext
+    {
+      ParentObjectType = "sequence",
+      ParentObjectId = "seq-001"
+    });
+
+    context.DirectPath.Should().Be("/authoring/commands/cmd-001");
+    context.ParentPath.Should().Be("/authoring/sequences/seq-001");
+    context.PathKind.Should().Be("relative-route");
+  }
+}

--- a/tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionHierarchyContextTests.cs
@@ -4,13 +4,10 @@ using Xunit;
 
 namespace GameBot.UnitTests.ExecutionLogs;
 
-public sealed class ExecutionHierarchyContextTests
-{
+public sealed class ExecutionHierarchyContextTests {
   [Fact]
-  public void BuildUsesParentAsRootWhenRootNotProvided()
-  {
-    var context = ExecutionHierarchyBuilder.Build(new ExecutionLogContext
-    {
+  public void BuildUsesParentAsRootWhenRootNotProvided() {
+    var context = ExecutionHierarchyBuilder.Build(new ExecutionLogContext {
       ParentExecutionId = "parent-001",
       Depth = 2,
       SequenceIndex = 3
@@ -23,10 +20,8 @@ public sealed class ExecutionHierarchyContextTests
   }
 
   [Fact]
-  public void BuildPrefersExplicitRootExecutionIdWhenProvided()
-  {
-    var context = ExecutionHierarchyBuilder.Build(new ExecutionLogContext
-    {
+  public void BuildPrefersExplicitRootExecutionIdWhenProvided() {
+    var context = ExecutionHierarchyBuilder.Build(new ExecutionLogContext {
       RootExecutionId = "root-123",
       ParentExecutionId = "parent-002",
       Depth = -5
@@ -38,8 +33,7 @@ public sealed class ExecutionHierarchyContextTests
   }
 
   [Fact]
-  public void BuildGeneratesRootWhenNoContextProvided()
-  {
+  public void BuildGeneratesRootWhenNoContextProvided() {
     var context = ExecutionHierarchyBuilder.Build(null);
 
     context.RootExecutionId.Should().NotBeNullOrWhiteSpace();
@@ -48,10 +42,8 @@ public sealed class ExecutionHierarchyContextTests
   }
 
   [Fact]
-  public void NavigationBuilderCreatesDirectAndParentPathsForNestedCommand()
-  {
-    var context = ExecutionNavigationBuilder.Build("command", "cmd-001", new ExecutionLogContext
-    {
+  public void NavigationBuilderCreatesDirectAndParentPathsForNestedCommand() {
+    var context = ExecutionNavigationBuilder.Build("command", "cmd-001", new ExecutionLogContext {
       ParentObjectType = "sequence",
       ParentObjectId = "seq-001"
     });

--- a/tests/unit/ExecutionLogs/ExecutionLogEntryMappingTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionLogEntryMappingTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using Xunit;
+
+namespace GameBot.UnitTests.ExecutionLogs;
+
+public sealed class ExecutionLogEntryMappingTests {
+  [Fact]
+  public async Task AddAndGetRoundTripPreservesRequiredExecutionLogFields() {
+    var storageRoot = CreateTempStorageRoot();
+    using var repository = new FileExecutionLogRepository(storageRoot);
+
+    var now = DateTimeOffset.UtcNow;
+    var entry = new ExecutionLogEntry {
+      Id = "entry-mapping-001",
+      TimestampUtc = now,
+      ExecutionType = "command",
+      FinalStatus = "success",
+      ObjectRef = new ExecutionObjectReference("command", "cmd-001", "Command Snapshot", "v1"),
+      Navigation = new ExecutionNavigationContext("/authoring/commands/cmd-001", "/authoring/sequences/seq-001"),
+      Hierarchy = new ExecutionHierarchyContext("root-001", "parent-001", 1, 2),
+      Summary = "Command executed successfully",
+      Details = new[] {
+        new ExecutionDetailItem("tap", "Tap executed", new Dictionary<string, object?> { ["x"] = 15, ["y"] = 25 }, "normal")
+      },
+      StepOutcomes = new[] {
+        new ExecutionStepOutcome(1, "primitiveTap", "executed", null, null)
+      },
+      RetentionExpiresUtc = now.AddDays(30)
+    };
+
+    await repository.AddAsync(entry).ConfigureAwait(false);
+    var saved = await repository.GetAsync(entry.Id).ConfigureAwait(false);
+
+    saved.Should().NotBeNull();
+    saved!.Id.Should().Be(entry.Id);
+    saved.ExecutionType.Should().Be("command");
+    saved.FinalStatus.Should().Be("success");
+    saved.ObjectRef.ObjectType.Should().Be("command");
+    saved.ObjectRef.ObjectId.Should().Be("cmd-001");
+    saved.ObjectRef.DisplayNameSnapshot.Should().Be("Command Snapshot");
+    saved.Navigation.DirectPath.Should().Be("/authoring/commands/cmd-001");
+    saved.Hierarchy.RootExecutionId.Should().Be("root-001");
+    saved.StepOutcomes.Should().ContainSingle();
+    saved.Details.Should().ContainSingle();
+  }
+
+  [Fact]
+  public async Task QueryFiltersOnRequiredIdentityAndStatusFields() {
+    var storageRoot = CreateTempStorageRoot();
+    using var repository = new FileExecutionLogRepository(storageRoot);
+
+    await repository.AddAsync(new ExecutionLogEntry {
+      Id = "entry-filter-hit",
+      TimestampUtc = DateTimeOffset.UtcNow,
+      ExecutionType = "sequence",
+      FinalStatus = "failure",
+      ObjectRef = new ExecutionObjectReference("sequence", "seq-keep", "Keep Sequence"),
+      Navigation = new ExecutionNavigationContext("/authoring/sequences/seq-keep", null),
+      Hierarchy = new ExecutionHierarchyContext("entry-filter-hit", null, 0, null),
+      Summary = "Failed",
+      RetentionExpiresUtc = DateTimeOffset.UtcNow.AddDays(7)
+    }).ConfigureAwait(false);
+
+    await repository.AddAsync(new ExecutionLogEntry {
+      Id = "entry-filter-miss",
+      TimestampUtc = DateTimeOffset.UtcNow,
+      ExecutionType = "sequence",
+      FinalStatus = "success",
+      ObjectRef = new ExecutionObjectReference("sequence", "seq-skip", "Skip Sequence"),
+      Navigation = new ExecutionNavigationContext("/authoring/sequences/seq-skip", null),
+      Hierarchy = new ExecutionHierarchyContext("entry-filter-miss", null, 0, null),
+      Summary = "Succeeded",
+      RetentionExpiresUtc = DateTimeOffset.UtcNow.AddDays(7)
+    }).ConfigureAwait(false);
+
+    var page = await repository.QueryAsync(new ExecutionLogQuery {
+      ObjectType = "sequence",
+      ObjectId = "seq-keep",
+      FinalStatus = "failure",
+      PageSize = 10
+    }).ConfigureAwait(false);
+
+    page.Items.Should().ContainSingle();
+    page.Items[0].Id.Should().Be("entry-filter-hit");
+    page.Items[0].ObjectRef.DisplayNameSnapshot.Should().Be("Keep Sequence");
+  }
+
+  private static string CreateTempStorageRoot() {
+    var root = Path.Combine(Path.GetTempPath(), "GameBot.UnitTests", Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(root);
+    return root;
+  }
+}

--- a/tests/unit/ExecutionLogs/ExecutionLogSanitizerTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionLogSanitizerTests.cs
@@ -5,11 +5,9 @@ using Xunit;
 
 namespace GameBot.UnitTests.ExecutionLogs;
 
-public sealed class ExecutionLogSanitizerTests
-{
+public sealed class ExecutionLogSanitizerTests {
   [Fact]
-  public void SanitizeDetailsRedactsSensitiveKeys()
-  {
+  public void SanitizeDetailsRedactsSensitiveKeys() {
     var details = new[]
     {
       new ExecutionDetailItem(
@@ -35,8 +33,7 @@ public sealed class ExecutionLogSanitizerTests
   }
 
   [Fact]
-  public void SanitizeDetailsKeepsSensitivityWhenNoSensitiveKeys()
-  {
+  public void SanitizeDetailsKeepsSensitivityWhenNoSensitiveKeys() {
     var details = new[]
     {
       new ExecutionDetailItem(

--- a/tests/unit/ExecutionLogs/ExecutionLogSanitizerTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionLogSanitizerTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Xunit;
+
+namespace GameBot.UnitTests.ExecutionLogs;
+
+public sealed class ExecutionLogSanitizerTests
+{
+  [Fact]
+  public void SanitizeDetailsRedactsSensitiveKeys()
+  {
+    var details = new[]
+    {
+      new ExecutionDetailItem(
+        "step",
+        "detail",
+        new Dictionary<string, object?>
+        {
+          ["token"] = "abc",
+          ["apiKey"] = "xyz",
+          ["other"] = "value"
+        },
+        "normal")
+    };
+
+    var sanitized = ExecutionLogSanitizer.SanitizeDetails(details);
+
+    sanitized.Should().HaveCount(1);
+    sanitized[0].Attributes.Should().NotBeNull();
+    sanitized[0].Attributes!["token"].Should().Be("[REDACTED]");
+    sanitized[0].Attributes!["apiKey"].Should().Be("[REDACTED]");
+    sanitized[0].Attributes!["other"].Should().Be("value");
+    sanitized[0].Sensitivity.Should().Be("redacted");
+  }
+
+  [Fact]
+  public void SanitizeDetailsKeepsSensitivityWhenNoSensitiveKeys()
+  {
+    var details = new[]
+    {
+      new ExecutionDetailItem(
+        "step",
+        "detail",
+        new Dictionary<string, object?>
+        {
+          ["x"] = 10,
+          ["reason"] = "not_found"
+        },
+        "normal")
+    };
+
+    var sanitized = ExecutionLogSanitizer.SanitizeDetails(details);
+
+    sanitized[0].Attributes!["x"].Should().Be(10);
+    sanitized[0].Attributes!["reason"].Should().Be("not_found");
+    sanitized[0].Sensitivity.Should().Be("normal");
+  }
+}

--- a/tools/coverage/execution-log-coverage-20260227.json
+++ b/tools/coverage/execution-log-coverage-20260227.json
@@ -1,0 +1,27 @@
+{
+  "timestampUtc": "2026-02-28T08:30:00Z",
+  "feature": "028-execution-log",
+  "measurements": [
+    {
+      "file": "src/GameBot.Service/Services/CommandExecutor.cs",
+      "statementCoveragePercent": 85.71,
+      "source": "runTests coverage"
+    },
+    {
+      "file": "src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs",
+      "statementCoveragePercent": 85.32,
+      "source": "runTests coverage"
+    }
+  ],
+  "coberturaSample": {
+    "file": "tools/coverage/output/coverage.cobertura.xml",
+    "lineRatePercent": 87.8,
+    "branchRatePercent": 70.0,
+    "source": "dotnet test coverlet output"
+  },
+  "thresholds": {
+    "lineMinPercent": 80.0,
+    "branchMinPercent": 70.0
+  },
+  "assessment": "pass"
+}

--- a/tools/coverage/execution-log-perf-20260227.json
+++ b/tools/coverage/execution-log-perf-20260227.json
@@ -1,0 +1,10 @@
+﻿{
+    "timestampUtc":  "2026-02-28T08:26:28.2031467Z",
+    "endpointWrite":  "PUT /api/execution-logs/retention",
+    "endpointQuery":  "GET /api/execution-logs?pageSize=50",
+    "iterations":  25,
+    "writeP95Ms":  4.44,
+    "writeAvgMs":  10.68,
+    "queryP95Ms":  6.31,
+    "queryAvgMs":  4.51
+}


### PR DESCRIPTION
## Summary
- implement persisted execution-log backend for command and sequence executions
- add list/detail and retention endpoints under `/api/execution-logs`
- add hierarchy + navigation context, step outcome normalization, sanitization/redaction, conciseness bounds, and retention cleanup worker
- add comprehensive unit/integration/contract coverage for US1-US3 and update docs/evidence artifacts

## Validation
- `dotnet test -c Debug` (latest run: 318 passed, 0 failed)
- scoped format verification on touched files (`dotnet format ... whitespace --verify-no-changes`)

## Notes
- includes performance evidence artifact `tools/coverage/execution-log-perf-20260227.json`
- feature tasks checklist in `specs/028-execution-log/tasks.md` is fully checked off