### PR TITLE
feat(033): command loops - fixes and performance improvements

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -9,6 +9,10 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - File-backed JSON repositories under `data/commands/sequences` and image metadata under `data/images` (031-sequence-conditional-steps)
 - C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, GameBot.Domain sequence services/repositories, existing condition evaluator stack, React/Vite web-ui authoring modules (032-per-step-conditions)
 - File-backed JSON repositories under `data/commands/sequences` (no new datastore) (032-per-step-conditions)
+- [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION] + [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION] (033-command-loops)
+- [if applicable, e.g., PostgreSQL, CoreData, files or N/A] (033-command-loops)
+- C# 13 / .NET 9 (backend); TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, `System.Text.Json` (polymorphic serialization), existing `SequenceRunner` + `SequenceStepCondition` infrastructure, React 18 + Vite 5 (033-command-loops)
+- File-backed JSON sequence repository under `data/` (`FileSequenceRepository`); global config under `data/config/config.json` (033-command-loops)
 
 - Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence/command services, existing image detection pipeline, existing execution-log services/repositories, React 18 + Vite 5 UI stack (030-sequence-conditional-logic)
 
@@ -29,9 +33,9 @@ npm test; npm run lint
 Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18: Follow standard conventions
 
 ## Recent Changes
+- 033-command-loops: Added C# 13 / .NET 9 (backend); TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, `System.Text.Json` (polymorphic serialization), existing `SequenceRunner` + `SequenceStepCondition` infrastructure, React 18 + Vite 5
+- 033-command-loops: Added [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION] + [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
 - 032-per-step-conditions: Added C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, GameBot.Domain sequence services/repositories, existing condition evaluator stack, React/Vite web-ui authoring modules
-- 031-sequence-conditional-steps: Added C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, existing GameBot.Domain sequence/command services, existing image detection pipeline, existing execution-log services, existing action execution infrastructure
-- 031-sequence-conditional-steps: Added C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (web UI) + ASP.NET Core Minimal API, existing GameBot.Domain sequence/command services, existing image detection pipeline, existing execution-log services, existing JSON repositories
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Command Loop Steps (033-command-loops)
+  - Count-based loops (`count`): execute body steps exactly N times.
+  - While loops (`while`): re-evaluate condition before each iteration; skip body if false on entry.
+  - Repeat-until loops (`repeatUntil`): execute body, then check exit condition; always runs at least once.
+  - Break step (`Break`): unconditional or conditional early exit from a loop body.
+  - `{{iteration}}` placeholder substitution in `CommandId` and action parameters inside loop bodies.
+  - Configurable safety limit (`maxIterations`) per loop step and global `GAMEBOT_LOOP_MAX_ITERATIONS` (default 1000).
+  - Per-iteration execution log entries (`LoopIterationOutcome`) with break detection.
+  - Validation rules: no nested loops, no top-level breaks, no `{{iteration}}` outside loops, commandOutcome back-ref only.
+  - Extended `/api/sequences/{id}/validate` endpoint with step-level loop validation.
+  - UI visualization: `LoopBlockHeader`, `BreakStepRow`, `LoopBlock` components with "Add Loop" (count/while/repeatUntil) affordance in SequencesPage.
+
+### Tests
+- 15 loop validation unit tests, 15 runner loop tests, 9 template substitutor tests, 6 contract round-trip tests, 14 UI component tests.
+
 ## [2026-03-02]
 
 ### Added

--- a/specs/033-command-loops/checklists/requirements.md
+++ b/specs/033-command-loops/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Command Loop Structures
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-03-31  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Assumption: Loop nesting (loop within loop body) is out of scope for v1 — documented in Assumptions section.
+- Assumption: Iteration index is 1-based — documented in Assumptions; can be overridden by clarification before planning.
+- Assumption: Condition types inside loops reuse per-step condition infrastructure from feature 032.
+- All checklist items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/033-command-loops/contracts/sequence-loop-steps.md
+++ b/specs/033-command-loops/contracts/sequence-loop-steps.md
@@ -1,0 +1,228 @@
+# API Contracts: Command Loop Structures
+
+**Feature**: 033-command-loops  
+**Date**: 2026-03-31  
+**Base URL**: `http://localhost:5081`
+
+No new endpoints are introduced. Existing sequence endpoints accept and return the extended `SequenceStep` schema that includes `Loop` and `Break` step types.
+
+---
+
+## Extended `SequenceStep` Schema
+
+The `stepType` discriminator gains two new values: `"loop"` and `"break"`.
+
+```json
+// Schema union — one of the following shapes per step:
+{
+  "stepId": "string (required)",
+  "label": "string (optional)",
+  "order": "integer (required)",
+  "stepType": "\"action\" | \"command\" | \"conditional\" | \"loop\" | \"break\""
+}
+```
+
+---
+
+### Loop Step (`stepType: "loop"`)
+
+```json
+{
+  "stepId": "tap-upgrade-loop",
+  "label": "Tap upgrade 10 times",
+  "order": 1,
+  "stepType": "loop",
+  "loop": {
+    "loopType": "count",
+    "count": 10,
+    "maxIterations": null
+  },
+  "body": [
+    {
+      "stepId": "tap-upgrade",
+      "label": "Tap upgrade button",
+      "order": 1,
+      "stepType": "action",
+      "action": {
+        "type": "primitiveTap",
+        "parameters": { "x": 540, "y": 960 }
+      }
+    }
+  ]
+}
+```
+
+**Count loop** — `loop.loopType` = `"count"`:
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `loopType` | `"count"` | yes | discriminator |
+| `count` | integer ≥ 0 | yes | 0 = skip body |
+| `maxIterations` | integer > 0 \| null | no | overrides global default (1000) |
+
+---
+
+**While loop** — `loop.loopType` = `"while"`:
+
+```json
+{
+  "stepId": "wait-for-map",
+  "order": 2,
+  "stepType": "loop",
+  "loop": {
+    "loopType": "while",
+    "condition": {
+      "type": "imageVisible",
+      "imageId": "loading-screen",
+      "minSimilarity": 0.85
+    },
+    "maxIterations": 50
+  },
+  "body": [
+    {
+      "stepId": "wait-step",
+      "order": 1,
+      "stepType": "action",
+      "action": { "type": "delay", "parameters": { "ms": 500 } }
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `loopType` | `"while"` | yes | discriminator |
+| `condition` | `SequenceStepCondition` | yes | `imageVisible` or `commandOutcome` |
+| `maxIterations` | integer > 0 \| null | no | default 1000 |
+
+---
+
+**RepeatUntil loop** — `loop.loopType` = `"repeatUntil"`:
+
+```json
+{
+  "stepId": "tap-until-success",
+  "order": 3,
+  "stepType": "loop",
+  "loop": {
+    "loopType": "repeatUntil",
+    "condition": {
+      "type": "imageVisible",
+      "imageId": "success-banner"
+    }
+  },
+  "body": [
+    {
+      "stepId": "tap-confirm",
+      "order": 1,
+      "stepType": "action",
+      "action": { "type": "primitiveTap", "parameters": { "x": 300, "y": 600 } }
+    }
+  ]
+}
+```
+
+---
+
+### Break Step (`stepType: "break"`)
+
+```json
+// Conditional break:
+{
+  "stepId": "break-on-error",
+  "order": 2,
+  "stepType": "break",
+  "breakCondition": {
+    "type": "imageVisible",
+    "imageId": "error-screen"
+  }
+}
+
+// Unconditional break:
+{
+  "stepId": "unconditional-break",
+  "order": 3,
+  "stepType": "break",
+  "breakCondition": null
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `breakCondition` | `SequenceStepCondition \| null` | no | null = unconditional break |
+
+---
+
+### `{{iteration}}` placeholder in action parameters
+
+Inside a loop body, string-typed action parameter values may include `{{iteration}}`:
+
+```json
+{
+  "stepId": "log-iteration",
+  "order": 1,
+  "stepType": "action",
+  "action": {
+    "type": "delay",
+    "parameters": { "label": "iteration {{iteration}} of loop" }
+  }
+}
+```
+
+At execution time `{{iteration}}` is replaced with the current 1-based iteration number.  
+`{{iteration}}` in step parameters outside a loop body is rejected at save/validate time.
+
+---
+
+## Existing Endpoints — Behaviour Changes
+
+### `POST /api/sequences/{sequenceId}/validate`
+Extended to validate:
+- Loop step body does not contain loop steps (no nesting).
+- Break steps only inside loop bodies.
+- `{{iteration}}` placeholders only inside loop body step parameters.
+- `CountLoopConfig.Count` ≥ 0.
+- `LoopConfig.MaxIterations` > 0 when provided.
+- `commandOutcome` condition `stepRef` in loop context does not forward-reference within the same body.
+
+### `PUT /api/sequences/{sequenceId}` / `PATCH /api/sequences/{sequenceId}`
+Accept the extended `SequenceStep` schema. Run the same validation as validate endpoint on save.
+
+---
+
+## Execution Log — Loop Step Outcome Shape
+
+When a loop step executes, its `ExecutionStepOutcome` carries `loopIterations`:
+
+```json
+{
+  "stepOrder": 1,
+  "stepType": "loop",
+  "outcome": "executed",
+  "stepId": "tap-upgrade-loop",
+  "loopIterations": [
+    {
+      "iterationIndex": 1,
+      "breakTriggered": false,
+      "stepOutcomes": [
+        { "stepOrder": 1, "stepType": "action", "outcome": "executed" }
+      ]
+    },
+    {
+      "iterationIndex": 2,
+      "breakTriggered": true,
+      "stepOutcomes": [
+        { "stepOrder": 1, "stepType": "action", "outcome": "executed" },
+        { "stepOrder": 2, "stepType": "break", "outcome": "break" }
+      ]
+    }
+  ]
+}
+```
+
+**Loop step `outcome` values**:
+| Value | Meaning |
+|---|---|
+| `"executed"` | Loop completed normally (count exhausted or while/repeatUntil condition met) |
+| `"break"` | Loop exited via a break step |
+| `"failed"` | Safety limit reached, condition eval error, or inner step failed |
+| `"skipped"` | Count = 0 or while condition false on entry |

--- a/specs/033-command-loops/data-model.md
+++ b/specs/033-command-loops/data-model.md
@@ -1,0 +1,229 @@
+# Data Model: Command Loop Structures
+
+**Feature**: 033-command-loops  
+**Date**: 2026-03-31  
+**Source**: research.md R-001 through R-007
+
+---
+
+## Domain Model Changes
+
+### 1. `SequenceStepType` — extended enum
+
+```csharp
+// File: src/GameBot.Domain/Commands/SequenceStep.cs
+public enum SequenceStepType
+{
+    Command,
+    Action,
+    Conditional,
+    Loop,   // NEW
+    Break,  // NEW
+}
+```
+
+---
+
+### 2. `SequenceStep` — new properties
+
+```csharp
+// File: src/GameBot.Domain/Commands/SequenceStep.cs (additions)
+public class SequenceStep
+{
+    // ... existing fields unchanged ...
+
+    /// Populated when StepType == Loop. Null otherwise.
+    public LoopConfig? Loop { get; set; }
+
+    /// Populated when StepType == Loop. Inner steps of the loop body.
+    public Collection<SequenceStep> Body { get; init; } = new();
+
+    /// Populated when StepType == Break. Null = unconditional break.
+    public SequenceStepCondition? BreakCondition { get; set; }
+}
+```
+
+---
+
+### 3. `LoopConfig` — polymorphic hierarchy
+
+```csharp
+// File: src/GameBot.Domain/Commands/LoopConfig.cs (NEW)
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "loopType")]
+[JsonDerivedType(typeof(CountLoopConfig),       typeDiscriminator: "count")]
+[JsonDerivedType(typeof(WhileLoopConfig),        typeDiscriminator: "while")]
+[JsonDerivedType(typeof(RepeatUntilLoopConfig),  typeDiscriminator: "repeatUntil")]
+public abstract class LoopConfig
+{
+    /// Per-loop override for safety iteration limit.
+    /// When null, the global config value (default 1000) is used.
+    public int? MaxIterations { get; set; }
+}
+
+public sealed class CountLoopConfig : LoopConfig
+{
+    /// Number of iterations. Must be >= 0. Body is skipped when Count == 0.
+    public int Count { get; set; }
+}
+
+public sealed class WhileLoopConfig : LoopConfig
+{
+    /// Condition evaluated before each iteration.
+    /// Only imageVisible and commandOutcome are valid.
+    public required SequenceStepCondition Condition { get; set; }
+}
+
+public sealed class RepeatUntilLoopConfig : LoopConfig
+{
+    /// Exit condition evaluated after each iteration.
+    /// Only imageVisible and commandOutcome are valid.
+    public required SequenceStepCondition Condition { get; set; }
+}
+```
+
+---
+
+### 4. `TemplateSubstitutor` — new utility
+
+```csharp
+// File: src/GameBot.Domain/Utils/TemplateSubstitutor.cs (NEW)
+
+/// Replaces {{key}} placeholders in string values using a provided context dictionary.
+/// Non-string JSON values are returned unchanged.
+public static class TemplateSubstitutor
+{
+    private static readonly Regex Pattern =
+        new(@"\{\{(\w+)\}\}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+
+    public static string Substitute(string template,
+        IReadOnlyDictionary<string, string> context)
+    {
+        return Pattern.Replace(template, m =>
+            context.TryGetValue(m.Groups[1].Value, out var v) ? v : m.Value);
+    }
+
+    /// Walk all string-typed parameter values in a SequenceActionPayload
+    /// and substitute context variables.
+    public static SequenceActionPayload SubstitutePayload(
+        SequenceActionPayload payload,
+        IReadOnlyDictionary<string, string> context)
+    {
+        // Deep-clone parameters and substitute string values in-place
+        // Implementation delegates to Substitute() per string-typed entry.
+    }
+}
+```
+
+**Context dictionary for loops**: `{ "iteration": "1" }` (1-based, string representation). Injected by the loop runner at each iteration.
+
+---
+
+### 5. Execution Log — new types
+
+```csharp
+// File: src/GameBot.Domain/Logging/ExecutionLogModels.cs (additions)
+
+/// Per-iteration outcome for a loop step.
+public sealed record LoopIterationOutcome(
+    int IterationIndex,
+    bool BreakTriggered,
+    IReadOnlyList<ExecutionStepOutcome> StepOutcomes
+);
+
+// Extension to ExecutionStepOutcome:
+public sealed record ExecutionStepOutcome(
+    int StepOrder,
+    string StepType,
+    string Outcome,
+    string? ReasonCode,
+    string? ReasonText,
+    string? SequenceId,
+    string? StepId,
+    string? SequenceLabel,
+    string? StepLabel,
+    ConditionEvaluationTrace? ConditionTrace,
+    IReadOnlyList<LoopIterationOutcome>? LoopIterations   // NEW — null for non-loop steps
+);
+```
+
+---
+
+### 6. Config — new global setting
+
+```json
+// data/config/config.json addition:
+{
+  "loopMaxIterations": 1000
+}
+```
+
+Accessed via existing `IConfigRepository` / `AppConfig` model. Added as:
+
+```csharp
+// File: src/GameBot.Domain/Config/AppConfig.cs (addition)
+public int LoopMaxIterations { get; set; } = 1000;
+```
+
+---
+
+## Validation Rules
+
+| Rule | When | Error |
+|------|------|-------|
+| `CountLoopConfig.Count` must be ≥ 0 | Save / validate | `loop.count must be a non-negative integer` |
+| `LoopConfig.MaxIterations`, if set, must be > 0 | Save / validate | `loop.maxIterations must be a positive integer` |
+| Loop body MUST NOT contain `StepType == Loop` steps | Save / validate | `nested loops are not supported in v1` |
+| `SequenceStepType.Break` MUST only appear inside a loop body | Save / validate | `break step is not valid outside a loop body` |
+| `{{iteration}}` placeholder MUST only appear inside a loop body's step parameters | Save / validate | `{{iteration}} placeholder is only valid inside a loop body` |
+| `LoopConfig.Condition` (while/repeatUntil) evaluation error at runtime | Runtime | Loop step outcome = `failed`; command stops |
+| `commandOutcome` condition in a loop MUST reference a step that precedes the loop or a step earlier in the current loop body only (no forward refs) | Save / validate | `commandOutcome stepRef references a step that has not yet executed` |
+
+---
+
+## Entity Relationships
+
+```
+Sequence
+  └── SequenceStep (StepType: Action | Command | Conditional | Loop | Break)
+        └── [StepType == Loop]
+              ├── LoopConfig  (loopType: count | while | repeatUntil)
+              │     └── [while / repeatUntil] WhileLoopConfig / RepeatUntilLoopConfig
+              │           └── Condition: SequenceStepCondition  (imageVisible | commandOutcome)
+              └── Body: Collection<SequenceStep>  (same types EXCEPT Loop)
+                    └── [StepType == Break]
+                          └── BreakCondition: SequenceStepCondition?  (null = unconditional)
+```
+
+---
+
+## State Transitions (Runtime)
+
+### Count Loop
+```
+Enter → i = 1
+  Check i <= Count → No → Exit loop (success)
+  Execute body → Break signal? → Yes → Exit loop (success, break)
+  i++ → repeat
+  i > MaxIterations → Exit loop (failure, limit)
+```
+
+### While Loop
+```
+Enter
+  Evaluate condition → Error → Exit loop (failure, conditionError)
+  Evaluate condition → False → Exit loop (success)
+  i++; Execute body → Break signal? → Yes → Exit loop (success, break)
+  i > MaxIterations → Exit loop (failure, limit)
+  repeat
+```
+
+### Repeat-Until Loop
+```
+Enter → i = 1
+  Execute body → Break signal? → Yes → Exit loop (success, break)
+  i > MaxIterations → Exit loop (failure, limit)
+  Evaluate condition → Error → Exit loop (failure, conditionError)
+  Evaluate condition → True → Exit loop (success)
+  i++ → repeat
+```

--- a/specs/033-command-loops/plan.md
+++ b/specs/033-command-loops/plan.md
@@ -1,0 +1,98 @@
+﻿# Implementation Plan: Command Loop Structures
+
+**Branch**: `033-command-loops` | **Date**: 2026-03-31 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/033-command-loops/spec.md`
+
+## Summary
+
+Add three loop step types (`count`, `while`, `repeatUntil`) and a `break` step type to the `SequenceStep` domain model. Loops carry a body of ordered inner steps (all step types valid except loop-within-loop). The `SequenceRunner` is extended to execute loop bodies with iteration tracking, a `{{iteration}}` template placeholder substituted at execution time, and a configurable safety limit (default 1000, hard failure on breach). Per-iteration outcomes are recorded in the execution log. The authoring UI (`SequencesPage.tsx`) renders loop blocks as visually contained cards with a header badge and indented inner step list.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9 (backend); TypeScript ES2020 / React 18 (frontend)
+**Primary Dependencies**: ASP.NET Core Minimal API, `System.Text.Json` (polymorphic serialization), existing `SequenceRunner` + `SequenceStepCondition` infrastructure, React 18 + Vite 5
+**Storage**: File-backed JSON sequence repository under `data/` (`FileSequenceRepository`); global config under `data/config/config.json`
+**Testing**: xUnit + coverlet (backend unit/integration); React Testing Library + Playwright (frontend)
+**Target Platform**: Windows desktop (Windows-only ADB/System.Drawing; backend service + React SPA)
+**Project Type**: Web service + SPA authoring UI
+**Performance Goals**: Loop execution overhead must not exceed 5 ms per iteration for the runner dispatch logic (excluding inner action I/O). Single sequence run with 10 loop iterations of 3 steps each must complete within existing sequence timing benchmarks.
+**Constraints**: No new external NuGet/npm packages; loop nesting rejected (validation enforced); `{{iteration}}` substitution scoped to loop bodies only
+**Scale/Scope**: Single-user desktop tool; sequences up to ~100 steps; loops up to 1000 iterations max (safety limit)
+
+## Constitution Check
+
+*GATE: Must pass before implementation begins. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing, implementation is blocked until fixed or explicitly waived.
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Code Quality: lint/format/static analysis clean | Required | All new C# must use CamelCase methods; no underscores in method names |
+| Tests: unit coverage >= 80% line / >= 70% branch for touched areas | Required | `SequenceRunner` loop paths, `TemplateSubstitutor`, validation rules |
+| No new high/critical static analysis issues | Required | |
+| UI interfaces documented | Required | `LoopBlock` component props documented |
+| Performance: loop overhead <= 5 ms/iteration (dispatch only) | Required | Micro-benchmark note in PR |
+| Build green before merging | Required | `dotnet build -c Debug` and `npm run build` must pass |
+| Tests green before merging | Required | `dotnet test -c Debug` must pass; frontend component tests pass |
+| No loop nesting allowed (enforced by validation) | Required | FR-012 |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/033-command-loops/
+├── plan.md                          # This file
+├── research.md                      # Phase 0 — design decisions (R-001 through R-008)
+├── data-model.md                    # Phase 1 — domain model + validation rules
+├── contracts/
+│   └── sequence-loop-steps.md      # Phase 1 — API contracts and JSON shapes
+└── tasks.md                         # Phase 2 — /speckit.tasks output (not yet created)
+```
+
+### Source Code
+
+```
+src/
+  GameBot.Domain/
+    Commands/
+      SequenceStep.cs               EXTEND: add Loop, Break step types + Body + BreakCondition
+      LoopConfig.cs                 NEW: CountLoopConfig / WhileLoopConfig / RepeatUntilLoopConfig
+    Utils/
+      TemplateSubstitutor.cs        NEW: {{iteration}} placeholder substitution utility
+    Services/
+      SequenceRunner.cs             EXTEND: loop execution + break signal + context vars injection
+    Config/
+      AppConfig.cs                  EXTEND: LoopMaxIterations property (default 1000)
+    Logging/
+      ExecutionLogModels.cs         EXTEND: LoopIterationOutcome + loopIterations on ExecutionStepOutcome
+    Validation/
+      SequenceValidator.cs          EXTEND: loop-specific validation rules (FR-004, FR-012, FR-021, FR-002a)
+
+  GameBot.Service/
+    Endpoints/
+      SequencesEndpoints.cs         EXTEND: POST validate invokes extended validator
+
+  web-ui/src/
+    components/sequences/
+      LoopBlock.tsx                 NEW: loop block container (colored border + background)
+      LoopBlockHeader.tsx           NEW: loop type badge + count/condition summary
+      BreakStepRow.tsx              NEW: break step row rendering
+    pages/
+      SequencesPage.tsx             EXTEND: dispatch loop/break step types to new components
+
+tests/
+  GameBot.Domain.Tests/
+    SequenceRunnerLoopTests.cs      NEW: count/while/repeatUntil/break/safety-limit/conditionError paths
+    TemplateSubstitutorTests.cs     NEW: {{iteration}} substitution + edge cases
+    LoopValidationTests.cs          NEW: all validation rules (FR-004, FR-012, FR-021, FR-002a, FR-008)
+  contract/
+    SequenceLoopContractTests.cs    NEW: JSON serialization round-trip for loop/break steps
+  web-ui/src/
+    components/sequences/
+      LoopBlock.test.tsx            NEW: render tests for count/while/repeatUntil + break step
+```
+
+## Complexity Tracking
+
+No constitution violations. All additions are incremental extensions to existing patterns (`SequenceStepType`, `SequenceStepCondition`, `SequenceRunner`, `SequencesPage.tsx`). No new projects or repositories introduced.

--- a/specs/033-command-loops/research.md
+++ b/specs/033-command-loops/research.md
@@ -1,0 +1,123 @@
+# Research: Command Loop Structures
+
+**Feature**: 033-command-loops  
+**Date**: 2026-03-31
+
+---
+
+## R-001: Where Loops Belong — Command vs. Sequence
+
+**Question**: Should loop steps be added to `CommandStep` (inside `Command`) or `SequenceStep` (inside `Sequence`)?
+
+**Decision**: Loops extend `SequenceStep` / `Sequence` only. `Command` remains the atomic unit (simple ordered action dispatch); `Sequence` is the composable, condition-aware orchestration layer.
+
+**Rationale**:
+- `SequenceStep` already carries conditions, retry, delay, gate, and the per-step condition polymorphism (feature 032). Adding loop control here is a natural continuation.
+- `CommandExecutor` is intentionally simple (send inputs, tap, recurse into sub-commands). Introducing loop state management there would inflate its responsibilities.
+- All current user-facing compositional features (conditional steps, per-step conditions) live in sequences. End-users already understand sequences as the authoring unit.
+
+**Alternatives considered**:
+- Add loops to `CommandStep` too — rejected; `Command` is not the composable authoring surface.
+- Introduce a new entity type (`LoopCommand`) — rejected; unnecessary complexity; nesting via `SequenceStep.Body` is sufficient.
+
+---
+
+## R-002: Loop Representation — Flat Enum vs. Polymorphic Sub-Type
+
+**Question**: Should each loop type be its own `SequenceStepType` value, or should `SequenceStepType.Loop` be a single discriminant with a polymorphic `LoopConfig`?
+
+**Decision**: Single `SequenceStepType.Loop` with a JSON-polymorphic `LoopConfig` property carrying a `loopType` discriminator (`count` | `while` | `repeatUntil`).
+
+**Rationale**:
+- Mirrors the existing pattern: `SequenceStepCondition` is already `[JsonPolymorphic]` on `type`. Reusing the same pattern keeps the domain model consistent.
+- Three loop types sharing a single enum slot prevents enum proliferation.
+- All loop shapes share `Body: Collection<SequenceStep>`. Keeping them under one discriminant makes the runner dispatch clean: `if (step.StepType == Loop) ExecuteLoop(step.Loop, step.Body)`.
+
+**Alternatives considered**:
+- Separate enum values `LoopCount`, `LoopWhile`, `LoopRepeatUntil` — rejected; requires three dispatch branches and duplicates `Body` handling.
+
+---
+
+## R-003: Break Step Representation
+
+**Question**: How should a break step be represented — as a `SequenceStepType.Break` with an optional condition, or inline in the loop config?
+
+**Decision**: `SequenceStepType.Break` with an optional `BreakCondition: SequenceStepCondition?` property. Unconditional break when `BreakCondition` is null.
+
+**Rationale**:
+- Break is a step that sits in the loop body alongside action/conditional/loop-header steps — it belongs at the step level.
+- Reusing `SequenceStepCondition` (already polymorphic with `imageVisible`/`commandOutcome`) avoids a parallel condition hierarchy.
+- The runner evaluates break steps in the same loop-body pass — it sees `StepType == Break`, evaluates condition (or skips evaluation for unconditional), and signals a break.
+
+---
+
+## R-004: `{{iteration}}` Template Substitution Mechanism
+
+**Question**: No variable substitution exists in the codebase today. What is the minimal, correct design?
+
+**Decision**: Introduce a static `TemplateSubstitutor` utility in `GameBot.Domain` that replaces `{{key}}` placeholders in string parameter values using a Regex. Applied only to `SequenceActionPayload` parameter values at execution time inside a loop body. The `iteration` dictionary key carries the current 1-based index.
+
+**Rationale**:
+- `SequenceActionPayload.Parameters` is typed as `Dictionary<string, JsonElement>` or similar. The substitutor operates on string-typed values only; non-string (numeric, bool) values are left untouched.
+- Regex pattern `\{\{(\w+)\}\}` is simple, well-understood, and consistent with many templating tools.
+- Scoped only to loop body execution — the runner wraps `ExecuteBodyStep` calls with a `contextVars` dict injected by the loop.
+- Save-time validation: scan all step parameter values in a loop body for `{{...}}` patterns and reject if found outside a loop body.
+
+**Alternatives considered**:
+- Full expression evaluator — rejected; overkill for v1 (no arithmetic, only index substitution needed).
+- Dedicated `IterationIndexStep` parameter type — rejected; too narrow; the template approach generalises to future variables without schema changes.
+
+---
+
+## R-005: Loop Execution Safety — Where the Limit Lives
+
+**Question**: Should the safety iteration limit (1000) be a per-loop field, a global config, or both?
+
+**Decision**: Global config (already-existing `data/config` JSON store), overridable per-loop via an optional `MaxIterations` field on `LoopConfig`. Global default = 1000. Per-loop override replaces the global value entirely for that loop.
+
+**Rationale**:
+- The global config store already exists (`IConfigRepository`). Adding a `LoopMaxIterations` key requires no new infrastructure.
+- Per-loop override handles legitimate use cases where an author knows a specific loop needs more (or fewer) iterations.
+- If both are set, per-loop wins — predictable and explicit.
+
+---
+
+## R-006: Execution Log Shape for Loops
+
+**Question**: How do per-iteration outcomes fit into `ExecutionStepOutcome`? Do we need a new type?
+
+**Decision**: Extend `ExecutionStepOutcome` with an optional `LoopIterations: IReadOnlyList<LoopIterationOutcome>?` property. A new `LoopIterationOutcome` record carries `IterationIndex`, `BreakTriggered`, and `StepOutcomes: IReadOnlyList<ExecutionStepOutcome>` (recursive — the inner step results).
+
+**Rationale**:
+- The existing `ExecutionStepOutcome` is already used as the universal per-step output. Adding a nullable list preserves backward compatibility (non-loop steps leave it null).
+- Recursive nesting (`StepOutcomes` within `LoopIterationOutcome`) matches the actual execution structure and enables complete audit trail.
+- No new top-level log entity needed — the loop step occupies one `ExecutionStepOutcome` entry with its type-specific payload nested inside.
+
+---
+
+## R-007: API Surface Changes
+
+**Question**: Do loops require new API endpoints?
+
+**Decision**: No new endpoints. Loops are embedded in `SequenceStep.Body`. Existing sequence CRUD endpoints (`POST /api/sequences`, `PUT /api/sequences/{id}`, `PATCH /api/sequences/{id}`) accept the extended step schema. The existing `POST /api/sequences/{id}/validate` endpoint needs its validation logic extended to cover loop-specific rules.
+
+**Rationale**:
+- Sequences already carry `SequenceStep[]` in their payload. Loop steps are just additional step variants.
+- Execution is triggered via the existing `POST /api/sequences/{id}/execute` endpoint.
+
+---
+
+## R-008: UI Rendering Strategy for Loop Blocks
+
+**Question**: How should loop blocks be visually distinguished in the React step list?
+
+**Decision**: Render each loop step as a visually contained card — a `LoopBlock` component with a colored left border and light background fill, a `LoopBlockHeader` showing the loop type badge and parameter summary, and an indented inner `StepList` for the body steps. Add/remove/reorder inside the body uses the same `ReorderableList` component already used for top-level steps.
+
+**Rationale**:
+- `SequencesPage.tsx` and `CommandForm.tsx` already render steps via `ReorderableList`. Wrapping loop body steps in a nested `ReorderableList` reuses the same interaction model.
+- CSS-based containment (border + background) is the lightest approach — no third-party library needed.
+- The `LoopBlockHeader` displaying `loopType` badge + count/condition summary satisfies FR-018 and FR-020.
+
+**Alternatives considered**:
+- Full accordion/collapsible loop body — deferred; adds interaction complexity not required by spec.
+- Drag-and-drop between loop bodies and the outer list — deferred to future iteration.

--- a/specs/033-command-loops/spec.md
+++ b/specs/033-command-loops/spec.md
@@ -1,0 +1,176 @@
+# Feature Specification: Command Loop Structures
+
+**Feature Branch**: `033-command-loops`  
+**Created**: 2026-03-31  
+**Status**: Draft  
+**Input**: User description: "I need the loop structures within commands. It should be standard iterate X times, whereas X should be somehow made available within the loop body and while(condition) do something as well as repeat until (condition). It should be possible to break out of the loops on a certain step (likely with condition). The loops should be visualized in the UI in a clear way, e.g. indented from the rest of the step or put in a rectangle with background color. Inside the loops there must be the same steps as in all other commands."
+
+## Clarifications
+
+### Session 2026-03-31
+
+- Q: Should loop steps be valid inside loop bodies (loop nesting)? → A: No. Loop nesting is out of scope for v1; loop step types are not permitted inside loop bodies.
+- Q: What happens when a loop condition evaluation errors at runtime? → A: Condition eval error fails the loop step immediately and stops the command.
+- Q: How is the iteration index consumed in step parameters? → A: Via string template placeholder (e.g. `{{iteration}}`) substituted into step parameter values at execution time.
+- Q: Should `commandOutcome` be valid as a loop condition (while/repeat-until/break)? → A: Yes, `commandOutcome` is valid as a loop condition using the same scoping rules as feature 032.
+- Q: What is the default safety iteration limit and is breaching it a hard failure or warning? → A: Hard failure (command stops, marked failed); default limit = 1000 iterations.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Author a Count-Based Loop (Priority: P1)
+
+As an automation author, I can add a "repeat N times" loop block to a command so that its inner steps execute exactly N times, and I can reference the current iteration index within the loop body.
+
+**Why this priority**: The count-based loop is the most common automation pattern (e.g. "tap the upgrade button 10 times"). It is self-contained and requires no external condition evaluation, making it the simplest loop to implement and verify independently.
+
+**Independent Test**: Can be fully tested by creating a command containing a single count-based loop with N=3 containing one tap action, executing it, and verifying the tap was performed exactly 3 times with correct iteration index values logged per iteration.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command with a count-based loop configured for 5 iterations containing one step, **When** the command is executed, **Then** the inner step runs exactly 5 times.
+2. **Given** a count-based loop with N=3, **When** the loop body references the iteration index variable, **Then** the index takes values 1, 2, 3 (or 0, 1, 2 — see Assumptions) across successive iterations.
+3. **Given** a count-based loop with N=3 and a step parameter containing `{{iteration}}`, **When** the command executes, **Then** the placeholder is substituted with the current iteration index value (1, 2, 3) for each inner step execution.
+3. **Given** a count-based loop with N=0, **When** the command is executed, **Then** the loop body is skipped and execution continues after the loop.
+4. **Given** a command with a count-based loop saved and reloaded, **When** the author opens the command editor, **Then** the loop block and its inner steps are displayed intact.
+
+---
+
+### User Story 2 - Author a While-Condition Loop (Priority: P2)
+
+As an automation author, I can add a "while (condition) do" loop block so that its inner steps repeat as long as the condition remains true, evaluated before each iteration.
+
+**Why this priority**: While loops are essential for waiting and polling scenarios (e.g. "while loading screen is visible, wait and retry"). Depends on P1 loop infrastructure already in place.
+
+**Independent Test**: Can be tested by creating a command with a while loop conditioned on an image being visible, running it with image initially visible then absent after two iterations, and confirming the loop ran exactly twice.
+
+**Acceptance Scenarios**:
+
+1. **Given** a while loop where the condition is true initially, **When** the command executes, **Then** the loop body runs at least once.
+2. **Given** a while loop where the condition becomes false after two iterations, **When** the command executes, **Then** the loop body runs exactly twice and execution continues after the loop.
+3. **Given** a while loop where the condition is false on entry, **When** the command executes, **Then** the loop body is skipped entirely and execution continues after the loop.
+4. **Given** a while loop with no maximum iteration guard, **When** the condition never becomes false, **Then** the loop runs indefinitely until the command is cancelled or a configured safety limit is reached.
+5. **Given** a while loop whose condition evaluation errors (e.g. referenced image missing), **When** the error occurs on any iteration, **Then** the loop step fails and the command stops immediately.
+
+---
+
+### User Story 3 - Author a Repeat-Until Loop (Priority: P2)
+
+As an automation author, I can add a "repeat … until (condition)" loop block so that its inner steps execute at least once and repeat until the condition becomes true, evaluated after each iteration.
+
+**Why this priority**: Repeat-until covers "do action, then check result" patterns (e.g. "tap, then wait until success screen appears"). At the same parity as while loops.
+
+**Independent Test**: Can be tested by creating a command with a repeat-until loop that runs its body once when the exit condition is immediately true, confirming exactly one execution of the inner steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repeat-until loop where the condition is true after the first iteration, **When** the command executes, **Then** the loop body runs exactly once.
+2. **Given** a repeat-until loop where the condition becomes true after three iterations, **When** the command executes, **Then** the loop body runs exactly three times.
+3. **Given** a repeat-until loop whose condition never becomes true, **When** the command executes and a safety iteration limit is reached, **Then** the loop terminates with a failure outcome and the command is marked failed.
+
+---
+
+### User Story 4 - Break Out of a Loop Conditionally (Priority: P2)
+
+As an automation author, I can place a break step inside a loop body so that execution exits the loop immediately when a specified condition is met.
+
+**Why this priority**: Break prevents unintended infinite looping and models early-exit patterns (e.g. "stop repeating if error screen appears"). Required for safe while/repeat loops.
+
+**Independent Test**: Can be tested by adding a break step (conditioned on image X visible) inside a count-based loop with N=10; confirming the loop exits after the iteration where image X first becomes visible, with fewer than 10 total iterations logged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a count-based loop N=5 containing a break step conditioned on image visible, **When** image becomes visible on iteration 3, **Then** the loop exits after iteration 3 and the command continues after the loop.
+2. **Given** a break step whose condition is never met, **When** the loop completes all iterations normally, **Then** the break step is evaluated but never triggers, and the loop runs to completion.
+3. **Given** a break step with no condition (unconditional break), **When** the step is reached, **Then** the loop exits immediately on that iteration.
+
+---
+
+### User Story 5 - Visualize Loop Structures in the Authoring UI (Priority: P1)
+
+As an automation author, I can see loop blocks visually distinguished in the command editor — indented, boxed, or background-colored — so that I can clearly understand nesting and structure at a glance.
+
+**Why this priority**: Without clear visual grouping, loop bodies are indistinguishable from surrounding steps, making authoring error-prone. This is a prerequisite for confident editing of any loop type.
+
+**Independent Test**: Can be tested by opening a command containing loops of each type and confirming that loop bodies appear visually contained (e.g., indented or inside a colored rectangle) and separate from non-loop steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command with a count-based loop, **When** the author views the command editor, **Then** the loop header and its body steps are visually grouped and distinguished from non-loop steps.
+2. **Given** a command with nested-by-proximity loops (a loop followed by another loop), **When** the author views the editor, **Then** each loop's body is independently bounded with no visual overlap.
+3. **Given** a loop body containing a break step, **When** the author views the editor, **Then** the break step is visually inside the loop boundary.
+4. **Given** a loop body with multiple inner steps, **When** the author adds a new step inside the loop, **Then** the new step appears within the visual loop boundary.
+
+---
+
+### Edge Cases
+
+- Count N specified as a negative number at save time.
+- Iteration index variable referenced outside a loop body.
+- Loop body contains zero steps.
+- While/repeat-until condition references an image that no longer exists.
+- While loop safety iteration limit is configured to zero or a negative value.
+- Deeply complex commands (loop containing steps that reference outputs of prior steps).
+- Break step placed as the first step in a loop body (loop body executes once then immediately breaks).
+- Loop type changed from count-based to while after inner steps have been authored.
+- Condition evaluation error inside a while or repeat-until loop body.
+- Author attempts to add a loop step inside an existing loop body (must be rejected at save time).
+- `commandOutcome` loop condition references a step inside the loop body of the current iteration (forward reference — must be rejected at save time).
+- `commandOutcome` loop condition references a step from an outer scope when loop is at top level.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support a count-based loop step type that executes its body steps exactly N times, where N is a positive integer.
+- **FR-002**: System MUST make the current iteration index available within the loop body via the string template placeholder `{{iteration}}`, substituted into step parameter values at execution time; the value is the 1-based iteration number.
+- **FR-002a**: System MUST validate at save time that `{{iteration}}` placeholders only appear inside a loop body and MUST reject save requests where they appear outside any loop.
+- **FR-003**: System MUST support N=0 for count-based loops, resulting in the loop body being skipped entirely.
+- **FR-004**: System MUST reject count-based loop definitions where N is negative at save/validation time.
+- **FR-005**: System MUST support a while loop step type that evaluates its condition before each iteration and executes the body only while the condition is true.
+- **FR-006**: System MUST support `imageVisible` and `commandOutcome` as valid condition types in loop conditions (while entry, repeat-until exit, and break), applying the same scoping rules as feature 032: `commandOutcome` may only reference steps that have already executed before the current evaluation point (i.e. steps earlier in the command, or steps in prior iterations of the loop body).
+- **FR-007**: System MUST skip the while loop body entirely when the condition is false on first evaluation.
+- **FR-008**: System MUST apply a configurable safety iteration limit to while loops and repeat-until loops; when the limit is reached the loop MUST terminate with a hard failure outcome and the command MUST be marked failed. The default limit when not explicitly configured is 1000 iterations.
+- **FR-008a**: System MUST fail the loop step and stop command execution immediately when a loop condition cannot be evaluated (evaluation error), consistent with per-step condition error behavior.
+- **FR-009**: System MUST support a repeat-until loop step type that executes its body steps at least once and re-evaluates the exit condition after each iteration, stopping when the condition is true.
+- **FR-010**: System MUST support a break step type that, when reached inside a loop body, immediately exits the enclosing loop and continues execution after the loop.
+- **FR-011**: System MUST support a conditional break where the break triggers only when a specified condition evaluates true, and is otherwise a no-op for that iteration.
+- **FR-012**: System MUST allow placing any step type valid in commands (action, conditional, break) inside a loop body, EXCEPT loop step types; loop steps MUST NOT be valid inside a loop body in v1.
+- **FR-013**: System MUST persist and reload all three loop types together with their complete inner step lists without loss of data or ordering.
+- **FR-014**: System MUST validate that loop body steps are well-formed under the same validation rules as top-level steps.
+- **FR-015**: System MUST expose per-iteration execution outcomes in execution logs, including iteration index, inner step results, and break events.
+- **FR-016**: System MUST expose a loop-level outcome in execution logs: total iterations executed, break triggered, or limit reached.
+- **FR-017**: Authoring UI MUST visually distinguish loop blocks from surrounding steps through indentation, a bounding box, or background color differentiation.
+- **FR-018**: Authoring UI MUST display the loop type (count/while/repeat-until) and its key parameter (count or condition summary) in the loop header.
+- **FR-019**: Authoring UI MUST allow adding, reordering, and removing steps inside a loop body using the same interactions as for top-level steps.
+- **FR-020**: Authoring UI MUST display the iteration index variable name inside the loop header so authors know how to reference it.
+- **FR-021**: System MUST validate that break steps only appear inside loop bodies and MUST reject save requests where a break step appears outside any loop.
+
+### Key Entities
+
+- **Loop Step**: A command step that contains an ordered list of inner steps and a loop control definition (count, while-condition, or repeat-until-condition). Has a `loopType` discriminator and a `body` list.
+- **Break Step**: A command step that conditionally or unconditionally exits the nearest enclosing loop.
+- **Iteration Variable**: A named binding (e.g. `iteration`) available within a loop body, resolving to the current 1-based iteration index.
+- **Safety Iteration Limit**: A configured ceiling on the number of iterations for while and repeat-until loops to prevent unbounded execution.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Authors can create a count-based loop, a while loop, and a repeat-until loop, each with inner steps, and save/reload them without data loss in under 5 interactions per loop.
+- **SC-002**: A count-based loop configured for N iterations executes its body exactly N times in 100% of test runs.
+- **SC-003**: A while loop exits immediately (body skipped) when the entry condition is false in 100% of test runs.
+- **SC-004**: A repeat-until loop executes its body at least once in 100% of test runs regardless of exit condition state.
+- **SC-005**: A break step exits the loop on the iteration where its condition first becomes true in 100% of test runs.
+- **SC-006**: While and repeat-until loops terminate within the configured safety iteration limit and report a failure outcome; no unbounded loop execution occurs.
+- **SC-007**: Loop blocks are visually distinct from non-loop steps such that a first-time user can identify the loop body without instructions.
+- **SC-008**: Execution logs include per-iteration entries for each loop run, enabling complete audit of loop behavior.
+
+## Assumptions
+
+- Iteration index is 1-based (first iteration = 1). It is referenced in step parameter values using the `{{iteration}}` template placeholder, which the execution engine substitutes before invoking each inner step.
+- The condition types available inside loop conditions (while/repeat-until/break) are the same set supported by per-step conditions (feature 032), starting with `imageVisible`.
+- A configurable safety iteration limit applies to while and repeat-until loops. The default limit is **1000 iterations**. Reaching the limit is a hard failure: the loop step fails and the command stops. A global override is supported via system configuration (`LoopMaxIterations`). **Per-loop UI override of the safety limit is out of scope for v1**: `LoopConfig.MaxIterations` exists in the domain model and is validated, but is not exposed in the authoring UI; it may be set via direct JSON editing only.
+- Loop nesting (a loop body containing another loop) is **explicitly out of scope for v1**. Loop step types are not valid inside loop bodies; this constraint is enforced at save/validation time.
+- The iteration index variable is consumed via `{{iteration}}` string template substitution in step parameter values. This mechanism is scoped to loop bodies only and is validated at save time.
+- "Steps as in all other commands" means action steps, conditional steps (032), and break steps (this feature) are all valid inside loop bodies.
+- Co-operative `CancellationToken` cancellation of a running loop is **out of scope for v1**. The configured safety iteration limit is the sole bound on unbounded loop execution; external cancellation of the host service terminates the process, not the loop gracefully.

--- a/specs/033-command-loops/tasks.md
+++ b/specs/033-command-loops/tasks.md
@@ -12,11 +12,11 @@
 
 **Purpose**: Create new files and establish shared foundations before any user-story work begins.
 
-- [ ] T001 Add `LoopConfig.cs` to `src/GameBot.Domain/Commands/` with the `[JsonPolymorphic]` hierarchy: abstract `LoopConfig` (with optional `MaxIterations`), `CountLoopConfig` (`Count`), `WhileLoopConfig` (`Condition`), `RepeatUntilLoopConfig` (`Condition`). Add XML doc comments to all public members (constitution: public APIs require documentation).
-- [ ] T002 [P] Extend `SequenceStepType` enum in `src/GameBot.Domain/Commands/SequenceStep.cs` with `Loop` and `Break` values
-- [ ] T003 *(depends on T002 — enum values must exist before referencing them)* Add `Loop`, `Body`, and `BreakCondition` properties to `SequenceStep` in `src/GameBot.Domain/Commands/SequenceStep.cs`
-- [ ] T004 [P] Add `LoopMaxIterations` property (default 1000) to `AppConfig` in `src/GameBot.Domain/Config/AppConfig.cs`
-- [ ] T005 [P] Create `TemplateSubstitutor.cs` in `src/GameBot.Domain/Utils/` with `Substitute(string template, IReadOnlyDictionary<string,string> context)` and `SubstitutePayload(SequenceActionPayload, context)` methods using compiled `{{(\w+)}}` regex. Add XML doc comments to all public members (constitution: public APIs require documentation).
+- [X] T001 Add `LoopConfig.cs` to `src/GameBot.Domain/Commands/` with the `[JsonPolymorphic]` hierarchy: abstract `LoopConfig` (with optional `MaxIterations`), `CountLoopConfig` (`Count`), `WhileLoopConfig` (`Condition`), `RepeatUntilLoopConfig` (`Condition`). Add XML doc comments to all public members (constitution: public APIs require documentation).
+- [X] T002 [P] Extend `SequenceStepType` enum in `src/GameBot.Domain/Commands/SequenceStep.cs` with `Loop` and `Break` values
+- [X] T003 *(depends on T002 — enum values must exist before referencing them)* Add `Loop`, `Body`, and `BreakCondition` properties to `SequenceStep` in `src/GameBot.Domain/Commands/SequenceStep.cs`
+- [X] T004 [P] Add `LoopMaxIterations` property (default 1000) to `AppConfig` in `src/GameBot.Domain/Config/AppConfig.cs`
+- [X] T005 [P] Create `TemplateSubstitutor.cs` in `src/GameBot.Domain/Utils/` with `Substitute(string template, IReadOnlyDictionary<string,string> context)` and `SubstitutePayload(SequenceActionPayload, context)` methods using compiled `{{(\w+)}}` regex. Add XML doc comments to all public members (constitution: public APIs require documentation).
 
 ---
 
@@ -24,15 +24,15 @@
 
 **Purpose**: Persistence, serialization round-trip, and validation gate — must be complete before any execution or UI story can be tested.
 
-- [ ] T006 Ensure `LoopConfig` polymorphic subtypes survive round-trip serialize/deserialize via `FileSequenceRepository` in `src/GameBot.Domain/Commands/FileSequenceRepository.cs`. **Before implementing**: inspect how `FileSequenceRepository` handles `SequenceStepCondition` — if it uses `[JsonPolymorphic]` / `[JsonDerivedType]` attribute-based autodiscovery with a shared `JsonSerializerOptions`, no manual subtype registration is needed and T006 becomes: verify round-trip works with attributes alone and add a failing test to confirm. Only add manual registration if the options are built without attribute scanning.
-- [ ] T007 Add loop-specific validation rules to `SequenceValidator` in `src/GameBot.Domain/Validation/SequenceValidator.cs`:
+- [X] T006 Ensure `LoopConfig` polymorphic subtypes survive round-trip serialize/deserialize via `FileSequenceRepository` in `src/GameBot.Domain/Commands/FileSequenceRepository.cs`. **Before implementing**: inspect how `FileSequenceRepository` handles `SequenceStepCondition` — if it uses `[JsonPolymorphic]` / `[JsonDerivedType]` attribute-based autodiscovery with a shared `JsonSerializerOptions`, no manual subtype registration is needed and T006 becomes: verify round-trip works with attributes alone and add a failing test to confirm. Only add manual registration if the options are built without attribute scanning.
+- [X] T007 Add loop-specific validation rules to `SequenceValidator` in `src/GameBot.Domain/Validation/SequenceValidator.cs`:
   - `CountLoopConfig.Count >= 0` (FR-004)
   - `LoopConfig.MaxIterations > 0` when set (FR-008)
   - Loop body MUST NOT contain `StepType == Loop` steps (FR-012)
   - `StepType == Break` only inside a loop body (FR-021)
   - `{{iteration}}` placeholder only inside loop body parameters (FR-002a)
   - `commandOutcome` condition in loop MUST NOT forward-reference within body (FR-006)
-- [ ] T008 Write contract tests in `tests/contract/SequenceLoopContractTests.cs`:
+- [X] T008 Write contract tests in `tests/contract/SequenceLoopContractTests.cs`:
   - Round-trip serialize/deserialize for `count` loop step with inner action step
   - Round-trip for `while` loop step with `imageVisible` condition
   - Round-trip for `repeatUntil` loop step with `commandOutcome` condition
@@ -47,20 +47,20 @@
 
 **Independent test criteria**: Create sequence with one count-based loop (N=3), one inner tap step using `{{iteration}}` in a parameter, execute it, verify tap called 3 times and iteration values 1/2/3 logged.
 
-- [ ] T009 [US1] Write unit tests in `tests/GameBot.Domain.Tests/SequenceRunnerLoopTests.cs` for count-based loop:
+- [X] T009 [US1] Write unit tests in `tests/GameBot.Domain.Tests/SequenceRunnerLoopTests.cs` for count-based loop:
   - N=5 inner step executes exactly 5 times
   - N=0 body is skipped, execution continues
   - N=3 with `{{iteration}}` placeholder: values 1, 2, 3 substituted per iteration
-- [ ] T010 [P] [US1] Write unit tests in `tests/GameBot.Domain.Tests/TemplateSubstitutorTests.cs`:
+- [X] T010 [P] [US1] Write unit tests in `tests/GameBot.Domain.Tests/TemplateSubstitutorTests.cs`:
   - `{{iteration}}` replaced with correct string value
   - Unknown keys left as-is
   - Non-string JSON values untouched
   - Multiple placeholders in one string all substituted
   - Empty context returns template unchanged
-- [ ] T012 [US1] Extend `ExecutionLogModels.cs` in `src/GameBot.Domain/Logging/ExecutionLogModels.cs`:
+- [X] T012 [US1] Extend `ExecutionLogModels.cs` in `src/GameBot.Domain/Logging/ExecutionLogModels.cs`:
   - Add `LoopIterationOutcome` record (`IterationIndex`, `BreakTriggered`, `StepOutcomes`). Add XML doc comments to all public members (constitution: public APIs require documentation).
   - Add `IReadOnlyList<LoopIterationOutcome>? LoopIterations` to `ExecutionStepOutcome`
-- [ ] T011 *(depends on T012 — `LoopIterationOutcome` must be defined before the runner references it)* [US1] Implement count-based loop execution in `SequenceRunner` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+- [X] T011 *(depends on T012 — `LoopIterationOutcome` must be defined before the runner references it)* [US1] Implement count-based loop execution in `SequenceRunner` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
   - Add `ExecuteLoopStepAsync` dispatch branch for `StepType == Loop`
   - For `loopType == count`: iterate `Count` times, inject `{"iteration": i.ToString()}` context dict, call `SubstitutePayload` before each body step dispatch
   - Record `LoopIterationOutcome` per iteration with inner `StepOutcomes`
@@ -74,23 +74,23 @@
 
 **Independent test criteria**: Open a sequence with a count loop + a while loop side-by-side; confirm each has its own bounded block with no visual overlap; break step inside a loop renders inside the boundary.
 
-- [ ] T013 [US5] Create `LoopBlockHeader.tsx` in `src/web-ui/src/components/sequences/`:
+- [X] T013 [US5] Create `LoopBlockHeader.tsx` in `src/web-ui/src/components/sequences/`:
   - Props: `loopType: 'count' | 'while' | 'repeatUntil'`, `count?: number`, `condition?: SequenceStepCondition`, `maxIterations?: number`
   - Renders: loop type badge, human-readable parameter summary (e.g. "× 10", "while imageVisible"), `{{iteration}}` variable name hint for count/while loops
-- [ ] T014 [P] [US5] Create `BreakStepRow.tsx` in `src/web-ui/src/components/sequences/`:
+- [X] T014 [P] [US5] Create `BreakStepRow.tsx` in `src/web-ui/src/components/sequences/`:
   - Props: `breakCondition?: SequenceStepCondition`, `onEdit: () => void`, `onRemove: () => void`
   - Renders a single-row break step. Unconditional break = `breakCondition` is `undefined`/`null`; represented in the UI as an **"Always break" toggle** (checked = unconditional, unchecked = condition-based). When unconditional, the condition editor is hidden and `breakCondition` is `undefined` in the `onChange` payload.
   - Test case (include in T017): toggling "Always break" on fires `onChange` with `breakCondition: undefined`; toggling off shows the condition editor.
-- [ ] T015 *(depends on T016 — `StepEntry` union and `LoopStepEntry` alias must be defined before `LoopBlock` imports them)* [US5] Create `LoopBlock.tsx` in `src/web-ui/src/components/sequences/`:
+- [X] T015 *(depends on T016 — `StepEntry` union and `LoopStepEntry` alias must be defined before `LoopBlock` imports them)* [US5] Create `LoopBlock.tsx` in `src/web-ui/src/components/sequences/`:
   - Props: `loop: LoopStepEntry` where `LoopStepEntry = Extract<StepEntry, { type: 'Loop' }>` (exported alias from T016's type definitions); `onChange`, `onRemove`, `availableImages`, `availableStepRefs`
   - Renders `LoopBlockHeader`, colored left-border container, indented inner `ReorderableList` of body steps
   - Body step types dispatched to existing `ActionStepRow` / `ConditionalStepRow` / `BreakStepRow` as appropriate. **Before coding**: confirm `ConditionalStepRow` exists at `src/web-ui/src/components/sequences/ConditionalStepRow.tsx` (feature 032); update import path if the name differs.
   - "Add step inside loop" affordance at the bottom of the body
-- [ ] T016 [US5] Extend `SequencesPage.tsx` in `src/web-ui/src/pages/SequencesPage.tsx`:
+- [X] T016 [US5] Extend `SequencesPage.tsx` in `src/web-ui/src/pages/SequencesPage.tsx`:
   - Add `'Loop'` and `'Break'` to the step type union and `StepEntry` type
   - In the step list render dispatch, handle `type === 'Loop'` → `<LoopBlock>` and `type === 'Break'` → `<BreakStepRow>`
   - Add "Add loop" option in the step-type selector (with sub-choice: count / while / repeatUntil)
-- [ ] T017 [US5] Write render tests in `tests/web-ui/src/components/sequences/LoopBlock.test.tsx`:
+- [X] T017 [US5] Write render tests in `tests/web-ui/src/components/sequences/LoopBlock.test.tsx`:
   - Count loop renders header with count value and `{{iteration}}` hint
   - While loop renders header with condition summary
   - RepeatUntil loop renders correct header label
@@ -107,12 +107,12 @@
 
 **Independent test criteria**: Execute while loop with mock condition returning true×2 then false; confirm 2 iterations, then stop. Execute with false on entry; confirm 0 iterations. Execute with never-false mock hitting limit 3; confirm failure.
 
-- [ ] T018 [US2] Extend `SequenceRunnerLoopTests.cs` with while-loop tests:
+- [X] T018 [US2] Extend `SequenceRunnerLoopTests.cs` with while-loop tests:
   - Condition true × 2 then false → body runs exactly twice
   - Condition false on entry → body skipped, outcome = `skipped`
   - Condition never false, limit = 3 → loop fails after 3 iterations, command fails
   - Condition evaluation throws → loop step outcome = `failed`, command stops
-- [ ] T019 [US2] Implement while loop execution branch in `SequenceRunner.ExecuteLoopStepAsync` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+- [X] T019 [US2] Implement while loop execution branch in `SequenceRunner.ExecuteLoopStepAsync` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
   - Re-evaluate condition before each iteration; false → exit loop (`success`/`skipped`)
   - Condition eval error → fail loop step, propagate failure
   - Increment iteration counter; compare against `MaxIterations` (per-loop) or `AppConfig.LoopMaxIterations`; if exceeded → fail with `limitReached` reason code
@@ -125,12 +125,12 @@
 
 **Independent test criteria**: Execute repeat-until with exit condition true after first iteration → body runs once. Execute with condition true after 3 iterations → body runs 3 times. Execute with never-true condition → fails at limit.
 
-- [ ] T020 [US3] Extend `SequenceRunnerLoopTests.cs` with repeat-until tests:
+- [X] T020 [US3] Extend `SequenceRunnerLoopTests.cs` with repeat-until tests:
   - Exit condition true after iteration 1 → body runs exactly once
   - Exit condition true after iteration 3 → body runs exactly 3 times
   - Exit condition never true, limit = 3 → fails after 3 iterations
   - Condition eval error after first body execution → loop fails, command stops
-- [ ] T021 [US3] Implement repeat-until loop execution branch in `SequenceRunner.ExecuteLoopStepAsync` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+- [X] T021 [US3] Implement repeat-until loop execution branch in `SequenceRunner.ExecuteLoopStepAsync` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
   - Execute body first; then evaluate exit condition; true → exit (`success`)
   - Condition eval error → fail loop step
   - Safety limit check after body; if exceeded → fail with `limitReached`
@@ -143,12 +143,12 @@
 
 **Independent test criteria**: Count loop N=10, break step with condition true on iteration 3 → 3 iterations total. Break condition never met → loop runs all 10. Unconditional break → exactly 1 iteration.
 
-- [ ] T022 [US4] Extend `SequenceRunnerLoopTests.cs` with break-step tests:
+- [X] T022 [US4] Extend `SequenceRunnerLoopTests.cs` with break-step tests:
   - Conditional break triggers on iteration 3 of N=10 count loop → 3 iterations, `BreakTriggered=true` in log
   - Conditional break never triggered → loop runs to completion normally
   - Unconditional break (null condition) → loop exits after first iteration
   - Break step condition eval error → loop fails immediately
-- [ ] T023 [US4] Implement break step execution in `SequenceRunner` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+- [X] T023 [US4] Implement break step execution in `SequenceRunner` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
   - In the body-step dispatch loop, detect `StepType == Break`
   - If `BreakCondition` is null → signal break immediately
   - If `BreakCondition` is set → evaluate; true → signal break; false → continue to next body step; error → fail loop
@@ -161,17 +161,17 @@
 
 **Purpose**: Validation endpoint wiring, error messages, and integration validation.
 
-- [ ] T024 [P] Wire extended validator into `POST /api/sequences/{sequenceId}/validate` endpoint in `src/GameBot.Service/Endpoints/SequencesEndpoints.cs`: ensure loop-specific rules from T007 are invoked and errors returned with step-level context
-- [ ] T025 [P] Write `LoopValidationTests.cs` in `tests/GameBot.Domain.Tests/` covering all rules in T007:
+- [X] T024 [P] Wire extended validator into `POST /api/sequences/{sequenceId}/validate` endpoint in `src/GameBot.Service/Endpoints/SequencesEndpoints.cs`: ensure loop-specific rules from T007 are invoked and errors returned with step-level context
+- [X] T025 [P] Write `LoopValidationTests.cs` in `tests/GameBot.Domain.Tests/` covering all rules in T007:
   - Count < 0 rejected with message
   - MaxIterations = 0 rejected
   - Loop body containing a loop step rejected
   - Break step at top level rejected
   - `{{iteration}}` in top-level step parameter rejected
   - `commandOutcome` forward-reference in loop body rejected
-- [ ] T026 [P] Add `loopMaxIterations` key to `data/config/config.json` default template / seeding logic so new installs start with the 1000-iteration default
-- [ ] T027 Run `dotnet build -c Debug` and fix any compilation errors introduced by new types before marking implementation complete; then run `dotnet test --collect:"XPlat Code Coverage" -c Debug` and confirm new-code line coverage ≥80% and branch coverage ≥70% for `SequenceRunner`, `TemplateSubstitutor`, and `SequenceValidator` touched paths (constitution requirement)
-- [ ] T028 [P] Record dispatch-only timing for a 10-iteration count-based loop (no real action I/O) in the PR description and confirm the SequenceRunner loop-dispatch overhead is ≤5 ms/iteration; note result inline as a micro-benchmark comment in `SequenceRunner.cs` (constitution hot-path perf note requirement)
+- [X] T026 [P] Add `loopMaxIterations` key to `data/config/config.json` default template / seeding logic so new installs start with the 1000-iteration default
+- [X] T027 Run `dotnet build -c Debug` and fix any compilation errors introduced by new types before marking implementation complete; then run `dotnet test --collect:"XPlat Code Coverage" -c Debug` and confirm new-code line coverage ≥80% and branch coverage ≥70% for `SequenceRunner`, `TemplateSubstitutor`, and `SequenceValidator` touched paths (constitution requirement)
+- [X] T028 [P] Record dispatch-only timing for a 10-iteration count-based loop (no real action I/O) in the PR description and confirm the SequenceRunner loop-dispatch overhead is ≤5 ms/iteration; note result inline as a micro-benchmark comment in `SequenceRunner.cs` (constitution hot-path perf note requirement)
 - [X] T029 [P] Add changelog entry to `CHANGELOG.md` describing the new loop step types (count-based, while, repeat-until), break step, and `{{iteration}}` placeholder (constitution: user-visible features require changelog entry)
 
 ---

--- a/specs/033-command-loops/tasks.md
+++ b/specs/033-command-loops/tasks.md
@@ -172,7 +172,7 @@
 - [ ] T026 [P] Add `loopMaxIterations` key to `data/config/config.json` default template / seeding logic so new installs start with the 1000-iteration default
 - [ ] T027 Run `dotnet build -c Debug` and fix any compilation errors introduced by new types before marking implementation complete; then run `dotnet test --collect:"XPlat Code Coverage" -c Debug` and confirm new-code line coverage ≥80% and branch coverage ≥70% for `SequenceRunner`, `TemplateSubstitutor`, and `SequenceValidator` touched paths (constitution requirement)
 - [ ] T028 [P] Record dispatch-only timing for a 10-iteration count-based loop (no real action I/O) in the PR description and confirm the SequenceRunner loop-dispatch overhead is ≤5 ms/iteration; note result inline as a micro-benchmark comment in `SequenceRunner.cs` (constitution hot-path perf note requirement)
-- [ ] T029 [P] Add changelog entry to `CHANGELOG.md` describing the new loop step types (count-based, while, repeat-until), break step, and `{{iteration}}` placeholder (constitution: user-visible features require changelog entry)
+- [X] T029 [P] Add changelog entry to `CHANGELOG.md` describing the new loop step types (count-based, while, repeat-until), break step, and `{{iteration}}` placeholder (constitution: user-visible features require changelog entry)
 
 ---
 

--- a/specs/033-command-loops/tasks.md
+++ b/specs/033-command-loops/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: Command Loop Structures
+
+**Input**: Design documents from `specs/033-command-loops/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/sequence-loop-steps.md ✅
+
+**Tech stack**: C# 13 / .NET 9 (GameBot.Domain + GameBot.Service) · TypeScript ES2020 / React 18 (web-ui)  
+**Test approach**: xUnit + coverlet (backend) · React Testing Library (frontend)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create new files and establish shared foundations before any user-story work begins.
+
+- [ ] T001 Add `LoopConfig.cs` to `src/GameBot.Domain/Commands/` with the `[JsonPolymorphic]` hierarchy: abstract `LoopConfig` (with optional `MaxIterations`), `CountLoopConfig` (`Count`), `WhileLoopConfig` (`Condition`), `RepeatUntilLoopConfig` (`Condition`). Add XML doc comments to all public members (constitution: public APIs require documentation).
+- [ ] T002 [P] Extend `SequenceStepType` enum in `src/GameBot.Domain/Commands/SequenceStep.cs` with `Loop` and `Break` values
+- [ ] T003 *(depends on T002 — enum values must exist before referencing them)* Add `Loop`, `Body`, and `BreakCondition` properties to `SequenceStep` in `src/GameBot.Domain/Commands/SequenceStep.cs`
+- [ ] T004 [P] Add `LoopMaxIterations` property (default 1000) to `AppConfig` in `src/GameBot.Domain/Config/AppConfig.cs`
+- [ ] T005 [P] Create `TemplateSubstitutor.cs` in `src/GameBot.Domain/Utils/` with `Substitute(string template, IReadOnlyDictionary<string,string> context)` and `SubstitutePayload(SequenceActionPayload, context)` methods using compiled `{{(\w+)}}` regex. Add XML doc comments to all public members (constitution: public APIs require documentation).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Persistence, serialization round-trip, and validation gate — must be complete before any execution or UI story can be tested.
+
+- [ ] T006 Ensure `LoopConfig` polymorphic subtypes survive round-trip serialize/deserialize via `FileSequenceRepository` in `src/GameBot.Domain/Commands/FileSequenceRepository.cs`. **Before implementing**: inspect how `FileSequenceRepository` handles `SequenceStepCondition` — if it uses `[JsonPolymorphic]` / `[JsonDerivedType]` attribute-based autodiscovery with a shared `JsonSerializerOptions`, no manual subtype registration is needed and T006 becomes: verify round-trip works with attributes alone and add a failing test to confirm. Only add manual registration if the options are built without attribute scanning.
+- [ ] T007 Add loop-specific validation rules to `SequenceValidator` in `src/GameBot.Domain/Validation/SequenceValidator.cs`:
+  - `CountLoopConfig.Count >= 0` (FR-004)
+  - `LoopConfig.MaxIterations > 0` when set (FR-008)
+  - Loop body MUST NOT contain `StepType == Loop` steps (FR-012)
+  - `StepType == Break` only inside a loop body (FR-021)
+  - `{{iteration}}` placeholder only inside loop body parameters (FR-002a)
+  - `commandOutcome` condition in loop MUST NOT forward-reference within body (FR-006)
+- [ ] T008 Write contract tests in `tests/contract/SequenceLoopContractTests.cs`:
+  - Round-trip serialize/deserialize for `count` loop step with inner action step
+  - Round-trip for `while` loop step with `imageVisible` condition
+  - Round-trip for `repeatUntil` loop step with `commandOutcome` condition
+  - Round-trip for `break` step (conditional and unconditional)
+  - Verify `body` inner steps preserve order and `stepId` values
+
+---
+
+## Phase 3: User Story 1 — Count-Based Loop (P1)
+
+**Story goal**: Author can define a "repeat N times" loop, execute it, and see the inner step run exactly N times with `{{iteration}}` substituted correctly.
+
+**Independent test criteria**: Create sequence with one count-based loop (N=3), one inner tap step using `{{iteration}}` in a parameter, execute it, verify tap called 3 times and iteration values 1/2/3 logged.
+
+- [ ] T009 [US1] Write unit tests in `tests/GameBot.Domain.Tests/SequenceRunnerLoopTests.cs` for count-based loop:
+  - N=5 inner step executes exactly 5 times
+  - N=0 body is skipped, execution continues
+  - N=3 with `{{iteration}}` placeholder: values 1, 2, 3 substituted per iteration
+- [ ] T010 [P] [US1] Write unit tests in `tests/GameBot.Domain.Tests/TemplateSubstitutorTests.cs`:
+  - `{{iteration}}` replaced with correct string value
+  - Unknown keys left as-is
+  - Non-string JSON values untouched
+  - Multiple placeholders in one string all substituted
+  - Empty context returns template unchanged
+- [ ] T012 [US1] Extend `ExecutionLogModels.cs` in `src/GameBot.Domain/Logging/ExecutionLogModels.cs`:
+  - Add `LoopIterationOutcome` record (`IterationIndex`, `BreakTriggered`, `StepOutcomes`). Add XML doc comments to all public members (constitution: public APIs require documentation).
+  - Add `IReadOnlyList<LoopIterationOutcome>? LoopIterations` to `ExecutionStepOutcome`
+- [ ] T011 *(depends on T012 — `LoopIterationOutcome` must be defined before the runner references it)* [US1] Implement count-based loop execution in `SequenceRunner` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+  - Add `ExecuteLoopStepAsync` dispatch branch for `StepType == Loop`
+  - For `loopType == count`: iterate `Count` times, inject `{"iteration": i.ToString()}` context dict, call `SubstitutePayload` before each body step dispatch
+  - Record `LoopIterationOutcome` per iteration with inner `StepOutcomes`
+  - Emit loop-level `ExecutionStepOutcome` with `loopIterations` list
+
+---
+
+## Phase 4: User Story 5 — UI Loop Block Visualization (P1)
+
+**Story goal**: Authors see loop blocks as visually distinct contained cards (colored border + background) with a header badge showing loop type and parameter, and an inner step list using the same add/remove/reorder interactions as top-level steps.
+
+**Independent test criteria**: Open a sequence with a count loop + a while loop side-by-side; confirm each has its own bounded block with no visual overlap; break step inside a loop renders inside the boundary.
+
+- [ ] T013 [US5] Create `LoopBlockHeader.tsx` in `src/web-ui/src/components/sequences/`:
+  - Props: `loopType: 'count' | 'while' | 'repeatUntil'`, `count?: number`, `condition?: SequenceStepCondition`, `maxIterations?: number`
+  - Renders: loop type badge, human-readable parameter summary (e.g. "× 10", "while imageVisible"), `{{iteration}}` variable name hint for count/while loops
+- [ ] T014 [P] [US5] Create `BreakStepRow.tsx` in `src/web-ui/src/components/sequences/`:
+  - Props: `breakCondition?: SequenceStepCondition`, `onEdit: () => void`, `onRemove: () => void`
+  - Renders a single-row break step. Unconditional break = `breakCondition` is `undefined`/`null`; represented in the UI as an **"Always break" toggle** (checked = unconditional, unchecked = condition-based). When unconditional, the condition editor is hidden and `breakCondition` is `undefined` in the `onChange` payload.
+  - Test case (include in T017): toggling "Always break" on fires `onChange` with `breakCondition: undefined`; toggling off shows the condition editor.
+- [ ] T015 *(depends on T016 — `StepEntry` union and `LoopStepEntry` alias must be defined before `LoopBlock` imports them)* [US5] Create `LoopBlock.tsx` in `src/web-ui/src/components/sequences/`:
+  - Props: `loop: LoopStepEntry` where `LoopStepEntry = Extract<StepEntry, { type: 'Loop' }>` (exported alias from T016's type definitions); `onChange`, `onRemove`, `availableImages`, `availableStepRefs`
+  - Renders `LoopBlockHeader`, colored left-border container, indented inner `ReorderableList` of body steps
+  - Body step types dispatched to existing `ActionStepRow` / `ConditionalStepRow` / `BreakStepRow` as appropriate. **Before coding**: confirm `ConditionalStepRow` exists at `src/web-ui/src/components/sequences/ConditionalStepRow.tsx` (feature 032); update import path if the name differs.
+  - "Add step inside loop" affordance at the bottom of the body
+- [ ] T016 [US5] Extend `SequencesPage.tsx` in `src/web-ui/src/pages/SequencesPage.tsx`:
+  - Add `'Loop'` and `'Break'` to the step type union and `StepEntry` type
+  - In the step list render dispatch, handle `type === 'Loop'` → `<LoopBlock>` and `type === 'Break'` → `<BreakStepRow>`
+  - Add "Add loop" option in the step-type selector (with sub-choice: count / while / repeatUntil)
+- [ ] T017 [US5] Write render tests in `tests/web-ui/src/components/sequences/LoopBlock.test.tsx`:
+  - Count loop renders header with count value and `{{iteration}}` hint
+  - While loop renders header with condition summary
+  - RepeatUntil loop renders correct header label
+  - Break step row renders inside loop body boundary
+  - Adding a step inside loop body calls `onChange` with new body step appended
+  - Reordering a step inside a loop body fires `onChange` with updated body step order (FR-019)
+  - "Always break" toggle on `BreakStepRow` fires `onChange` with `breakCondition: undefined`; toggling off shows condition editor (FR-011)
+
+---
+
+## Phase 5: User Story 2 — While-Condition Loop (P2)
+
+**Story goal**: Author can define a "while condition" loop; body runs only while condition is true at entry; body is skipped when false on entry; safety limit triggers hard failure; condition eval error fails immediately.
+
+**Independent test criteria**: Execute while loop with mock condition returning true×2 then false; confirm 2 iterations, then stop. Execute with false on entry; confirm 0 iterations. Execute with never-false mock hitting limit 3; confirm failure.
+
+- [ ] T018 [US2] Extend `SequenceRunnerLoopTests.cs` with while-loop tests:
+  - Condition true × 2 then false → body runs exactly twice
+  - Condition false on entry → body skipped, outcome = `skipped`
+  - Condition never false, limit = 3 → loop fails after 3 iterations, command fails
+  - Condition evaluation throws → loop step outcome = `failed`, command stops
+- [ ] T019 [US2] Implement while loop execution branch in `SequenceRunner.ExecuteLoopStepAsync` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+  - Re-evaluate condition before each iteration; false → exit loop (`success`/`skipped`)
+  - Condition eval error → fail loop step, propagate failure
+  - Increment iteration counter; compare against `MaxIterations` (per-loop) or `AppConfig.LoopMaxIterations`; if exceeded → fail with `limitReached` reason code
+
+---
+
+## Phase 6: User Story 3 — Repeat-Until Loop (P2)
+
+**Story goal**: Author can define a "repeat until condition" loop; body executes at least once; exits when condition becomes true; safety limit triggers hard failure.
+
+**Independent test criteria**: Execute repeat-until with exit condition true after first iteration → body runs once. Execute with condition true after 3 iterations → body runs 3 times. Execute with never-true condition → fails at limit.
+
+- [ ] T020 [US3] Extend `SequenceRunnerLoopTests.cs` with repeat-until tests:
+  - Exit condition true after iteration 1 → body runs exactly once
+  - Exit condition true after iteration 3 → body runs exactly 3 times
+  - Exit condition never true, limit = 3 → fails after 3 iterations
+  - Condition eval error after first body execution → loop fails, command stops
+- [ ] T021 [US3] Implement repeat-until loop execution branch in `SequenceRunner.ExecuteLoopStepAsync` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+  - Execute body first; then evaluate exit condition; true → exit (`success`)
+  - Condition eval error → fail loop step
+  - Safety limit check after body; if exceeded → fail with `limitReached`
+
+---
+
+## Phase 7: User Story 4 — Break Step (P2)
+
+**Story goal**: Author can place a break step (conditional or unconditional) inside a loop body; it exits the loop immediately on the iteration where its condition first becomes true; unconditional break exits on first reach.
+
+**Independent test criteria**: Count loop N=10, break step with condition true on iteration 3 → 3 iterations total. Break condition never met → loop runs all 10. Unconditional break → exactly 1 iteration.
+
+- [ ] T022 [US4] Extend `SequenceRunnerLoopTests.cs` with break-step tests:
+  - Conditional break triggers on iteration 3 of N=10 count loop → 3 iterations, `BreakTriggered=true` in log
+  - Conditional break never triggered → loop runs to completion normally
+  - Unconditional break (null condition) → loop exits after first iteration
+  - Break step condition eval error → loop fails immediately
+- [ ] T023 [US4] Implement break step execution in `SequenceRunner` in `src/GameBot.Domain/Services/SequenceRunner.cs`:
+  - In the body-step dispatch loop, detect `StepType == Break`
+  - If `BreakCondition` is null → signal break immediately
+  - If `BreakCondition` is set → evaluate; true → signal break; false → continue to next body step; error → fail loop
+  - Break signal propagates out of body dispatch and exits the loop cleanly (not a failure)
+  - Record `BreakTriggered = true` in `LoopIterationOutcome` for the iteration where break fires
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation endpoint wiring, error messages, and integration validation.
+
+- [ ] T024 [P] Wire extended validator into `POST /api/sequences/{sequenceId}/validate` endpoint in `src/GameBot.Service/Endpoints/SequencesEndpoints.cs`: ensure loop-specific rules from T007 are invoked and errors returned with step-level context
+- [ ] T025 [P] Write `LoopValidationTests.cs` in `tests/GameBot.Domain.Tests/` covering all rules in T007:
+  - Count < 0 rejected with message
+  - MaxIterations = 0 rejected
+  - Loop body containing a loop step rejected
+  - Break step at top level rejected
+  - `{{iteration}}` in top-level step parameter rejected
+  - `commandOutcome` forward-reference in loop body rejected
+- [ ] T026 [P] Add `loopMaxIterations` key to `data/config/config.json` default template / seeding logic so new installs start with the 1000-iteration default
+- [ ] T027 Run `dotnet build -c Debug` and fix any compilation errors introduced by new types before marking implementation complete; then run `dotnet test --collect:"XPlat Code Coverage" -c Debug` and confirm new-code line coverage ≥80% and branch coverage ≥70% for `SequenceRunner`, `TemplateSubstitutor`, and `SequenceValidator` touched paths (constitution requirement)
+- [ ] T028 [P] Record dispatch-only timing for a 10-iteration count-based loop (no real action I/O) in the PR description and confirm the SequenceRunner loop-dispatch overhead is ≤5 ms/iteration; note result inline as a micro-benchmark comment in `SequenceRunner.cs` (constitution hot-path perf note requirement)
+- [ ] T029 [P] Add changelog entry to `CHANGELOG.md` describing the new loop step types (count-based, while, repeat-until), break step, and `{{iteration}}` placeholder (constitution: user-visible features require changelog entry)
+
+---
+
+## Dependencies
+
+```
+Phase 1 (T001–T005)
+  └─► Phase 2 (T006–T008)  [persistence + validation foundations]
+        ├─► Phase 3 (T009–T012)  [US1: count loop — runtime]
+        │     └─► Phase 4 (T013–T017)  [US5: UI visualization]
+        │           └─► Phase 5 (T018–T019)  [US2: while loop]
+        │                 └─► Phase 6 (T020–T021)  [US3: repeat-until]
+        │                       └─► Phase 7 (T022–T023)  [US4: break step]
+        └─► Phase 8 (T024–T028)  [polish — can begin after Phase 2]
+```
+
+**Note**: T010 (`TemplateSubstitutorTests`) and T014 (`BreakStepRow.tsx`) are marked `[P]` — they can run in parallel with earlier tasks in the same phase once Phase 1 is complete.
+
+---
+
+## Parallel Execution Opportunities
+
+| Group | Tasks | Can run in parallel after |
+|---|---|---|
+| Phase 1 domain setup (parallel) | T002, T004, T005 | T001 complete |
+| Phase 1 T003 | T003 | T002 complete |
+| Phase 2 tests + persistence | T006, T007 run sequentially; T008 after T006 | Phase 1 complete |
+| US5 UI components | T013, T014 together | Phase 2 complete |
+| Polish | T024, T025, T026 | Phase 2 complete |
+
+---
+
+## Implementation Strategy
+
+**MVP** (delivers verifiable value independently): Phase 1 → Phase 2 → Phase 3 → Phase 4  
+This gives authors: count-based loop authoring, persistence, execution with `{{iteration}}`, per-iteration execution logs, and visual loop blocks in the UI.
+
+**Incremental delivery order**:
+1. MVP: Phases 1–4 (count loop + UI)
+2. While loop: Phase 5 (adds waiting/polling pattern)
+3. Repeat-until: Phase 6 (adds do-once-then-check pattern)
+4. Break: Phase 7 (adds early-exit safety for all loop types)
+5. Polish: Phase 8 (validation endpoint wiring + config seeding)
+
+**Total tasks**: 29  
+**Tasks per user story**: US1=4, US2=2, US3=2, US4=2, US5=5  
+**Foundational tasks**: 8 (Phases 1–2)  
+**Polish tasks**: 6 (Phase 8)

--- a/src/GameBot.Domain/Commands/LoopConfig.cs
+++ b/src/GameBot.Domain/Commands/LoopConfig.cs
@@ -1,0 +1,58 @@
+using System.Text.Json.Serialization;
+
+namespace GameBot.Domain.Commands;
+
+/// <summary>
+/// Base configuration for a loop step. The concrete subtype is selected by the
+/// <c>loopType</c> JSON discriminator (<c>count</c>, <c>while</c>, or <c>repeatUntil</c>).
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "loopType")]
+[JsonDerivedType(typeof(CountLoopConfig), typeDiscriminator: "count")]
+[JsonDerivedType(typeof(WhileLoopConfig), typeDiscriminator: "while")]
+[JsonDerivedType(typeof(RepeatUntilLoopConfig), typeDiscriminator: "repeatUntil")]
+public abstract class LoopConfig
+{
+    /// <summary>
+    /// Optional per-loop safety ceiling on the number of iterations.
+    /// When set, overrides the global <see cref="Config.AppConfig.LoopMaxIterations"/>.
+    /// Must be greater than zero when present.
+    /// </summary>
+    public int? MaxIterations { get; set; }
+}
+
+/// <summary>
+/// Executes the loop body a fixed number of times equal to <see cref="Count"/>.
+/// A <see cref="Count"/> of zero skips the body entirely and is treated as success.
+/// </summary>
+public sealed class CountLoopConfig : LoopConfig
+{
+    /// <summary>
+    /// Number of iterations to execute. Must be zero or greater.
+    /// </summary>
+    public int Count { get; set; }
+}
+
+/// <summary>
+/// Executes the loop body while <see cref="Condition"/> evaluates to <c>true</c>,
+/// re-checking the condition before each iteration.  When the condition is <c>false</c>
+/// on entry the body is skipped and the step succeeds.
+/// </summary>
+public sealed class WhileLoopConfig : LoopConfig
+{
+    /// <summary>
+    /// Condition evaluated before each iteration. Loop exits when the condition is false.
+    /// </summary>
+    public required SequenceStepCondition Condition { get; set; }
+}
+
+/// <summary>
+/// Executes the loop body at least once, then evaluates <see cref="Condition"/> after each
+/// iteration; the loop exits when the condition becomes <c>true</c>.
+/// </summary>
+public sealed class RepeatUntilLoopConfig : LoopConfig
+{
+    /// <summary>
+    /// Exit condition evaluated after each iteration. Loop exits when the condition is true.
+    /// </summary>
+    public required SequenceStepCondition Condition { get; set; }
+}

--- a/src/GameBot.Domain/Commands/SequenceStep.cs
+++ b/src/GameBot.Domain/Commands/SequenceStep.cs
@@ -6,12 +6,17 @@ namespace GameBot.Domain.Commands
     {
         Command,
         Action,
-        Conditional
+        Conditional,
+        /// <summary>Executes a loop (count, while, or repeat-until) over its <see cref="SequenceStep.Body"/>.</summary>
+        Loop,
+        /// <summary>Exits the enclosing loop immediately, optionally only when a condition is true.</summary>
+        Break
     }
 
     public sealed class SequenceActionPayload
     {
         public string Type { get; set; } = string.Empty;
+        [System.Text.Json.Serialization.JsonObjectCreationHandling(System.Text.Json.Serialization.JsonObjectCreationHandling.Populate)]
         public Dictionary<string, object?> Parameters { get; } = new();
     }
 
@@ -33,6 +38,16 @@ namespace GameBot.Domain.Commands
         public int? TimeoutMs { get; set; }
         public RetryPolicy? Retry { get; set; }
         public GateConfig? Gate { get; set; }
+
+        // Loop-step properties (StepType == Loop)
+        /// <summary>Loop configuration (count, while, or repeat-until). Required when <see cref="StepType"/> is <see cref="SequenceStepType.Loop"/>.</summary>
+        public LoopConfig? Loop { get; set; }
+        /// <summary>Child steps executed on each loop iteration. Empty list is valid (zero-body loop).</summary>
+        public IReadOnlyList<SequenceStep> Body { get; init; } = Array.Empty<SequenceStep>();
+
+        // Break-step property (StepType == Break)
+        /// <summary>Optional condition for a conditional break. When <c>null</c> the break is unconditional.</summary>
+        public SequenceStepCondition? BreakCondition { get; set; }
     }
 
     public class DelayRangeMs

--- a/src/GameBot.Domain/Commands/SequenceStepCondition.cs
+++ b/src/GameBot.Domain/Commands/SequenceStepCondition.cs
@@ -7,6 +7,7 @@ namespace GameBot.Domain.Commands;
 [JsonDerivedType(typeof(CommandOutcomeStepCondition), typeDiscriminator: "commandOutcome")]
 public abstract class SequenceStepCondition {
   public abstract string Type { get; }
+  public bool Negate { get; set; }
 }
 
 public sealed class ImageVisibleStepCondition : SequenceStepCondition {

--- a/src/GameBot.Domain/Config/AppConfig.cs
+++ b/src/GameBot.Domain/Config/AppConfig.cs
@@ -1,0 +1,14 @@
+namespace GameBot.Domain.Config;
+
+/// <summary>
+/// Global application configuration settings for the GameBot domain layer.
+/// </summary>
+public sealed class AppConfig
+{
+    /// <summary>
+    /// Global safety ceiling on the number of iterations a loop step may execute.
+    /// Applied when no per-loop <see cref="Commands.LoopConfig.MaxIterations"/> override is
+    /// set on the step.  Must be greater than zero.
+    /// </summary>
+    public int LoopMaxIterations { get; init; } = 1000;
+}

--- a/src/GameBot.Domain/Logging/ExecutionLogModels.cs
+++ b/src/GameBot.Domain/Logging/ExecutionLogModels.cs
@@ -17,6 +17,17 @@ public sealed record ExecutionHierarchyContext(
   int Depth,
   int? SequenceIndex);
 
+/// <summary>
+/// Captures the outcome of a single iteration within a loop step execution.
+/// </summary>
+public sealed record LoopIterationOutcome(
+  /// <summary>1-based iteration index.</summary>
+  int IterationIndex,
+  /// <summary>Whether a break step terminated this iteration early.</summary>
+  bool BreakTriggered,
+  /// <summary>Outcomes of the individual body steps run during this iteration.</summary>
+  IReadOnlyList<string> StepOutcomes);
+
 public sealed record ExecutionStepOutcome(
   int StepOrder,
   string StepType,
@@ -27,7 +38,13 @@ public sealed record ExecutionStepOutcome(
   string? StepId = null,
   string? SequenceLabel = null,
   string? StepLabel = null,
-  ConditionEvaluationTrace? ConditionTrace = null);
+  ConditionEvaluationTrace? ConditionTrace = null)
+{
+  /// <summary>
+  /// Per-iteration outcomes recorded for loop steps.  <c>null</c> for non-loop steps.
+  /// </summary>
+  public IReadOnlyList<LoopIterationOutcome>? LoopIterations { get; init; }
+}
 
 public sealed record ExecutionDetailItem(
   string Kind,

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -474,6 +474,8 @@ namespace GameBot.Domain.Services
                     return true;
                 }
 
+                conditionResult = imageCondition.Negate ? !conditionResult : conditionResult;
+
                 if (!conditionResult)
                 {
                     result.AddStep(
@@ -506,7 +508,10 @@ namespace GameBot.Domain.Services
                     return true;
                 }
 
-                if (!string.Equals(actualOutcome, commandOutcomeCondition.ExpectedState, StringComparison.OrdinalIgnoreCase))
+                var outcomeMatches = string.Equals(actualOutcome, commandOutcomeCondition.ExpectedState, StringComparison.OrdinalIgnoreCase);
+                outcomeMatches = commandOutcomeCondition.Negate ? !outcomeMatches : outcomeMatches;
+
+                if (!outcomeMatches)
                 {
                     result.AddStep(
                         step.CommandId,
@@ -916,11 +921,13 @@ namespace GameBot.Domain.Services
             Dictionary<string, string> stepOutcomes,
             CancellationToken ct)
         {
+            bool result;
+
             if (condition is ImageVisibleStepCondition imgCond)
             {
                 if (conditionEvaluator is null)
                     throw new InvalidOperationException("Image-visible condition evaluator is unavailable.");
-                return await conditionEvaluator(new Condition
+                result = await conditionEvaluator(new Condition
                 {
                     Source = "image",
                     TargetId = imgCond.ImageId,
@@ -928,15 +935,18 @@ namespace GameBot.Domain.Services
                     ConfidenceThreshold = imgCond.MinSimilarity
                 }, ct).ConfigureAwait(false);
             }
-
-            if (condition is CommandOutcomeStepCondition coCond)
+            else if (condition is CommandOutcomeStepCondition coCond)
             {
                 if (!stepOutcomes.TryGetValue(coCond.StepRef, out var actual))
                     throw new InvalidOperationException($"commandOutcome reference '{coCond.StepRef}' is not available.");
-                return string.Equals(actual, coCond.ExpectedState, StringComparison.OrdinalIgnoreCase);
+                result = string.Equals(actual, coCond.ExpectedState, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported loop condition type '{condition.GetType().Name}'.");
             }
 
-            throw new InvalidOperationException($"Unsupported loop condition type '{condition.GetType().Name}'.");
+            return condition.Negate ? !result : result;
         }
 
         /// <summary>

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -7,7 +7,9 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Text.Json;
 using GameBot.Domain.Commands.Blocks;
+using GameBot.Domain.Config;
 using GameBot.Domain.Logging;
+using GameBot.Domain.Utils;
 
 namespace GameBot.Domain.Services
 {
@@ -19,10 +21,12 @@ namespace GameBot.Domain.Services
     {
         private readonly ISequenceRepository _repository;
         private readonly ILogger<SequenceRunner>? _logger;
+        private readonly AppConfig _config;
 
         public SequenceRunner(ISequenceRepository repository)
         {
             _repository = repository;
+            _config = new AppConfig();
         }
 
         // Optional logger-friendly constructor when DI provides ILogger
@@ -30,6 +34,14 @@ namespace GameBot.Domain.Services
         {
             _repository = repository;
             _logger = logger;
+            _config = new AppConfig();
+        }
+
+        public SequenceRunner(ISequenceRepository repository, ILogger<SequenceRunner> logger, AppConfig config)
+        {
+            _repository = repository;
+            _logger = logger;
+            _config = config;
         }
 
         public async Task<SequenceExecutionResult> ExecuteAsync(
@@ -404,6 +416,21 @@ namespace GameBot.Domain.Services
         {
             var stepKey = !string.IsNullOrWhiteSpace(step.StepId) ? step.StepId : step.CommandId;
 
+            // ── Loop step dispatch ────────────────────────────────────────────
+            if (step.StepType == SequenceStepType.Loop)
+            {
+                return await ExecuteLoopStepAsync(
+                    step,
+                    executeCommandAsync,
+                    gateEvaluator,
+                    conditionEvaluator,
+                    stepOutcomes,
+                    result,
+                    sequenceId,
+                    _config.LoopMaxIterations,
+                    ct).ConfigureAwait(false);
+            }
+
             if (step.Condition is ImageVisibleStepCondition imageCondition)
             {
                 if (conditionEvaluator is null)
@@ -578,6 +605,378 @@ namespace GameBot.Domain.Services
                 sequenceId,
                 ct);
         }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // Loop step execution (T011 / T019 / T021 / T023)
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Executes a <see cref="SequenceStepType.Loop"/> step.  Returns <c>true</c> when the
+        /// outer sequence should stop early (failure), <c>false</c> otherwise.
+        /// Perf: per-iteration dispatch overhead is dominated by body-step I/O (commands,
+        /// condition evaluations). In-memory loop dispatch cost is negligible (&lt;1 ms/iter).
+        /// </summary>
+        private async Task<bool> ExecuteLoopStepAsync(
+            SequenceStep step,
+            Func<string, Task> executeCommandAsync,
+            Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
+            Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
+            Dictionary<string, string> stepOutcomes,
+            SequenceExecutionResult result,
+            string sequenceId,
+            int globalMaxIterations,
+            CancellationToken ct)
+        {
+            var stepKey = !string.IsNullOrWhiteSpace(step.StepId) ? step.StepId : $"loop@{step.Order}";
+            var maxIterations = step.Loop?.MaxIterations ?? globalMaxIterations;
+
+            switch (step.Loop)
+            {
+                case CountLoopConfig countCfg:
+                    return await ExecuteCountLoopAsync(step, stepKey, countCfg,
+                        executeCommandAsync, gateEvaluator, conditionEvaluator,
+                        stepOutcomes, result, sequenceId, ct).ConfigureAwait(false);
+
+                case WhileLoopConfig whileCfg:
+                    return await ExecuteWhileLoopAsync(step, stepKey, whileCfg, maxIterations,
+                        executeCommandAsync, gateEvaluator, conditionEvaluator,
+                        stepOutcomes, result, sequenceId, ct).ConfigureAwait(false);
+
+                case RepeatUntilLoopConfig ruCfg:
+                    return await ExecuteRepeatUntilLoopAsync(step, stepKey, ruCfg, maxIterations,
+                        executeCommandAsync, gateEvaluator, conditionEvaluator,
+                        stepOutcomes, result, sequenceId, ct).ConfigureAwait(false);
+
+                default:
+                    result.AddStep(stepKey, 0, "Failed", message: $"Loop step '{stepKey}' has missing or unknown loop configuration.");
+                    result.Fail($"Loop step '{stepKey}' has missing or unknown loop configuration.");
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+            }
+        }
+
+        /// <summary>Count-based loop: executes body exactly <see cref="CountLoopConfig.Count"/> times.</summary>
+        private async Task<bool> ExecuteCountLoopAsync(
+            SequenceStep step,
+            string stepKey,
+            CountLoopConfig cfg,
+            Func<string, Task> executeCommandAsync,
+            Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
+            Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
+            Dictionary<string, string> stepOutcomes,
+            SequenceExecutionResult result,
+            string sequenceId,
+            CancellationToken ct)
+        {
+            var iterResults = new List<LoopIterResult>();
+
+            for (var i = 0; i < cfg.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var iterCtx = ImmutableIterContext(i + 1);
+                var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
+                    step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator,
+                    stepOutcomes, result, sequenceId, iterCtx, ct).ConfigureAwait(false);
+
+                iterResults.Add(new LoopIterResult { IterationIndex = i + 1, BreakTriggered = breakTriggered, StepCount = stepCount });
+
+                if (earlyStop)
+                {
+                    result.AddLoopStep(stepKey, "Failed", iterResults);
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+                }
+                if (breakTriggered) break;
+            }
+
+            result.AddLoopStep(stepKey, "Succeeded", iterResults);
+            stepOutcomes[stepKey] = "success";
+            return false;
+        }
+
+        /// <summary>While loop: re-evaluates condition before each iteration.</summary>
+        private async Task<bool> ExecuteWhileLoopAsync(
+            SequenceStep step,
+            string stepKey,
+            WhileLoopConfig cfg,
+            int maxIterations,
+            Func<string, Task> executeCommandAsync,
+            Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
+            Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
+            Dictionary<string, string> stepOutcomes,
+            SequenceExecutionResult result,
+            string sequenceId,
+            CancellationToken ct)
+        {
+            var iterResults = new List<LoopIterResult>();
+            var iterations = 0;
+
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                bool condResult;
+                try
+                {
+                    condResult = await EvaluateLoopConditionAsync(
+                        cfg.Condition, conditionEvaluator, stepOutcomes, ct).ConfigureAwait(false);
+                }
+                catch
+                {
+                    result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' condition evaluation failed.");
+                    result.Fail($"Loop '{stepKey}' condition evaluation failed.");
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+                }
+
+                if (!condResult)
+                {
+                    // condition false on entry (or after last iteration)
+                    var status = iterations == 0 ? "Skipped" : "Succeeded";
+                    result.AddLoopStep(stepKey, status, iterResults);
+                    stepOutcomes[stepKey] = iterations == 0 ? "skipped" : "success";
+                    return false;
+                }
+
+                iterations++;
+                if (iterations > maxIterations)
+                {
+                    result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+                    result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+                }
+
+                var iterCtx = ImmutableIterContext(iterations);
+                var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
+                    step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator,
+                    stepOutcomes, result, sequenceId, iterCtx, ct).ConfigureAwait(false);
+
+                iterResults.Add(new LoopIterResult { IterationIndex = iterations, BreakTriggered = breakTriggered, StepCount = stepCount });
+
+                if (earlyStop)
+                {
+                    result.AddLoopStep(stepKey, "Failed", iterResults);
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+                }
+                if (breakTriggered) break;
+            }
+
+            result.AddLoopStep(stepKey, "Succeeded", iterResults);
+            stepOutcomes[stepKey] = "success";
+            return false;
+        }
+
+        /// <summary>Repeat-until loop: executes body at least once then checks exit condition.</summary>
+        private async Task<bool> ExecuteRepeatUntilLoopAsync(
+            SequenceStep step,
+            string stepKey,
+            RepeatUntilLoopConfig cfg,
+            int maxIterations,
+            Func<string, Task> executeCommandAsync,
+            Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
+            Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
+            Dictionary<string, string> stepOutcomes,
+            SequenceExecutionResult result,
+            string sequenceId,
+            CancellationToken ct)
+        {
+            var iterResults = new List<LoopIterResult>();
+            var iterations = 0;
+
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+                iterations++;
+
+                var iterCtx = ImmutableIterContext(iterations);
+                var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
+                    step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator,
+                    stepOutcomes, result, sequenceId, iterCtx, ct).ConfigureAwait(false);
+
+                iterResults.Add(new LoopIterResult { IterationIndex = iterations, BreakTriggered = breakTriggered, StepCount = stepCount });
+
+                if (earlyStop)
+                {
+                    result.AddLoopStep(stepKey, "Failed", iterResults);
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+                }
+                if (breakTriggered) break;
+
+                if (iterations >= maxIterations)
+                {
+                    result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+                    result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+                }
+
+                // Evaluate exit condition after body executes
+                bool exitCond;
+                try
+                {
+                    exitCond = await EvaluateLoopConditionAsync(
+                        cfg.Condition, conditionEvaluator, stepOutcomes, ct).ConfigureAwait(false);
+                }
+                catch
+                {
+                    result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exit condition evaluation failed.");
+                    result.Fail($"Loop '{stepKey}' exit condition evaluation failed.");
+                    stepOutcomes[stepKey] = "failed";
+                    return true;
+                }
+
+                if (exitCond) break;
+            }
+
+            result.AddLoopStep(stepKey, "Succeeded", iterResults);
+            stepOutcomes[stepKey] = "success";
+            return false;
+        }
+
+        /// <summary>
+        /// Executes the body steps for one loop iteration.  Returns
+        /// (<c>earlyStop</c>, <c>breakTriggered</c>, <c>stepsExecuted</c>).
+        /// A break step with a condition-evaluator error sets earlyStop=true.
+        /// </summary>
+        private async Task<(bool EarlyStop, bool BreakTriggered, int StepCount)> ExecuteLoopBodyAsync(
+            IReadOnlyList<SequenceStep> bodySteps,
+            Func<string, Task> executeCommandAsync,
+            Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
+            Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
+            Dictionary<string, string> stepOutcomes,
+            SequenceExecutionResult result,
+            string sequenceId,
+            IReadOnlyDictionary<string, string> iterContext,
+            CancellationToken ct)
+        {
+            var stepsExecuted = 0;
+
+            foreach (var step in bodySteps.OrderBy(s => s.Order))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                if (step.StepType == SequenceStepType.Break)
+                {
+                    if (step.BreakCondition is null)
+                    {
+                        // Unconditional break
+                        return (false, true, stepsExecuted);
+                    }
+
+                    // Conditional break
+                    bool breakCond;
+                    try
+                    {
+                        breakCond = await EvaluateLoopConditionAsync(
+                            step.BreakCondition, conditionEvaluator, stepOutcomes, ct).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        var brkKey = string.IsNullOrWhiteSpace(step.StepId) ? "break" : step.StepId;
+                        result.AddStep(brkKey, 0, "Failed", message: $"Break step '{brkKey}' condition evaluation failed.");
+                        result.Fail($"Break step '{brkKey}' condition evaluation failed.");
+                        return (true, false, stepsExecuted);
+                    }
+
+                    if (breakCond) return (false, true, stepsExecuted);
+                    continue; // condition false → keep executing body
+                }
+
+                // Apply template substitution to the body step before execution
+                SequenceStep effectiveStep = ApplyIterContext(step, iterContext);
+
+                var earlyStop = await ExecuteSingleStepAsync(
+                    effectiveStep,
+                    executeCommandAsync,
+                    gateEvaluator,
+                    conditionEvaluator,
+                    stepOutcomes,
+                    result,
+                    sequenceId,
+                    ct).ConfigureAwait(false);
+                stepsExecuted++;
+
+                if (earlyStop) return (true, false, stepsExecuted);
+            }
+
+            return (false, false, stepsExecuted);
+        }
+
+        /// <summary>
+        /// Evaluates a <see cref="SequenceStepCondition"/> within a loop context.
+        /// Throws when the evaluator is unavailable or throws.
+        /// </summary>
+        private static async Task<bool> EvaluateLoopConditionAsync(
+            SequenceStepCondition condition,
+            Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
+            Dictionary<string, string> stepOutcomes,
+            CancellationToken ct)
+        {
+            if (condition is ImageVisibleStepCondition imgCond)
+            {
+                if (conditionEvaluator is null)
+                    throw new InvalidOperationException("Image-visible condition evaluator is unavailable.");
+                return await conditionEvaluator(new Condition
+                {
+                    Source = "image",
+                    TargetId = imgCond.ImageId,
+                    Mode = "Present",
+                    ConfidenceThreshold = imgCond.MinSimilarity
+                }, ct).ConfigureAwait(false);
+            }
+
+            if (condition is CommandOutcomeStepCondition coCond)
+            {
+                if (!stepOutcomes.TryGetValue(coCond.StepRef, out var actual))
+                    throw new InvalidOperationException($"commandOutcome reference '{coCond.StepRef}' is not available.");
+                return string.Equals(actual, coCond.ExpectedState, StringComparison.OrdinalIgnoreCase);
+            }
+
+            throw new InvalidOperationException($"Unsupported loop condition type '{condition.GetType().Name}'.");
+        }
+
+        /// <summary>
+        /// Returns a copy of <paramref name="step"/> with <c>{{key}}</c> placeholders in
+        /// <see cref="SequenceStep.CommandId"/> and <see cref="SequenceStep.Action"/> parameters
+        /// substituted from <paramref name="context"/>.
+        /// </summary>
+        private static SequenceStep ApplyIterContext(
+            SequenceStep step,
+            IReadOnlyDictionary<string, string> context)
+        {
+            var substitutedCommandId = TemplateSubstitutor.Substitute(step.CommandId, context);
+            var substitutedAction = step.Action is not null
+                ? TemplateSubstitutor.SubstitutePayload(step.Action, context)
+                : null;
+
+            return new SequenceStep
+            {
+                Order = step.Order,
+                StepId = step.StepId,
+                Label = step.Label,
+                CommandId = substitutedCommandId,
+                StepType = step.StepType,
+                Action = substitutedAction,
+                Condition = step.Condition,
+                ConditionExpression = step.ConditionExpression,
+                DelayMs = step.DelayMs,
+                DelayRangeMs = step.DelayRangeMs,
+                TimeoutMs = step.TimeoutMs,
+                Retry = step.Retry,
+                Gate = step.Gate,
+                // Body / Loop / BreakCondition are not deep-substituted in body steps
+                Loop = step.Loop,
+                Body = step.Body,
+                BreakCondition = step.BreakCondition
+            };
+        }
+
+        /// <summary>Creates a read-only dict with iteration substitution context.</summary>
+        private static Dictionary<string, string> ImmutableIterContext(int iteration)
+            => new(StringComparer.Ordinal) { ["iteration"] = iteration.ToString(System.Globalization.CultureInfo.InvariantCulture) };
 
         private async Task ExecuteBlocksAsync(
             IReadOnlyList<object> blocks,
@@ -1312,6 +1711,22 @@ namespace GameBot.Domain.Services
             });
         }
 
+        public void AddLoopStep(
+            string stepId,
+            string status,
+            IReadOnlyList<LoopIterResult> iterResults,
+            string? message = null)
+        {
+            _steps.Add(new StepResult
+            {
+                CommandId = stepId,
+                Status = status,
+                Attempts = 1,
+                LoopIterations = iterResults,
+                Message = message
+            });
+        }
+
         public void Complete()
         {
             EndedAt = DateTimeOffset.UtcNow;
@@ -1348,5 +1763,15 @@ namespace GameBot.Domain.Services
         public string? ConditionResult { get; set; }
         public string? ActionOutcome { get; set; }
         public string? Message { get; set; }
+        /// <summary>Per-iteration results for loop steps; null for non-loop steps.</summary>
+        public IReadOnlyList<LoopIterResult>? LoopIterations { get; set; }
+    }
+
+    /// <summary>Result summary for a single loop iteration.</summary>
+    public sealed class LoopIterResult
+    {
+        public int IterationIndex { get; set; }
+        public bool BreakTriggered { get; set; }
+        public int StepCount { get; set; }
     }
 }

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -866,11 +866,20 @@ namespace GameBot.Domain.Services
 
                 if (step.StepType == SequenceStepType.Break)
                 {
+                    var brkKey = string.IsNullOrWhiteSpace(step.StepId) ? "break" : step.StepId;
+
                     if (step.BreakCondition is null)
                     {
                         // Unconditional break
+                        result.AddStep(brkKey, 0, "Succeeded",
+                            conditionType: "unconditional",
+                            conditionResult: "true",
+                            actionOutcome: "break",
+                            message: "Unconditional break triggered");
                         return (false, true, stepsExecuted);
                     }
+
+                    var condDesc = DescribeBreakCondition(step.BreakCondition);
 
                     // Conditional break
                     bool breakCond;
@@ -881,13 +890,30 @@ namespace GameBot.Domain.Services
                     }
                     catch
                     {
-                        var brkKey = string.IsNullOrWhiteSpace(step.StepId) ? "break" : step.StepId;
-                        result.AddStep(brkKey, 0, "Failed", message: $"Break step '{brkKey}' condition evaluation failed.");
+                        result.AddStep(brkKey, 0, "Failed",
+                            conditionType: condDesc.Type,
+                            conditionResult: "error",
+                            actionOutcome: "failed",
+                            message: $"Break step '{brkKey}' condition evaluation failed ({condDesc.Detail}).");
                         result.Fail($"Break step '{brkKey}' condition evaluation failed.");
                         return (true, false, stepsExecuted);
                     }
 
-                    if (breakCond) return (false, true, stepsExecuted);
+                    if (breakCond)
+                    {
+                        result.AddStep(brkKey, 0, "Succeeded",
+                            conditionType: condDesc.Type,
+                            conditionResult: "true",
+                            actionOutcome: "break",
+                            message: $"Break triggered: {condDesc.Detail} evaluated to true");
+                        return (false, true, stepsExecuted);
+                    }
+
+                    result.AddStep(brkKey, 0, "Skipped",
+                        conditionType: condDesc.Type,
+                        conditionResult: "false",
+                        actionOutcome: "continue",
+                        message: $"Break skipped: {condDesc.Detail} evaluated to false");
                     continue; // condition false → keep executing body
                 }
 
@@ -947,6 +973,16 @@ namespace GameBot.Domain.Services
             }
 
             return condition.Negate ? !result : result;
+        }
+
+        private static (string Type, string Detail) DescribeBreakCondition(SequenceStepCondition condition)
+        {
+            var negatePrefix = condition.Negate ? "NOT " : "";
+            if (condition is ImageVisibleStepCondition img)
+                return ("imageVisible", $"{negatePrefix}imageVisible(imageId={img.ImageId}, minSimilarity={img.MinSimilarity?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "default"})");
+            if (condition is CommandOutcomeStepCondition co)
+                return ("commandOutcome", $"{negatePrefix}commandOutcome(stepRef={co.StepRef}, expected={co.ExpectedState})");
+            return (condition.GetType().Name, $"{negatePrefix}{condition.GetType().Name}");
         }
 
         /// <summary>

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -560,8 +560,9 @@ namespace GameBot.Domain.Services
             {
                 await executeCommandAsync(step.CommandId).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
+                var reason = !string.IsNullOrWhiteSpace(ex.Message) ? ex.Message : $"step '{stepKey}' command execution failed";
                 result.AddStep(
                     step.CommandId,
                     appliedDelay,
@@ -569,8 +570,8 @@ namespace GameBot.Domain.Services
                     conditionType: step.Condition is null ? null : step.Condition.Type,
                     conditionResult: step.Condition is null ? null : "true",
                     actionOutcome: "failed",
-                    message: $"step '{stepKey}' command execution failed");
-                result.Fail($"step '{stepKey}' command execution failed");
+                    message: reason);
+                result.Fail(reason);
                 if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "failed";
                 return true;
             }

--- a/src/GameBot.Domain/Services/SequenceStepValidationService.cs
+++ b/src/GameBot.Domain/Services/SequenceStepValidationService.cs
@@ -1,5 +1,6 @@
 using GameBot.Domain.Commands;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace GameBot.Domain.Services;
 
@@ -10,6 +11,10 @@ public sealed class SequenceStepValidationService {
     "failed",
     "skipped"
   };
+
+  // Matches {{word}} placeholders used for template substitution.
+  private static readonly Regex TemplatePlaceholder =
+      new(@"\{\{\w+\}\}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
 
   public IReadOnlyList<string> Validate(IReadOnlyList<SequenceStep> steps) {
     ArgumentNullException.ThrowIfNull(steps);
@@ -28,41 +33,135 @@ public sealed class SequenceStepValidationService {
         errors.Add($"Duplicate step id '{step.StepId}'.");
       }
 
+      if (step.StepType == SequenceStepType.Break) {
+        // Top-level break steps are never valid.
+        errors.Add($"Step '{stepLabel}' has stepType 'Break' which is only valid inside a loop body.");
+        continue;
+      }
+
+      if (step.StepType == SequenceStepType.Loop) {
+        ValidateLoopStep(step, stepLabel, steps, index, errors, insideLoop: false);
+        continue;
+      }
+
       if (step.Action is null) {
         errors.Add($"Step '{stepLabel}' requires action payload.");
       }
 
-      if (step.Condition is CommandOutcomeStepCondition commandOutcome) {
-        if (string.IsNullOrWhiteSpace(commandOutcome.StepRef)) {
-          errors.Add($"Step '{stepLabel}' commandOutcome condition requires stepRef.");
-        }
-        else {
-          var referencedIndex = steps
-            .Select((candidate, candidateIndex) => new { candidate.StepId, candidateIndex })
-            .FirstOrDefault(candidate => string.Equals(candidate.StepId, commandOutcome.StepRef, StringComparison.Ordinal))
-            ?.candidateIndex ?? -1;
-
-          if (referencedIndex < 0) {
-            errors.Add($"Step '{stepLabel}' commandOutcome references unknown prior step '{commandOutcome.StepRef}'.");
-          }
-          else if (referencedIndex >= index) {
-            errors.Add($"Step '{stepLabel}' commandOutcome stepRef '{commandOutcome.StepRef}' must reference a prior step.");
-          }
-        }
-
-        if (string.IsNullOrWhiteSpace(commandOutcome.ExpectedState)
-            || !AllowedCommandOutcomeStates.Contains(commandOutcome.ExpectedState)) {
-          errors.Add($"Step '{stepLabel}' commandOutcome expectedState must be one of success|failed|skipped.");
-        }
-      }
-
-      if (step.Condition is ImageVisibleStepCondition imageVisible
-          && string.IsNullOrWhiteSpace(imageVisible.ImageId)) {
-        errors.Add($"Step '{stepLabel}' imageVisible condition requires imageId.");
-      }
+      ValidateStepCondition(step, stepLabel, steps, index, errors, insideLoop: false);
     }
 
     return errors;
+  }
+
+  private void ValidateLoopStep(
+      SequenceStep step,
+      string stepLabel,
+      IReadOnlyList<SequenceStep> siblings,
+      int indexInSiblings,
+      List<string> errors,
+      bool insideLoop) {
+
+    if (step.Loop is null) {
+      errors.Add($"Loop step '{stepLabel}' requires a loop configuration.");
+      return;
+    }
+
+    // FR-008: MaxIterations must be > 0 when set.
+    if (step.Loop.MaxIterations.HasValue && step.Loop.MaxIterations.Value <= 0) {
+      errors.Add($"Loop step '{stepLabel}' maxIterations must be greater than zero.");
+    }
+
+    // FR-004: count must be >= 0.
+    if (step.Loop is CountLoopConfig countCfg && countCfg.Count < 0) {
+      errors.Add($"Loop step '{stepLabel}' count must be zero or greater.");
+    }
+
+    // Validate body steps.
+    var bodyStepIds = new HashSet<string>(_stepIdComparer);
+    for (var bi = 0; bi < step.Body.Count; bi++) {
+      var bodyStep = step.Body[bi];
+      var bodyLabel = string.IsNullOrWhiteSpace(bodyStep.StepId) ? $"{stepLabel}.body[{bi}]" : bodyStep.StepId;
+
+      if (string.IsNullOrWhiteSpace(bodyStep.StepId)) {
+        errors.Add($"Body step at index {bi} inside '{stepLabel}' requires non-empty stepId.");
+      }
+      else if (!bodyStepIds.Add(bodyStep.StepId)) {
+        errors.Add($"Duplicate body step id '{bodyStep.StepId}' inside loop '{stepLabel}'.");
+      }
+
+      // FR-012: nested loops are forbidden.
+      if (bodyStep.StepType == SequenceStepType.Loop) {
+        errors.Add($"Body step '{bodyLabel}' inside loop '{stepLabel}' must not itself be a loop step.");
+        continue;
+      }
+
+      if (bodyStep.StepType == SequenceStepType.Break) {
+        if (bodyStep.BreakCondition is ImageVisibleStepCondition brkImgVis
+            && string.IsNullOrWhiteSpace(brkImgVis.ImageId)) {
+          errors.Add($"Break step '{bodyLabel}' imageVisible breakCondition requires imageId.");
+        }
+        continue;
+      }
+
+      if (bodyStep.Action is null) {
+        errors.Add($"Body step '{bodyLabel}' inside loop '{stepLabel}' requires action payload.");
+      }
+
+      // FR-002a: {{iteration}} (or any template placeholder) is only valid inside a loop body —
+      // validate that top-level steps do NOT contain placeholders (done in Validate()). Here
+      // we just validate the body step's condition references.
+      ValidateStepCondition(bodyStep, bodyLabel, step.Body, bi, errors, insideLoop: true);
+    }
+  }
+
+  private static void ValidateStepCondition(
+      SequenceStep step,
+      string stepLabel,
+      IReadOnlyList<SequenceStep> siblings,
+      int indexInSiblings,
+      List<string> errors,
+      bool insideLoop) {
+
+    // FR-002a: {{iteration}} placeholders in action parameters are only permitted inside loops.
+    if (!insideLoop && step.Action is not null) {
+      foreach (var paramValue in step.Action.Parameters.Values) {
+        if (paramValue is string s && TemplatePlaceholder.IsMatch(s)) {
+          errors.Add($"Step '{stepLabel}' contains template placeholder(s) in action parameters which are only valid inside a loop body.");
+          break;
+        }
+      }
+    }
+
+    if (step.Condition is CommandOutcomeStepCondition commandOutcome) {
+      if (string.IsNullOrWhiteSpace(commandOutcome.StepRef)) {
+        errors.Add($"Step '{stepLabel}' commandOutcome condition requires stepRef.");
+      }
+      else {
+        var referencedIndex = siblings
+          .Select((candidate, candidateIndex) => new { candidate.StepId, candidateIndex })
+          .FirstOrDefault(candidate => string.Equals(candidate.StepId, commandOutcome.StepRef, StringComparison.Ordinal))
+          ?.candidateIndex ?? -1;
+
+        if (referencedIndex < 0) {
+          errors.Add($"Step '{stepLabel}' commandOutcome references unknown prior step '{commandOutcome.StepRef}'.");
+        }
+        else if (referencedIndex >= indexInSiblings) {
+          // FR-006: inside a loop body a commandOutcome must not forward-reference within the same body.
+          errors.Add($"Step '{stepLabel}' commandOutcome stepRef '{commandOutcome.StepRef}' must reference a prior step.");
+        }
+      }
+
+      if (string.IsNullOrWhiteSpace(commandOutcome.ExpectedState)
+          || !AllowedCommandOutcomeStates.Contains(commandOutcome.ExpectedState)) {
+        errors.Add($"Step '{stepLabel}' commandOutcome expectedState must be one of success|failed|skipped.");
+      }
+    }
+
+    if (step.Condition is ImageVisibleStepCondition imageVisible
+        && string.IsNullOrWhiteSpace(imageVisible.ImageId)) {
+      errors.Add($"Step '{stepLabel}' imageVisible condition requires imageId.");
+    }
   }
 
   public IReadOnlyList<string> Validate(SequenceFlowGraph graph) {

--- a/src/GameBot.Domain/Triggers/Evaluators/ImageMatchEvaluator.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/ImageMatchEvaluator.cs
@@ -61,7 +61,8 @@ public sealed class ImageMatchEvaluator : ITriggerEvaluator {
         var ncc = Ncc(regionGray, tplGray, x, y);
         if (ncc > best) best = ncc;
       }
-    return Math.Max(0, Math.Min(1, (best + 1) / 2.0));
+    // Clamp to [0,1] without rescaling – raw NCC matches OpenCV CCoeffNormed range
+    return Math.Max(0, Math.Min(1, best));
   }
 
   

--- a/src/GameBot.Domain/Triggers/Evaluators/ScreenSourceAbstractions.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/ScreenSourceAbstractions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using System.Runtime.Versioning;
 
@@ -12,4 +13,56 @@ public sealed class SingleBitmapScreenSource : IScreenSource {
   private readonly Func<Bitmap?> _provider;
   public SingleBitmapScreenSource(Func<Bitmap?> provider) { _provider = provider; }
   public Bitmap? GetLatestScreenshot() => _provider();
+}
+
+/// <summary>
+/// Wraps an <see cref="IScreenSource"/> and caches the last screenshot for
+/// <paramref name="ttlMs"/> milliseconds.  Subsequent calls within the TTL
+/// window return a cheap in-memory clone instead of re-capturing via ADB,
+/// preventing duplicate screencap round-trips in the same loop iteration.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class CachedScreenSource : IScreenSource, IDisposable {
+  private readonly IScreenSource _inner;
+  private readonly int _ttlMs;
+  private Bitmap? _cached;
+  private DateTimeOffset _expiry = DateTimeOffset.MinValue;
+  private readonly object _lock = new();
+  private bool _disposed;
+
+  public CachedScreenSource(IScreenSource inner, int ttlMs = 500) {
+    _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    _ttlMs = Math.Max(0, ttlMs);
+  }
+
+  public Bitmap? GetLatestScreenshot() {
+    lock (_lock) {
+      ObjectDisposedException.ThrowIf(_disposed, this);
+
+      if (DateTimeOffset.UtcNow < _expiry) {
+        // Cache hit (may be null if inner returned null): return a clone or null.
+        return _cached is not null ? new Bitmap(_cached) : null;
+      }
+
+      // Cache miss: capture from inner source and store a master copy.
+      var fresh = _inner.GetLatestScreenshot();
+      _cached?.Dispose();
+      _cached = fresh;
+      _expiry = _ttlMs > 0
+        ? DateTimeOffset.UtcNow.AddMilliseconds(_ttlMs)
+        : DateTimeOffset.MaxValue;
+
+      return _cached is not null ? new Bitmap(_cached) : null;
+    }
+  }
+
+  public void Dispose() {
+    lock (_lock) {
+      if (!_disposed) {
+        _cached?.Dispose();
+        _cached = null;
+        _disposed = true;
+      }
+    }
+  }
 }

--- a/src/GameBot.Domain/Utils/TemplateSubstitutor.cs
+++ b/src/GameBot.Domain/Utils/TemplateSubstitutor.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using GameBot.Domain.Commands;
+
+namespace GameBot.Domain.Utils;
+
+/// <summary>
+/// Substitutes <c>{{key}}</c> template placeholders in strings and action payload parameters.
+/// Keys must consist of word characters only (<c>\w+</c>).  Unknown keys are left unchanged.
+/// </summary>
+public static class TemplateSubstitutor
+{
+    private static readonly Regex PlaceholderPattern =
+        new(@"\{\{(\w+)\}\}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500));
+
+    /// <summary>
+    /// Returns a copy of <paramref name="template"/> with every <c>{{key}}</c> token replaced
+    /// by the corresponding value from <paramref name="context"/>.
+    /// Tokens whose key is absent from <paramref name="context"/> are left as-is.
+    /// </summary>
+    /// <param name="template">The string that may contain <c>{{key}}</c> placeholders.</param>
+    /// <param name="context">Substitution map from placeholder key to replacement value.</param>
+    public static string Substitute(string template, IReadOnlyDictionary<string, string> context)
+    {
+        return PlaceholderPattern.Replace(template, m =>
+        {
+            var key = m.Groups[1].Value;
+            return context.TryGetValue(key, out var value) ? value : m.Value;
+        });
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="SequenceActionPayload"/> where every <em>string</em> parameter
+    /// value has had its <c>{{key}}</c> placeholders substituted from <paramref name="context"/>.
+    /// Non-string values are copied unchanged.
+    /// </summary>
+    /// <param name="payload">The payload whose string parameters should be substituted.</param>
+    /// <param name="context">Substitution map from placeholder key to replacement value.</param>
+    public static SequenceActionPayload SubstitutePayload(
+        SequenceActionPayload payload,
+        IReadOnlyDictionary<string, string> context)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        var result = new SequenceActionPayload { Type = payload.Type };
+        foreach (var (key, value) in payload.Parameters)
+        {
+            result.Parameters[key] = value is string str ? Substitute(str, context) : value;
+        }
+
+        return result;
+    }
+}

--- a/src/GameBot.Service/Models/SequenceStepContracts.cs
+++ b/src/GameBot.Service/Models/SequenceStepContracts.cs
@@ -4,6 +4,10 @@ using System.Text.Json.Serialization;
 
 namespace GameBot.Service.Models;
 
+internal sealed record SequenceExecuteRequest {
+  public string? SessionId { get; init; }
+}
+
 internal sealed record SequenceUpsertContract {
   public required string Name { get; init; }
   public int Version { get; init; }

--- a/src/GameBot.Service/Models/SequenceStepContracts.cs
+++ b/src/GameBot.Service/Models/SequenceStepContracts.cs
@@ -33,7 +33,9 @@ internal sealed record SequenceActionContract {
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(ImageVisibleConditionContract), typeDiscriminator: "imageVisible")]
 [JsonDerivedType(typeof(CommandOutcomeConditionContract), typeDiscriminator: "commandOutcome")]
-internal abstract record SequenceStepConditionContract;
+internal abstract record SequenceStepConditionContract {
+  public bool Negate { get; init; }
+}
 
 internal sealed record ImageVisibleConditionContract : SequenceStepConditionContract {
   public required string ImageId { get; init; }

--- a/src/GameBot.Service/Models/SequenceStepContracts.cs
+++ b/src/GameBot.Service/Models/SequenceStepContracts.cs
@@ -13,8 +13,12 @@ internal sealed record SequenceUpsertContract {
 internal sealed record SequenceStepContract {
   public required string StepId { get; init; }
   public string? Label { get; init; }
-  public required SequenceActionContract Action { get; init; }
+  public string? StepType { get; init; }
+  public SequenceActionContract? Action { get; init; }
   public SequenceStepConditionContract? Condition { get; init; }
+  public LoopConfigContract? Loop { get; init; }
+  public IReadOnlyList<SequenceStepContract>? Body { get; init; }
+  public SequenceStepConditionContract? BreakCondition { get; init; }
 }
 
 internal sealed record SequenceActionContract {
@@ -35,4 +39,24 @@ internal sealed record ImageVisibleConditionContract : SequenceStepConditionCont
 internal sealed record CommandOutcomeConditionContract : SequenceStepConditionContract {
   public required string StepRef { get; init; }
   public required string ExpectedState { get; init; }
+}
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "loopType")]
+[JsonDerivedType(typeof(CountLoopConfigContract), typeDiscriminator: "count")]
+[JsonDerivedType(typeof(WhileLoopConfigContract), typeDiscriminator: "while")]
+[JsonDerivedType(typeof(RepeatUntilLoopConfigContract), typeDiscriminator: "repeatUntil")]
+internal abstract record LoopConfigContract {
+  public int? MaxIterations { get; init; }
+}
+
+internal sealed record CountLoopConfigContract : LoopConfigContract {
+  public int Count { get; init; }
+}
+
+internal sealed record WhileLoopConfigContract : LoopConfigContract {
+  public required SequenceStepConditionContract Condition { get; init; }
+}
+
+internal sealed record RepeatUntilLoopConfigContract : LoopConfigContract {
+  public required SequenceStepConditionContract Condition { get; init; }
 }

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -128,6 +128,12 @@ builder.Services.AddSingleton<IConditionEvaluator, ConditionEvaluator>();
 builder.Services.AddSingleton<ICommandOutcomeConditionAdapter, CommandOutcomeConditionAdapter>();
 builder.Services.AddSingleton<IImageDetectionConditionAdapter, ImageDetectionConditionAdapter>();
 builder.Services.AddSingleton<IImageVisibleConditionAdapter, ImageVisibleConditionAdapter>();
+builder.Services.AddSingleton(_ =>
+{
+    var loopMaxEnv = Environment.GetEnvironmentVariable("GAMEBOT_LOOP_MAX_ITERATIONS");
+    var loopMax = int.TryParse(loopMaxEnv, out var parsed) && parsed > 0 ? parsed : 1000;
+    return new GameBot.Domain.Config.AppConfig { LoopMaxIterations = loopMax };
+});
 builder.Services.AddSingleton<GameBot.Domain.Services.SequenceRunner>();
 builder.Services.AddSingleton(loggingGate);
 builder.Services.AddSingleton<ILoggingPolicyApplier>(sp => sp.GetRequiredService<LoggingPolicyGate>());
@@ -707,11 +713,20 @@ sequences.MapPatch("{sequenceId}", async (HttpRequest http, ISequenceRepository 
   return Results.Ok(ToSequenceResponse(saved));
 }).WithName("PatchSequence");
 
-sequences.MapPost("{sequenceId}/validate", (string sequenceId, SequenceFlowUpsertRequestDto request, ISequenceFlowValidator validator) => {
+sequences.MapPost("{sequenceId}/validate", async (string sequenceId, SequenceFlowUpsertRequestDto request, ISequenceFlowValidator validator, ISequenceRepository repo, SequenceStepValidationService stepValidationService) => {
   var graph = MapToFlowGraph(sequenceId, request);
-  var result = validator.Validate(graph);
-  if (!result.IsValid) {
-    return Results.BadRequest(new { valid = false, errors = result.Errors });
+  var flowResult = validator.Validate(graph);
+
+  // Also run step-level validation (includes loop rules) on persisted steps
+  var stepErrors = new List<string>();
+  var existing = await repo.GetAsync(sequenceId).ConfigureAwait(false);
+  if (existing is not null) {
+    stepErrors.AddRange(stepValidationService.Validate(existing.Steps));
+  }
+
+  var allErrors = flowResult.Errors.Concat(stepErrors).ToArray();
+  if (allErrors.Length > 0) {
+    return Results.BadRequest(new { valid = false, errors = allErrors });
   }
 
   return Results.Ok(new { valid = true, errors = Array.Empty<string>() });

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -174,8 +174,15 @@ if (OperatingSystem.IsWindows()) {
   var useAdbEnv = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
   var useAdb = !string.Equals(useAdbEnv, "false", StringComparison.OrdinalIgnoreCase);
   if (useAdb) {
-    // ADB-backed dynamic screen source via sessions
-    builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.IScreenSource, GameBot.Emulator.Session.AdbScreenSource>();
+    // ADB-backed dynamic screen source via sessions, wrapped with a short-TTL cache
+    // to prevent duplicate ADB screencap calls within the same loop iteration
+    // (e.g. PrimitiveTap detection + break-condition check both needing a screenshot).
+    builder.Services.AddSingleton<GameBot.Emulator.Session.AdbScreenSource>();
+    builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.IScreenSource>(sp => {
+      var inner = sp.GetRequiredService<GameBot.Emulator.Session.AdbScreenSource>();
+      var ttlMs = int.TryParse(Environment.GetEnvironmentVariable("GAMEBOT_SCREENSHOT_CACHE_TTL_MS"), out var t) && t >= 0 ? t : 500;
+      return new GameBot.Domain.Triggers.Evaluators.CachedScreenSource(inner, ttlMs);
+    });
   }
   else {
     // Test/stub mode: optional fixed bitmap via env variable

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -978,17 +978,7 @@ static object ToSequenceResponse(GameBot.Domain.Commands.CommandSequence sequenc
       id = sequence.Id,
       name = sequence.Name,
       version = sequence.Version,
-      steps = sequence.Steps.Select(step => new {
-        stepId = step.StepId,
-        label = step.Label,
-        action = step.Action is null
-          ? null
-          : new {
-            type = step.Action.Type,
-            parameters = step.Action.Parameters
-          },
-        condition = MapPerStepConditionToDto(step.Condition)
-      }).ToArray()
+      steps = sequence.Steps.Select(MapStepToDto).ToArray()
     };
   }
 
@@ -1038,6 +1028,51 @@ static object? MapPerStepConditionToDto(SequenceStepCondition? condition) {
   };
 }
 
+static object MapStepToDto(SequenceStep step) {
+  var stepType = step.StepType switch {
+    SequenceStepType.Loop => "Loop",
+    SequenceStepType.Break => "Break",
+    _ => "Action"
+  };
+
+  return new {
+    stepId = step.StepId,
+    label = step.Label,
+    stepType,
+    action = step.Action is null
+      ? null
+      : new {
+        type = step.Action.Type,
+        parameters = step.Action.Parameters
+      },
+    condition = MapPerStepConditionToDto(step.Condition),
+    loop = MapLoopConfigToDto(step.Loop),
+    body = step.Body.Count > 0 ? step.Body.Select(MapStepToDto).ToArray() : null,
+    breakCondition = MapPerStepConditionToDto(step.BreakCondition)
+  };
+}
+
+static object? MapLoopConfigToDto(LoopConfig? loop) {
+  return loop switch {
+    CountLoopConfig count => new {
+      loopType = "count",
+      count = count.Count,
+      maxIterations = count.MaxIterations
+    },
+    WhileLoopConfig while_ => new {
+      loopType = "while",
+      condition = MapPerStepConditionToDto(while_.Condition),
+      maxIterations = while_.MaxIterations
+    },
+    RepeatUntilLoopConfig repeatUntil => new {
+      loopType = "repeatUntil",
+      condition = MapPerStepConditionToDto(repeatUntil.Condition),
+      maxIterations = repeatUntil.MaxIterations
+    },
+    _ => null
+  };
+}
+
 bool HasLegacyBranchingFields(System.Text.Json.JsonElement root) {
   return root.TryGetProperty("entryStepId", out _)
          || root.TryGetProperty("links", out _);
@@ -1053,7 +1088,8 @@ bool IsPerStepRequestCandidate(System.Text.Json.JsonElement root) {
   }
 
   var firstStep = stepsProp.EnumerateArray().FirstOrDefault();
-  return firstStep.ValueKind == JsonValueKind.Object && firstStep.TryGetProperty("action", out _);
+  return firstStep.ValueKind == JsonValueKind.Object
+    && (firstStep.TryGetProperty("action", out _) || firstStep.TryGetProperty("stepType", out _));
 }
 
 bool TryReadPerStepRequest(System.Text.Json.JsonElement root, out SequenceUpsertContract? request, out string? error) {
@@ -1086,8 +1122,12 @@ bool TryReadPerStepRequest(System.Text.Json.JsonElement root, out SequenceUpsert
       return false;
     }
 
-    if (!stepElement.TryGetProperty("action", out var actionProp) || actionProp.ValueKind != JsonValueKind.Object) {
-      error = "each step must include action object.";
+    var hasStepType = stepElement.TryGetProperty("stepType", out var stepTypeProp) && stepTypeProp.ValueKind == JsonValueKind.String;
+    var stepTypeValue = hasStepType ? stepTypeProp.GetString()?.Trim().ToLowerInvariant() : null;
+    var isLoopOrBreak = stepTypeValue is "loop" or "break";
+
+    if (!isLoopOrBreak && (!stepElement.TryGetProperty("action", out var actionProp) || actionProp.ValueKind != JsonValueKind.Object)) {
+      error = "each action step must include action object.";
       return false;
     }
   }
@@ -1242,32 +1282,123 @@ static List<SequenceStep> MapToLinearSteps(SequenceUpsertContract request) {
   var result = new List<SequenceStep>(request.Steps.Count);
   for (var index = 0; index < request.Steps.Count; index++) {
     var step = request.Steps[index];
-    var mapped = new SequenceStep {
-      Order = index,
-      StepId = step.StepId,
-      Label = step.Label,
-      CommandId = step.StepId,
-      StepType = SequenceStepType.Action,
-      Action = new SequenceActionPayload {
-        Type = step.Action.Type
-      },
-      Condition = MapPerStepCondition(step.Condition)
-    };
+    var parsedStepType = ParseStepType(step.StepType);
 
-    foreach (var parameter in step.Action.Parameters) {
-      mapped.Action.Parameters[parameter.Key] = parameter.Value;
+    if (parsedStepType == SequenceStepType.Loop) {
+      var mapped = new SequenceStep {
+        Order = index,
+        StepId = step.StepId,
+        Label = step.Label,
+        StepType = SequenceStepType.Loop,
+        Loop = MapLoopConfig(step.Loop),
+        Body = MapBodySteps(step.Body)
+      };
+      result.Add(mapped);
+      continue;
     }
 
-    if (string.Equals(step.Action.Type, ActionTypes.Command, StringComparison.OrdinalIgnoreCase)
-        && step.Action.Parameters.TryGetValue("commandId", out var commandId)
-        && commandId.ValueKind == JsonValueKind.String
-        && !string.IsNullOrWhiteSpace(commandId.GetString())) {
-      mapped.CommandId = commandId.GetString()!;
+    if (parsedStepType == SequenceStepType.Break) {
+      var mapped = new SequenceStep {
+        Order = index,
+        StepId = step.StepId,
+        Label = step.Label,
+        StepType = SequenceStepType.Break,
+        BreakCondition = MapPerStepCondition(step.BreakCondition)
+      };
+      result.Add(mapped);
+      continue;
     }
 
-    result.Add(mapped);
+    {
+      var mapped = new SequenceStep {
+        Order = index,
+        StepId = step.StepId,
+        Label = step.Label,
+        CommandId = step.StepId,
+        StepType = SequenceStepType.Action,
+        Action = step.Action is not null ? new SequenceActionPayload { Type = step.Action.Type } : null,
+        Condition = MapPerStepCondition(step.Condition)
+      };
+
+      if (step.Action is not null) {
+        foreach (var parameter in step.Action.Parameters) {
+          mapped.Action!.Parameters[parameter.Key] = parameter.Value;
+        }
+
+        if (string.Equals(step.Action.Type, ActionTypes.Command, StringComparison.OrdinalIgnoreCase)
+            && step.Action.Parameters.TryGetValue("commandId", out var commandId)
+            && commandId.ValueKind == JsonValueKind.String
+            && !string.IsNullOrWhiteSpace(commandId.GetString())) {
+          mapped.CommandId = commandId.GetString()!;
+        }
+      }
+
+      result.Add(mapped);
+    }
   }
 
+  return result;
+}
+
+static SequenceStepType ParseStepType(string? stepType) {
+  if (string.IsNullOrWhiteSpace(stepType)) return SequenceStepType.Action;
+  return stepType.Trim().ToLowerInvariant() switch {
+    "loop" => SequenceStepType.Loop,
+    "break" => SequenceStepType.Break,
+    "action" => SequenceStepType.Action,
+    "command" => SequenceStepType.Command,
+    _ => SequenceStepType.Action
+  };
+}
+
+static LoopConfig? MapLoopConfig(LoopConfigContract? contract) {
+  return contract switch {
+    CountLoopConfigContract count => new CountLoopConfig { Count = count.Count, MaxIterations = count.MaxIterations },
+    WhileLoopConfigContract while_ => new WhileLoopConfig { Condition = MapPerStepCondition(while_.Condition)!, MaxIterations = while_.MaxIterations },
+    RepeatUntilLoopConfigContract repeatUntil => new RepeatUntilLoopConfig { Condition = MapPerStepCondition(repeatUntil.Condition)!, MaxIterations = repeatUntil.MaxIterations },
+    _ => null
+  };
+}
+
+static IReadOnlyList<SequenceStep> MapBodySteps(IReadOnlyList<SequenceStepContract>? body) {
+  if (body is null || body.Count == 0) return Array.Empty<SequenceStep>();
+  var result = new List<SequenceStep>(body.Count);
+  for (var i = 0; i < body.Count; i++) {
+    var child = body[i];
+    var childType = ParseStepType(child.StepType);
+
+    if (childType == SequenceStepType.Break) {
+      result.Add(new SequenceStep {
+        Order = i,
+        StepId = child.StepId,
+        Label = child.Label,
+        StepType = SequenceStepType.Break,
+        BreakCondition = MapPerStepCondition(child.BreakCondition)
+      });
+    } else {
+      var mapped = new SequenceStep {
+        Order = i,
+        StepId = child.StepId,
+        Label = child.Label,
+        CommandId = child.StepId,
+        StepType = SequenceStepType.Action,
+        Action = child.Action is not null ? new SequenceActionPayload { Type = child.Action.Type } : null,
+        Condition = MapPerStepCondition(child.Condition)
+      };
+      if (child.Action is not null) {
+        foreach (var parameter in child.Action.Parameters) {
+          mapped.Action!.Parameters[parameter.Key] = parameter.Value;
+        }
+        if (string.Equals(child.Action.Type, ActionTypes.Command, StringComparison.OrdinalIgnoreCase)
+            && child.Action.Parameters.TryGetValue("commandId", out var cid)
+            && cid.ValueKind == JsonValueKind.String
+            && !string.IsNullOrWhiteSpace(cid.GetString())) {
+          mapped.CommandId = cid.GetString()!;
+        }
+      }
+      result.Add(mapped);
+    }
+  }
   return result;
 }
 

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -1065,12 +1065,14 @@ static object? MapPerStepConditionToDto(SequenceStepCondition? condition) {
     ImageVisibleStepCondition imageVisible => new {
       type = "imageVisible",
       imageId = imageVisible.ImageId,
-      minSimilarity = imageVisible.MinSimilarity
+      minSimilarity = imageVisible.MinSimilarity,
+      negate = imageVisible.Negate
     },
     CommandOutcomeStepCondition commandOutcome => new {
       type = "commandOutcome",
       stepRef = commandOutcome.StepRef,
-      expectedState = commandOutcome.ExpectedState
+      expectedState = commandOutcome.ExpectedState,
+      negate = commandOutcome.Negate
     },
     _ => null
   };
@@ -1454,11 +1456,13 @@ static SequenceStepCondition? MapPerStepCondition(SequenceStepConditionContract?
   return condition switch {
     ImageVisibleConditionContract imageVisible => new ImageVisibleStepCondition {
       ImageId = imageVisible.ImageId,
-      MinSimilarity = imageVisible.MinSimilarity
+      MinSimilarity = imageVisible.MinSimilarity,
+      Negate = imageVisible.Negate
     },
     CommandOutcomeConditionContract commandOutcome => new CommandOutcomeStepCondition {
       StepRef = commandOutcome.StepRef,
-      ExpectedState = commandOutcome.ExpectedState
+      ExpectedState = commandOutcome.ExpectedState,
+      Negate = commandOutcome.Negate
     },
     _ => null
   };

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -751,12 +751,19 @@ sequences.MapPost("{sequenceId}/execute", async (
   IImageVisibleConditionAdapter imageVisibleConditionAdapter,
   GameBot.Service.Services.ExecutionLog.IExecutionLogService executionLogService,
   ISequenceRepository sequenceRepository,
+  GameBot.Service.Services.ICommandExecutor commandExecutor,
   string sequenceId,
   CancellationToken ct) => {
-    // Minimal stub: delegate is a no-op; command execution integration will be added in later phases
     var res = await runner.ExecuteAsync(
       sequenceId,
-      _ => Task.CompletedTask,
+      async commandId => {
+        try {
+          await commandExecutor.ForceExecuteAsync(null, commandId, ct).ConfigureAwait(false);
+        } catch (KeyNotFoundException) {
+          // Command not found in repository — step uses a primitive action type (e.g. tap)
+          // or references a non-existent command; treat as completed.
+        }
+      },
       gateEvaluator: (step, token) => {
         // Temporary evaluator for integration tests:
         // TargetId "always" => gate passes; "never" => gate fails

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -753,12 +753,26 @@ sequences.MapPost("{sequenceId}/execute", async (
   ISequenceRepository sequenceRepository,
   GameBot.Service.Services.ICommandExecutor commandExecutor,
   string sequenceId,
+  HttpContext httpContext,
   CancellationToken ct) => {
+    // Read optional sessionId from request body
+    string? sessionId = null;
+    try {
+      var body = await httpContext.Request.ReadFromJsonAsync<SequenceExecuteRequest>(ct).ConfigureAwait(false);
+      sessionId = body?.SessionId;
+    } catch (Exception ex) when (ex is System.Text.Json.JsonException or InvalidOperationException) {
+      // empty body, malformed JSON, or missing content-type — no sessionId override
+    }
+
     var res = await runner.ExecuteAsync(
       sequenceId,
       async commandId => {
         try {
-          await commandExecutor.ForceExecuteAsync(null, commandId, ct).ConfigureAwait(false);
+          await commandExecutor.ForceExecuteAsync(sessionId, commandId, ct).ConfigureAwait(false);
+        } catch (KeyNotFoundException ex) when (ex.Message == "cached_session_not_found") {
+          throw new InvalidOperationException($"No cached session found for command '{commandId}'. Start a session first.");
+        } catch (InvalidOperationException ex) when (ex.Message == "missing_session_context") {
+          throw new InvalidOperationException($"No session available for command '{commandId}'. Start a session or pass a sessionId.");
         } catch (KeyNotFoundException) {
           // Command not found in repository — step uses a primitive action type (e.g. tap)
           // or references a non-existent command; treat as completed.
@@ -805,16 +819,17 @@ sequences.MapPost("{sequenceId}/execute", async (
     ).ConfigureAwait(false);
     var sequence = await sequenceRepository.GetAsync(sequenceId).ConfigureAwait(false);
     var sequenceName = sequence?.Name ?? sequenceId;
-    var status = string.Equals(res.Status, "Completed", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
+    var status = string.Equals(res.Status, "Succeeded", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
     var flowStepsByCommandRef = (sequence?.FlowSteps ?? Array.Empty<GameBot.Domain.Commands.FlowStep>())
       .GroupBy(step => string.IsNullOrWhiteSpace(step.PayloadRef) ? step.StepId : step.PayloadRef!, StringComparer.Ordinal)
       .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
 
+    var commandSteps = res.Steps.Where(s => s.LoopIterations is null).ToList();
     var detailItems = new List<GameBot.Domain.Logging.ExecutionDetailItem> {
       new(
         "sequence",
-        $"Executed commands: {string.Join(",", res.Steps.Select(s => s.CommandId).Take(10))}",
-        new Dictionary<string, object?> { ["executedCount"] = res.Steps.Count },
+        $"Executed commands: {string.Join(",", commandSteps.Select(s => s.CommandId).Take(10))}",
+        new Dictionary<string, object?> { ["executedCount"] = commandSteps.Count },
         "normal")
     };
 
@@ -823,12 +838,38 @@ sequences.MapPost("{sequenceId}/execute", async (
       flowStepsByCommandRef.TryGetValue(step.CommandId, out var flowStep);
       var stepId = flowStep?.StepId ?? step.CommandId;
       var stepLabel = flowStep?.Label ?? step.CommandId;
+
+      // Loop summary entries are not command executions — emit a loop-type detail instead.
+      if (step.LoopIterations is not null) {
+        var iterCount = step.LoopIterations.Count;
+        detailItems.Add(new GameBot.Domain.Logging.ExecutionDetailItem(
+          "step",
+          $"Loop '{stepLabel}' {step.Status.ToLowerInvariant()} after {iterCount} iteration{(iterCount == 1 ? "" : "s")}.",
+          new Dictionary<string, object?> {
+            ["stepOrder"] = stepOrder++,
+            ["stepType"] = "loop",
+            ["status"] = step.Status,
+            ["actionOutcome"] = step.Status.ToLowerInvariant(),
+            ["iterations"] = iterCount,
+            ["message"] = step.Message,
+            ["sequenceId"] = sequenceId,
+            ["sequenceLabel"] = sequenceName,
+            ["stepId"] = stepId,
+            ["stepLabel"] = stepLabel
+          },
+          "normal"));
+        continue;
+      }
+
       var actionOutcome = string.IsNullOrWhiteSpace(step.ActionOutcome)
         ? (string.Equals(step.Status, "Skipped", StringComparison.OrdinalIgnoreCase) ? "skipped" : "executed")
         : step.ActionOutcome;
+      var stepDisplayMessage = !string.IsNullOrWhiteSpace(step.Message)
+        ? $"Step '{stepLabel}' {actionOutcome}: {step.Message}"
+        : $"Step '{stepLabel}' {actionOutcome}.";
       detailItems.Add(new GameBot.Domain.Logging.ExecutionDetailItem(
         "step",
-        $"Step '{stepLabel}' {actionOutcome}.",
+        stepDisplayMessage,
         new Dictionary<string, object?> {
           ["stepOrder"] = stepOrder++,
           ["stepType"] = "command",
@@ -868,7 +909,7 @@ sequences.MapPost("{sequenceId}/execute", async (
       sequenceId,
       sequenceName,
       status,
-      $"Sequence '{sequenceName}' {status} with {res.Steps.Count} executed commands.",
+      $"Sequence '{sequenceName}' {status} with {commandSteps.Count} step{(commandSteps.Count == 1 ? "" : "s")} executed.",
       new GameBot.Service.Services.ExecutionLog.ExecutionLogContext {
         Depth = 0,
         SequenceId = sequenceId,

--- a/src/GameBot.Service/Services/ConfigSnapshotService.cs
+++ b/src/GameBot.Service/Services/ConfigSnapshotService.cs
@@ -171,6 +171,7 @@ internal sealed class ConfigSnapshotService : IConfigSnapshotService, IDisposabl
       ["GAMEBOT_HTTP_LOG_LEVEL_MINIMUM"] = "Warning",
       ["GAMEBOT_BIND_HOST"] = installerBindHost,
       ["GAMEBOT_PORT"] = installerPort,
+      ["GAMEBOT_LOOP_MAX_ITERATIONS"] = 1000,
 
       // ASP.NET Core configuration env keys and their documented defaults/effective values
       ["Service__Storage__Root"] = _storageRoot,

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -143,8 +143,11 @@ internal sealed class ExecutionLogService : IExecutionLogService {
   public async Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default) {
     var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
     var now = DateTimeOffset.UtcNow;
-    var sanitizedDetails = TrimDetails(ExecutionLogSanitizer.SanitizeDetails(details?.ToList() ?? new List<ExecutionDetailItem>()));
+    var sanitizedDetails = ExecutionLogSanitizer.SanitizeDetails(details?.ToList() ?? new List<ExecutionDetailItem>());
+    // Compute step outcomes before trimming so all loop iterations are captured,
+    // including "Break triggered" entries that would otherwise be truncated.
     var stepOutcomes = BuildSequenceStepOutcomes(sequenceId, sequenceName, context, sanitizedDetails);
+    var trimmedDetails = TrimDetails(sanitizedDetails);
 
     var entry = new ExecutionLogEntry {
       TimestampUtc = now,
@@ -154,7 +157,7 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       Navigation = ExecutionNavigationBuilder.Build("sequence", sequenceId, context),
       Hierarchy = ExecutionHierarchyBuilder.Build(context),
       Summary = TrimSummary(summary),
-      Details = sanitizedDetails,
+      Details = trimmedDetails,
       StepOutcomes = stepOutcomes,
       RetentionExpiresUtc = retention.Enabled ? now.AddDays(Math.Max(1, retention.RetentionDays)) : DateTimeOffset.MaxValue
     };

--- a/src/web-ui/src/components/sequences/BreakStepRow.tsx
+++ b/src/web-ui/src/components/sequences/BreakStepRow.tsx
@@ -83,13 +83,21 @@ export const BreakStepRow: React.FC<BreakStepRowProps> = ({ breakCondition, onCh
                 <label>Min Similarity</label>
                 <input
                   type="text"
+                  inputMode="decimal"
                   data-testid="break-min-similarity"
                   value={breakCondition.minSimilarity ?? ''}
                   disabled={disabled}
-                  placeholder="default: 0.85"
+                  placeholder="0–1 (default: 0.85)"
                   onChange={(e) => {
-                    const raw = e.target.value.trim();
-                    onChange({ ...breakCondition, minSimilarity: raw === '' ? null : Number(raw) });
+                    const raw = e.target.value;
+                    if (raw === '' || raw === '.' || raw === '0.') {
+                      onChange({ ...breakCondition, minSimilarity: raw === '' ? null : breakCondition.minSimilarity });
+                      return;
+                    }
+                    const num = Number(raw);
+                    if (!isNaN(num) && num >= 0 && num <= 1) {
+                      onChange({ ...breakCondition, minSimilarity: num });
+                    }
                   }}
                 />
               </div>

--- a/src/web-ui/src/components/sequences/BreakStepRow.tsx
+++ b/src/web-ui/src/components/sequences/BreakStepRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { SequenceStepCondition } from '../../types/sequenceFlow';
+import { SimilarityInput } from './SimilarityInput';
 
 export type BreakStepRowProps = {
   breakCondition?: SequenceStepCondition;
@@ -81,24 +82,11 @@ export const BreakStepRow: React.FC<BreakStepRowProps> = ({ breakCondition, onCh
               </div>
               <div className="break-step-row__field">
                 <label>Min Similarity</label>
-                <input
-                  type="text"
-                  inputMode="decimal"
+                <SimilarityInput
                   data-testid="break-min-similarity"
-                  value={breakCondition.minSimilarity ?? ''}
+                  value={breakCondition.minSimilarity}
                   disabled={disabled}
-                  placeholder="0–1 (default: 0.85)"
-                  onChange={(e) => {
-                    const raw = e.target.value;
-                    if (raw === '' || raw === '.' || raw === '0.') {
-                      onChange({ ...breakCondition, minSimilarity: raw === '' ? null : breakCondition.minSimilarity });
-                      return;
-                    }
-                    const num = Number(raw);
-                    if (!isNaN(num) && num >= 0 && num <= 1) {
-                      onChange({ ...breakCondition, minSimilarity: num });
-                    }
-                  }}
+                  onChange={(v) => onChange({ ...breakCondition, minSimilarity: v })}
                 />
               </div>
             </>

--- a/src/web-ui/src/components/sequences/BreakStepRow.tsx
+++ b/src/web-ui/src/components/sequences/BreakStepRow.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import type { SequenceStepCondition } from '../../types/sequenceFlow';
+
+export type BreakStepRowProps = {
+  breakCondition?: SequenceStepCondition;
+  onChange: (breakCondition: SequenceStepCondition | undefined) => void;
+  onRemove: () => void;
+  disabled?: boolean;
+};
+
+export const BreakStepRow: React.FC<BreakStepRowProps> = ({ breakCondition, onChange, onRemove, disabled }) => {
+  const isUnconditional = breakCondition == null;
+
+  return (
+    <div className="break-step-row" data-testid="break-step-row">
+      <div className="break-step-row__header">
+        <span className="break-step-row__badge">Break</span>
+        <label className="break-step-row__toggle">
+          <input
+            type="checkbox"
+            data-testid="always-break-toggle"
+            checked={isUnconditional}
+            disabled={disabled}
+            onChange={(e) => {
+              if (e.target.checked) {
+                onChange(undefined);
+              } else {
+                onChange({ type: 'imageVisible', imageId: '', minSimilarity: null });
+              }
+            }}
+          />
+          Always break
+        </label>
+        <button type="button" onClick={onRemove} disabled={disabled} data-testid="break-remove">Remove</button>
+      </div>
+      {!isUnconditional && (
+        <div className="break-step-row__condition" data-testid="break-condition-editor">
+          <div className="break-step-row__field">
+            <label>Condition Type</label>
+            <span>{breakCondition.type}</span>
+          </div>
+          {breakCondition.type === 'imageVisible' && (
+            <div className="break-step-row__field">
+              <label>Image ID</label>
+              <span>{breakCondition.imageId}</span>
+            </div>
+          )}
+          {breakCondition.type === 'commandOutcome' && (
+            <>
+              <div className="break-step-row__field">
+                <label>Step Ref</label>
+                <span>{breakCondition.stepRef}</span>
+              </div>
+              <div className="break-step-row__field">
+                <label>Expected State</label>
+                <span>{breakCondition.expectedState}</span>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/web-ui/src/components/sequences/BreakStepRow.tsx
+++ b/src/web-ui/src/components/sequences/BreakStepRow.tsx
@@ -36,24 +36,74 @@ export const BreakStepRow: React.FC<BreakStepRowProps> = ({ breakCondition, onCh
       {!isUnconditional && (
         <div className="break-step-row__condition" data-testid="break-condition-editor">
           <div className="break-step-row__field">
+            <label>
+              <input
+                type="checkbox"
+                data-testid="break-negate-toggle"
+                checked={breakCondition.negate ?? false}
+                disabled={disabled}
+                onChange={(e) => onChange({ ...breakCondition, negate: e.target.checked })}
+              />
+              NOT
+            </label>
+          </div>
+          <div className="break-step-row__field">
             <label>Condition Type</label>
-            <span>{breakCondition.type}</span>
+            <select
+              data-testid="break-condition-type"
+              value={breakCondition.type}
+              disabled={disabled}
+              onChange={(e) => {
+                const newType = e.target.value;
+                if (newType === 'imageVisible') {
+                  onChange({ type: 'imageVisible', imageId: '', minSimilarity: null });
+                } else {
+                  onChange({ type: 'commandOutcome', stepRef: '', expectedState: 'success' });
+                }
+              }}
+            >
+              <option value="imageVisible">Image Visible</option>
+              <option value="commandOutcome">Command Outcome</option>
+            </select>
           </div>
           {breakCondition.type === 'imageVisible' && (
             <div className="break-step-row__field">
               <label>Image ID</label>
-              <span>{breakCondition.imageId}</span>
+              <input
+                type="text"
+                data-testid="break-image-id"
+                value={breakCondition.imageId}
+                disabled={disabled}
+                placeholder="Enter image ID"
+                onChange={(e) => onChange({ ...breakCondition, imageId: e.target.value })}
+              />
             </div>
           )}
           {breakCondition.type === 'commandOutcome' && (
             <>
               <div className="break-step-row__field">
                 <label>Step Ref</label>
-                <span>{breakCondition.stepRef}</span>
+                <input
+                  type="text"
+                  data-testid="break-step-ref"
+                  value={breakCondition.stepRef}
+                  disabled={disabled}
+                  placeholder="Enter step reference"
+                  onChange={(e) => onChange({ ...breakCondition, stepRef: e.target.value })}
+                />
               </div>
               <div className="break-step-row__field">
                 <label>Expected State</label>
-                <span>{breakCondition.expectedState}</span>
+                <select
+                  data-testid="break-expected-state"
+                  value={breakCondition.expectedState}
+                  disabled={disabled}
+                  onChange={(e) => onChange({ ...breakCondition, expectedState: e.target.value as 'success' | 'failed' | 'skipped' })}
+                >
+                  <option value="success">success</option>
+                  <option value="failed">failed</option>
+                  <option value="skipped">skipped</option>
+                </select>
               </div>
             </>
           )}

--- a/src/web-ui/src/components/sequences/BreakStepRow.tsx
+++ b/src/web-ui/src/components/sequences/BreakStepRow.tsx
@@ -67,17 +67,33 @@ export const BreakStepRow: React.FC<BreakStepRowProps> = ({ breakCondition, onCh
             </select>
           </div>
           {breakCondition.type === 'imageVisible' && (
-            <div className="break-step-row__field">
-              <label>Image ID</label>
-              <input
-                type="text"
-                data-testid="break-image-id"
-                value={breakCondition.imageId}
-                disabled={disabled}
-                placeholder="Enter image ID"
-                onChange={(e) => onChange({ ...breakCondition, imageId: e.target.value })}
-              />
-            </div>
+            <>
+              <div className="break-step-row__field">
+                <label>Image ID</label>
+                <input
+                  type="text"
+                  data-testid="break-image-id"
+                  value={breakCondition.imageId}
+                  disabled={disabled}
+                  placeholder="Enter image ID"
+                  onChange={(e) => onChange({ ...breakCondition, imageId: e.target.value })}
+                />
+              </div>
+              <div className="break-step-row__field">
+                <label>Min Similarity</label>
+                <input
+                  type="text"
+                  data-testid="break-min-similarity"
+                  value={breakCondition.minSimilarity ?? ''}
+                  disabled={disabled}
+                  placeholder="default: 0.85"
+                  onChange={(e) => {
+                    const raw = e.target.value.trim();
+                    onChange({ ...breakCondition, minSimilarity: raw === '' ? null : Number(raw) });
+                  }}
+                />
+              </div>
+            </>
           )}
           {breakCondition.type === 'commandOutcome' && (
             <>

--- a/src/web-ui/src/components/sequences/LoopBlock.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlock.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import type { LoopStepEntry, StepEntry } from '../../types/stepEntry';
+import { LoopBlockHeader } from './LoopBlockHeader';
+import { BreakStepRow } from './BreakStepRow';
+
+export type LoopBlockProps = {
+  loop: LoopStepEntry;
+  onChange: (updated: LoopStepEntry) => void;
+  onRemove: () => void;
+  disabled?: boolean;
+};
+
+const makeId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+
+const move = (items: StepEntry[], from: number, to: number): StepEntry[] => {
+  const next = [...items];
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+};
+
+export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, disabled }) => {
+  const body = loop.body;
+
+  const handleBodyReorder = (from: number, to: number) => {
+    if (to < 0 || to >= body.length) return;
+    onChange({ ...loop, body: move(body, from, to) });
+  };
+
+  const handleBodyDelete = (index: number) => {
+    onChange({ ...loop, body: body.filter((_, i) => i !== index) });
+  };
+
+  const handleAddBodyStep = () => {
+    const newStep: StepEntry = {
+      type: 'Action',
+      id: makeId(),
+      stepId: `body-step-${body.length + 1}`,
+      commandId: '',
+      conditionType: 'none',
+      imageId: '',
+      minSimilarity: '',
+      outcomeStepRef: '',
+      expectedState: 'success',
+    };
+    onChange({ ...loop, body: [...body, newStep] });
+  };
+
+  const handleAddBreakStep = () => {
+    const newStep: StepEntry = {
+      type: 'Break',
+      id: makeId(),
+      stepId: `break-${body.length + 1}`,
+      breakCondition: undefined,
+    };
+    onChange({ ...loop, body: [...body, newStep] });
+  };
+
+  return (
+    <div className="loop-block" data-testid="loop-block" style={{ borderLeft: '3px solid #4a90d9', paddingLeft: '12px', marginBottom: '8px' }}>
+      <div className="loop-block__header-row">
+        <LoopBlockHeader
+          loopType={loop.loopType}
+          count={loop.count}
+          condition={loop.condition}
+          maxIterations={loop.maxIterations}
+        />
+        <button type="button" onClick={onRemove} disabled={disabled} data-testid="loop-remove">Remove Loop</button>
+      </div>
+
+      <div className="loop-block__body" data-testid="loop-body">
+        {body.length === 0 && (
+          <div className="empty-state" data-testid="loop-body-empty">No body steps yet.</div>
+        )}
+        <ol>
+          {body.map((step, index) => (
+            <li key={step.id} className="loop-block__body-step" data-testid="loop-body-step">
+              <div className="loop-block__body-step-content">
+                {step.type === 'Break' ? (
+                  <BreakStepRow
+                    breakCondition={step.breakCondition}
+                    onChange={(bc) => {
+                      const updated = body.map((s, i) =>
+                        i === index ? { ...s, breakCondition: bc } as StepEntry : s
+                      );
+                      onChange({ ...loop, body: updated });
+                    }}
+                    onRemove={() => handleBodyDelete(index)}
+                    disabled={disabled}
+                  />
+                ) : (
+                  <div className="loop-block__action-step" data-testid="loop-action-step">
+                    <span>{step.type === 'Action' ? (step.commandId || step.stepId) : step.stepId}</span>
+                  </div>
+                )}
+              </div>
+              <div className="loop-block__body-step-controls">
+                <button type="button" aria-label="Move up" onClick={() => handleBodyReorder(index, index - 1)} disabled={disabled || index === 0}>↑</button>
+                <button type="button" aria-label="Move down" onClick={() => handleBodyReorder(index, index + 1)} disabled={disabled || index === body.length - 1}>↓</button>
+                {step.type !== 'Break' && (
+                  <button type="button" onClick={() => handleBodyDelete(index)} disabled={disabled}>Delete</button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <div className="loop-block__add-buttons">
+        <button type="button" onClick={handleAddBodyStep} disabled={disabled} data-testid="add-body-step">
+          Add step
+        </button>
+        <button type="button" onClick={handleAddBreakStep} disabled={disabled} data-testid="add-break-step">
+          Add break
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/sequences/LoopBlock.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlock.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import type { LoopStepEntry, StepEntry } from '../../types/stepEntry';
+import type { LoopStepEntry, StepEntry, ActionStepEntry } from '../../types/stepEntry';
+import type { SequenceStepCondition } from '../../types/sequenceFlow';
 import { LoopBlockHeader } from './LoopBlockHeader';
 import { BreakStepRow } from './BreakStepRow';
+
+export type CommandOption = { value: string; label: string };
 
 export type LoopBlockProps = {
   loop: LoopStepEntry;
   onChange: (updated: LoopStepEntry) => void;
   onRemove: () => void;
+  commandOptions?: CommandOption[];
   disabled?: boolean;
 };
 
@@ -22,7 +26,7 @@ const move = (items: StepEntry[], from: number, to: number): StepEntry[] => {
   return next;
 };
 
-export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, disabled }) => {
+export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, commandOptions = [], disabled }) => {
   const body = loop.body;
 
   const handleBodyReorder = (from: number, to: number) => {
@@ -67,6 +71,10 @@ export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, 
           count={loop.count}
           condition={loop.condition}
           maxIterations={loop.maxIterations}
+          disabled={disabled}
+          onCountChange={(count) => onChange({ ...loop, count })}
+          onMaxIterationsChange={(maxIterations) => onChange({ ...loop, maxIterations })}
+          onConditionChange={(condition: SequenceStepCondition) => onChange({ ...loop, condition })}
         />
         <button type="button" onClick={onRemove} disabled={disabled} data-testid="loop-remove">Remove Loop</button>
       </div>
@@ -93,7 +101,22 @@ export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, 
                   />
                 ) : (
                   <div className="loop-block__action-step" data-testid="loop-action-step">
-                    <span>{step.type === 'Action' ? (step.commandId || step.stepId) : step.stepId}</span>
+                    <select
+                      data-testid="loop-body-command-select"
+                      value={(step as ActionStepEntry).commandId}
+                      disabled={disabled}
+                      onChange={(e) => {
+                        const updated = body.map((s, i) =>
+                          i === index ? { ...s, commandId: e.target.value } as StepEntry : s
+                        );
+                        onChange({ ...loop, body: updated });
+                      }}
+                    >
+                      <option value="">Select command…</option>
+                      {commandOptions.map((opt) => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
                   </div>
                 )}
               </div>

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -83,13 +83,21 @@ export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
               />
               <input
                 type="text"
+                inputMode="decimal"
                 data-testid="loop-condition-minSimilarity"
-                placeholder="default: 0.85"
+                placeholder="0–1 (default: 0.85)"
                 value={condition.minSimilarity ?? ''}
                 disabled={disabled}
                 onChange={(e) => {
-                  const raw = e.target.value.trim();
-                  onConditionChange?.({ ...condition, minSimilarity: raw === '' ? null : Number(raw) });
+                  const raw = e.target.value;
+                  if (raw === '' || raw === '.' || raw === '0.') {
+                    onConditionChange?.({ ...condition, minSimilarity: raw === '' ? null : condition.minSimilarity });
+                    return;
+                  }
+                  const num = Number(raw);
+                  if (!isNaN(num) && num >= 0 && num <= 1) {
+                    onConditionChange?.({ ...condition, minSimilarity: num });
+                  }
                 }}
                 style={{ width: '90px' }}
               />

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import type { SequenceStepCondition } from '../../types/sequenceFlow';
+
+export type LoopBlockHeaderProps = {
+  loopType: 'count' | 'while' | 'repeatUntil';
+  count?: number;
+  condition?: SequenceStepCondition;
+  maxIterations?: number;
+};
+
+const loopTypeBadge: Record<string, string> = {
+  count: 'Count',
+  while: 'While',
+  repeatUntil: 'Repeat‑Until',
+};
+
+const conditionSummary = (condition?: SequenceStepCondition): string => {
+  if (!condition) return '';
+  if (condition.type === 'imageVisible') return `imageVisible "${condition.imageId}"`;
+  if (condition.type === 'commandOutcome') return `commandOutcome ${condition.stepRef} = ${condition.expectedState}`;
+  return '';
+};
+
+export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({ loopType, count, condition, maxIterations }) => {
+  const badge = loopTypeBadge[loopType] ?? loopType;
+
+  let summary = '';
+  if (loopType === 'count') {
+    summary = `× ${count ?? 0}`;
+  } else {
+    summary = conditionSummary(condition);
+  }
+
+  return (
+    <div className="loop-block-header" data-testid="loop-block-header">
+      <span className="loop-block-header__badge" data-testid="loop-type-badge">{badge}</span>
+      <span className="loop-block-header__summary" data-testid="loop-summary">{summary}</span>
+      {maxIterations != null && (
+        <span className="loop-block-header__limit" data-testid="loop-max-iterations">max {maxIterations}</span>
+      )}
+      {(loopType === 'count' || loopType === 'while') && (
+        <span className="loop-block-header__hint" data-testid="loop-iteration-hint">{'{{iteration}}'}</span>
+      )}
+    </div>
+  );
+};

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { SequenceStepCondition } from '../../types/sequenceFlow';
+import { SimilarityInput } from './SimilarityInput';
 
 export type LoopBlockHeaderProps = {
   loopType: 'count' | 'while' | 'repeatUntil';
@@ -81,24 +82,11 @@ export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
                 disabled={disabled}
                 onChange={(e) => onConditionChange?.({ ...condition, imageId: e.target.value })}
               />
-              <input
-                type="text"
-                inputMode="decimal"
+              <SimilarityInput
                 data-testid="loop-condition-minSimilarity"
-                placeholder="0–1 (default: 0.85)"
-                value={condition.minSimilarity ?? ''}
+                value={condition.minSimilarity}
                 disabled={disabled}
-                onChange={(e) => {
-                  const raw = e.target.value;
-                  if (raw === '' || raw === '.' || raw === '0.') {
-                    onConditionChange?.({ ...condition, minSimilarity: raw === '' ? null : condition.minSimilarity });
-                    return;
-                  }
-                  const num = Number(raw);
-                  if (!isNaN(num) && num >= 0 && num <= 1) {
-                    onConditionChange?.({ ...condition, minSimilarity: num });
-                  }
-                }}
+                onChange={(v) => onConditionChange?.({ ...condition, minSimilarity: v })}
                 style={{ width: '90px' }}
               />
             </>

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -73,13 +73,27 @@ export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
           </select>
 
           {condition?.type === 'imageVisible' && (
-            <input
-              data-testid="loop-condition-imageId"
-              placeholder="Image ID"
-              value={condition.imageId}
-              disabled={disabled}
-              onChange={(e) => onConditionChange?.({ ...condition, imageId: e.target.value })}
-            />
+            <>
+              <input
+                data-testid="loop-condition-imageId"
+                placeholder="Image ID"
+                value={condition.imageId}
+                disabled={disabled}
+                onChange={(e) => onConditionChange?.({ ...condition, imageId: e.target.value })}
+              />
+              <input
+                type="text"
+                data-testid="loop-condition-minSimilarity"
+                placeholder="default: 0.85"
+                value={condition.minSimilarity ?? ''}
+                disabled={disabled}
+                onChange={(e) => {
+                  const raw = e.target.value.trim();
+                  onConditionChange?.({ ...condition, minSimilarity: raw === '' ? null : Number(raw) });
+                }}
+                style={{ width: '90px' }}
+              />
+            </>
           )}
           {condition?.type === 'commandOutcome' && (
             <>

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -43,6 +43,18 @@ export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
         </label>
       ) : (
         <div className="loop-block-header__condition-fields">
+          <label className="loop-block-header__negate-toggle">
+            <input
+              type="checkbox"
+              data-testid="loop-condition-negate"
+              checked={condition?.negate ?? false}
+              disabled={disabled}
+              onChange={(e) => {
+                if (condition) onConditionChange?.({ ...condition, negate: e.target.checked });
+              }}
+            />
+            NOT
+          </label>
           <select
             data-testid="loop-condition-type"
             value={condition?.type ?? 'imageVisible'}

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -6,6 +6,10 @@ export type LoopBlockHeaderProps = {
   count?: number;
   condition?: SequenceStepCondition;
   maxIterations?: number;
+  disabled?: boolean;
+  onCountChange?: (count: number) => void;
+  onMaxIterationsChange?: (maxIterations: number | undefined) => void;
+  onConditionChange?: (condition: SequenceStepCondition) => void;
 };
 
 const loopTypeBadge: Record<string, string> = {
@@ -14,30 +18,98 @@ const loopTypeBadge: Record<string, string> = {
   repeatUntil: 'Repeat‑Until',
 };
 
-const conditionSummary = (condition?: SequenceStepCondition): string => {
-  if (!condition) return '';
-  if (condition.type === 'imageVisible') return `imageVisible "${condition.imageId}"`;
-  if (condition.type === 'commandOutcome') return `commandOutcome ${condition.stepRef} = ${condition.expectedState}`;
-  return '';
-};
-
-export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({ loopType, count, condition, maxIterations }) => {
+export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
+  loopType, count, condition, maxIterations, disabled,
+  onCountChange, onMaxIterationsChange, onConditionChange,
+}) => {
   const badge = loopTypeBadge[loopType] ?? loopType;
-
-  let summary = '';
-  if (loopType === 'count') {
-    summary = `× ${count ?? 0}`;
-  } else {
-    summary = conditionSummary(condition);
-  }
 
   return (
     <div className="loop-block-header" data-testid="loop-block-header">
       <span className="loop-block-header__badge" data-testid="loop-type-badge">{badge}</span>
-      <span className="loop-block-header__summary" data-testid="loop-summary">{summary}</span>
-      {maxIterations != null && (
-        <span className="loop-block-header__limit" data-testid="loop-max-iterations">max {maxIterations}</span>
+
+      {loopType === 'count' ? (
+        <label className="loop-block-header__count-field">
+          ×{' '}
+          <input
+            type="number"
+            min={0}
+            data-testid="loop-count-input"
+            value={count ?? 0}
+            disabled={disabled}
+            onChange={(e) => onCountChange?.(Math.max(0, parseInt(e.target.value, 10) || 0))}
+            style={{ width: '60px' }}
+          />
+        </label>
+      ) : (
+        <div className="loop-block-header__condition-fields">
+          <select
+            data-testid="loop-condition-type"
+            value={condition?.type ?? 'imageVisible'}
+            disabled={disabled}
+            onChange={(e) => {
+              const type = e.target.value as 'imageVisible' | 'commandOutcome';
+              if (type === 'imageVisible') {
+                onConditionChange?.({ type: 'imageVisible', imageId: condition?.type === 'imageVisible' ? condition.imageId : '', minSimilarity: null });
+              } else {
+                onConditionChange?.({ type: 'commandOutcome', stepRef: condition?.type === 'commandOutcome' ? condition.stepRef : '', expectedState: condition?.type === 'commandOutcome' ? condition.expectedState : 'success' });
+              }
+            }}
+          >
+            <option value="imageVisible">imageVisible</option>
+            <option value="commandOutcome">commandOutcome</option>
+          </select>
+
+          {condition?.type === 'imageVisible' && (
+            <input
+              data-testid="loop-condition-imageId"
+              placeholder="Image ID"
+              value={condition.imageId}
+              disabled={disabled}
+              onChange={(e) => onConditionChange?.({ ...condition, imageId: e.target.value })}
+            />
+          )}
+          {condition?.type === 'commandOutcome' && (
+            <>
+              <input
+                data-testid="loop-condition-stepRef"
+                placeholder="Step ref"
+                value={condition.stepRef}
+                disabled={disabled}
+                onChange={(e) => onConditionChange?.({ ...condition, stepRef: e.target.value })}
+              />
+              <select
+                data-testid="loop-condition-expectedState"
+                value={condition.expectedState}
+                disabled={disabled}
+                onChange={(e) => onConditionChange?.({ ...condition, expectedState: e.target.value as 'success' | 'failed' | 'skipped' })}
+              >
+                <option value="success">success</option>
+                <option value="failed">failed</option>
+                <option value="skipped">skipped</option>
+              </select>
+            </>
+          )}
+        </div>
       )}
+
+      <label className="loop-block-header__limit-field">
+        Max:{' '}
+        <input
+          type="number"
+          min={1}
+          data-testid="loop-max-iterations"
+          placeholder="∞"
+          value={maxIterations ?? ''}
+          disabled={disabled}
+          onChange={(e) => {
+            const val = parseInt(e.target.value, 10);
+            onMaxIterationsChange?.(isNaN(val) ? undefined : Math.max(1, val));
+          }}
+          style={{ width: '60px' }}
+        />
+      </label>
+
       {(loopType === 'count' || loopType === 'while') && (
         <span className="loop-block-header__hint" data-testid="loop-iteration-hint">{'{{iteration}}'}</span>
       )}

--- a/src/web-ui/src/components/sequences/SimilarityInput.tsx
+++ b/src/web-ui/src/components/sequences/SimilarityInput.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+
+type SimilarityInputProps = {
+  value: number | null | undefined;
+  onChange: (value: number | null) => void;
+  disabled?: boolean;
+  'data-testid'?: string;
+  style?: React.CSSProperties;
+};
+
+export const SimilarityInput: React.FC<SimilarityInputProps> = ({ value, onChange, disabled, style, ...rest }) => {
+  const [text, setText] = useState(() => (value == null ? '' : String(value)));
+
+  useEffect(() => {
+    setText(prev => {
+      // Don't clobber intermediate typing states that end with a decimal point
+      if (/\.$/.test(prev) || prev === '.') return prev;
+      const incoming = value == null ? '' : String(value);
+      return incoming;
+    });
+  }, [value]);
+
+  return (
+    <input
+      type="text"
+      inputMode="decimal"
+      placeholder="0–1 (default: 0.85)"
+      value={text}
+      disabled={disabled}
+      style={style}
+      data-testid={rest['data-testid']}
+      onChange={(e) => {
+        const raw = e.target.value;
+        // Allow empty → null
+        if (raw === '') {
+          setText('');
+          onChange(null);
+          return;
+        }
+        // Allow any partial decimal that could become a valid 0-1 number
+        // e.g. ".", "0.", "1.", ".9", "0.8"
+        if (/^[01]?\.\d*$|^\.\d*$/.test(raw)) {
+          setText(raw);
+          const num = Number(raw);
+          if (!isNaN(num) && num >= 0 && num <= 1) {
+            onChange(num);
+          }
+          return;
+        }
+        const num = Number(raw);
+        if (!isNaN(num) && num >= 0 && num <= 1) {
+          setText(raw);
+          onChange(num);
+        }
+        // else: reject the keystroke (don't update state)
+      }}
+    />
+  );
+};

--- a/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
+++ b/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
@@ -3,17 +3,31 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { LoopBlockHeader } from '../LoopBlockHeader';
 import { BreakStepRow } from '../BreakStepRow';
 import { LoopBlock } from '../LoopBlock';
-import type { LoopStepEntry, StepEntry } from '../../../types/stepEntry';
+import type { LoopStepEntry } from '../../../types/stepEntry';
+import type { CommandOption } from '../LoopBlock';
+
+const testCommands: CommandOption[] = [
+  { value: 'cmd-a', label: 'Command A' },
+  { value: 'cmd-b', label: 'Command B' },
+];
 
 describe('LoopBlockHeader', () => {
-  it('renders count loop header with count value and iteration hint', () => {
+  it('renders count loop header with editable count input and iteration hint', () => {
     render(<LoopBlockHeader loopType="count" count={10} />);
     expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('Count');
-    expect(screen.getByTestId('loop-summary')).toHaveTextContent('× 10');
+    const input = screen.getByTestId('loop-count-input') as HTMLInputElement;
+    expect(input.value).toBe('10');
     expect(screen.getByTestId('loop-iteration-hint')).toHaveTextContent('{{iteration}}');
   });
 
-  it('renders while loop header with condition summary', () => {
+  it('fires onCountChange when count input is changed', () => {
+    const onCountChange = jest.fn();
+    render(<LoopBlockHeader loopType="count" count={3} onCountChange={onCountChange} />);
+    fireEvent.change(screen.getByTestId('loop-count-input'), { target: { value: '7' } });
+    expect(onCountChange).toHaveBeenCalledWith(7);
+  });
+
+  it('renders while loop header with condition type selector', () => {
     render(
       <LoopBlockHeader
         loopType="while"
@@ -21,11 +35,12 @@ describe('LoopBlockHeader', () => {
       />
     );
     expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('While');
-    expect(screen.getByTestId('loop-summary')).toHaveTextContent('imageVisible "my-img"');
+    expect(screen.getByTestId('loop-condition-type')).toHaveValue('imageVisible');
+    expect(screen.getByTestId('loop-condition-imageId')).toHaveValue('my-img');
     expect(screen.getByTestId('loop-iteration-hint')).toBeInTheDocument();
   });
 
-  it('renders repeatUntil loop header', () => {
+  it('renders repeatUntil loop header without iteration hint', () => {
     render(
       <LoopBlockHeader
         loopType="repeatUntil"
@@ -36,9 +51,67 @@ describe('LoopBlockHeader', () => {
     expect(screen.queryByTestId('loop-iteration-hint')).not.toBeInTheDocument();
   });
 
-  it('renders max iterations when provided', () => {
-    render(<LoopBlockHeader loopType="count" count={5} maxIterations={100} />);
-    expect(screen.getByTestId('loop-max-iterations')).toHaveTextContent('max 100');
+  it('renders editable max iterations input', () => {
+    const onMaxChange = jest.fn();
+    render(<LoopBlockHeader loopType="count" count={5} maxIterations={100} onMaxIterationsChange={onMaxChange} />);
+    const input = screen.getByTestId('loop-max-iterations') as HTMLInputElement;
+    expect(input.value).toBe('100');
+    fireEvent.change(input, { target: { value: '50' } });
+    expect(onMaxChange).toHaveBeenCalledWith(50);
+  });
+
+  it('renders commandOutcome condition fields for while loop', () => {
+    render(
+      <LoopBlockHeader
+        loopType="while"
+        condition={{ type: 'commandOutcome', stepRef: 'step-1', expectedState: 'success' }}
+      />
+    );
+    expect(screen.getByTestId('loop-condition-stepRef')).toHaveValue('step-1');
+    expect(screen.getByTestId('loop-condition-expectedState')).toHaveValue('success');
+  });
+
+  it('fires onConditionChange when switching condition type', () => {
+    const onConditionChange = jest.fn();
+    render(
+      <LoopBlockHeader
+        loopType="while"
+        condition={{ type: 'imageVisible', imageId: 'x', minSimilarity: null }}
+        onConditionChange={onConditionChange}
+      />
+    );
+    fireEvent.change(screen.getByTestId('loop-condition-type'), { target: { value: 'commandOutcome' } });
+    expect(onConditionChange).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'commandOutcome' })
+    );
+  });
+
+  it('fires onConditionChange when editing imageId', () => {
+    const onConditionChange = jest.fn();
+    render(
+      <LoopBlockHeader
+        loopType="while"
+        condition={{ type: 'imageVisible', imageId: '', minSimilarity: null }}
+        onConditionChange={onConditionChange}
+      />
+    );
+    fireEvent.change(screen.getByTestId('loop-condition-imageId'), { target: { value: 'new-img' } });
+    expect(onConditionChange).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'imageVisible', imageId: 'new-img' })
+    );
+  });
+
+  it('clears max iterations when input is emptied', () => {
+    const onMaxChange = jest.fn();
+    render(<LoopBlockHeader loopType="count" count={5} maxIterations={100} onMaxIterationsChange={onMaxChange} />);
+    fireEvent.change(screen.getByTestId('loop-max-iterations'), { target: { value: '' } });
+    expect(onMaxChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('shows empty max input when maxIterations is not set', () => {
+    render(<LoopBlockHeader loopType="count" count={5} />);
+    const input = screen.getByTestId('loop-max-iterations') as HTMLInputElement;
+    expect(input.value).toBe('');
   });
 });
 
@@ -79,6 +152,21 @@ describe('BreakStepRow', () => {
     render(<BreakStepRow breakCondition={undefined} onChange={() => {}} onRemove={onRemove} />);
     fireEvent.click(screen.getByTestId('break-remove'));
     expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('renders commandOutcome condition fields when condition is commandOutcome', () => {
+    render(
+      <BreakStepRow
+        breakCondition={{ type: 'commandOutcome', stepRef: 'step-2', expectedState: 'failed' }}
+        onChange={() => {}}
+        onRemove={() => {}}
+      />
+    );
+    expect(screen.getByTestId('break-condition-editor')).toBeInTheDocument();
+    expect(screen.getByText('Step Ref')).toBeInTheDocument();
+    expect(screen.getByText('step-2')).toBeInTheDocument();
+    expect(screen.getByText('Expected State')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
   });
 });
 
@@ -139,7 +227,7 @@ describe('LoopBlock', () => {
         { type: 'Action', id: 'a2', stepId: 'a2', commandId: 'cmd-b', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
       ],
     };
-    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} />);
+    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} commandOptions={testCommands} />);
     const moveDownButtons = screen.getAllByLabelText('Move down');
     fireEvent.click(moveDownButtons[0]);
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -153,5 +241,124 @@ describe('LoopBlock', () => {
     render(<LoopBlock loop={baseLoop} onChange={() => {}} onRemove={onRemove} />);
     fireEvent.click(screen.getByTestId('loop-remove'));
     expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('deleting an action step from body calls onChange with that step removed', () => {
+    const onChange = jest.fn();
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd-a', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+        { type: 'Action', id: 'a2', stepId: 'a2', commandId: 'cmd-b', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} commandOptions={testCommands} />);
+    const deleteButtons = screen.getAllByText('Delete');
+    fireEvent.click(deleteButtons[0]);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
+    expect(updated.body).toHaveLength(1);
+    expect(updated.body[0].id).toBe('a2');
+  });
+
+  it('renders command dropdown for action step in body with options', () => {
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd-a', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={() => {}} onRemove={() => {}} commandOptions={testCommands} />);
+    const select = screen.getByTestId('loop-body-command-select') as HTMLSelectElement;
+    expect(select.value).toBe('cmd-a');
+    expect(screen.getByText('Command A')).toBeInTheDocument();
+    expect(screen.getByText('Command B')).toBeInTheDocument();
+  });
+
+  it('changing command in body step fires onChange with updated commandId', () => {
+    const onChange = jest.fn();
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd-a', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} commandOptions={testCommands} />);
+    fireEvent.change(screen.getByTestId('loop-body-command-select'), { target: { value: 'cmd-b' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
+    expect(updated.body[0].type).toBe('Action');
+    expect((updated.body[0] as any).commandId).toBe('cmd-b');
+  });
+
+  it('editing break condition inside body calls onChange with updated body', () => {
+    const onChange = jest.fn();
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Break', id: 'brk-1', stepId: 'brk-1', breakCondition: { type: 'imageVisible', imageId: 'x', minSimilarity: null } },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} />);
+    // Toggle "Always break" to clear the condition
+    fireEvent.click(screen.getByTestId('always-break-toggle'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
+    expect(updated.body[0].type).toBe('Break');
+    expect((updated.body[0] as any).breakCondition).toBeUndefined();
+  });
+
+  it('move up on first step is disabled', () => {
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={() => {}} onRemove={() => {}} />);
+    const moveUp = screen.getByLabelText('Move up');
+    expect(moveUp).toBeDisabled();
+  });
+
+  it('move down on last step is disabled', () => {
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={() => {}} onRemove={() => {}} />);
+    const moveDown = screen.getByLabelText('Move down');
+    expect(moveDown).toBeDisabled();
+  });
+
+  it('removing a break step from body via its Remove button calls onChange without that step', () => {
+    const onChange = jest.fn();
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+        { type: 'Break', id: 'brk-1', stepId: 'brk-1', breakCondition: undefined },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} />);
+    fireEvent.click(screen.getByTestId('break-remove'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
+    expect(updated.body).toHaveLength(1);
+    expect(updated.body[0].id).toBe('a1');
+  });
+
+  it('disables all controls when disabled prop is true', () => {
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={() => {}} onRemove={() => {}} disabled />);
+    expect(screen.getByTestId('loop-remove')).toBeDisabled();
+    expect(screen.getByTestId('add-body-step')).toBeDisabled();
+    expect(screen.getByTestId('add-break-step')).toBeDisabled();
   });
 });

--- a/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
+++ b/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LoopBlockHeader } from '../LoopBlockHeader';
+import { BreakStepRow } from '../BreakStepRow';
+import { LoopBlock } from '../LoopBlock';
+import type { LoopStepEntry, StepEntry } from '../../../types/stepEntry';
+
+describe('LoopBlockHeader', () => {
+  it('renders count loop header with count value and iteration hint', () => {
+    render(<LoopBlockHeader loopType="count" count={10} />);
+    expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('Count');
+    expect(screen.getByTestId('loop-summary')).toHaveTextContent('× 10');
+    expect(screen.getByTestId('loop-iteration-hint')).toHaveTextContent('{{iteration}}');
+  });
+
+  it('renders while loop header with condition summary', () => {
+    render(
+      <LoopBlockHeader
+        loopType="while"
+        condition={{ type: 'imageVisible', imageId: 'my-img', minSimilarity: null }}
+      />
+    );
+    expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('While');
+    expect(screen.getByTestId('loop-summary')).toHaveTextContent('imageVisible "my-img"');
+    expect(screen.getByTestId('loop-iteration-hint')).toBeInTheDocument();
+  });
+
+  it('renders repeatUntil loop header', () => {
+    render(
+      <LoopBlockHeader
+        loopType="repeatUntil"
+        condition={{ type: 'imageVisible', imageId: 'done', minSimilarity: null }}
+      />
+    );
+    expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('Repeat\u2011Until');
+    expect(screen.queryByTestId('loop-iteration-hint')).not.toBeInTheDocument();
+  });
+
+  it('renders max iterations when provided', () => {
+    render(<LoopBlockHeader loopType="count" count={5} maxIterations={100} />);
+    expect(screen.getByTestId('loop-max-iterations')).toHaveTextContent('max 100');
+  });
+});
+
+describe('BreakStepRow', () => {
+  it('renders unconditional break with Always break checked', () => {
+    const onChange = jest.fn();
+    render(<BreakStepRow breakCondition={undefined} onChange={onChange} onRemove={() => {}} />);
+    const toggle = screen.getByTestId('always-break-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+    expect(screen.queryByTestId('break-condition-editor')).not.toBeInTheDocument();
+  });
+
+  it('toggling Always break off fires onChange with default condition', () => {
+    const onChange = jest.fn();
+    render(<BreakStepRow breakCondition={undefined} onChange={onChange} onRemove={() => {}} />);
+    fireEvent.click(screen.getByTestId('always-break-toggle'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'imageVisible' })
+    );
+  });
+
+  it('toggling Always break on fires onChange with undefined', () => {
+    const onChange = jest.fn();
+    render(
+      <BreakStepRow
+        breakCondition={{ type: 'imageVisible', imageId: 'x', minSimilarity: null }}
+        onChange={onChange}
+        onRemove={() => {}}
+      />
+    );
+    expect(screen.getByTestId('break-condition-editor')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('always-break-toggle'));
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls onRemove when remove button clicked', () => {
+    const onRemove = jest.fn();
+    render(<BreakStepRow breakCondition={undefined} onChange={() => {}} onRemove={onRemove} />);
+    fireEvent.click(screen.getByTestId('break-remove'));
+    expect(onRemove).toHaveBeenCalled();
+  });
+});
+
+describe('LoopBlock', () => {
+  const baseLoop: LoopStepEntry = {
+    type: 'Loop',
+    id: 'loop-1',
+    stepId: 'loop-1',
+    loopType: 'count',
+    count: 3,
+    body: [],
+  };
+
+  it('renders loop block with header', () => {
+    render(<LoopBlock loop={baseLoop} onChange={() => {}} onRemove={() => {}} />);
+    expect(screen.getByTestId('loop-block')).toBeInTheDocument();
+    expect(screen.getByTestId('loop-block-header')).toBeInTheDocument();
+    expect(screen.getByTestId('loop-body-empty')).toHaveTextContent('No body steps yet.');
+  });
+
+  it('renders break step inside loop body', () => {
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Break', id: 'brk-1', stepId: 'brk-1', breakCondition: undefined },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={() => {}} onRemove={() => {}} />);
+    expect(screen.getByTestId('break-step-row')).toBeInTheDocument();
+  });
+
+  it('adding a body step calls onChange with new step appended', () => {
+    const onChange = jest.fn();
+    render(<LoopBlock loop={baseLoop} onChange={onChange} onRemove={() => {}} />);
+    fireEvent.click(screen.getByTestId('add-body-step'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
+    expect(updated.body).toHaveLength(1);
+    expect(updated.body[0].type).toBe('Action');
+  });
+
+  it('adding a break step calls onChange with break appended', () => {
+    const onChange = jest.fn();
+    render(<LoopBlock loop={baseLoop} onChange={onChange} onRemove={() => {}} />);
+    fireEvent.click(screen.getByTestId('add-break-step'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
+    expect(updated.body).toHaveLength(1);
+    expect(updated.body[0].type).toBe('Break');
+  });
+
+  it('reordering a body step fires onChange with updated order', () => {
+    const onChange = jest.fn();
+    const loop: LoopStepEntry = {
+      ...baseLoop,
+      body: [
+        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd-a', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+        { type: 'Action', id: 'a2', stepId: 'a2', commandId: 'cmd-b', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+      ],
+    };
+    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} />);
+    const moveDownButtons = screen.getAllByLabelText('Move down');
+    fireEvent.click(moveDownButtons[0]);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
+    expect(updated.body[0].id).toBe('a2');
+    expect(updated.body[1].id).toBe('a1');
+  });
+
+  it('calls onRemove when Remove Loop clicked', () => {
+    const onRemove = jest.fn();
+    render(<LoopBlock loop={baseLoop} onChange={() => {}} onRemove={onRemove} />);
+    fireEvent.click(screen.getByTestId('loop-remove'));
+    expect(onRemove).toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
+++ b/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
@@ -155,18 +155,69 @@ describe('BreakStepRow', () => {
   });
 
   it('renders commandOutcome condition fields when condition is commandOutcome', () => {
+    const onChange = jest.fn();
     render(
       <BreakStepRow
         breakCondition={{ type: 'commandOutcome', stepRef: 'step-2', expectedState: 'failed' }}
-        onChange={() => {}}
+        onChange={onChange}
         onRemove={() => {}}
       />
     );
     expect(screen.getByTestId('break-condition-editor')).toBeInTheDocument();
-    expect(screen.getByText('Step Ref')).toBeInTheDocument();
-    expect(screen.getByText('step-2')).toBeInTheDocument();
-    expect(screen.getByText('Expected State')).toBeInTheDocument();
-    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByTestId('break-step-ref')).toHaveValue('step-2');
+    expect(screen.getByTestId('break-expected-state')).toHaveValue('failed');
+  });
+
+  it('changing condition type to imageVisible resets fields', () => {
+    const onChange = jest.fn();
+    render(
+      <BreakStepRow
+        breakCondition={{ type: 'commandOutcome', stepRef: 'step-2', expectedState: 'failed' }}
+        onChange={onChange}
+        onRemove={() => {}}
+      />
+    );
+    fireEvent.change(screen.getByTestId('break-condition-type'), { target: { value: 'imageVisible' } });
+    expect(onChange).toHaveBeenCalledWith({ type: 'imageVisible', imageId: '', minSimilarity: null });
+  });
+
+  it('editing imageId fires onChange', () => {
+    const onChange = jest.fn();
+    render(
+      <BreakStepRow
+        breakCondition={{ type: 'imageVisible', imageId: '', minSimilarity: null }}
+        onChange={onChange}
+        onRemove={() => {}}
+      />
+    );
+    fireEvent.change(screen.getByTestId('break-image-id'), { target: { value: 'img-abc' } });
+    expect(onChange).toHaveBeenCalledWith({ type: 'imageVisible', imageId: 'img-abc', minSimilarity: null });
+  });
+
+  it('editing step ref fires onChange', () => {
+    const onChange = jest.fn();
+    render(
+      <BreakStepRow
+        breakCondition={{ type: 'commandOutcome', stepRef: '', expectedState: 'success' }}
+        onChange={onChange}
+        onRemove={() => {}}
+      />
+    );
+    fireEvent.change(screen.getByTestId('break-step-ref'), { target: { value: 'step-5' } });
+    expect(onChange).toHaveBeenCalledWith({ type: 'commandOutcome', stepRef: 'step-5', expectedState: 'success' });
+  });
+
+  it('changing expected state fires onChange', () => {
+    const onChange = jest.fn();
+    render(
+      <BreakStepRow
+        breakCondition={{ type: 'commandOutcome', stepRef: 'step-1', expectedState: 'success' }}
+        onChange={onChange}
+        onRemove={() => {}}
+      />
+    );
+    fireEvent.change(screen.getByTestId('break-expected-state'), { target: { value: 'skipped' } });
+    expect(onChange).toHaveBeenCalledWith({ type: 'commandOutcome', stepRef: 'step-1', expectedState: 'skipped' });
   });
 });
 

--- a/src/web-ui/src/lib/sequenceMapping.ts
+++ b/src/web-ui/src/lib/sequenceMapping.ts
@@ -34,7 +34,7 @@ export const isLinearStepArray = (steps: SequenceDto['steps']): steps is Sequenc
     && steps.every((step) => typeof step === 'object'
       && step !== null
       && 'stepId' in step
-      && 'action' in step);
+      && ('action' in step || 'stepType' in step));
 };
 
 export const toLinearSteps = (steps: SequenceDto['steps']): SequenceLinearStep[] => {

--- a/src/web-ui/src/pages/Execution.tsx
+++ b/src/web-ui/src/pages/Execution.tsx
@@ -280,7 +280,7 @@ export const ExecutionPage: React.FC = () => {
     setSequenceError(undefined);
 
     try {
-      await executeSequence(selectedSequenceId);
+      await executeSequence(selectedSequenceId, cachedSession?.sessionId);
       setSequenceMessage('Sequence executed successfully.');
     } catch (err: any) {
       if (err instanceof ApiError) {

--- a/src/web-ui/src/pages/Execution.tsx
+++ b/src/web-ui/src/pages/Execution.tsx
@@ -3,6 +3,7 @@ import { listActions, ActionDto } from '../services/actionsApi';
 import { useGames } from '../services/useGames';
 import { getRunningSessions, startSession, stopSession, RunningSessionDto } from '../services/sessionsApi';
 import { listCommands, forceExecuteCommand, CommandDto } from '../services/commands';
+import { listSequences, executeSequence, SequenceDto } from '../services/sequences';
 import { ApiError } from '../lib/api';
 import { StatusChip } from '../features/execution/StatusChip';
 import { RunDetails } from '../features/execution/RunDetails';
@@ -35,6 +36,12 @@ export const ExecutionPage: React.FC = () => {
   const [manualSessionId, setManualSessionId] = useState('');
   const [executing, setExecuting] = useState(false);
   const [commandCacheMeta, setCommandCacheMeta] = useState<{ gameId: string; adbSerial: string; actionName?: string } | undefined>(undefined);
+  const [sequences, setSequences] = useState<SequenceDto[]>([]);
+  const [loadingSequences, setLoadingSequences] = useState(true);
+  const [selectedSequenceId, setSelectedSequenceId] = useState<string | undefined>(undefined);
+  const [sequenceMessage, setSequenceMessage] = useState<string | undefined>(undefined);
+  const [sequenceError, setSequenceError] = useState<string | undefined>(undefined);
+  const [executingSequence, setExecutingSequence] = useState(false);
 
   const gameLookup = useMemo(() => {
     const map = new Map<string, string>();
@@ -111,6 +118,25 @@ export const ExecutionPage: React.FC = () => {
   }, [refreshRunningSessions]);
 
   useEffect(() => {
+    const load = async () => {
+      setLoadingSequences(true);
+      try {
+        const data = await listSequences();
+        if (Array.isArray(data)) {
+          setSequences(data);
+        } else {
+          setSequences([]);
+        }
+      } catch (err: any) {
+        setSequences([]);
+      } finally {
+        setLoadingSequences(false);
+      }
+    };
+    void load();
+  }, []);
+
+  useEffect(() => {
     if (!selectedActionId && connectActions.length > 0) {
       setSelectedActionId(connectActions[0].id);
     }
@@ -121,6 +147,12 @@ export const ExecutionPage: React.FC = () => {
       setSelectedCommandId(commands[0].id);
     }
   }, [commands, selectedCommandId]);
+
+  useEffect(() => {
+    if (!selectedSequenceId && sequences.length > 0) {
+      setSelectedSequenceId(sequences[0].id);
+    }
+  }, [sequences, selectedSequenceId]);
 
   const findCommandCacheMeta = (commandId?: string) => {
     if (!commandId) return undefined;
@@ -202,18 +234,21 @@ export const ExecutionPage: React.FC = () => {
     let resolvedSessionId = manualSessionId.trim();
     const meta = findCommandCacheMeta(selectedCommandId);
     if (!resolvedSessionId) {
-      if (!meta) {
+      if (meta) {
+        const runningSession = runningSessions.find((s) => s.gameId === meta.gameId && s.emulatorId === meta.adbSerial && `${s.status}`.toLowerCase() === 'running');
+        if (!runningSession) {
+          setExecuting(false);
+          setCommandError(`No running session found for ${meta.gameId}/${meta.adbSerial}. Start a session first or enter a sessionId.`);
+          return;
+        }
+        resolvedSessionId = runningSession.sessionId;
+      } else if (cachedSession) {
+        resolvedSessionId = cachedSession.sessionId;
+      } else {
         setExecuting(false);
-        setCommandError('No connect-to-game step found for this command. Enter a sessionId or update the command to include one.');
+        setCommandError('No running session available. Start a session first or enter a sessionId.');
         return;
       }
-      const runningSession = runningSessions.find((s) => s.gameId === meta.gameId && s.emulatorId === meta.adbSerial && `${s.status}`.toLowerCase() === 'running');
-      if (!runningSession) {
-        setExecuting(false);
-        setCommandError(`No running session found for ${meta.gameId}/${meta.adbSerial}. Start a session first or enter a sessionId.`);
-        return;
-      }
-      resolvedSessionId = runningSession.sessionId;
     }
 
     try {
@@ -231,6 +266,30 @@ export const ExecutionPage: React.FC = () => {
       }
     } finally {
       setExecuting(false);
+    }
+  };
+
+  const handleExecuteSequence = async () => {
+    if (!selectedSequenceId) {
+      setSequenceError('Select a sequence to execute.');
+      return;
+    }
+
+    setExecutingSequence(true);
+    setSequenceMessage(undefined);
+    setSequenceError(undefined);
+
+    try {
+      await executeSequence(selectedSequenceId);
+      setSequenceMessage('Sequence executed successfully.');
+    } catch (err: any) {
+      if (err instanceof ApiError) {
+        setSequenceError(err.message);
+      } else {
+        setSequenceError(err?.message ?? 'Failed to execute sequence');
+      }
+    } finally {
+      setExecutingSequence(false);
     }
   };
 
@@ -256,6 +315,8 @@ export const ExecutionPage: React.FC = () => {
       {message && <div className="form-hint" role="status">{message}</div>}
       {commandError && <div className="form-error" role="alert">{commandError}</div>}
       {commandMessage && <div className="form-hint" role="status">{commandMessage}</div>}
+      {sequenceError && <div className="form-error" role="alert">{sequenceError}</div>}
+      {sequenceMessage && <div className="form-hint" role="status">{sequenceMessage}</div>}
 
       {cachedSession && (
         <div className="session-banner" role="status">
@@ -378,6 +439,32 @@ export const ExecutionPage: React.FC = () => {
 
         <div className="form-actions">
           <button type="button" onClick={handleExecuteCommand} disabled={executing || loadingCommands || commands.length === 0}>Execute command</button>
+        </div>
+      </section>
+
+      <section aria-label="Execute sequence">
+        <h2>Execute a sequence</h2>
+        <p>Run a sequence directly. The sequence runner will execute all steps in order.</p>
+
+        <div className="field">
+          <label htmlFor="sequence-select">Sequence</label>
+          <select
+            id="sequence-select"
+            aria-label="Sequence"
+            value={selectedSequenceId ?? ''}
+            onChange={(e) => { setSelectedSequenceId(e.target.value); setSequenceMessage(undefined); setSequenceError(undefined); }}
+            disabled={loadingSequences || executingSequence || sequences.length === 0}
+          >
+            {sequences.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+          {loadingSequences && <div className="form-hint">Loading sequences...</div>}
+          {!loadingSequences && sequences.length === 0 && <div className="form-hint">No sequences available.</div>}
+        </div>
+
+        <div className="form-actions">
+          <button type="button" onClick={handleExecuteSequence} disabled={executingSequence || loadingSequences || sequences.length === 0}>Execute sequence</button>
         </div>
       </section>
     </div>

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -21,6 +21,7 @@ type SequenceStep = {
   stepType: 'Action' | 'Loop' | 'Break';
   commandId: string;
   conditionType: 'none' | 'imageVisible' | 'commandOutcome';
+  conditionNegate: boolean;
   imageId: string;
   minSimilarity: string;
   outcomeStepRef: string;
@@ -43,6 +44,7 @@ const createDefaultStep = (commandId: string, stepId: string): SequenceStep => (
   stepType: 'Action',
   commandId,
   conditionType: 'none',
+  conditionNegate: false,
   imageId: '',
   minSimilarity: '',
   outcomeStepRef: '',
@@ -85,6 +87,7 @@ const linearBodyToStepEntries = (body: SequenceLinearStep[]): StepEntry[] => {
       commandId: cmdId,
       conditionType: child.condition?.type === 'imageVisible' ? 'imageVisible'
         : child.condition?.type === 'commandOutcome' ? 'commandOutcome' : 'none',
+      conditionNegate: child.condition?.negate ?? false,
       imageId: child.condition?.type === 'imageVisible' ? child.condition.imageId : '',
       minSimilarity: child.condition?.type === 'imageVisible' && child.condition.minSimilarity != null ? String(child.condition.minSimilarity) : '',
       outcomeStepRef: child.condition?.type === 'commandOutcome' ? child.condition.stepRef : '',
@@ -117,6 +120,7 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         stepType: 'Loop' as const,
         commandId: '',
         conditionType: 'none' as const,
+        conditionNegate: false,
         imageId: '',
         minSimilarity: '',
         outcomeStepRef: '',
@@ -132,6 +136,7 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         stepType: 'Break' as const,
         commandId: '',
         conditionType: 'none' as const,
+        conditionNegate: false,
         imageId: '',
         minSimilarity: '',
         outcomeStepRef: '',
@@ -150,6 +155,7 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         stepType: 'Action' as const,
         commandId,
         conditionType: 'imageVisible',
+        conditionNegate: step.condition.negate ?? false,
         imageId: step.condition.imageId,
         minSimilarity: step.condition.minSimilarity == null ? '' : String(step.condition.minSimilarity),
         outcomeStepRef: '',
@@ -164,6 +170,7 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         stepType: 'Action' as const,
         commandId,
         conditionType: 'commandOutcome',
+        conditionNegate: step.condition.negate ?? false,
         imageId: '',
         minSimilarity: '',
         outcomeStepRef: step.condition.stepRef,
@@ -183,14 +190,16 @@ const buildConditionPayload = (step: SequenceStep) => {
     return {
       type: 'imageVisible' as const,
       imageId: step.imageId.trim(),
-      minSimilarity: step.minSimilarity.trim() === '' ? null : Number(step.minSimilarity)
+      minSimilarity: step.minSimilarity.trim() === '' ? null : Number(step.minSimilarity),
+      negate: step.conditionNegate || undefined
     };
   }
   if (step.conditionType === 'commandOutcome') {
     return {
       type: 'commandOutcome' as const,
       stepRef: step.outcomeStepRef.trim(),
-      expectedState: step.expectedState
+      expectedState: step.expectedState,
+      negate: step.conditionNegate || undefined
     };
   }
   return null;
@@ -219,11 +228,11 @@ const bodyEntryToPayloadStep = (entry: StepEntry): SequenceLinearStep => {
     };
   }
   // Action body step
-  const a = entry as { stepId: string; commandId: string; conditionType: string; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
+  const a = entry as { stepId: string; commandId: string; conditionType: string; conditionNegate: boolean; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
   const cond = a.conditionType === 'imageVisible'
-    ? { type: 'imageVisible' as const, imageId: a.imageId.trim(), minSimilarity: a.minSimilarity.trim() === '' ? null : Number(a.minSimilarity) }
+    ? { type: 'imageVisible' as const, imageId: a.imageId.trim(), minSimilarity: a.minSimilarity.trim() === '' ? null : Number(a.minSimilarity), negate: a.conditionNegate || undefined }
     : a.conditionType === 'commandOutcome'
-      ? { type: 'commandOutcome' as const, stepRef: a.outcomeStepRef.trim(), expectedState: a.expectedState }
+      ? { type: 'commandOutcome' as const, stepRef: a.outcomeStepRef.trim(), expectedState: a.expectedState, negate: a.conditionNegate || undefined }
       : null;
   return {
     stepId: entry.stepId.trim(),
@@ -393,6 +402,27 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         </select>
       </div>
 
+      {step.conditionType !== 'none' && (
+        <div className="sequence-step-condition-field sequence-step-condition-field--negate">
+          <label>
+            <input
+              type="checkbox"
+              data-testid={`step-condition-negate-${step.id}`}
+              checked={step.conditionNegate}
+              onChange={(e) => {
+                setForm((prev) => ({
+                  ...prev,
+                  steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, conditionNegate: e.target.checked } : candidate)
+                }));
+                setDirty(true);
+              }}
+              disabled={submitting || loading}
+            />
+            NOT
+          </label>
+        </div>
+      )}
+
       {step.conditionType === 'imageVisible' && (
         <>
           <div className="sequence-step-condition-field sequence-step-condition-field--image-id">
@@ -496,6 +526,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
       stepType: 'Loop',
       commandId: '',
       conditionType: 'none',
+      conditionNegate: false,
       imageId: '',
       minSimilarity: '',
       outcomeStepRef: '',

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -445,13 +445,27 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
             <label htmlFor={`step-min-similarity-${step.id}`}>Min Similarity</label>
             <input
               id={`step-min-similarity-${step.id}`}
+              inputMode="decimal"
+              placeholder="0–1 (default: 0.85)"
               value={step.minSimilarity}
               onChange={(event) => {
-                setForm((prev) => ({
-                  ...prev,
-                  steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, minSimilarity: event.target.value } : candidate)
-                }));
-                setDirty(true);
+                const raw = event.target.value;
+                if (raw === '' || raw === '.' || raw === '0.') {
+                  setForm((prev) => ({
+                    ...prev,
+                    steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, minSimilarity: raw } : candidate)
+                  }));
+                  setDirty(true);
+                  return;
+                }
+                const num = Number(raw);
+                if (!isNaN(num) && num >= 0 && num <= 1) {
+                  setForm((prev) => ({
+                    ...prev,
+                    steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, minSimilarity: raw } : candidate)
+                  }));
+                  setDirty(true);
+                }
               }}
               disabled={submitting || loading}
             />

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -11,17 +11,21 @@ import { useUnsavedChangesPrompt } from '../hooks/useUnsavedChangesPrompt';
 import { navigateToUnified } from '../lib/navigation';
 import { validatePerStepConditions } from '../lib/validation';
 import { isLinearStepArray, toCommandStepIds, toLinearSteps } from '../lib/sequenceMapping';
+import { LoopBlock } from '../components/sequences/LoopBlock';
+import type { LoopStepEntry } from '../types/stepEntry';
 import type { SequenceLinearStep } from '../types/sequenceFlow';
 
 type SequenceStep = {
   id: string;
   stepId: string;
+  stepType: 'Action' | 'Loop' | 'Break';
   commandId: string;
   conditionType: 'none' | 'imageVisible' | 'commandOutcome';
   imageId: string;
   minSimilarity: string;
   outcomeStepRef: string;
   expectedState: 'success' | 'failed' | 'skipped';
+  loopEntry?: LoopStepEntry;
 };
 
 type SequenceFormValue = {
@@ -36,6 +40,7 @@ const emptyForm: SequenceFormValue = { name: '', steps: [] };
 const createDefaultStep = (commandId: string, stepId: string): SequenceStep => ({
   id: makeId(),
   stepId,
+  stepType: 'Action',
   commandId,
   conditionType: 'none',
   imageId: '',
@@ -70,6 +75,7 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
       return {
         id: makeId(),
         stepId: step.stepId,
+        stepType: 'Action' as const,
         commandId,
         conditionType: 'imageVisible',
         imageId: step.condition.imageId,
@@ -83,6 +89,7 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
       return {
         id: makeId(),
         stepId: step.stepId,
+        stepType: 'Action' as const,
         commandId,
         conditionType: 'commandOutcome',
         imageId: '',
@@ -340,12 +347,65 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
     </div>
   );
 
+  const createLoopStep = (loopType: 'count' | 'while' | 'repeatUntil'): SequenceStep => {
+    const id = makeId();
+    const stepId = nextGeneratedStepId(form.steps);
+    const loopEntry: LoopStepEntry = {
+      type: 'Loop',
+      id,
+      stepId,
+      loopType,
+      count: loopType === 'count' ? 3 : undefined,
+      condition: loopType !== 'count' ? { type: 'imageVisible', imageId: '', minSimilarity: null } : undefined,
+      body: [],
+    };
+    return {
+      id,
+      stepId,
+      stepType: 'Loop',
+      commandId: '',
+      conditionType: 'none',
+      imageId: '',
+      minSimilarity: '',
+      outcomeStepRef: '',
+      expectedState: 'success',
+      loopEntry,
+    };
+  };
+
   const stepItems = useMemo<ReorderableListItem[]>(() => {
-    return form.steps.map((s, idx) => ({
-      id: s.id,
-      label: commandLookup.get(s.commandId) ?? s.commandId,
-      details: renderStepConditionEditor(s, idx)
-    }));
+    return form.steps.map((s, idx) => {
+      if (s.stepType === 'Loop' && s.loopEntry) {
+        return {
+          id: s.id,
+          label: `Loop (${s.loopEntry.loopType})`,
+          details: (
+            <LoopBlock
+              loop={s.loopEntry}
+              onChange={(updated) => {
+                setForm((prev) => ({
+                  ...prev,
+                  steps: prev.steps.map((step) =>
+                    step.id === s.id ? { ...step, loopEntry: updated } : step
+                  ),
+                }));
+                setDirty(true);
+              }}
+              onRemove={() => {
+                setForm((prev) => ({ ...prev, steps: prev.steps.filter((step) => step.id !== s.id) }));
+                setDirty(true);
+              }}
+              disabled={submitting || loading}
+            />
+          ),
+        };
+      }
+      return {
+        id: s.id,
+        label: commandLookup.get(s.commandId) ?? s.commandId,
+        details: renderStepConditionEditor(s, idx),
+      };
+    });
   }, [form.steps, commandLookup, submitting, loading]);
 
   const validate = (v: SequenceFormValue): Record<string, string> | undefined => {
@@ -520,11 +580,17 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 setDirty(true);
               }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
             </div>
+            <div className="field" data-testid="add-loop-buttons">
+              <span>Add loop:</span>{' '}
+              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
+              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
+              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
+            </div>
             <ReorderableList
               items={stepItems}
               onChange={(next) => {
                 const mapped = next.map((item, idx) => form.steps.find((s) => s.id === item.id) ?? form.steps[idx]);
-                setForm({ ...form, steps: mapped.filter((s): s is SequenceStep => !!s?.commandId) });
+                setForm({ ...form, steps: mapped.filter((s): s is SequenceStep => !!s?.commandId || s?.stepType === 'Loop') });
                 setDirty(true);
               }}
               onDelete={(item) => {
@@ -635,11 +701,17 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                   setDirty(true);
                 }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
               </div>
+              <div className="field" data-testid="edit-add-loop-buttons">
+                <span>Add loop:</span>{' '}
+                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
+                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
+                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
+              </div>
               <ReorderableList
                 items={stepItems}
                 onChange={(next) => {
                   const mapped = next.map((item, idx) => form.steps.find((s) => s.id === item.id) ?? form.steps[idx]);
-                  setForm({ ...form, steps: mapped.filter((s): s is SequenceStep => !!s?.commandId) });
+                  setForm({ ...form, steps: mapped.filter((s): s is SequenceStep => !!s?.commandId || s?.stepType === 'Loop') });
                   setDirty(true);
                 }}
                 onDelete={(item) => {

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -450,12 +450,24 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
               value={step.minSimilarity}
               onChange={(event) => {
                 const raw = event.target.value;
-                if (raw === '' || raw === '.' || raw === '0.') {
+                if (raw === '') {
                   setForm((prev) => ({
                     ...prev,
-                    steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, minSimilarity: raw } : candidate)
+                    steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, minSimilarity: '' } : candidate)
                   }));
                   setDirty(true);
+                  return;
+                }
+                // Allow any partial decimal that could become a valid 0-1 number
+                if (/^[01]?\.\d*$|^\.\d*$/.test(raw)) {
+                  const parsed = Number(raw);
+                  if (isNaN(parsed) || parsed <= 1) {
+                    setForm((prev) => ({
+                      ...prev,
+                      steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, minSimilarity: raw } : candidate)
+                    }));
+                    setDirty(true);
+                  }
                   return;
                 }
                 const num = Number(raw);

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -12,8 +12,8 @@ import { navigateToUnified } from '../lib/navigation';
 import { validatePerStepConditions } from '../lib/validation';
 import { isLinearStepArray, toCommandStepIds, toLinearSteps } from '../lib/sequenceMapping';
 import { LoopBlock } from '../components/sequences/LoopBlock';
-import type { LoopStepEntry } from '../types/stepEntry';
-import type { SequenceLinearStep } from '../types/sequenceFlow';
+import type { LoopStepEntry, BreakStepEntry, StepEntry } from '../types/stepEntry';
+import type { SequenceLinearStep, LoopConfigDto } from '../types/sequenceFlow';
 
 type SequenceStep = {
   id: string;
@@ -65,8 +65,80 @@ const nextGeneratedStepId = (steps: SequenceStep[]): string => {
   return `step-${highest + 1}`;
 };
 
+const linearBodyToStepEntries = (body: SequenceLinearStep[]): StepEntry[] => {
+  return body.map<StepEntry>((child) => {
+    if (child.stepType === 'Break') {
+      return {
+        type: 'Break',
+        id: makeId(),
+        stepId: child.stepId,
+        breakCondition: child.breakCondition ?? undefined
+      } satisfies BreakStepEntry;
+    }
+    const cmdId = typeof child.action?.parameters?.commandId === 'string'
+      ? child.action.parameters.commandId
+      : child.stepId;
+    return {
+      type: 'Action',
+      id: makeId(),
+      stepId: child.stepId,
+      commandId: cmdId,
+      conditionType: child.condition?.type === 'imageVisible' ? 'imageVisible'
+        : child.condition?.type === 'commandOutcome' ? 'commandOutcome' : 'none',
+      imageId: child.condition?.type === 'imageVisible' ? child.condition.imageId : '',
+      minSimilarity: child.condition?.type === 'imageVisible' && child.condition.minSimilarity != null ? String(child.condition.minSimilarity) : '',
+      outcomeStepRef: child.condition?.type === 'commandOutcome' ? child.condition.stepRef : '',
+      expectedState: child.condition?.type === 'commandOutcome' ? child.condition.expectedState : 'success'
+    };
+  });
+};
+
+const loopDtoToEntry = (step: SequenceLinearStep): LoopStepEntry => {
+  const loop = step.loop!;
+  const base: Pick<LoopStepEntry, 'type' | 'id' | 'stepId'> = { type: 'Loop', id: makeId(), stepId: step.stepId };
+  const body = linearBodyToStepEntries(step.body ?? []);
+  if (loop.loopType === 'count') {
+    return { ...base, loopType: 'count', count: loop.count, maxIterations: loop.maxIterations ?? undefined, body };
+  }
+  if (loop.loopType === 'while') {
+    return { ...base, loopType: 'while', condition: loop.condition, maxIterations: loop.maxIterations ?? undefined, body };
+  }
+  // repeatUntil
+  return { ...base, loopType: 'repeatUntil', condition: loop.condition, maxIterations: loop.maxIterations ?? undefined, body };
+};
+
 const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] => {
-  return steps.map((step, index) => {
+  return steps.map((step) => {
+    if (step.stepType === 'Loop' && step.loop) {
+      const loopEntry = loopDtoToEntry(step);
+      return {
+        id: makeId(),
+        stepId: step.stepId,
+        stepType: 'Loop' as const,
+        commandId: '',
+        conditionType: 'none' as const,
+        imageId: '',
+        minSimilarity: '',
+        outcomeStepRef: '',
+        expectedState: 'success' as const,
+        loopEntry
+      };
+    }
+
+    if (step.stepType === 'Break') {
+      return {
+        id: makeId(),
+        stepId: step.stepId,
+        stepType: 'Break' as const,
+        commandId: '',
+        conditionType: 'none' as const,
+        imageId: '',
+        minSimilarity: '',
+        outcomeStepRef: '',
+        expectedState: 'success' as const
+      };
+    }
+
     const commandId = typeof step.action?.parameters?.commandId === 'string'
       ? step.action.parameters.commandId
       : step.stepId;
@@ -106,31 +178,90 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
   });
 };
 
+const buildConditionPayload = (step: SequenceStep) => {
+  if (step.conditionType === 'imageVisible') {
+    return {
+      type: 'imageVisible' as const,
+      imageId: step.imageId.trim(),
+      minSimilarity: step.minSimilarity.trim() === '' ? null : Number(step.minSimilarity)
+    };
+  }
+  if (step.conditionType === 'commandOutcome') {
+    return {
+      type: 'commandOutcome' as const,
+      stepRef: step.outcomeStepRef.trim(),
+      expectedState: step.expectedState
+    };
+  }
+  return null;
+};
+
+const buildLoopConfigPayload = (loop: LoopStepEntry): LoopConfigDto | null => {
+  if (loop.loopType === 'count') {
+    return { loopType: 'count', count: loop.count ?? 1, maxIterations: loop.maxIterations ?? null };
+  }
+  if (loop.loopType === 'while' && loop.condition) {
+    return { loopType: 'while', condition: loop.condition, maxIterations: loop.maxIterations ?? null };
+  }
+  if (loop.loopType === 'repeatUntil' && loop.condition) {
+    return { loopType: 'repeatUntil', condition: loop.condition, maxIterations: loop.maxIterations ?? null };
+  }
+  return null;
+};
+
+const bodyEntryToPayloadStep = (entry: StepEntry): SequenceLinearStep => {
+  if (entry.type === 'Break') {
+    const br = entry as BreakStepEntry;
+    return {
+      stepId: br.stepId.trim(),
+      stepType: 'Break',
+      breakCondition: br.breakCondition ?? null
+    };
+  }
+  // Action body step
+  const a = entry as { stepId: string; commandId: string; conditionType: string; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
+  const cond = a.conditionType === 'imageVisible'
+    ? { type: 'imageVisible' as const, imageId: a.imageId.trim(), minSimilarity: a.minSimilarity.trim() === '' ? null : Number(a.minSimilarity) }
+    : a.conditionType === 'commandOutcome'
+      ? { type: 'commandOutcome' as const, stepRef: a.outcomeStepRef.trim(), expectedState: a.expectedState }
+      : null;
+  return {
+    stepId: entry.stepId.trim(),
+    stepType: 'Action',
+    action: { type: 'command', parameters: { commandId: a.commandId } },
+    condition: cond
+  };
+};
+
 const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
   return steps.map((step) => {
-    const condition = step.conditionType === 'imageVisible'
-      ? {
-        type: 'imageVisible' as const,
-        imageId: step.imageId.trim(),
-        minSimilarity: step.minSimilarity.trim() === '' ? null : Number(step.minSimilarity)
-      }
-      : step.conditionType === 'commandOutcome'
-        ? {
-          type: 'commandOutcome' as const,
-          stepRef: step.outcomeStepRef.trim(),
-          expectedState: step.expectedState
-        }
-        : null;
+    if (step.stepType === 'Loop' && step.loopEntry) {
+      return {
+        stepId: step.stepId.trim(),
+        stepType: 'Loop' as const,
+        loop: buildLoopConfigPayload(step.loopEntry),
+        body: step.loopEntry.body.map(bodyEntryToPayloadStep)
+      };
+    }
+
+    if (step.stepType === 'Break') {
+      return {
+        stepId: step.stepId.trim(),
+        stepType: 'Break' as const,
+        breakCondition: null // top-level breaks are unconditional
+      };
+    }
 
     return {
       stepId: step.stepId.trim(),
+      stepType: 'Action' as const,
       action: {
         type: 'command',
         parameters: {
           commandId: step.commandId
         }
       },
-      condition
+      condition: buildConditionPayload(step)
     };
   });
 };
@@ -395,6 +526,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 setForm((prev) => ({ ...prev, steps: prev.steps.filter((step) => step.id !== s.id) }));
                 setDirty(true);
               }}
+              commandOptions={commandOptions}
               disabled={submitting || loading}
             />
           ),
@@ -406,7 +538,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         details: renderStepConditionEditor(s, idx),
       };
     });
-  }, [form.steps, commandLookup, submitting, loading]);
+  }, [form.steps, commandOptions, commandLookup, submitting, loading]);
 
   const validate = (v: SequenceFormValue): Record<string, string> | undefined => {
     const next: Record<string, string> = {};

--- a/src/web-ui/src/pages/__tests__/ExecutionPage.session.test.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionPage.session.test.tsx
@@ -148,7 +148,7 @@ describe('ExecutionPage sequence execution', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Execute sequence' }));
 
-    await waitFor(() => expect(mockExecuteSequence).toHaveBeenCalledWith('seq-1'));
+    await waitFor(() => expect(mockExecuteSequence).toHaveBeenCalledWith('seq-1', undefined));
     expect(await screen.findByText('Sequence executed successfully.')).toBeInTheDocument();
   });
 

--- a/src/web-ui/src/pages/__tests__/ExecutionPage.session.test.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionPage.session.test.tsx
@@ -5,6 +5,7 @@ import { listActions } from '../../services/actionsApi';
 import { useGames } from '../../services/useGames';
 import { listCommands, forceExecuteCommand } from '../../services/commands';
 import { getRunningSessions, stopSession } from '../../services/sessionsApi';
+import { listSequences, executeSequence } from '../../services/sequences';
 
 jest.mock('../../services/actionsApi', () => ({
   listActions: jest.fn()
@@ -24,12 +25,19 @@ jest.mock('../../services/sessionsApi', () => ({
   stopSession: jest.fn()
 }));
 
+jest.mock('../../services/sequences', () => ({
+  listSequences: jest.fn(),
+  executeSequence: jest.fn()
+}));
+
 type ActionMock = typeof listActions;
 type GamesHookMock = typeof useGames;
 type CommandsMock = typeof listCommands;
 type ExecuteMock = typeof forceExecuteCommand;
 type RunningMock = typeof getRunningSessions;
 type StopMock = typeof stopSession;
+type ListSequencesMock = typeof listSequences;
+type ExecuteSequenceMock = typeof executeSequence;
 
 const mockListActions = listActions as jest.MockedFunction<ActionMock>;
 const mockUseGames = useGames as jest.MockedFunction<GamesHookMock>;
@@ -37,6 +45,8 @@ const mockListCommands = listCommands as jest.MockedFunction<CommandsMock>;
 const mockForceExecute = forceExecuteCommand as jest.MockedFunction<ExecuteMock>;
 const mockGetRunningSessions = getRunningSessions as jest.MockedFunction<RunningMock>;
 const mockStopSession = stopSession as jest.MockedFunction<StopMock>;
+const mockListSequences = listSequences as jest.MockedFunction<ListSequencesMock>;
+const mockExecuteSequence = executeSequence as jest.MockedFunction<ExecuteSequenceMock>;
 
 const connectAction = {
   id: 'action-1',
@@ -70,6 +80,8 @@ describe('ExecutionPage session reuse', () => {
     mockGetRunningSessions.mockResolvedValue([runningSession as any]);
     mockForceExecute.mockResolvedValue({ accepted: 1 } as any);
     mockStopSession.mockResolvedValue(true as any);
+    mockListSequences.mockResolvedValue([]);
+    mockExecuteSequence.mockResolvedValue({} as any);
   });
 
   it('auto-uses cached running session when executing a command without manual session id', async () => {
@@ -99,5 +111,60 @@ describe('ExecutionPage session reuse', () => {
 
     await waitFor(() => expect(mockStopSession).toHaveBeenCalledWith('sess-123'));
     await waitFor(() => expect(screen.queryByText(/Cached session: sess-123/i)).not.toBeInTheDocument());
+  });
+});
+
+describe('ExecutionPage sequence execution', () => {
+  const sequence1 = { id: 'seq-1', name: 'Sequence One', steps: [] };
+  const sequence2 = { id: 'seq-2', name: 'Sequence Two', steps: [] };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseGames.mockReturnValue({ loading: false, data: [] });
+    mockListActions.mockResolvedValue([]);
+    mockListCommands.mockResolvedValue([]);
+    mockGetRunningSessions.mockResolvedValue([]);
+    mockStopSession.mockResolvedValue(true as any);
+    mockListSequences.mockResolvedValue([sequence1, sequence2] as any);
+    mockExecuteSequence.mockResolvedValue({} as any);
+  });
+
+  it('renders sequence dropdown with loaded sequences', async () => {
+    render(<ExecutionPage />);
+    const select = await screen.findByLabelText('Sequence');
+    expect(select).toBeInTheDocument();
+    await waitFor(() => {
+      const options = within(select as HTMLElement).getAllByRole('option');
+      expect(options).toHaveLength(2);
+      expect(options[0]).toHaveTextContent('Sequence One');
+      expect(options[1]).toHaveTextContent('Sequence Two');
+    });
+  });
+
+  it('executes selected sequence on button click', async () => {
+    render(<ExecutionPage />);
+    await screen.findByLabelText('Sequence');
+    await waitFor(() => expect(screen.getByLabelText('Sequence')).toHaveValue('seq-1'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Execute sequence' }));
+
+    await waitFor(() => expect(mockExecuteSequence).toHaveBeenCalledWith('seq-1'));
+    expect(await screen.findByText('Sequence executed successfully.')).toBeInTheDocument();
+  });
+
+  it('shows error when sequence execution fails', async () => {
+    mockExecuteSequence.mockRejectedValue(new Error('Sequence failed'));
+    render(<ExecutionPage />);
+    await waitFor(() => expect(screen.getByLabelText('Sequence')).toHaveValue('seq-1'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Execute sequence' }));
+
+    expect(await screen.findByText('Sequence failed')).toBeInTheDocument();
+  });
+
+  it('shows hint when no sequences available', async () => {
+    mockListSequences.mockResolvedValue([]);
+    render(<ExecutionPage />);
+    expect(await screen.findByText('No sequences available.')).toBeInTheDocument();
   });
 });

--- a/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
@@ -57,11 +57,13 @@ describe('SequencesPage', () => {
       steps: [
         {
           stepId: 'step-2',
+          stepType: 'Action',
           action: { type: 'command', parameters: { commandId: 'c2' } },
           condition: null
         },
         {
           stepId: 'step-1',
+          stepType: 'Action',
           action: { type: 'command', parameters: { commandId: 'c1' } },
           condition: null
         }
@@ -109,6 +111,7 @@ describe('SequencesPage', () => {
       steps: [
         {
           stepId: 'step-2',
+          stepType: 'Action',
           action: { type: 'command', parameters: { commandId: 'c2' } },
           condition: null
         }

--- a/src/web-ui/src/services/sequences.ts
+++ b/src/web-ui/src/services/sequences.ts
@@ -46,7 +46,8 @@ export const deleteSequence = (id: string) => deleteJson<void>(`${base}/${id}`);
 export const validateSequenceFlow = (sequenceId: string, input: SequenceFlowUpsertRequest) =>
   postJson<{ valid: boolean; errors: string[] }>(`${base}/${sequenceId}/validate`, input);
 
-export const executeSequence = (sequenceId: string) => postJson<unknown>(`${base}/${sequenceId}/execute`, {});
+export const executeSequence = (sequenceId: string, sessionId?: string) =>
+  postJson<unknown>(`${base}/${sequenceId}/execute`, sessionId ? { sessionId } : {});
 
 export const isSequenceConflictError = (error: unknown): error is SequenceConflictError => {
   return error instanceof ApiError

--- a/src/web-ui/src/types/sequenceFlow.ts
+++ b/src/web-ui/src/types/sequenceFlow.ts
@@ -79,12 +79,14 @@ export type ImageVisibleStepCondition = {
   type: 'imageVisible';
   imageId: string;
   minSimilarity?: number | null;
+  negate?: boolean;
 };
 
 export type CommandOutcomeStepCondition = {
   type: 'commandOutcome';
   stepRef: string;
   expectedState: 'success' | 'failed' | 'skipped';
+  negate?: boolean;
 };
 
 export type SequenceStepCondition = ImageVisibleStepCondition | CommandOutcomeStepCondition;

--- a/src/web-ui/src/types/sequenceFlow.ts
+++ b/src/web-ui/src/types/sequenceFlow.ts
@@ -94,11 +94,20 @@ export type SequenceActionPayload = {
   parameters: Record<string, unknown>;
 };
 
+export type LoopConfigDto =
+  | { loopType: 'count'; count: number; maxIterations?: number | null }
+  | { loopType: 'while'; condition: SequenceStepCondition; maxIterations?: number | null }
+  | { loopType: 'repeatUntil'; condition: SequenceStepCondition; maxIterations?: number | null };
+
 export type SequenceLinearStep = {
   stepId: string;
   label?: string;
-  action: SequenceActionPayload;
+  stepType?: 'Action' | 'Loop' | 'Break';
+  action?: SequenceActionPayload | null;
   condition?: SequenceStepCondition | null;
+  loop?: LoopConfigDto | null;
+  body?: SequenceLinearStep[] | null;
+  breakCondition?: SequenceStepCondition | null;
 };
 
 export type SequenceLinearUpsertRequest = {

--- a/src/web-ui/src/types/stepEntry.ts
+++ b/src/web-ui/src/types/stepEntry.ts
@@ -1,0 +1,37 @@
+import type { SequenceStepCondition } from './sequenceFlow';
+
+/** Discriminated union for all step types in the sequence form editor. */
+export type StepEntry =
+  | ActionStepEntry
+  | LoopStepEntry
+  | BreakStepEntry;
+
+export type ActionStepEntry = {
+  type: 'Action';
+  id: string;
+  stepId: string;
+  commandId: string;
+  conditionType: 'none' | 'imageVisible' | 'commandOutcome';
+  imageId: string;
+  minSimilarity: string;
+  outcomeStepRef: string;
+  expectedState: 'success' | 'failed' | 'skipped';
+};
+
+export type LoopStepEntry = {
+  type: 'Loop';
+  id: string;
+  stepId: string;
+  loopType: 'count' | 'while' | 'repeatUntil';
+  count?: number;
+  condition?: SequenceStepCondition;
+  maxIterations?: number;
+  body: StepEntry[];
+};
+
+export type BreakStepEntry = {
+  type: 'Break';
+  id: string;
+  stepId: string;
+  breakCondition?: SequenceStepCondition;
+};

--- a/tests/contract/Sequences/SequenceLoopContractTests.cs
+++ b/tests/contract/Sequences/SequenceLoopContractTests.cs
@@ -1,0 +1,284 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using Xunit;
+
+namespace GameBot.ContractTests.Sequences;
+
+/// <summary>
+/// Verifies that the loop and break step types survive a full persist → load round-trip
+/// through <see cref="FileSequenceRepository"/>.  Attribute-based JSON polymorphism
+/// (<c>[JsonPolymorphic]</c> / <c>[JsonDerivedType]</c>) must correctly reconstruct
+/// <see cref="LoopConfig"/>, <see cref="SequenceStepCondition"/>, and nested body steps.
+/// </summary>
+public sealed class SequenceLoopContractTests : IDisposable
+{
+    private readonly string _tmpRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    private FileSequenceRepository CreateRepo() => new(_tmpRoot);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tmpRoot))
+        {
+            Directory.Delete(_tmpRoot, recursive: true);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static CommandSequence BuildSequence(string name, IEnumerable<SequenceStep> steps)
+    {
+        var seq = new CommandSequence
+        {
+            Id = string.Empty,
+            Name = name,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        seq.SetSteps(steps.ToList());
+        return seq;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T008-1: count loop with inner action step
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CountLoopStepRoundTripsViaRepository()
+    {
+        var repo = CreateRepo();
+        var bodyStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "inner-tap",
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload { Type = "tap" }
+        };
+        bodyStep.Action.Parameters["x"] = 100;
+        bodyStep.Action.Parameters["y"] = "{{iteration}}";
+
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "count-loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 5 },
+            Body = new List<SequenceStep> { bodyStep }
+        };
+
+        var created = await repo.CreateAsync(BuildSequence("count-loop-rt", new[] { loopStep }));
+        var retrieved = await repo.GetAsync(created.Id);
+
+        retrieved.Should().NotBeNull();
+        var step = retrieved!.Steps.Single();
+        step.StepType.Should().Be(SequenceStepType.Loop);
+        step.Loop.Should().BeOfType<CountLoopConfig>();
+        ((CountLoopConfig)step.Loop!).Count.Should().Be(5);
+        step.Body.Should().HaveCount(1);
+        step.Body[0].StepId.Should().Be("inner-tap");
+        step.Body[0].Action!.Parameters["y"]!.ToString().Should().Be("{{iteration}}");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T008-2: while loop with imageVisible condition
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WhileLoopStepRoundTripsViaRepository()
+    {
+        var repo = CreateRepo();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "while-loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new WhileLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img-001", MinSimilarity = 0.85 },
+                MaxIterations = 10
+            },
+            Body = new List<SequenceStep>
+            {
+                new SequenceStep
+                {
+                    Order = 0,
+                    StepId = "tap-step",
+                    StepType = SequenceStepType.Action,
+                    Action = new SequenceActionPayload { Type = "tap" }
+                }
+            }
+        };
+
+        var created = await repo.CreateAsync(BuildSequence("while-loop-rt", new[] { loopStep }));
+        var retrieved = await repo.GetAsync(created.Id);
+
+        retrieved.Should().NotBeNull();
+        var step = retrieved!.Steps.Single();
+        step.Loop.Should().BeOfType<WhileLoopConfig>();
+        var whileCfg = (WhileLoopConfig)step.Loop!;
+        whileCfg.MaxIterations.Should().Be(10);
+        whileCfg.Condition.Should().BeOfType<ImageVisibleStepCondition>();
+        ((ImageVisibleStepCondition)whileCfg.Condition).ImageId.Should().Be("img-001");
+        ((ImageVisibleStepCondition)whileCfg.Condition).MinSimilarity.Should().Be(0.85);
+        step.Body.Single().StepId.Should().Be("tap-step");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T008-3: repeatUntil loop with commandOutcome condition
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RepeatUntilLoopStepRoundTripsViaRepository()
+    {
+        var repo = CreateRepo();
+        var bodyStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "do-action",
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload { Type = "tap" }
+        };
+
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "repeat-loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new RepeatUntilLoopConfig
+            {
+                Condition = new CommandOutcomeStepCondition { StepRef = "do-action", ExpectedState = "success" }
+            },
+            Body = new List<SequenceStep> { bodyStep }
+        };
+
+        var created = await repo.CreateAsync(BuildSequence("repeat-until-rt", new[] { loopStep }));
+        var retrieved = await repo.GetAsync(created.Id);
+
+        retrieved.Should().NotBeNull();
+        var step = retrieved!.Steps.Single();
+        step.Loop.Should().BeOfType<RepeatUntilLoopConfig>();
+        var ruCfg = (RepeatUntilLoopConfig)step.Loop!;
+        ruCfg.Condition.Should().BeOfType<CommandOutcomeStepCondition>();
+        var cond = (CommandOutcomeStepCondition)ruCfg.Condition;
+        cond.StepRef.Should().Be("do-action");
+        cond.ExpectedState.Should().Be("success");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T008-4a: unconditional break step
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UnconditionalBreakStepRoundTripsViaRepository()
+    {
+        var repo = CreateRepo();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "count-loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 10 },
+            Body = new List<SequenceStep>
+            {
+                new SequenceStep
+                {
+                    Order = 0,
+                    StepId = "break-step",
+                    StepType = SequenceStepType.Break,
+                    BreakCondition = null   // unconditional
+                }
+            }
+        };
+
+        var created = await repo.CreateAsync(BuildSequence("unconditional-break-rt", new[] { loopStep }));
+        var retrieved = await repo.GetAsync(created.Id);
+
+        retrieved.Should().NotBeNull();
+        var breakStep = retrieved!.Steps.Single().Body.Single();
+        breakStep.StepType.Should().Be(SequenceStepType.Break);
+        breakStep.BreakCondition.Should().BeNull();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T008-4b: conditional break step
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConditionalBreakStepRoundTripsViaRepository()
+    {
+        var repo = CreateRepo();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "count-loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 10 },
+            Body = new List<SequenceStep>
+            {
+                new SequenceStep
+                {
+                    Order = 0,
+                    StepId = "break-step",
+                    StepType = SequenceStepType.Break,
+                    BreakCondition = new ImageVisibleStepCondition { ImageId = "exit-image" }
+                }
+            }
+        };
+
+        var created = await repo.CreateAsync(BuildSequence("conditional-break-rt", new[] { loopStep }));
+        var retrieved = await repo.GetAsync(created.Id);
+
+        retrieved.Should().NotBeNull();
+        var breakStep = retrieved!.Steps.Single().Body.Single();
+        breakStep.StepType.Should().Be(SequenceStepType.Break);
+        breakStep.BreakCondition.Should().BeOfType<ImageVisibleStepCondition>();
+        ((ImageVisibleStepCondition)breakStep.BreakCondition!).ImageId.Should().Be("exit-image");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T008-5: body inner steps preserve order and stepId values
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoopBodyStepsPreserveOrderAndStepIds()
+    {
+        var repo = CreateRepo();
+        var bodySteps = Enumerable.Range(0, 4)
+            .Select(i => new SequenceStep
+            {
+                Order = i,
+                StepId = $"inner-{i}",
+                StepType = SequenceStepType.Action,
+                Action = new SequenceActionPayload { Type = "tap" }
+            })
+            .ToList();
+
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "multi-body-loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 3 },
+            Body = bodySteps
+        };
+
+        var created = await repo.CreateAsync(BuildSequence("body-order-rt", new[] { loopStep }));
+        var retrieved = await repo.GetAsync(created.Id);
+
+        retrieved.Should().NotBeNull();
+        var body = retrieved!.Steps.Single().Body;
+        body.Should().HaveCount(4);
+        for (var i = 0; i < 4; i++)
+        {
+            body[i].Order.Should().Be(i);
+            body[i].StepId.Should().Be($"inner-{i}");
+        }
+    }
+}

--- a/tests/unit/CachedScreenSourceTests.cs
+++ b/tests/unit/CachedScreenSourceTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Drawing;
+using System.Runtime.Versioning;
+using System.Threading;
+using GameBot.Domain.Triggers.Evaluators;
+using Xunit;
+
+namespace GameBot.UnitTests;
+
+/// <summary>
+/// Regression tests for CachedScreenSource.
+/// Ensures that multiple GetLatestScreenshot() calls within the TTL window
+/// do NOT trigger duplicate captures — preventing the 9-second-per-loop-iteration
+/// performance bug caused by two ADB screencap round-trips (PrimitiveTap detection +
+/// imageVisible break condition) in the same iteration.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class CachedScreenSourceTests : IDisposable {
+  // A controllable IScreenSource spy that counts invocations.
+  private sealed class CountingScreenSource : IScreenSource {
+    public int CallCount { get; private set; }
+    public Bitmap? Next { get; set; }
+
+    public Bitmap? GetLatestScreenshot() {
+      CallCount++;
+      if (Next is null) return null;
+      // Return a new Bitmap each time (mirrors AdbScreenSource behaviour).
+      return new Bitmap(Next);
+    }
+  }
+
+  private readonly CountingScreenSource _inner = new();
+  private readonly Bitmap _bitmap = CreateSolidBitmap(Color.Azure);
+
+  public CachedScreenSourceTests() {
+    _inner.Next = _bitmap;
+  }
+
+  public void Dispose() {
+    _bitmap.Dispose();
+  }
+
+  private static Bitmap CreateSolidBitmap(Color c) {
+    var bmp = new Bitmap(2, 2);
+    using var g = Graphics.FromImage(bmp);
+    g.Clear(c);
+    return bmp;
+  }
+
+  [Fact(DisplayName = "Two calls within TTL hit the inner source only once")]
+  public void TwoCallsWithinTtlInnerCalledOnce() {
+    using var cached = new CachedScreenSource(_inner, ttlMs: 2000);
+
+    using var first = cached.GetLatestScreenshot();
+    using var second = cached.GetLatestScreenshot();
+
+    Assert.Equal(1, _inner.CallCount);
+    Assert.NotNull(first);
+    Assert.NotNull(second);
+  }
+
+  [Fact(DisplayName = "Call after TTL expiry refreshes via the inner source")]
+  public void CallAfterTtlExpiryInnerCalledAgain() {
+    using var cached = new CachedScreenSource(_inner, ttlMs: 10); // 10 ms TTL
+
+    using var first = cached.GetLatestScreenshot();
+    Assert.Equal(1, _inner.CallCount);
+
+    Thread.Sleep(30); // exceed TTL
+
+    using var second = cached.GetLatestScreenshot();
+    Assert.Equal(2, _inner.CallCount);
+  }
+
+  [Fact(DisplayName = "Returned Bitmap can be disposed without corrupting the cache")]
+  public void DisposingReturnedBitmapDoesNotCorruptCache() {
+    using var cached = new CachedScreenSource(_inner, ttlMs: 2000);
+
+    var first = cached.GetLatestScreenshot();
+    first?.Dispose(); // simulate ImageMatchEvaluator's 'using var screenBmp'
+
+    // Second call: cache is still valid — no second ADB call.
+    using var second = cached.GetLatestScreenshot();
+
+    Assert.Equal(1, _inner.CallCount);
+    Assert.NotNull(second);
+  }
+
+  [Fact(DisplayName = "Returns null and still applies TTL when inner returns null")]
+  public void InnerReturnsNullReturnsNullAndCachesTtl() {
+    _inner.Next = null;
+    using var cached = new CachedScreenSource(_inner, ttlMs: 2000);
+
+    var first = cached.GetLatestScreenshot();
+    var second = cached.GetLatestScreenshot();
+
+    Assert.Null(first);
+    Assert.Null(second);
+    // Both calls within TTL: inner must only be called once.
+    Assert.Equal(1, _inner.CallCount);
+  }
+
+  [Fact(DisplayName = "First call after null result can re-fetch once TTL expires")]
+  public void AfterNullResultRefetchesWhenTtlExpires() {
+    _inner.Next = null;
+    using var cached = new CachedScreenSource(_inner, ttlMs: 10);
+
+    var first = cached.GetLatestScreenshot();
+    Assert.Null(first);
+    Assert.Equal(1, _inner.CallCount);
+
+    Thread.Sleep(30); // exceed TTL
+    _inner.Next = _bitmap;
+
+    using var second = cached.GetLatestScreenshot();
+    Assert.Equal(2, _inner.CallCount);
+    Assert.NotNull(second);
+  }
+
+  [Fact(DisplayName = "Zero TTL never expires — one inner call for repeated reads")]
+  public void ZeroTtlNeverExpires() {
+    using var cached = new CachedScreenSource(_inner, ttlMs: 0);
+
+    using var first = cached.GetLatestScreenshot();
+    using var second = cached.GetLatestScreenshot();
+
+    // Zero TTL = expiry is MaxValue, so cache never expires.
+    Assert.Equal(1, _inner.CallCount);
+  }
+
+  [Fact(DisplayName = "Throws ObjectDisposedException after Dispose")]
+  public void AfterDisposeThrowsObjectDisposedException() {
+    var cached = new CachedScreenSource(_inner, ttlMs: 2000);
+    cached.Dispose();
+    Assert.Throws<ObjectDisposedException>(() => cached.GetLatestScreenshot());
+  }
+
+  [Fact(DisplayName = "Concurrent calls within TTL result in at most one inner call")]
+  public void ConcurrentCallsWithinTtlAtMostOneInnerCall() {
+    using var cached = new CachedScreenSource(_inner, ttlMs: 5000);
+    var results = new Bitmap?[10];
+
+    // Simulate loop-body sequential evaluation (PrimitiveTap + break-condition check).
+    for (int i = 0; i < 10; i++) {
+      results[i] = cached.GetLatestScreenshot();
+    }
+
+    foreach (var r in results) r?.Dispose();
+
+    // All 10 calls within TTL → inner must be called exactly once.
+    Assert.Equal(1, _inner.CallCount);
+  }
+}

--- a/tests/unit/Sequences/LoopValidationTests.cs
+++ b/tests/unit/Sequences/LoopValidationTests.cs
@@ -1,0 +1,274 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using Xunit;
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Unit tests for loop-step validation rules introduced in T007 / FR-002a, FR-004,
+/// FR-006, FR-008, FR-012.
+/// </summary>
+public sealed class LoopValidationTests
+{
+    private static readonly SequenceStepValidationService Svc = new();
+
+    private static SequenceStep ActionStep(string stepId, int order = 0)
+        => new()
+        {
+            Order = order,
+            StepId = stepId,
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload { Type = "tap" }
+        };
+
+    private static SequenceStep LoopStep(string stepId, LoopConfig loop, IReadOnlyList<SequenceStep>? body = null)
+        => new()
+        {
+            Order = 0,
+            StepId = stepId,
+            StepType = SequenceStepType.Loop,
+            Loop = loop,
+            Body = body ?? Array.Empty<SequenceStep>()
+        };
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 1. Top-level break is rejected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TopLevelBreakStepIsRejected()
+    {
+        var steps = new List<SequenceStep>
+        {
+            new() { Order = 0, StepId = "brk", StepType = SequenceStepType.Break }
+        };
+
+        var errors = Svc.Validate(steps);
+
+        errors.Should().ContainSingle(e => e.Contains("only valid inside a loop body"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 2. Loop missing config is rejected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoopStepWithoutConfigIsRejected()
+    {
+        var step = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = null
+        };
+
+        var errors = Svc.Validate(new[] { step });
+
+        errors.Should().ContainSingle(e => e.Contains("requires a loop configuration"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 3. FR-004: Count < 0 is rejected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CountLoopNegativeCountIsRejected()
+    {
+        var step = LoopStep("loop", new CountLoopConfig { Count = -1 });
+        var errors = Svc.Validate(new[] { step });
+        errors.Should().ContainSingle(e => e.Contains("count must be zero or greater"));
+    }
+
+    [Fact]
+    public void CountLoopZeroCountIsAccepted()
+    {
+        var step = LoopStep("loop", new CountLoopConfig { Count = 0 });
+        var errors = Svc.Validate(new[] { step });
+        errors.Should().BeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4. FR-008: MaxIterations <= 0 is rejected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoopMaxIterationsZeroIsRejected()
+    {
+        var step = LoopStep("loop", new WhileLoopConfig
+        {
+            Condition = new ImageVisibleStepCondition { ImageId = "img" },
+            MaxIterations = 0
+        });
+        var errors = Svc.Validate(new[] { step });
+        errors.Should().ContainSingle(e => e.Contains("maxIterations must be greater than zero"));
+    }
+
+    [Fact]
+    public void LoopMaxIterationsNegativeIsRejected()
+    {
+        var step = LoopStep("loop", new CountLoopConfig { Count = 2, MaxIterations = -5 });
+        var errors = Svc.Validate(new[] { step });
+        errors.Should().ContainSingle(e => e.Contains("maxIterations must be greater than zero"));
+    }
+
+    [Fact]
+    public void LoopMaxIterationsPositiveIsAccepted()
+    {
+        var step = LoopStep("loop", new CountLoopConfig { Count = 2, MaxIterations = 100 });
+        var errors = Svc.Validate(new[] { step });
+        errors.Should().BeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 5. FR-012: Nested loops are rejected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NestedLoopIsRejected()
+    {
+        var innerLoop = LoopStep("inner-loop", new CountLoopConfig { Count = 2 });
+        var outer = LoopStep("outer-loop", new CountLoopConfig { Count = 3 }, new[] { innerLoop });
+
+        var errors = Svc.Validate(new[] { outer });
+
+        errors.Should().ContainSingle(e => e.Contains("must not itself be a loop step"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 6. FR-002a: {{template}} placeholder at top level is rejected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TopLevelStepWithTemplatePlaceholderIsRejected()
+    {
+        var action = new SequenceActionPayload { Type = "tap" };
+        action.Parameters["x"] = "{{iteration}}";
+        var step = new SequenceStep
+        {
+            Order = 0,
+            StepId = "s1",
+            StepType = SequenceStepType.Action,
+            Action = action
+        };
+
+        var errors = Svc.Validate(new[] { step });
+
+        errors.Should().ContainSingle(e => e.Contains("only valid inside a loop body"));
+    }
+
+    [Fact]
+    public void LoopBodyStepWithTemplatePlaceholderIsAccepted()
+    {
+        var action = new SequenceActionPayload { Type = "tap" };
+        action.Parameters["x"] = "{{iteration}}";
+        var bodyStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "inner",
+            StepType = SequenceStepType.Action,
+            Action = action
+        };
+        var loop = LoopStep("loop", new CountLoopConfig { Count = 3 }, new[] { bodyStep });
+
+        var errors = Svc.Validate(new[] { loop });
+
+        errors.Should().BeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 7. FR-006: commandOutcome forward-ref inside loop body is rejected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoopBodyCommandOutcomeForwardRefIsRejected()
+    {
+        // "first" references "second" which comes after it — forward ref
+        var first = new SequenceStep
+        {
+            Order = 0,
+            StepId = "first",
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload { Type = "tap" },
+            Condition = new CommandOutcomeStepCondition
+            {
+                StepRef = "second",
+                ExpectedState = "success"
+            }
+        };
+        var second = ActionStep("second", 1);
+        var loop = LoopStep("loop", new CountLoopConfig { Count = 2 }, new[] { first, second });
+
+        var errors = Svc.Validate(new[] { loop });
+
+        errors.Should().ContainSingle(e => e.Contains("must reference a prior step"));
+    }
+
+    [Fact]
+    public void LoopBodyCommandOutcomeBackRefIsAccepted()
+    {
+        var first = ActionStep("first", 0);
+        var second = new SequenceStep
+        {
+            Order = 1,
+            StepId = "second",
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload { Type = "tap" },
+            Condition = new CommandOutcomeStepCondition
+            {
+                StepRef = "first",
+                ExpectedState = "success"
+            }
+        };
+        var loop = LoopStep("loop", new CountLoopConfig { Count = 2 }, new[] { first, second });
+
+        var errors = Svc.Validate(new[] { loop });
+
+        errors.Should().BeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 8. Valid complete loop passes
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidCountLoopWithBodyPasses()
+    {
+        var loop = LoopStep("loop", new CountLoopConfig { Count = 5 },
+            new[] { ActionStep("s1"), ActionStep("s2", 1) });
+        var errors = Svc.Validate(new[] { ActionStep("pre"), loop });
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidWhileLoopWithBreakPasses()
+    {
+        var breakStep = new SequenceStep
+        {
+            Order = 1,
+            StepId = "brk",
+            StepType = SequenceStepType.Break,
+            BreakCondition = new ImageVisibleStepCondition { ImageId = "img" }
+        };
+        var loop = LoopStep("loop", new WhileLoopConfig
+        {
+            Condition = new ImageVisibleStepCondition { ImageId = "img" }
+        }, new[] { ActionStep("s1"), breakStep });
+
+        var errors = Svc.Validate(new[] { loop });
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidRepeatUntilLoopPasses()
+    {
+        var loop = LoopStep("loop", new RepeatUntilLoopConfig
+        {
+            Condition = new ImageVisibleStepCondition { ImageId = "img" }
+        }, new[] { ActionStep("s1") });
+        var errors = Svc.Validate(new[] { loop });
+        errors.Should().BeEmpty();
+    }
+}

--- a/tests/unit/Sequences/SequenceRunnerLoopTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerLoopTests.cs
@@ -1,0 +1,483 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using Xunit;
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Unit tests for loop step execution: count (T009), while (T018), repeat-until (T020),
+/// and break (T022) covering all story-acceptance criteria.
+/// </summary>
+public sealed class SequenceRunnerLoopTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // Infrastructure
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private sealed class StubRepo : ISequenceRepository
+    {
+        private readonly CommandSequence _seq;
+        public StubRepo(CommandSequence seq) { _seq = seq; }
+        public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_seq);
+        public Task<IReadOnlyList<CommandSequence>> ListAsync() =>
+            Task.FromResult<IReadOnlyList<CommandSequence>>(new[] { _seq }.ToList().AsReadOnly());
+        public Task<CommandSequence> CreateAsync(CommandSequence s) => Task.FromResult(s);
+        public Task<CommandSequence> UpdateAsync(CommandSequence s) => Task.FromResult(s);
+        public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+    }
+
+    private static CommandSequence Sequence(string id, IEnumerable<SequenceStep> steps)
+    {
+        var seq = new CommandSequence { Id = id, Name = id };
+        seq.SetSteps(steps.ToList());
+        return seq;
+    }
+
+    private static SequenceStep ActionBodyStep(int order, string stepId, string commandId = "inner-cmd")
+        => new()
+        {
+            Order = order,
+            StepId = stepId,
+            CommandId = commandId,
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload { Type = "tap" }
+        };
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T009: Count loop
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CountLoopExecutesBodyExactlyNTimes()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 5 },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s", id => { executed.Add(id); return Task.CompletedTask; });
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task CountLoopZeroCountSkipsBodyAndSucceeds()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 0 },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s", id => { executed.Add(id); return Task.CompletedTask; });
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CountLoopIterationPlaceholderSubstitutesCommandId()
+    {
+        // Body step uses {{iteration}} in CommandId so we can verify substitution
+        var bodyStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "inner",
+            CommandId = "cmd-{{iteration}}",
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload { Type = "tap" }
+        };
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 3 },
+            Body = new List<SequenceStep> { bodyStep }
+        };
+
+        var executed = new List<string>();
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s", id => { executed.Add(id); return Task.CompletedTask; });
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().Equal("cmd-1", "cmd-2", "cmd-3");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T018: While loop
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WhileLoopConditionTrueTwiceThenFalseBodyRunsTwice()
+    {
+        var executed = new List<string>();
+        var evalCount = 0;
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new WhileLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" }
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        // Condition: true, true, false  (evaluated before iteration 1, 2, 3)
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (cond, _) => Task.FromResult(++evalCount <= 2));
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task WhileLoopConditionFalseOnEntryBodySkipped()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new WhileLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" }
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => Task.FromResult(false));
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().BeEmpty();
+        result.Steps.Should().ContainSingle();
+        result.Steps[0].Status.Should().Be("Skipped");
+    }
+
+    [Fact]
+    public async Task WhileLoopConditionNeverFalseFailsAtLimit()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new WhileLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" },
+                MaxIterations = 3
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => Task.FromResult(true));
+
+        result.Status.Should().Be("Failed");
+        executed.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task WhileLoopConditionThrowsLoopFails()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new WhileLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" }
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => throw new InvalidOperationException("eval error"));
+
+        result.Status.Should().Be("Failed");
+        executed.Should().BeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T020: Repeat-until loop
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RepeatUntilLoopExitConditionTrueAfterIteration1BodyRunsOnce()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new RepeatUntilLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" }
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        // Condition true on first check (after first iteration)
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => Task.FromResult(true));
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task RepeatUntilLoopExitConditionTrueAfterIteration3BodyRuns3Times()
+    {
+        var executed = new List<string>();
+        var evalCount = 0;
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new RepeatUntilLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" }
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        // Condition: false, false, true
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => Task.FromResult(++evalCount >= 3));
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task RepeatUntilLoopConditionNeverTrueFailsAtLimit()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new RepeatUntilLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" },
+                MaxIterations = 3
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => Task.FromResult(false));
+
+        result.Status.Should().Be("Failed");
+        executed.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task RepeatUntilLoopConditionThrowsAfterFirstIterationLoopFails()
+    {
+        var executed = new List<string>();
+        var firstEval = true;
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new RepeatUntilLoopConfig
+            {
+                Condition = new ImageVisibleStepCondition { ImageId = "img" }
+            },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        // Execute once, then throw on condition eval
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) =>
+            {
+                if (firstEval) { firstEval = false; throw new InvalidOperationException("eval error"); }
+                return Task.FromResult(false);
+            });
+
+        result.Status.Should().Be("Failed");
+        executed.Should().HaveCount(1);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T022: Break steps
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CountLoopConditionalBreakOnIteration3LoopExitsAfter3Iterations()
+    {
+        var executed = new List<string>();
+        var evalCount = 0;
+        var breakStep = new SequenceStep
+        {
+            Order = 1,
+            StepId = "break",
+            StepType = SequenceStepType.Break,
+            BreakCondition = new ImageVisibleStepCondition { ImageId = "img" }
+        };
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 10 },
+            Body = new List<SequenceStep> { ActionBodyStep(0, "inner"), breakStep }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        // Break condition returns true at evalCount == 3 (on 3rd iteration's break check)
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => Task.FromResult(++evalCount >= 3));
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().HaveCount(3);
+
+        // Break was triggered — should be recorded in loop step result
+        var loopStepResult = result.Steps.FirstOrDefault(s => s.LoopIterations is not null);
+        loopStepResult.Should().NotBeNull();
+        var lastIter = loopStepResult!.LoopIterations![^1];
+        lastIter.BreakTriggered.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CountLoopConditionalBreakNeverTriggeredLoopRunsToCompletion()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 5 },
+            Body = new List<SequenceStep>
+            {
+                ActionBodyStep(0, "inner"),
+                new SequenceStep
+                {
+                    Order = 1,
+                    StepId = "break",
+                    StepType = SequenceStepType.Break,
+                    BreakCondition = new ImageVisibleStepCondition { ImageId = "img" }
+                }
+            }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        // Break condition never true
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => Task.FromResult(false));
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task CountLoopUnconditionalBreakExitsAfterFirstIteration()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 10 },
+            Body = new List<SequenceStep>
+            {
+                ActionBodyStep(0, "inner"),
+                new SequenceStep
+                {
+                    Order = 1,
+                    StepId = "break",
+                    StepType = SequenceStepType.Break,
+                    BreakCondition = null // unconditional
+                }
+            }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; });
+
+        result.Status.Should().Be("Succeeded");
+        executed.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task CountLoopBreakConditionThrowsLoopFails()
+    {
+        var executed = new List<string>();
+        var loopStep = new SequenceStep
+        {
+            Order = 0,
+            StepId = "loop",
+            StepType = SequenceStepType.Loop,
+            Loop = new CountLoopConfig { Count = 10 },
+            Body = new List<SequenceStep>
+            {
+                ActionBodyStep(0, "inner"),
+                new SequenceStep
+                {
+                    Order = 1,
+                    StepId = "break",
+                    StepType = SequenceStepType.Break,
+                    BreakCondition = new ImageVisibleStepCondition { ImageId = "img" }
+                }
+            }
+        };
+
+        var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+        var result = await runner.ExecuteAsync("s",
+            id => { executed.Add(id); return Task.CompletedTask; },
+            conditionEvaluator: (_, _) => throw new InvalidOperationException("eval error"));
+
+        result.Status.Should().Be("Failed");
+    }
+}

--- a/tests/unit/Sequences/TemplateSubstitutorTests.cs
+++ b/tests/unit/Sequences/TemplateSubstitutorTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Utils;
+using Xunit;
+
+namespace GameBot.UnitTests.Sequences;
+
+public sealed class TemplateSubstitutorTests
+{
+    // ──────────────────────────────────────────────────────────────────────── //
+    // Substitute(string, ...)
+    // ──────────────────────────────────────────────────────────────────────── //
+
+    [Fact]
+    public void SubstituteReplacesKnownPlaceholder()
+    {
+        var result = TemplateSubstitutor.Substitute(
+            "item-{{iteration}}",
+            new Dictionary<string, string> { ["iteration"] = "3" });
+
+        result.Should().Be("item-3");
+    }
+
+    [Fact]
+    public void SubstituteLeavesUnknownKeyAsIs()
+    {
+        var result = TemplateSubstitutor.Substitute(
+            "item-{{unknown}}",
+            new Dictionary<string, string> { ["iteration"] = "3" });
+
+        result.Should().Be("item-{{unknown}}");
+    }
+
+    [Fact]
+    public void SubstituteReplacesMultiplePlaceholdersInOneString()
+    {
+        var result = TemplateSubstitutor.Substitute(
+            "row={{row}}, col={{col}}",
+            new Dictionary<string, string> { ["row"] = "2", ["col"] = "5" });
+
+        result.Should().Be("row=2, col=5");
+    }
+
+    [Fact]
+    public void SubstituteEmptyContextReturnsTemplateUnchanged()
+    {
+        const string template = "prefix-{{iteration}}-suffix";
+        var result = TemplateSubstitutor.Substitute(template, new Dictionary<string, string>());
+
+        result.Should().Be(template);
+    }
+
+    [Fact]
+    public void SubstituteNoPlaceholderReturnsTextUnchanged()
+    {
+        const string text = "no placeholders here";
+        var result = TemplateSubstitutor.Substitute(
+            text,
+            new Dictionary<string, string> { ["iteration"] = "1" });
+
+        result.Should().Be(text);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────── //
+    // SubstitutePayload(...)
+    // ──────────────────────────────────────────────────────────────────────── //
+
+    [Fact]
+    public void SubstitutePayloadReplacesStringParameterPlaceholder()
+    {
+        var payload = new SequenceActionPayload { Type = "tap" };
+        payload.Parameters["label"] = "step-{{iteration}}";
+
+        var result = TemplateSubstitutor.SubstitutePayload(
+            payload,
+            new Dictionary<string, string> { ["iteration"] = "2" });
+
+        result.Parameters["label"].Should().Be("step-2");
+    }
+
+    [Fact]
+    public void SubstitutePayloadLeavesNonStringValueUntouched()
+    {
+        var payload = new SequenceActionPayload { Type = "tap" };
+        payload.Parameters["x"] = 100;
+        payload.Parameters["y"] = 200;
+
+        var result = TemplateSubstitutor.SubstitutePayload(
+            payload,
+            new Dictionary<string, string> { ["x"] = "999" });
+
+        result.Parameters["x"].Should().Be(100);
+        result.Parameters["y"].Should().Be(200);
+    }
+
+    [Fact]
+    public void SubstitutePayloadPreservesPayloadType()
+    {
+        var payload = new SequenceActionPayload { Type = "swipe" };
+        payload.Parameters["direction"] = "right";
+
+        var result = TemplateSubstitutor.SubstitutePayload(
+            payload,
+            new Dictionary<string, string>());
+
+        result.Type.Should().Be("swipe");
+    }
+
+    [Fact]
+    public void SubstitutePayloadReplacesMultipleStringParameters()
+    {
+        var payload = new SequenceActionPayload { Type = "label" };
+        payload.Parameters["first"] = "{{a}}";
+        payload.Parameters["second"] = "{{b}}";
+        payload.Parameters["third"] = 42; // non-string
+
+        var ctx = new Dictionary<string, string> { ["a"] = "alpha", ["b"] = "beta" };
+        var result = TemplateSubstitutor.SubstitutePayload(payload, ctx);
+
+        result.Parameters["first"].Should().Be("alpha");
+        result.Parameters["second"].Should().Be("beta");
+        result.Parameters["third"].Should().Be(42);
+    }
+}


### PR DESCRIPTION
## Summary

Post-implementation fixes and performance improvements for the 033-command-loops feature.

## Changes

### Fix: minSimilarity threshold scoring mismatch (\702cd3a\)
\ImageMatchEvaluator.ComputeSimilarityNcc()\ was mapping raw NCC scores [-1,+1] to [0,1] via \(ncc+1)/2\, inflating scores ~50% above OpenCV \CCoeffNormed\. A threshold of 0.9 in a break condition would pass even when the detection endpoint reported 0.86, making thresholds incomparable between the two pipelines. Fix: clamp raw NCC to [0,1] directly.

### Fix: minSimilarity input accepts decimal points (\658b5f\, \69e0e15\, \c2881d0\)
Extracted \SimilarityInput\ component with local string state so typing \