### PR TITLE
feat(036): tap wait-and-retry + dynamic runtime config propagation

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -17,6 +17,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - In-memory only (no persistence); session-scoped cached frames held in `ConcurrentDictionary` (034-background-screenshot-service)
 - C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, existing `ConfigSnapshotService` + `IConfigApplier`, React 18 + Vite 7, HTML5 Drag and Drop API (no external DnD library) (035-ui-config-editor)
 - File-backed JSON under `data/config/config.json` (existing); parameter order persisted as key order in the JSON `parameters` object (035-ui-config-editor)
+- C# 13 / .NET 9 + ASP.NET Core Minimal API, OpenCvSharp (TemplateMatcher), SharpAdbClient/ADB integration, Microsoft.Extensions.Logging, existing `GameBot.Domain` and `GameBot.Emulator` libraries (036-tap-wait-retry)
+- Existing file-backed JSON repositories under `data/` (no new stores); configuration via `AppConfig` singleton (036-tap-wait-retry)
 
 - Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence/command services, existing image detection pipeline, existing execution-log services/repositories, React 18 + Vite 5 UI stack (030-sequence-conditional-logic)
 
@@ -37,9 +39,9 @@ npm test; npm run lint
 Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18: Follow standard conventions
 
 ## Recent Changes
+- 036-tap-wait-retry: Added C# 13 / .NET 9 + ASP.NET Core Minimal API, OpenCvSharp (TemplateMatcher), SharpAdbClient/ADB integration, Microsoft.Extensions.Logging, existing `GameBot.Domain` and `GameBot.Emulator` libraries
 - 035-ui-config-editor: Added C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, existing `ConfigSnapshotService` + `IConfigApplier`, React 18 + Vite 7, HTML5 Drag and Drop API (no external DnD library)
 - 034-background-screenshot-service: Added C# 13 / .NET 9 (backend); TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, SharpAdbClient/ADB integration (via existing `AdbClient`), System.Drawing (Bitmap), existing `ISessionManager`, `IScreenSource`, `CachedScreenSource` infrastructure
-- 033-command-loops: Added C# 13 / .NET 9 (backend); TypeScript ES2020 / React 18 (frontend) + ASP.NET Core Minimal API, `System.Text.Json` (polymorphic serialization), existing `SequenceRunner` + `SequenceStepCondition` infrastructure, React 18 + Vite 5
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Tap Wait-and-Retry Before Execution (036-tap-wait-retry)
+  - Primitive tap steps now wait for the target image to appear before tapping, retrying up to a configurable number of times.
+  - New environment variables for configuration:
+    - `GAMEBOT_TAP_RETRY_COUNT` — maximum retry cycles (default 3; 0 = single check, no retries).
+    - `GAMEBOT_TAP_RETRY_PROGRESSION` — multiplier applied to the wait time after each retry (default 1.0 = constant; >1 = exponential backoff).
+    - `GAMEBOT_CAPTURE_INTERVAL_MS` — now also used as the base wait time between retry cycles (default 500ms, min 50ms).
+  - Retry metadata encoded in `PrimitiveTapStepOutcome.Reason` field (e.g., `detected_after_2_retries`, `detection_failed_after_3_retries`, `cancelled_during_retry_N`).
+  - Immediate cancellation support: cancelling during any wait period stops the retry loop within 1ms.
+  - Source-generated `[LoggerMessage]` log entries for retry cycle tracing (EventIds 6009–6013).
+
 - Background Screenshot Service (034-background-screenshot-service)
   - Per-session background capture loop runs on a dedicated thread, taking ADB screenshots at a configurable interval (`GAMEBOT_CAPTURE_INTERVAL_MS`, default 500ms, min 50ms).
   - Cached frames available instantly via `BackgroundScreenCaptureService.GetCachedFrame()` — dual-format cache (PNG bytes + Bitmap) so consumers choose their preferred format.

--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "0",
-  "minor": "3",
+  "minor": "4",
   "patch": "0",
   "updatedBy": "bbqf",
-  "updatedAtUtc": "2026-04-14T00:00:00Z"
+  "updatedAtUtc": "2026-04-15T00:00:00Z"
 }

--- a/specs/036-tap-wait-retry/checklists/requirements.md
+++ b/specs/036-tap-wait-retry/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Tap Wait-and-Retry Before Execution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2025-04-15  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references the existing `GAMEBOT_CAPTURE_INTERVAL_MS` env var as context (existing system knowledge), not as a prescriptive implementation detail.

--- a/specs/036-tap-wait-retry/contracts/api-changes.md
+++ b/specs/036-tap-wait-retry/contracts/api-changes.md
@@ -1,0 +1,59 @@
+# API Contract Changes: 036 Tap Wait-and-Retry
+
+## No New Endpoints
+
+This feature does not add new API endpoints. All changes are to configuration and internal behaviour.
+
+## Configuration Parameters (New)
+
+The following environment variables are introduced. They are surfaced in the existing `GET /api/config` snapshot response alongside all other `GAMEBOT_*` parameters.
+
+### GAMEBOT_CAPTURE_INTERVAL_MS
+
+- **Type**: integer (milliseconds)
+- **Default**: 500
+- **Minimum**: 50
+- **Description**: Screenshot capture interval for the background capture service. Also used as the base wait time (WAIT_TIME) for primitive tap retry cycles.
+- **Note**: This env var already existed for `BackgroundScreenCaptureService` but was not previously included in `AppConfig` or the configuration file defaults. It is now promoted to `AppConfig` for dual use.
+
+### GAMEBOT_TAP_RETRY_COUNT
+
+- **Type**: integer
+- **Default**: 3
+- **Minimum**: 0
+- **Description**: Maximum number of retry cycles for primitive tap image detection. The system checks for the target image up to `COUNT + 1` times (initial check + COUNT retries). Setting to 0 means a single detection check with no retries.
+
+### GAMEBOT_TAP_RETRY_PROGRESSION
+
+- **Type**: double (floating-point)
+- **Default**: 1.0
+- **Minimum**: > 0 (exclusive; must be positive)
+- **Description**: Multiplier applied to the wait time after each unsuccessful retry cycle. `1.0` = constant intervals. `2.0` = doubling intervals (exponential backoff). Values between 0 and 1 create decreasing intervals.
+
+## PrimitiveTapStepOutcome Contract Changes
+
+The `PrimitiveTapStepOutcome` record structure is **unchanged**. New status/reason values are introduced:
+
+### New Status Value
+
+| Status | When | Description |
+|--------|------|-------------|
+| `"cancelled"` | Cancellation requested during retry | Step was cancelled mid-retry loop |
+
+### New Reason Patterns
+
+| Reason Pattern | Applies to Status | Description |
+|---------------|------------------|-------------|
+| `"detected_after_N_retries"` | `"executed"` | Image found after N retry cycles |
+| `"detection_failed_after_N_retries"` | `"skipped_detection_failed"` | Image not found after exhausting all N retry cycles |
+| `"cancelled_during_retry_N"` | `"cancelled"` | Cancellation occurred during retry cycle N |
+
+Where `N` is replaced with the actual cycle count (integer).
+
+## Execution Log Impact
+
+The execution log entries for primitive tap steps continue to use the existing `ExecutionLogService` mapping. The `Reason` field is passed through to execution log detail items, so retry metadata appears in log entries without any mapping changes:
+
+- **Successful tap**: Detail shows `"Tap executed at (x,y)."` — the reason `"detected_after_N_retries"` is captured in the `ExecutionStepOutcome.ReasonText`.
+- **Failed detection**: Detail shows `"Step N was not executed: detection_failed_after_N_retries"`.
+- **Cancelled**: Detail shows `"Step N was not executed: cancelled_during_retry_N"`.

--- a/specs/036-tap-wait-retry/data-model.md
+++ b/specs/036-tap-wait-retry/data-model.md
@@ -1,0 +1,91 @@
+# Data Model: 036 Tap Wait-and-Retry
+
+## Entities
+
+### AppConfig (Extended)
+
+Existing domain configuration class extended with three new properties for tap retry behaviour.
+
+| Field | Type | Default | Validation | Description |
+|-------|------|---------|------------|-------------|
+| LoopMaxIterations | int | 1000 | > 0 | Existing — global loop iteration ceiling |
+| **CaptureIntervalMs** | int | 500 | ≥ 50 | Base wait time between retry cycles; also used by BackgroundScreenCaptureService. Maps to `GAMEBOT_CAPTURE_INTERVAL_MS` env var. |
+| **TapRetryCount** | int | 3 | ≥ 0 | Maximum number of retry cycles for primitive tap detection. 0 = single check, no retries. Maps to `GAMEBOT_TAP_RETRY_COUNT` env var. |
+| **TapRetryProgression** | double | 1.0 | > 0 | Multiplier applied to wait time after each unsuccessful retry cycle. 1.0 = constant interval. Maps to `GAMEBOT_TAP_RETRY_PROGRESSION` env var. |
+
+### PrimitiveTapStepOutcome (Unchanged structure)
+
+Existing record — no schema changes. Retry metadata is encoded in existing fields.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| StepOrder | int | Position of the step in the command |
+| Status | string | Outcome status: `"executed"`, `"skipped_invalid_config"`, `"skipped_detection_failed"`, `"skipped_invalid_target"`, **`"cancelled"`** (new value) |
+| Reason | string? | Human-readable reason. New patterns: `"detected_after_N_retries"`, `"detection_failed_after_N_retries"`, `"cancelled_during_retry_N"` |
+| ResolvedPoint | PrimitiveTapResolvedPoint? | Resolved (x, y) tap coordinates |
+| DetectionConfidence | double? | Template match confidence score |
+
+### Configuration Parameters (Environment Variables + Config File)
+
+| Env Variable | Config Key | Type | Default | Description |
+|-------------|------------|------|---------|-------------|
+| `GAMEBOT_CAPTURE_INTERVAL_MS` | `CaptureIntervalMs` | int | 500 | Screenshot capture interval and base wait time (ms) |
+| `GAMEBOT_TAP_RETRY_COUNT` | `TapRetryCount` | int | 3 | Maximum detection retry cycles for primitive taps |
+| `GAMEBOT_TAP_RETRY_PROGRESSION` | `TapRetryProgression` | double | 1.0 | Wait time multiplier per retry cycle |
+
+## Relationships
+
+```
+AppConfig (singleton)
+  ├── CaptureIntervalMs ──→ BackgroundScreenCaptureService (capture loop interval)
+  ├── CaptureIntervalMs ──→ CommandExecutor (base WAIT_TIME for retry loop)
+  ├── TapRetryCount ──→ CommandExecutor (retry loop bound)
+  └── TapRetryProgression ──→ CommandExecutor (wait escalation factor)
+
+CommandExecutor.PrimitiveTap step
+  ├── uses IScreenSource.GetLatestScreenshot() (refreshed each retry cycle)
+  ├── uses IReferenceImageStore.TryGet() (once, before loop)
+  ├── uses ITemplateMatcher (each retry cycle)
+  └── produces PrimitiveTapStepOutcome (with retry metadata in Reason field)
+       └── consumed by ExecutionLogService (unchanged mapping)
+```
+
+## State Transitions
+
+### Retry Loop State Machine
+
+```
+[Start] ──→ Validate Config (services, template)
+  │
+  ├── Invalid ──→ [Skip with outcome]
+  │
+  └── Valid ──→ [Wait WAIT_TIME] ──→ [Detect Image]
+                    │                      │
+                    │                  ┌───┴───┐
+                    │              Found    Not Found
+                    │                │          │
+                    │                │     attempt < COUNT?
+                    │                │      │         │
+                    │                │     Yes        No
+                    │                │      │         │
+                    │                │  WAIT_TIME ×=  │
+                    │                │  PROGRESSION   │
+                    │                │      │         │
+                    │                │   [Wait]──→[Detect]
+                    │                │                │
+                    │                ▼                ▼
+                    │          [Execute Tap]   [Fail: exhausted]
+                    │                │
+                    ▼                ▼
+              [Cancelled]      [Outcome recorded]
+```
+
+At any point during `[Wait]`, a CancellationToken cancellation immediately aborts to `[Cancelled]`.
+
+## Validation Rules
+
+1. `CaptureIntervalMs` is clamped to minimum 50ms at startup (matches existing `BackgroundScreenCaptureService` behaviour).
+2. `TapRetryCount` < 0 → falls back to default 3 with a warning log.
+3. `TapRetryProgression` ≤ 0 → falls back to default 1.0 with a warning log.
+4. `TapRetryProgression` between 0 and 1 is valid (decreasing waits) but unusual — no special handling.
+5. No upper bound on per-cycle wait time per clarification decision.

--- a/specs/036-tap-wait-retry/plan.md
+++ b/specs/036-tap-wait-retry/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Tap Wait-and-Retry Before Execution
+
+**Branch**: `036-tap-wait-retry` | **Date**: 2025-04-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/036-tap-wait-retry/spec.md`
+
+## Summary
+
+Extend the primitive tap step in `CommandExecutor` with a configurable wait-and-retry loop before execution. Currently, detection is a single-shot attempt — if the reference image is not visible at the exact moment of execution, the step fails. This feature adds a retry loop that waits for the screenshot capture interval, checks for the image, and retries up to a configurable count with optional progressive backoff. Three configuration parameters are introduced: capture interval (base WAIT_TIME, existing env var `GAMEBOT_CAPTURE_INTERVAL_MS` promoted to `AppConfig`), retry count (COUNT, default 3), and wait progression multiplier (PROGRESSION, default 1).
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9  
+**Primary Dependencies**: ASP.NET Core Minimal API, OpenCvSharp (TemplateMatcher), SharpAdbClient/ADB integration, Microsoft.Extensions.Logging, existing `GameBot.Domain` and `GameBot.Emulator` libraries  
+**Storage**: Existing file-backed JSON repositories under `data/` (no new stores); configuration via `AppConfig` singleton  
+**Testing**: xUnit + coverlet for coverage enforcement; existing unit (266), contract (54), integration (169) tests all passing  
+**Target Platform**: Windows (System.Drawing, ADB, OpenCvSharp dependencies are Windows-only)  
+**Project Type**: Desktop service (ASP.NET Core Minimal API host + web UI)  
+**Performance Goals**: Retry loop adds at most `WAIT_TIME × (COUNT + 1)` latency (PROGRESSION=1) or `WAIT_TIME × (1 + (PROGRESSION^COUNT − 1) / (PROGRESSION − 1))` (PROGRESSION > 1), including the initial wait; each detection check < 50ms (existing pipeline); cancellation response < 100ms  
+**Constraints**: Must be immediately cancellable via CancellationToken; global config only (no per-step overrides); no new external packages  
+**Scale/Scope**: ~3 new config properties on `AppConfig`, ~80-120 LOC retry loop in `CommandExecutor`, ~5-8 new unit tests, ~3-5 new integration tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: Build and test runs are passing (verified: 0 warnings, 0 errors, 489/489 tests green).
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality Discipline | PASS | Feature adds <120 LOC to existing service; no new projects/dependencies; modular retry logic encapsulated in a single method |
+| II. Testing Standards | PASS (plan) | New unit tests for retry loop (success on 1st try, success on Nth try, failure after COUNT, cancellation, progression math, edge cases COUNT=0, invalid PROGRESSION). Integration tests for end-to-end retry with mock screenshot source. Coverage targets ≥80% line / ≥70% branch for new code. |
+| III. User Experience Consistency | PASS | Config parameters follow existing env-var + AppConfig pattern; log messages follow existing structured logging; step outcome states extend existing PrimitiveTapStepOutcome vocabulary ("executed", "skipped_detection_failed" → + "cancelled") |
+| IV. Performance Requirements | PASS | Worst-case latency is bounded and documented in spec (SC-005); no N+1 patterns; each retry reuses cached screenshot (no extra ADB calls); cancellation aborts immediately |
+| Quality Gates – DoD | PASS (plan) | No underscores in method names; all public APIs documented; config parameters documented in code and config file; changelog entry planned |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/036-tap-wait-retry/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (API endpoint changes)
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   └── Config/
+│       └── AppConfig.cs              # + TapRetryCount, TapRetryProgression, CaptureIntervalMs properties
+├── GameBot.Emulator/
+│   └── Session/
+│       └── BackgroundScreenCaptureService.cs  # No changes (captures at existing interval)
+└── GameBot.Service/
+    ├── Program.cs                     # + Wire new AppConfig properties from env vars
+    └── Services/
+        └── CommandExecutor.cs         # + Retry loop in PrimitiveTap handling
+
+tests/
+├── unit/
+│   └── Commands/
+│       └── CommandExecutorPrimitiveTapTests.cs  # + Retry loop unit tests
+└── integration/
+    └── Commands/
+        └── PrimitiveTapExecutionIntegrationTests.cs  # + Retry integration tests
+```
+
+**Structure Decision**: All changes fit within existing project boundaries. No new projects or directories needed. The retry logic is added to the existing `CommandExecutor.PrimitiveTap` handling path in `GameBot.Service`, with configuration properties added to the existing `AppConfig` class in `GameBot.Domain`.
+
+## Complexity Tracking
+
+No constitution violations. All changes are within existing project structure and follow established patterns.

--- a/specs/036-tap-wait-retry/quickstart.md
+++ b/specs/036-tap-wait-retry/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: 036 Tap Wait-and-Retry
+
+## What Changed
+
+Primitive tap actions now wait for their target image to appear on screen before executing the tap, with configurable retries and progressive backoff. Previously, if the image wasn't visible at the exact moment of execution, the tap failed.
+
+## Configuration
+
+Three settings control retry behaviour. All have sensible defaults and work out of the box.
+
+| Setting | Env Variable | Default | Description |
+|---------|-------------|---------|-------------|
+| Capture Interval | `GAMEBOT_CAPTURE_INTERVAL_MS` | 500 | Base wait time between retries (ms) |
+| Retry Count | `GAMEBOT_TAP_RETRY_COUNT` | 3 | Max retry cycles (0 = no retries) |
+| Progression | `GAMEBOT_TAP_RETRY_PROGRESSION` | 1.0 | Wait multiplier per retry (1.0 = constant) |
+
+### Example: Default behaviour (no config needed)
+
+With defaults, each primitive tap step:
+1. Waits 500ms
+2. Checks for image → if found, taps immediately
+3. If not found, waits another 500ms and rechecks (up to 3 retries)
+4. If still not found after 3 retries, fails
+
+Total worst-case wait: 2000ms (4 checks × 500ms waits).
+
+### Example: Exponential backoff
+
+Set `GAMEBOT_TAP_RETRY_COUNT=5` and `GAMEBOT_TAP_RETRY_PROGRESSION=2`:
+
+| Cycle | Wait Before Check |
+|-------|------------------|
+| 1 | 500ms |
+| 2 | 1000ms |
+| 3 | 2000ms |
+| 4 | 4000ms |
+| 5 | 8000ms |
+
+Total worst-case wait: 15,500ms.
+
+## Monitoring
+
+- **Debug logs**: Each retry cycle logs the cycle number, wait duration, and detection result.
+- **Info/Warning logs**: Final outcomes (image detected, retries exhausted, cancelled) log at higher levels.
+- **Execution logs**: The execution log entry records the final step outcome with retry count in the reason field (e.g., "detected_after_2_retries").
+
+## Cancellation
+
+If a sequence is stopped during a retry wait, the retry loop immediately aborts and the step is recorded as "cancelled" (not "failed").
+
+## No Impact On
+
+- Primitive tap steps without detection targets (unchanged behaviour)
+- Non-primitive-tap command steps (unchanged)
+- The background screenshot capture service (unchanged interval and behaviour)
+- Existing API endpoints (no new endpoints; config visible via existing `GET /api/config`)

--- a/specs/036-tap-wait-retry/research.md
+++ b/specs/036-tap-wait-retry/research.md
@@ -1,0 +1,110 @@
+# Research: 036 Tap Wait-and-Retry
+
+## R-001: Retry Loop Implementation Pattern
+
+**Decision**: Use `Task.Delay(waitMs, cancellationToken)` in a `for` loop wrapping the existing screenshot-fetch → template-match → coordinate-resolve flow. On `OperationCanceledException`, catch and report "cancelled" outcome.
+
+**Rationale**: `Task.Delay` with `CancellationToken` is the idiomatic .NET async cancellable wait. It provides immediate abort on cancellation (< 1ms response). The existing `CancellationToken ct` parameter is already threaded through `ForceExecuteDetailedAsync` → `ExecuteCommandRecursiveAsync` → the PrimitiveTap block, so no plumbing changes are needed.
+
+**Alternatives considered**:
+- `Thread.Sleep` — blocks the thread and is not cancellable; rejected.
+- `ManualResetEventSlim.Wait(ms, ct)` — synchronous, would need wrapping; more complex, no benefit over `Task.Delay`.
+- Polly retry library — adds external dependency for a simple loop; over-engineered.
+
+## R-002: AppConfig Extension Pattern
+
+**Decision**: Add three new `init` properties to `AppConfig`: `CaptureIntervalMs` (int, default 500), `TapRetryCount` (int, default 3), `TapRetryProgression` (double, default 1.0). Wire them in `Program.cs` alongside the existing `LoopMaxIterations` registration, following the same `int.TryParse(env var) ?? default` pattern.
+
+**Rationale**: The existing `AppConfig` is a simple POCO registered as a singleton. The `LoopMaxIterations` property follows an env-var-with-default pattern. The three new properties follow the same convention with environment variables:
+- `GAMEBOT_CAPTURE_INTERVAL_MS` → `CaptureIntervalMs` (also used by `BackgroundScreenCaptureService`)
+- `GAMEBOT_TAP_RETRY_COUNT` → `TapRetryCount`
+- `GAMEBOT_TAP_RETRY_PROGRESSION` → `TapRetryProgression`
+
+The `captureIntervalMs` local variable already exists in `Program.cs` (line 187) for the BackgroundScreenCaptureService. It will be reused when constructing `AppConfig`, ensuring the same value flows to both consumers.
+
+**Alternatives considered**:
+- Separate `TapRetryConfig` class — adds another DI registration; the existing `AppConfig` is designed for this purpose.
+- Options pattern (`IOptions<T>`) — would require restructuring; the project uses direct singleton registration and env vars; consistency wins.
+
+## R-003: Configuration Validation
+
+**Decision**: Validate in `Program.cs` at registration time, falling back to defaults for invalid values. Specifically:
+- `CaptureIntervalMs`: clamped to ≥50 (same as `BackgroundScreenCaptureService`)
+- `TapRetryCount`: non-negative integer; negative falls back to default 3
+- `TapRetryProgression`: must be > 0; values ≤ 0 fall back to default 1.0
+
+**Rationale**: Fail-safe at startup. Bad config should not crash the service; it should log a warning and use defaults. This matches the existing pattern where `BackgroundScreenCaptureService` clamps `captureIntervalMs` to min 50.
+
+**Alternatives considered**:
+- Throw on invalid config — breaks service startup for a non-critical setting; rejected.
+- Validate at each retry call site — adds runtime overhead and duplicates validation; prefer one-time at startup.
+
+## R-004: PrimitiveTapStepOutcome Extension for Retry Count
+
+**Decision**: Add an optional `RetryCount` property to `PrimitiveTapStepOutcome` by extending the sealed record with a new parameter (default null for backward compatibility). Alternatively, encode retry count in the existing `Reason` string field (e.g., "detected_after_2_retries").
+
+After analysis: Use the `Reason` field. The current record definition is `(StepOrder, Status, Reason, ResolvedPoint, DetectionConfidence)`. Adding a parameter changes the positional constructor signature, affecting all call sites (both production and tests). Encoding in `Reason` avoids schema changes while still providing the information in execution logs.
+
+Status values:
+- `"executed"` — tap succeeded (Reason: `null` if found on 1st attempt, `"detected_after_N_retries"` if found after retries)
+- `"skipped_detection_failed"` — all retries exhausted (Reason: `"detection_failed_after_N_retries"`)
+- `"cancelled"` — cancelled during retry (Reason: `"cancelled_during_retry_N"`)
+
+**Rationale**: Minimally invasive. The `Reason` field is already nullable and consumed as a string in both runtime logging and execution log persistence. No changes to `ExecutionLogService` mapping logic — it already passes `Reason` through to execution log entries.
+
+**Alternatives considered**:
+- New record field `int? RetryCount` — requires updating all 10+ call sites constructing `PrimitiveTapStepOutcome`, all test assertions, and the `ExecutionLogService` mapping; high churn for low value.
+- Separate retry event type — over-designed for additional metadata that fits naturally in `Reason`.
+
+## R-005: Retry Loop Insertion Point
+
+**Decision**: The retry loop wraps lines 223–277 of `CommandExecutor.cs` (from screenshot fetch through detection result). The initial wait and detection check are separated from the retry loop so that PROGRESSION is applied only between retries (not after the initial check). The loop structure:
+
+```
+// Before loop: validate services (existing L215-L221)
+// Validate template exists (existing L230-L233 — move before loop since template doesn't change)
+
+// Initial wait + detection check (FR-001)
+await Task.Delay(baseWaitMs, ct);
+// Fetch latest screenshot (L223)
+// Convert to Mat and run detection (L235-L257)
+// If detected → extract coordinates, validate, execute tap, return outcome
+
+// Retry loop (FR-002, FR-003)
+int currentWaitMs = baseWaitMs;
+for (int retry = 0; retry < retryCount; retry++) {
+    await Task.Delay(currentWaitMs, ct);
+    currentWaitMs = (int)(currentWaitMs * progression);  // progression applied after wait
+    
+    // Fetch latest screenshot
+    // Convert to Mat and run detection
+    // If detected → extract coordinates, validate, execute tap, break
+    // If not detected → log retry cycle, continue loop
+}
+// If loop exhausted → add failure outcome
+```
+
+This produces wait times matching the spec acceptance scenarios: for PROGRESSION=2, COUNT=3, base=500ms → initial wait 500ms, retry waits 500ms, 1000ms, 2000ms.
+
+The key insight: template lookup (`images.TryGet`) can be moved before the loop since the template image doesn't change between retries. Only the screenshot needs refreshing.
+
+**Rationale**: Minimal refactoring of existing code. The existing straight-line flow becomes the loop body, with the screenshot fetch moved inside the loop and template lookup moved outside.
+
+**Alternatives considered**:
+- Extract retry logic to a separate helper class — adds indirection for a single call site; can be refactored later if reuse emerges.
+- Extract the entire PrimitiveTap block to a method — good idea but scope creep; keep changes focused on the retry loop.
+
+## R-006: Logging Pattern
+
+**Decision**: Use the existing `Log` static class (high-performance source-generated logging) for retry cycle logging. Add new log methods:
+- `TapRetryWaiting(logger, stepOrder, cycle, waitMs)` at Debug level
+- `TapRetryDetected(logger, stepOrder, cycle)` at Information level
+- `TapRetryNotDetected(logger, stepOrder, cycle)` at Debug level
+- `TapRetryExhausted(logger, stepOrder, totalCycles)` at Warning level
+- `TapRetryCancelled(logger, stepOrder, cycle)` at Information level
+
+**Rationale**: Follows the existing `[LoggerMessage]` attribute pattern in `CommandExecutor.cs`. Individual retry cycles log at Debug (verbose, for troubleshooting). Final outcome events (detected, exhausted, cancelled) log at Info/Warning for operational visibility.
+
+**Alternatives considered**:
+- Structured logging with Serilog enrichers — the project uses `Microsoft.Extensions.Logging` with source generators; stay consistent.
+- Info-level for every cycle — too noisy for production with default config (3 cycles × N steps per execution).

--- a/specs/036-tap-wait-retry/spec.md
+++ b/specs/036-tap-wait-retry/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Tap Wait-and-Retry Before Execution
+
+**Feature Branch**: `036-tap-wait-retry`  
+**Created**: 2025-04-15  
+**Status**: Draft  
+**Input**: User description: "Extend primitive tap actions with a wait-and-retry mechanism before execution. Before a primitive tap action is executed, the system waits for the configured screenshot capture interval (WAIT_TIME). Two new configuration parameters are introduced: COUNT (max retry cycles, default 3) and PROGRESSION (wait time multiplier, default 1). On each retry cycle, if the expected image is not found and the retry count has not been exceeded, the system waits WAIT_TIME and then sets WAIT_TIME = WAIT_TIME × PROGRESSION. Once the image is found, the tap executes. If COUNT is exceeded, the action fails. All three variables must be documented and set in the configuration file."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Tap action waits for image before executing (Priority: P1)
+
+As a user running an automated game sequence, I want the system to automatically wait for an expected image to appear on screen before performing a tap, so that taps are only executed when the game is in the correct state and timing-sensitive UI transitions do not cause missed taps.
+
+**Why this priority**: This is the core value of the feature — making tap actions resilient to variable game loading times and UI transitions. Without this, taps fire immediately and often miss their target.
+
+**Independent Test**: Can be fully tested by configuring a primitive tap action with a reference image, starting the game in a state where the image appears after a short delay, and verifying the tap waits and then executes once the image is detected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a primitive tap step with a detection target configured, and the expected image is already visible on screen, **When** the step executes, **Then** the system detects the image on the first check (after an initial WAIT_TIME pause) and performs the tap immediately.
+2. **Given** a primitive tap step with a detection target configured, and the expected image appears after 2 screenshot cycles, **When** the step executes, **Then** the system waits through 2 retry cycles (pausing WAIT_TIME between each), detects the image on the 3rd check, and performs the tap.
+3. **Given** a primitive tap step with a detection target configured, and the expected image never appears, **When** the step executes and all retry cycles are exhausted (COUNT exceeded), **Then** the action fails with a clear indication that the expected image was not found within the allowed retry window.
+
+---
+
+### User Story 2 - Progressive wait time increases between retries (Priority: P2)
+
+As a user automating a game with variable load times, I want the wait time between retries to increase progressively (via a multiplier), so that the system can start with short waits for fast transitions and gradually extend waits for slower ones, reducing unnecessary delays while still catching slow loads.
+
+**Why this priority**: The progression multiplier adds flexibility beyond fixed-interval retries. It enables smarter waiting strategies, but the feature is still useful with the default PROGRESSION of 1 (no increase).
+
+**Independent Test**: Can be tested by setting PROGRESSION to a value greater than 1 (e.g., 2), configuring a tap action where the image appears late, and verifying via logs that each successive wait period is longer than the previous one according to the multiplier.
+
+**Acceptance Scenarios**:
+
+1. **Given** WAIT_TIME is 500ms, PROGRESSION is 2, and COUNT is 3, **When** the image is not found across all cycles, **Then** the system waits 500ms before the first recheck, 1000ms before the second recheck, and 2000ms before the third recheck (each wait doubles).
+2. **Given** WAIT_TIME is 500ms and PROGRESSION is 1, **When** the image is not found across retries, **Then** each wait interval remains 500ms (no progression).
+
+---
+
+### User Story 3 - Configuration parameters are persisted and documented (Priority: P2)
+
+As a system administrator or advanced user, I want the three parameters (screenshot capture interval, retry count, and wait progression) to be configurable in the application configuration file with sensible defaults, so that I can tune the retry behaviour without modifying code.
+
+**Why this priority**: Configuration is essential to make the feature usable in different game environments with varying response times. It is ranked P2 because it ships alongside P1 — but the defaults must be correct for zero-config use.
+
+**Independent Test**: Can be tested by verifying that default configuration values are applied when no explicit configuration is provided, and that overriding each parameter in the configuration file changes the observed retry behaviour.
+
+**Acceptance Scenarios**:
+
+1. **Given** no explicit configuration for retry count and progression, **When** a primitive tap step executes, **Then** the defaults of COUNT = 3 and PROGRESSION = 1 are used.
+2. **Given** the screenshot capture interval is not explicitly configured, **When** the system starts, **Then** the default capture interval (currently 500ms) is used as the base WAIT_TIME.
+3. **Given** a user sets COUNT = 5 and PROGRESSION = 1.5 in the configuration, **When** a primitive tap step executes and the image is not found, **Then** the system retries up to 5 times with progressively longer waits (500ms, 750ms, 1125ms, 1687ms, 2531ms).
+
+---
+
+### Edge Cases
+
+- What happens when COUNT is set to 0? The system should perform no retries — it checks for the image once, and if not found, fails immediately.
+- What happens when PROGRESSION is set to 0? The system should treat this as an invalid configuration and fall back to the default value of 1 (no progression).
+- What happens when PROGRESSION is less than 0? The system should treat negative values as invalid and fall back to the default value of 1.
+- What happens when the screenshot service is unavailable during a retry cycle? The system should treat a missing screenshot as "image not found" and continue the retry loop.
+- What happens when the tap action has no detection target? The existing behaviour is preserved — no wait-and-retry occurs; the step is skipped with an appropriate log message as it does today.
+- What happens when the reference image is not registered in the image store? The existing behaviour is preserved — the step fails with a "template_not_found" indication.
+- What happens when cancellation is requested during a retry wait? The retry loop is immediately cancellable — the current wait is aborted and the step is reported as "cancelled" (distinct from "failed").
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST wait for at least the configured screenshot capture interval before performing the first image detection check in a primitive tap step.
+- **FR-002**: System MUST re-check for the expected image after each wait period, up to the configured maximum retry count (COUNT).
+- **FR-003**: System MUST multiply the current wait time by the configured PROGRESSION factor after each unsuccessful retry cycle (not after the initial detection check), so that `next_wait = current_wait × PROGRESSION`.
+- **FR-004**: System MUST execute the tap action immediately once the expected image is detected during any retry cycle.
+- **FR-005**: System MUST fail the primitive tap step when the maximum retry count is exceeded without detecting the expected image, preserving the current failure behaviour and error reporting.
+- **FR-006**: System MUST expose a configuration parameter for the maximum number of retry cycles (COUNT) with a default value of 3.
+- **FR-007**: System MUST expose a configuration parameter for the wait time progression multiplier (PROGRESSION) with a default value of 1.
+- **FR-008**: System MUST use the background screenshot service capture interval as the base wait time (WAIT_TIME), which already defaults to 500ms via the existing `GAMEBOT_CAPTURE_INTERVAL_MS` environment variable — but MUST also be settable via the configuration file for discoverability.
+- **FR-009**: System MUST validate configuration values: COUNT must be a non-negative integer; PROGRESSION must be a positive number (> 0). Invalid values must fall back to defaults.
+- **FR-010**: System MUST log each retry cycle (cycle number, current wait time, detection result) via runtime logging (console/Application Insights) at an appropriate log level. Individual retry cycles MUST NOT be written to the persisted execution log; only the final step outcome (succeeded/failed/cancelled with total retry count) MUST be recorded in the execution log.
+- **FR-011**: System MUST document all three configuration parameters (capture interval, retry count, progression) in the configuration file with descriptions and default values.
+- **FR-012**: System MUST preserve existing behaviour for primitive tap steps that lack a detection target (no change to non-detection tap flows).
+- **FR-013**: System MUST support immediate cancellation of the retry loop when a cancellation is requested (e.g., sequence stop). The current wait MUST be aborted and the step outcome reported as "cancelled", distinct from a retry-exhaustion failure.
+
+### Key Entities
+
+- **Tap Retry Configuration**: The set of parameters governing wait-and-retry behaviour for primitive tap steps. Key attributes: base wait time (derived from capture interval), maximum retry count (COUNT), wait progression multiplier (PROGRESSION).
+- **Retry Cycle**: A single iteration of the wait-then-detect loop. Attributes: cycle number, wait duration applied, detection result (found/not found), elapsed time.
+- **Primitive Tap Step**: An existing command step type that locates a reference image on screen and taps its coordinates. Extended with retry logic before execution.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Primitive tap actions that depend on image detection succeed at least 95% of the time in scenarios where the target image appears within the configured retry window, compared to the current behaviour where they often fail due to timing. *(Aspirational outcome metric — verified indirectly via unit/integration test coverage, not a directly testable gate.)*
+- **SC-002**: Users can fully configure the retry behaviour (wait time, count, progression) without modifying any code, using only the configuration file.
+- **SC-003**: Each retry cycle and its outcome is visible in the application logs, enabling users to diagnose timing issues within seconds.
+- **SC-004**: The default configuration (COUNT = 3, PROGRESSION = 1, base wait from capture interval) works correctly out of the box with no explicit user configuration required.
+- **SC-005**: The total additional latency introduced by the retry mechanism does not exceed `WAIT_TIME × (COUNT + 1)` when PROGRESSION = 1, or `WAIT_TIME × (1 + (PROGRESSION^COUNT − 1) / (PROGRESSION − 1))` when PROGRESSION > 1, ensuring predictable worst-case execution time (includes the initial wait before the first detection check).
+- **SC-006**: Existing tap actions without detection targets continue to work identically to the current behaviour — no regressions. *(Verified by dedicated regression test for FR-012.)*
+
+## Clarifications
+
+### Session 2025-04-15
+
+- Q: How should the retry loop respond to cancellation requests during a wait cycle? → A: Immediately cancellable — abort the current wait, report step as "cancelled" (not "failed").
+- Q: Should there be an upper bound on the per-cycle wait time when PROGRESSION > 1? → A: No cap — let the formula run unconstrained.
+- Q: Should individual retry cycles be persisted to the execution log, or is runtime logging sufficient? → A: Runtime logging only — execution log records final step outcome with retry count.
+- Q: Should individual primitive tap steps be able to override global COUNT and PROGRESSION values? → A: Global configuration only — all primitive tap steps share the same settings.
+- Q: Should the system verify screenshot freshness before each retry detection check? → A: Use latest cached frame — trust that the capture interval naturally produces fresh frames.
+
+## Assumptions
+
+- The background screenshot capture service is running and providing updated screenshots at the configured interval. The retry mechanism uses whatever the latest cached frame is at detection time, without explicit freshness checks. Since the base WAIT_TIME equals the capture interval, a new frame will naturally be available after each wait cycle.
+- The existing `GAMEBOT_CAPTURE_INTERVAL_MS` environment variable (default 500ms) is the authoritative source for base wait time. The new configuration file entry provides the same value for discoverability but the environment variable takes precedence if both are set.
+- The existing template matching / image detection pipeline (OpenCvSharp TemplateMatcher) is used for each retry attempt — no changes to the detection algorithm itself.
+- PROGRESSION = 1 (default) means constant wait intervals (no exponential backoff). Values > 1 create exponential backoff. Fractional values between 0 and 1 would create decreasing waits, which is valid but unusual.
+- There is no upper bound on individual per-cycle wait times. Users who set high PROGRESSION values with high COUNT accept the resulting long waits; the cancellation mechanism (FR-013) provides an escape hatch.
+- Retry configuration (COUNT, PROGRESSION) is global only. Per-step overrides are explicitly out of scope for this feature and may be introduced in a future iteration if needed.

--- a/specs/036-tap-wait-retry/tasks.md
+++ b/specs/036-tap-wait-retry/tasks.md
@@ -1,0 +1,161 @@
+# Tasks: Tap Wait-and-Retry Before Execution
+
+**Input**: Design documents from `/specs/036-tap-wait-retry/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Required per constitution (Principle II: Testing Standards).
+
+**Organization**: Tasks are grouped by user story. US3 (configuration) is foundational — US1 and US2 depend on it.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new projects or directories needed. This phase verifies the build is green before changes begin.
+
+- [ ] T001 Verify build and all 489 tests pass (`dotnet build -c Debug && dotnet test -c Debug`)
+
+---
+
+## Phase 2: Foundational — Configuration (US3, Priority: P2) 🎯 Prerequisite
+
+**Purpose**: Introduce the three configuration properties that the retry loop depends on. Must be complete before US1/US2 work begins.
+
+**Goal**: AppConfig exposes CaptureIntervalMs, TapRetryCount, TapRetryProgression with env-var wiring and validation.
+
+**Independent Test**: Startup with/without env vars produces correct AppConfig values; invalid values fall back to defaults.
+
+### Tests for Configuration
+
+- [ ] T002 [P] [US3] Add unit tests for AppConfig default values and validation in `tests/unit/Config/AppConfigValidationTests.cs` — test default CaptureIntervalMs=500, TapRetryCount=3, TapRetryProgression=1.0; test negative TapRetryCount falls back to 3; test zero/negative TapRetryProgression falls back to 1.0; test CaptureIntervalMs clamped to ≥50
+
+### Implementation for Configuration
+
+- [ ] T003 [US3] Add CaptureIntervalMs, TapRetryCount, TapRetryProgression properties to `src/GameBot.Domain/Config/AppConfig.cs` with defaults (500, 3, 1.0) and XML doc comments per data-model.md
+- [ ] T004 [US3] Wire new AppConfig properties from env vars in `src/GameBot.Service/Program.cs` — parse GAMEBOT_CAPTURE_INTERVAL_MS (reuse existing local var), GAMEBOT_TAP_RETRY_COUNT, GAMEBOT_TAP_RETRY_PROGRESSION with validation and fallback per R-003; also feed captureIntervalMs from the same parsed value to BackgroundScreenCaptureService registration
+- [ ] T005 [US3] Verify build passes and T002 tests are green
+
+**Checkpoint**: AppConfig now carries all three retry config values. Retry loop implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Tap Wait-and-Retry Loop (Priority: P1) 🎯 MVP
+
+**Goal**: Primitive tap steps wait for the target image to appear, retrying up to COUNT times with WAIT_TIME delays, before executing the tap or failing.
+
+**Independent Test**: A primitive tap step with a detection target waits, detects on Nth attempt, and taps; or exhausts retries and fails; or is cancelled immediately.
+
+### Tests for User Story 1
+
+- [ ] T006 [P] [US1] Add unit test: image found on first attempt (after initial wait) — tap executes with status "executed" and null reason, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [ ] T007 [P] [US1] Add unit test: image found on 3rd attempt — tap executes with status "executed" and reason "detected_after_2_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [ ] T008 [P] [US1] Add unit test: image never found, COUNT=3 — step fails with status "skipped_detection_failed" and reason "detection_failed_after_3_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [ ] T009 [P] [US1] Add unit test: cancellation during wait — step reports status "cancelled" and reason "cancelled_during_retry_N", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [ ] T010 [P] [US1] Add unit test: COUNT=0 — single detection check, no retries; if not found, fails immediately with reason "detection_failed_after_0_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [ ] T011 [P] [US1] Add integration test: end-to-end retry with mock screenshot source returning image on 2nd call, in `tests/integration/Commands/PrimitiveTapExecutionIntegrationTests.cs`
+- [ ] T023 [P] [FR-012] Add regression test: primitive tap step without a detection target is unaffected by retry logic — still skips with existing behaviour, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Add source-generated `[LoggerMessage]` methods to the Log static class in `src/GameBot.Service/Services/CommandExecutor.cs` — TapRetryWaiting (Debug), TapRetryDetected (Info), TapRetryNotDetected (Debug), TapRetryExhausted (Warning), TapRetryCancelled (Info) per R-006
+- [ ] T013 [US1] Inject AppConfig into CommandExecutor constructor in `src/GameBot.Service/Services/CommandExecutor.cs` — add `_appConfig` field, receive via DI, read CaptureIntervalMs/TapRetryCount/TapRetryProgression
+- [ ] T014 [US1] Implement retry loop in PrimitiveTap handling block of `src/GameBot.Service/Services/CommandExecutor.cs` — move template lookup before loop (R-005); perform initial wait + detection check, then wrap retry cycles in `for` loop with `Task.Delay(currentWaitMs, ct)` followed by `currentWaitMs *= progression` (progression applied after each retry wait, not after initial check); handle OperationCanceledException for immediate cancellation (FR-013); encode retry metadata in Reason field per R-004
+- [ ] T015 [US1] Verify build passes and all tests (T006–T011 plus existing 489) are green
+
+**Checkpoint**: Primitive tap steps now wait and retry. US1 acceptance scenarios 1, 2, 3 are satisfied. Cancellation works.
+
+---
+
+## Phase 4: User Story 2 — Progressive Wait Time (Priority: P2)
+
+**Goal**: Wait time between retries increases by the PROGRESSION multiplier each cycle.
+
+**Independent Test**: With PROGRESSION=2, verify via logs/test assertions that wait times double each cycle.
+
+> **Note**: The progression math (`currentWaitMs *= progression`) is implemented as part of the retry loop in T014. This phase adds dedicated tests to verify the progression behaviour and edge cases.
+
+### Tests for User Story 2
+
+- [ ] T016 [P] [US2] Add unit test: PROGRESSION=2, WAIT_TIME=500, COUNT=3 — verify retry wait times are 500, 1000, 2000 ms (excluding the initial check wait), in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [ ] T017 [P] [US2] Add unit test: PROGRESSION=1 (default) — verify all wait intervals are equal (500ms each), in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [ ] T018 [P] [US2] Add unit test: invalid PROGRESSION (0 or negative) falls back to 1.0 — verify constant wait intervals, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+
+**Checkpoint**: Progression logic is verified. US2 acceptance scenarios 1 and 2 are satisfied.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, changelog, and final validation.
+
+- [ ] T019 [P] Add CHANGELOG.md entry documenting tap wait-and-retry feature, new configuration parameters, and their defaults
+- [ ] T020 [P] Add a class-level XML doc comment on `AppConfig` in `src/GameBot.Domain/Config/AppConfig.cs` describing the retry algorithm interaction (WAIT_TIME × PROGRESSION^N formula, state machine overview) — supplements the individual property doc comments added in T003
+- [ ] T021 Run full regression: `dotnet build -c Debug && dotnet test -c Debug` — all tests pass, 0 warnings, 0 errors
+- [ ] T022 Validate quickstart.md scenarios manually: default config works out of the box; overriding env vars changes retry behaviour
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Configuration (Phase 2 / US3)**: Depends on Phase 1 — BLOCKS Phase 3 and 4
+- **Retry Loop (Phase 3 / US1)**: Depends on Phase 2 (needs AppConfig properties)
+- **Progression (Phase 4 / US2)**: Depends on Phase 3 (progression is part of retry loop; Phase 4 adds verification tests)
+- **Polish (Phase 5)**: Depends on all prior phases
+
+### User Story Dependencies
+
+- **US3 (Configuration)**: Foundational — no dependencies on other stories
+- **US1 (Retry Loop)**: Depends on US3 (needs config values to parameterize loop)
+- **US2 (Progression)**: Depends on US1 (progression is embedded in retry loop logic)
+
+### Within Each Phase
+
+- Tests MUST be written first and MUST fail before implementation
+- Models/config before services
+- Services/logic before wiring
+- Verify build + tests green at each checkpoint
+
+### Parallel Opportunities
+
+Within Phase 2:
+- T002 (tests) can be written in parallel with understanding T003-T004, but must be committed first
+
+Within Phase 3:
+- T006–T011, T023 (all tests) can be written in parallel [P]
+- T012 (log methods) and T013 (DI injection) can be done in parallel [P] before T014
+
+Within Phase 4:
+- T016–T018 (all tests) can be written in parallel [P]
+
+Within Phase 5:
+- T019 and T020 can be done in parallel [P]
+
+---
+
+## Implementation Strategy
+
+### MVP Scope
+
+The MVP is **Phase 1 + Phase 2 + Phase 3** (US3 config + US1 retry loop). This delivers the core value: primitive taps wait for images before executing, with configurable retry count. Progression defaults to 1.0 (constant intervals), which is fully functional.
+
+### Incremental Delivery
+
+1. **Increment 1** (Phases 1-2): Configuration properties wired and validated — no behaviour change yet
+2. **Increment 2** (Phase 3): Retry loop active — full tap wait-and-retry with cancellation support
+3. **Increment 3** (Phase 4): Progression edge cases verified — confidence in backoff behaviour
+4. **Increment 4** (Phase 5): Documentation and regression — feature complete
+
+### Risk Mitigation
+
+- **Lowest risk**: AppConfig changes (Phase 2) are additive and backward-compatible
+- **Medium risk**: Retry loop (Phase 3) modifies the hot path in CommandExecutor — mitigated by comprehensive unit + integration tests
+- **No risk**: Progression (Phase 4) adds only test verification — the math is a single multiplication already in the loop

--- a/specs/036-tap-wait-retry/tasks.md
+++ b/specs/036-tap-wait-retry/tasks.md
@@ -19,7 +19,7 @@
 
 **Purpose**: No new projects or directories needed. This phase verifies the build is green before changes begin.
 
-- [ ] T001 Verify build and all 489 tests pass (`dotnet build -c Debug && dotnet test -c Debug`)
+- [X] T001 Verify build and all 489 tests pass (`dotnet build -c Debug && dotnet test -c Debug`)
 
 ---
 
@@ -33,13 +33,13 @@
 
 ### Tests for Configuration
 
-- [ ] T002 [P] [US3] Add unit tests for AppConfig default values and validation in `tests/unit/Config/AppConfigValidationTests.cs` — test default CaptureIntervalMs=500, TapRetryCount=3, TapRetryProgression=1.0; test negative TapRetryCount falls back to 3; test zero/negative TapRetryProgression falls back to 1.0; test CaptureIntervalMs clamped to ≥50
+- [X] T002 [P] [US3] Add unit tests for AppConfig default values and validation in `tests/unit/Config/AppConfigValidationTests.cs` — test default CaptureIntervalMs=500, TapRetryCount=3, TapRetryProgression=1.0; test negative TapRetryCount falls back to 3; test zero/negative TapRetryProgression falls back to 1.0; test CaptureIntervalMs clamped to ≥50
 
 ### Implementation for Configuration
 
-- [ ] T003 [US3] Add CaptureIntervalMs, TapRetryCount, TapRetryProgression properties to `src/GameBot.Domain/Config/AppConfig.cs` with defaults (500, 3, 1.0) and XML doc comments per data-model.md
-- [ ] T004 [US3] Wire new AppConfig properties from env vars in `src/GameBot.Service/Program.cs` — parse GAMEBOT_CAPTURE_INTERVAL_MS (reuse existing local var), GAMEBOT_TAP_RETRY_COUNT, GAMEBOT_TAP_RETRY_PROGRESSION with validation and fallback per R-003; also feed captureIntervalMs from the same parsed value to BackgroundScreenCaptureService registration
-- [ ] T005 [US3] Verify build passes and T002 tests are green
+- [X] T003 [US3] Add CaptureIntervalMs, TapRetryCount, TapRetryProgression properties to `src/GameBot.Domain/Config/AppConfig.cs` with defaults (500, 3, 1.0) and XML doc comments per data-model.md
+- [X] T004 [US3] Wire new AppConfig properties from env vars in `src/GameBot.Service/Program.cs` — parse GAMEBOT_CAPTURE_INTERVAL_MS (reuse existing local var), GAMEBOT_TAP_RETRY_COUNT, GAMEBOT_TAP_RETRY_PROGRESSION with validation and fallback per R-003; also feed captureIntervalMs from the same parsed value to BackgroundScreenCaptureService registration
+- [X] T005 [US3] Verify build passes and T002 tests are green
 
 **Checkpoint**: AppConfig now carries all three retry config values. Retry loop implementation can begin.
 
@@ -53,20 +53,20 @@
 
 ### Tests for User Story 1
 
-- [ ] T006 [P] [US1] Add unit test: image found on first attempt (after initial wait) — tap executes with status "executed" and null reason, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
-- [ ] T007 [P] [US1] Add unit test: image found on 3rd attempt — tap executes with status "executed" and reason "detected_after_2_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
-- [ ] T008 [P] [US1] Add unit test: image never found, COUNT=3 — step fails with status "skipped_detection_failed" and reason "detection_failed_after_3_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
-- [ ] T009 [P] [US1] Add unit test: cancellation during wait — step reports status "cancelled" and reason "cancelled_during_retry_N", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
-- [ ] T010 [P] [US1] Add unit test: COUNT=0 — single detection check, no retries; if not found, fails immediately with reason "detection_failed_after_0_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
-- [ ] T011 [P] [US1] Add integration test: end-to-end retry with mock screenshot source returning image on 2nd call, in `tests/integration/Commands/PrimitiveTapExecutionIntegrationTests.cs`
-- [ ] T023 [P] [FR-012] Add regression test: primitive tap step without a detection target is unaffected by retry logic — still skips with existing behaviour, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T006 [P] [US1] Add unit test: image found on first attempt (after initial wait) — tap executes with status "executed" and null reason, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T007 [P] [US1] Add unit test: image found on 3rd attempt — tap executes with status "executed" and reason "detected_after_2_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T008 [P] [US1] Add unit test: image never found, COUNT=3 — step fails with status "skipped_detection_failed" and reason "detection_failed_after_3_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T009 [P] [US1] Add unit test: cancellation during wait — step reports status "cancelled" and reason "cancelled_during_retry_N", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T010 [P] [US1] Add unit test: COUNT=0 — single detection check, no retries; if not found, fails immediately with reason "detection_failed_after_0_retries", in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T011 [P] [US1] Add integration test: end-to-end retry with mock screenshot source returning image on 2nd call, in `tests/integration/Commands/PrimitiveTapExecutionIntegrationTests.cs`
+- [X] T023 [P] [FR-012] Add regression test: primitive tap step without a detection target is unaffected by retry logic — still skips with existing behaviour, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Add source-generated `[LoggerMessage]` methods to the Log static class in `src/GameBot.Service/Services/CommandExecutor.cs` — TapRetryWaiting (Debug), TapRetryDetected (Info), TapRetryNotDetected (Debug), TapRetryExhausted (Warning), TapRetryCancelled (Info) per R-006
-- [ ] T013 [US1] Inject AppConfig into CommandExecutor constructor in `src/GameBot.Service/Services/CommandExecutor.cs` — add `_appConfig` field, receive via DI, read CaptureIntervalMs/TapRetryCount/TapRetryProgression
-- [ ] T014 [US1] Implement retry loop in PrimitiveTap handling block of `src/GameBot.Service/Services/CommandExecutor.cs` — move template lookup before loop (R-005); perform initial wait + detection check, then wrap retry cycles in `for` loop with `Task.Delay(currentWaitMs, ct)` followed by `currentWaitMs *= progression` (progression applied after each retry wait, not after initial check); handle OperationCanceledException for immediate cancellation (FR-013); encode retry metadata in Reason field per R-004
-- [ ] T015 [US1] Verify build passes and all tests (T006–T011 plus existing 489) are green
+- [X] T012 [US1] Add source-generated `[LoggerMessage]` methods to the Log static class in `src/GameBot.Service/Services/CommandExecutor.cs` — TapRetryWaiting (Debug), TapRetryDetected (Info), TapRetryNotDetected (Debug), TapRetryExhausted (Warning), TapRetryCancelled (Info) per R-006
+- [X] T013 [US1] Inject AppConfig into CommandExecutor constructor in `src/GameBot.Service/Services/CommandExecutor.cs` — add `_appConfig` field, receive via DI, read CaptureIntervalMs/TapRetryCount/TapRetryProgression
+- [X] T014 [US1] Implement retry loop in PrimitiveTap handling block of `src/GameBot.Service/Services/CommandExecutor.cs` — move template lookup before loop (R-005); perform initial wait + detection check, then wrap retry cycles in `for` loop with `Task.Delay(currentWaitMs, ct)` followed by `currentWaitMs *= progression` (progression applied after each retry wait, not after initial check); handle OperationCanceledException for immediate cancellation (FR-013); encode retry metadata in Reason field per R-004
+- [X] T015 [US1] Verify build passes and all tests (T006–T011 plus existing 489) are green
 
 **Checkpoint**: Primitive tap steps now wait and retry. US1 acceptance scenarios 1, 2, 3 are satisfied. Cancellation works.
 
@@ -82,9 +82,9 @@
 
 ### Tests for User Story 2
 
-- [ ] T016 [P] [US2] Add unit test: PROGRESSION=2, WAIT_TIME=500, COUNT=3 — verify retry wait times are 500, 1000, 2000 ms (excluding the initial check wait), in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
-- [ ] T017 [P] [US2] Add unit test: PROGRESSION=1 (default) — verify all wait intervals are equal (500ms each), in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
-- [ ] T018 [P] [US2] Add unit test: invalid PROGRESSION (0 or negative) falls back to 1.0 — verify constant wait intervals, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T016 [P] [US2] Add unit test: PROGRESSION=2, WAIT_TIME=500, COUNT=3 — verify retry wait times are 500, 1000, 2000 ms (excluding the initial check wait), in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T017 [P] [US2] Add unit test: PROGRESSION=1 (default) — verify all wait intervals are equal (500ms each), in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
+- [X] T018 [P] [US2] Add unit test: invalid PROGRESSION (0 or negative) falls back to 1.0 — verify constant wait intervals, in `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs`
 
 **Checkpoint**: Progression logic is verified. US2 acceptance scenarios 1 and 2 are satisfied.
 
@@ -94,10 +94,10 @@
 
 **Purpose**: Documentation, changelog, and final validation.
 
-- [ ] T019 [P] Add CHANGELOG.md entry documenting tap wait-and-retry feature, new configuration parameters, and their defaults
-- [ ] T020 [P] Add a class-level XML doc comment on `AppConfig` in `src/GameBot.Domain/Config/AppConfig.cs` describing the retry algorithm interaction (WAIT_TIME × PROGRESSION^N formula, state machine overview) — supplements the individual property doc comments added in T003
-- [ ] T021 Run full regression: `dotnet build -c Debug && dotnet test -c Debug` — all tests pass, 0 warnings, 0 errors
-- [ ] T022 Validate quickstart.md scenarios manually: default config works out of the box; overriding env vars changes retry behaviour
+- [X] T019 [P] Add CHANGELOG.md entry documenting tap wait-and-retry feature, new configuration parameters, and their defaults
+- [X] T020 [P] Add a class-level XML doc comment on `AppConfig` in `src/GameBot.Domain/Config/AppConfig.cs` describing the retry algorithm interaction (WAIT_TIME × PROGRESSION^N formula, state machine overview) — supplements the individual property doc comments added in T003
+- [X] T021 Run full regression: `dotnet build -c Debug && dotnet test -c Debug` — all tests pass, 0 warnings, 0 errors
+- [X] T022 Validate quickstart.md scenarios manually: default config works out of the box; overriding env vars changes retry behaviour
 
 ---
 

--- a/src/GameBot.Domain/Config/AppConfig.cs
+++ b/src/GameBot.Domain/Config/AppConfig.cs
@@ -16,7 +16,7 @@ public sealed class AppConfig
     /// Applied when no per-loop <see cref="Commands.LoopConfig.MaxIterations"/> override is
     /// set on the step.  Must be greater than zero.
     /// </summary>
-    public int LoopMaxIterations { get; init; } = 1000;
+    public int LoopMaxIterations { get; set; } = 1000;
 
     /// <summary>
     /// Base wait time in milliseconds between retry cycles and the initial detection check.
@@ -24,14 +24,14 @@ public sealed class AppConfig
     /// Maps to <c>GAMEBOT_CAPTURE_INTERVAL_MS</c> environment variable.
     /// Clamped to a minimum of 50 ms at startup.
     /// </summary>
-    public int CaptureIntervalMs { get; init; } = 500;
+    public int CaptureIntervalMs { get; set; } = 500;
 
     /// <summary>
     /// Maximum number of retry cycles for primitive tap image detection.
     /// <c>0</c> = single detection check with no retries; negative values fall back to default 3.
     /// Maps to <c>GAMEBOT_TAP_RETRY_COUNT</c> environment variable.
     /// </summary>
-    public int TapRetryCount { get; init; } = 3;
+    public int TapRetryCount { get; set; } = 3;
 
     /// <summary>
     /// Multiplier applied to the wait time after each unsuccessful retry cycle.
@@ -39,5 +39,17 @@ public sealed class AppConfig
     /// Must be positive (&gt; 0); invalid values fall back to default 1.0.
     /// Maps to <c>GAMEBOT_TAP_RETRY_PROGRESSION</c> environment variable.
     /// </summary>
-    public double TapRetryProgression { get; init; } = 1.0;
+    public double TapRetryProgression { get; set; } = 1.0;
+
+    /// <summary>
+    /// Maximum number of ADB retries per operation.
+    /// Maps to <c>GAMEBOT_ADB_RETRIES</c> environment variable. Default 2.
+    /// </summary>
+    public int AdbRetries { get; set; } = 2;
+
+    /// <summary>
+    /// Delay in milliseconds between ADB retry attempts.
+    /// Maps to <c>GAMEBOT_ADB_RETRY_DELAY_MS</c> environment variable. Default 100.
+    /// </summary>
+    public int AdbRetryDelayMs { get; set; } = 100;
 }

--- a/src/GameBot.Domain/Config/AppConfig.cs
+++ b/src/GameBot.Domain/Config/AppConfig.cs
@@ -2,6 +2,12 @@ namespace GameBot.Domain.Config;
 
 /// <summary>
 /// Global application configuration settings for the GameBot domain layer.
+/// <para>
+/// <b>Tap Retry Algorithm</b>: Primitive tap steps use a wait-and-retry loop before execution.
+/// The system waits <see cref="CaptureIntervalMs"/> before the initial detection check, then
+/// retries up to <see cref="TapRetryCount"/> times. Between retries the wait time is multiplied
+/// by <see cref="TapRetryProgression"/> (i.e. <c>nextWait = currentWait × TapRetryProgression</c>).
+/// </para>
 /// </summary>
 public sealed class AppConfig
 {
@@ -11,4 +17,27 @@ public sealed class AppConfig
     /// set on the step.  Must be greater than zero.
     /// </summary>
     public int LoopMaxIterations { get; init; } = 1000;
+
+    /// <summary>
+    /// Base wait time in milliseconds between retry cycles and the initial detection check.
+    /// Also used by <c>BackgroundScreenCaptureService</c> as the capture interval.
+    /// Maps to <c>GAMEBOT_CAPTURE_INTERVAL_MS</c> environment variable.
+    /// Clamped to a minimum of 50 ms at startup.
+    /// </summary>
+    public int CaptureIntervalMs { get; init; } = 500;
+
+    /// <summary>
+    /// Maximum number of retry cycles for primitive tap image detection.
+    /// <c>0</c> = single detection check with no retries; negative values fall back to default 3.
+    /// Maps to <c>GAMEBOT_TAP_RETRY_COUNT</c> environment variable.
+    /// </summary>
+    public int TapRetryCount { get; init; } = 3;
+
+    /// <summary>
+    /// Multiplier applied to the wait time after each unsuccessful retry cycle.
+    /// <c>1.0</c> = constant interval; values &gt; 1 create exponential backoff.
+    /// Must be positive (&gt; 0); invalid values fall back to default 1.0.
+    /// Maps to <c>GAMEBOT_TAP_RETRY_PROGRESSION</c> environment variable.
+    /// </summary>
+    public double TapRetryProgression { get; init; } = 1.0;
 }

--- a/src/GameBot.Emulator/Session/BackgroundScreenCaptureService.cs
+++ b/src/GameBot.Emulator/Session/BackgroundScreenCaptureService.cs
@@ -21,7 +21,7 @@ public sealed class BackgroundScreenCaptureService : IDisposable
 {
     private readonly ConcurrentDictionary<string, SessionCaptureLoop> _loops = new(StringComparer.OrdinalIgnoreCase);
     private readonly Func<string, IAdbScreenCaptureProvider> _captureProviderFactory;
-    private readonly int _captureIntervalMs;
+    private volatile int _captureIntervalMs;
     private readonly ILogger<BackgroundScreenCaptureService> _logger;
     private bool _disposed;
 
@@ -87,6 +87,17 @@ public sealed class BackgroundScreenCaptureService : IDisposable
         return _loops.TryGetValue(sessionId, out var loop) ? loop.GetMetrics() : null;
     }
 
+    /// <summary>Updates the capture interval for all active and future capture loops.</summary>
+    public void UpdateCaptureInterval(int intervalMs)
+    {
+        var clamped = Math.Max(50, intervalMs);
+        _captureIntervalMs = clamped;
+        foreach (var loop in _loops.Values)
+        {
+            loop.UpdateInterval(clamped);
+        }
+    }
+
     /// <summary>Stops all capture loops and releases resources.</summary>
     public void StopAll()
     {
@@ -139,7 +150,7 @@ internal sealed class SessionCaptureLoop : IDisposable
     private readonly string _sessionId;
     private readonly string _deviceSerial;
     private readonly IAdbScreenCaptureProvider _provider;
-    private readonly int _intervalMs;
+    private volatile int _intervalMs;
     private readonly ILogger _logger;
     private readonly CancellationTokenSource _cts = new();
 
@@ -195,6 +206,9 @@ internal sealed class SessionCaptureLoop : IDisposable
         Stop();
         _cts.Dispose();
     }
+
+    /// <summary>Updates the capture interval for this loop. Takes effect on the next iteration.</summary>
+    public void UpdateInterval(int intervalMs) => _intervalMs = Math.Max(50, intervalMs);
 
     public CaptureMetrics GetMetrics()
     {

--- a/src/GameBot.Emulator/Session/SessionManager.cs
+++ b/src/GameBot.Emulator/Session/SessionManager.cs
@@ -20,23 +20,21 @@ public sealed class SessionManager : ISessionManager {
   private readonly ILogger<AdbClient> _adbLogger;
   private readonly SessionOptions _options;
   private readonly bool _useAdb;
-  private readonly int _adbRetries;
-  private readonly int _adbRetryDelayMs;
+  private readonly GameBot.Domain.Config.AppConfig _appConfig;
   private TimeSpan IdleTimeout => TimeSpan.FromSeconds(Math.Max(1, _options.IdleTimeoutSeconds));
   private static readonly char[] LineSplit = new[] { '\r', '\n' };
 
-  public SessionManager(IOptions<SessionOptions> options, ILogger<SessionManager> logger, ILogger<AdbClient> adbLogger) {
+  public SessionManager(IOptions<SessionOptions> options, ILogger<SessionManager> logger, ILogger<AdbClient> adbLogger, GameBot.Domain.Config.AppConfig? appConfig = null) {
     ArgumentNullException.ThrowIfNull(options);
     ArgumentNullException.ThrowIfNull(logger);
     ArgumentNullException.ThrowIfNull(adbLogger);
     _options = options.Value;
     _logger = logger;
     _adbLogger = adbLogger;
+    _appConfig = appConfig ?? new GameBot.Domain.Config.AppConfig();
     // Always attempt ADB on Windows by default; allow disabling (tests/CI) with GAMEBOT_USE_ADB=false
     var useAdbEnv = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
     _useAdb = OperatingSystem.IsWindows() && !string.Equals(useAdbEnv, "false", StringComparison.OrdinalIgnoreCase);
-    _adbRetries = Math.Max(0, int.TryParse(Environment.GetEnvironmentVariable("GAMEBOT_ADB_RETRIES"), out var r) ? r : 2);
-    _adbRetryDelayMs = Math.Max(0, int.TryParse(Environment.GetEnvironmentVariable("GAMEBOT_ADB_RETRY_DELAY_MS"), out var d) ? d : 100);
     Log.SessionManagerStarted(_logger, _options.MaxConcurrentSessions, _options.IdleTimeoutSeconds);
   }
 
@@ -127,9 +125,9 @@ public sealed class SessionManager : ISessionManager {
               for (var attempt = 0; ; attempt++) {
                 var (code, _, _) = await adb.TapAsync(x, y, ct).ConfigureAwait(false);
                 if (code == 0) { ok = true; break; }
-                if (attempt >= _adbRetries || ct.IsCancellationRequested) break;
+                if (attempt >= _appConfig.AdbRetries || ct.IsCancellationRequested) break;
                 Log.AdbRetry(_logger, id, "tap", attempt + 1);
-                if (_adbRetryDelayMs > 0) await Task.Delay(_adbRetryDelayMs, ct).ConfigureAwait(false);
+                if (_appConfig.AdbRetryDelayMs > 0) await Task.Delay(_appConfig.AdbRetryDelayMs, ct).ConfigureAwait(false);
               }
             }
             else {
@@ -149,9 +147,9 @@ public sealed class SessionManager : ISessionManager {
               for (var attempt = 0; ; attempt++) {
                 var (code, _, _) = await adb.SwipeAsync(x1, y1, x2, y2, duration, ct).ConfigureAwait(false);
                 if (code == 0) { ok = true; break; }
-                if (attempt >= _adbRetries || ct.IsCancellationRequested) break;
+                if (attempt >= _appConfig.AdbRetries || ct.IsCancellationRequested) break;
                 Log.AdbRetry(_logger, id, "swipe", attempt + 1);
-                if (_adbRetryDelayMs > 0) await Task.Delay(_adbRetryDelayMs, ct).ConfigureAwait(false);
+                if (_appConfig.AdbRetryDelayMs > 0) await Task.Delay(_appConfig.AdbRetryDelayMs, ct).ConfigureAwait(false);
               }
             }
             else {
@@ -178,9 +176,9 @@ public sealed class SessionManager : ISessionManager {
               for (var attempt = 0; ; attempt++) {
                 var (code, _, _) = await adb.KeyEventAsync(keyCode, ct).ConfigureAwait(false);
                 if (code == 0) { ok = true; break; }
-                if (attempt >= _adbRetries || ct.IsCancellationRequested) break;
+                if (attempt >= _appConfig.AdbRetries || ct.IsCancellationRequested) break;
                 Log.AdbRetry(_logger, id, "key", attempt + 1);
-                if (_adbRetryDelayMs > 0) await Task.Delay(_adbRetryDelayMs, ct).ConfigureAwait(false);
+                if (_appConfig.AdbRetryDelayMs > 0) await Task.Delay(_appConfig.AdbRetryDelayMs, ct).ConfigureAwait(false);
               }
             }
             else {
@@ -239,10 +237,10 @@ public sealed class SessionManager : ISessionManager {
             png = await adb.GetScreenshotPngAsync(ct).ConfigureAwait(false);
             break;
           }
-          catch (InvalidOperationException) when (attempt < _adbRetries && !ct.IsCancellationRequested) {
+          catch (InvalidOperationException) when (attempt < _appConfig.AdbRetries && !ct.IsCancellationRequested) {
             attempt++;
             Log.AdbRetry(_logger, id, "screencap", attempt);
-            if (_adbRetryDelayMs > 0) await Task.Delay(_adbRetryDelayMs, ct).ConfigureAwait(false);
+            if (_appConfig.AdbRetryDelayMs > 0) await Task.Delay(_appConfig.AdbRetryDelayMs, ct).ConfigureAwait(false);
             continue;
           }
         }

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -151,12 +151,20 @@ builder.Services.AddSingleton(_ =>
     var retryProgressionEnv = Environment.GetEnvironmentVariable("GAMEBOT_TAP_RETRY_PROGRESSION");
     var retryProgression = double.TryParse(retryProgressionEnv, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var rpParsed) && rpParsed > 0 ? rpParsed : 1.0;
 
+    var adbRetriesEnv = Environment.GetEnvironmentVariable("GAMEBOT_ADB_RETRIES");
+    var adbRetries = int.TryParse(adbRetriesEnv, out var arParsed) && arParsed >= 0 ? arParsed : 2;
+
+    var adbRetryDelayEnv = Environment.GetEnvironmentVariable("GAMEBOT_ADB_RETRY_DELAY_MS");
+    var adbRetryDelay = int.TryParse(adbRetryDelayEnv, out var ardParsed) && ardParsed >= 0 ? ardParsed : 100;
+
     return new GameBot.Domain.Config.AppConfig
     {
         LoopMaxIterations = loopMax,
         CaptureIntervalMs = captureInterval,
         TapRetryCount = retryCount,
         TapRetryProgression = retryProgression,
+        AdbRetries = adbRetries,
+        AdbRetryDelayMs = adbRetryDelay,
     };
 });
 builder.Services.AddSingleton<GameBot.Domain.Services.SequenceRunner>();
@@ -174,7 +182,11 @@ builder.Services.AddSingleton(sp => {
 });
 builder.Services.AddSingleton<IRuntimeLoggingPolicyService>(sp => sp.GetRequiredService<RuntimeLoggingPolicyService>());
 // Config snapshot service (for /config endpoints and persisted snapshot generation)
-builder.Services.AddSingleton<GameBot.Service.Services.IConfigApplier, GameBot.Service.Services.ConfigApplier>();
+builder.Services.AddSingleton<GameBot.Service.Services.IConfigApplier>(sp =>
+    new GameBot.Service.Services.ConfigApplier(
+        sp.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitorCache<GameBot.Service.Hosted.TriggerWorkerOptions>>(),
+        sp.GetRequiredService<GameBot.Domain.Config.AppConfig>(),
+        sp.GetService<GameBot.Emulator.Session.BackgroundScreenCaptureService>()));
 builder.Services.AddSingleton<GameBot.Service.Services.IConfigSnapshotService>(sp => new GameBot.Service.Services.ConfigSnapshotService(storageRoot, sp.GetRequiredService<GameBot.Service.Services.IConfigApplier>()));
 builder.Services.AddSingleton<TriggerEvaluationService>();
 builder.Services.AddSingleton<ITriggerEvaluationCoordinator, TriggerEvaluationCoordinator>();

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -141,7 +141,23 @@ builder.Services.AddSingleton(_ =>
 {
     var loopMaxEnv = Environment.GetEnvironmentVariable("GAMEBOT_LOOP_MAX_ITERATIONS");
     var loopMax = int.TryParse(loopMaxEnv, out var parsed) && parsed > 0 ? parsed : 1000;
-    return new GameBot.Domain.Config.AppConfig { LoopMaxIterations = loopMax };
+
+    var captureIntervalEnv = Environment.GetEnvironmentVariable("GAMEBOT_CAPTURE_INTERVAL_MS");
+    var captureInterval = int.TryParse(captureIntervalEnv, out var ciParsed) && ciParsed > 0 ? Math.Max(ciParsed, 50) : 500;
+
+    var retryCountEnv = Environment.GetEnvironmentVariable("GAMEBOT_TAP_RETRY_COUNT");
+    var retryCount = int.TryParse(retryCountEnv, out var rcParsed) && rcParsed >= 0 ? rcParsed : 3;
+
+    var retryProgressionEnv = Environment.GetEnvironmentVariable("GAMEBOT_TAP_RETRY_PROGRESSION");
+    var retryProgression = double.TryParse(retryProgressionEnv, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var rpParsed) && rpParsed > 0 ? rpParsed : 1.0;
+
+    return new GameBot.Domain.Config.AppConfig
+    {
+        LoopMaxIterations = loopMax,
+        CaptureIntervalMs = captureInterval,
+        TapRetryCount = retryCount,
+        TapRetryProgression = retryProgression,
+    };
 });
 builder.Services.AddSingleton<GameBot.Domain.Services.SequenceRunner>();
 builder.Services.AddSingleton(loggingGate);
@@ -184,13 +200,13 @@ if (OperatingSystem.IsWindows()) {
   var useAdb = !string.Equals(useAdbEnv, "false", StringComparison.OrdinalIgnoreCase);
   if (useAdb) {
     // Background capture service: per-session ADB capture loops with configurable interval
-    var captureIntervalMs = int.TryParse(Environment.GetEnvironmentVariable("GAMEBOT_CAPTURE_INTERVAL_MS"), out var ci) && ci > 0 ? ci : 500;
     builder.Services.AddSingleton<GameBot.Emulator.Session.BackgroundScreenCaptureService>(sp => {
+      var appConfig = sp.GetRequiredService<GameBot.Domain.Config.AppConfig>();
       var adbLogger = sp.GetRequiredService<ILogger<GameBot.Emulator.Adb.AdbClient>>();
       Func<string, GameBot.Emulator.Session.IAdbScreenCaptureProvider> factory = serial =>
         new GameBot.Emulator.Session.AdbScreenCaptureProvider(serial, adbLogger);
       return new GameBot.Emulator.Session.BackgroundScreenCaptureService(
-        factory, captureIntervalMs, sp.GetRequiredService<ILogger<GameBot.Emulator.Session.BackgroundScreenCaptureService>>());
+        factory, appConfig.CaptureIntervalMs, sp.GetRequiredService<ILogger<GameBot.Emulator.Session.BackgroundScreenCaptureService>>());
     });
     // IScreenSource backed by background capture cache (replaces direct ADB + TTL cache chain)
     builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.IScreenSource>(sp => {

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -1,5 +1,6 @@
 using GameBot.Domain.Actions;
 using GameBot.Domain.Commands;
+using GameBot.Domain.Config;
 using GameBot.Domain.Logging;
 using GameBot.Domain.Services;
 using GameBot.Domain.Triggers;
@@ -23,8 +24,9 @@ internal sealed class CommandExecutor : ICommandExecutor {
   private readonly GameBot.Domain.Vision.ITemplateMatcher? _matcher;
   private readonly ISessionContextCache _sessionCache;
   private readonly IExecutionLogService? _executionLogService;
+  private readonly AppConfig _appConfig;
 
-  public CommandExecutor(ICommandRepository commands, IActionRepository actions, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, IExecutionLogService? executionLogService = null) {
+  public CommandExecutor(ICommandRepository commands, IActionRepository actions, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, AppConfig appConfig, IExecutionLogService? executionLogService = null) {
     _commands = commands;
     _actions = actions;
     _sessions = sessions;
@@ -35,6 +37,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _screen = screen;
     _matcher = matcher;
     _sessionCache = sessionCache;
+    _appConfig = appConfig;
     _executionLogService = executionLogService;
   }
 
@@ -50,6 +53,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _screen = null;
     _matcher = null;
     _sessionCache = sessionCache;
+    _appConfig = new AppConfig();
     _executionLogService = executionLogService;
   }
 
@@ -213,6 +217,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
           continue;
         }
 
+        var cancelCycleTracker = 0;
         try {
           var screenSrc = _screen;
           var images = _images;
@@ -223,69 +228,53 @@ internal sealed class CommandExecutor : ICommandExecutor {
             continue;
           }
 
-          var screenshotBmp = screenSrc.GetLatestScreenshot();
-          if (screenshotBmp is null) {
-            Log.DetectionSkip(_logger, "screenshot_unavailable");
-            stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_invalid_config", "screenshot_unavailable", null, null));
-            continue;
-          }
-
+          // Template lookup before loop — template doesn't change between retries (R-005)
           if (!images.TryGet(primitiveDetection.ReferenceImageId, out var templateBmp) || templateBmp is null) {
             Log.DetectionSkip(_logger, "template_not_found");
             stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_invalid_config", "template_not_found", null, null));
             continue;
           }
 
-          using var template = new System.Drawing.Bitmap(templateBmp);
-          using var screenMs = new System.IO.MemoryStream();
-          using var templateMs = new System.IO.MemoryStream();
-          screenshotBmp.Save(screenMs, System.Drawing.Imaging.ImageFormat.Png);
-          template.Save(templateMs, System.Drawing.Imaging.ImageFormat.Png);
-          using var screenMat = OpenCvSharp.Mat.FromImageData(screenMs.ToArray(), OpenCvSharp.ImreadModes.Color);
-          using var templateMat = OpenCvSharp.Mat.FromImageData(templateMs.ToArray(), OpenCvSharp.ImreadModes.Color);
+          var baseWaitMs = _appConfig.CaptureIntervalMs;
+          var retryCount = _appConfig.TapRetryCount;
+          var progression = _appConfig.TapRetryProgression;
+          var currentWaitMs = (double)baseWaitMs;
+          var detected = false;
 
-          var adapter = new GameBot.Domain.Services.ActionExecutionAdapter(matcher);
-          var primitiveAction = new GameBot.Domain.Actions.InputAction {
-            Type = "tap",
-            Args = new Dictionary<string, object> { ["x"] = 0, ["y"] = 0 }
-          };
+          // Initial wait + detection check (FR-001)
+          Log.TapRetryWaiting(_logger, step.Order, baseWaitMs, 0);
+          await Task.Delay(baseWaitMs, ct).ConfigureAwait(false);
 
-          var ok = adapter.TryApplyDetectionCoordinates(
-            primitiveAction,
-            primitiveDetection,
-            screenMat,
-            templateMat,
-            primitiveDetection.Confidence,
-            out var err,
-            DetectionSelectionStrategy.HighestConfidence);
+          detected = TryDetectAndTap(screenSrc, templateBmp, primitiveDetection, matcher, step, sessionId, stepOutcomes, ref totalAccepted, 0, ct);
 
-          if (!ok || err is not null) {
-            Log.DetectionSkip(_logger, err ?? "primitive_tap_detection_failed");
-            stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_detection_failed", err ?? "primitive_tap_detection_failed", null, null));
-            continue;
+          if (!detected) {
+            Log.TapRetryNotDetected(_logger, step.Order, 0);
+
+            // Retry loop (FR-002, FR-003)
+            for (int retry = 0; retry < retryCount; retry++) {
+              cancelCycleTracker = retry + 1;
+              var waitMs = (int)currentWaitMs;
+              Log.TapRetryWaiting(_logger, step.Order, waitMs, cancelCycleTracker);
+              await Task.Delay(waitMs, ct).ConfigureAwait(false);
+              currentWaitMs *= progression; // progression applied after each retry wait
+
+              detected = TryDetectAndTap(screenSrc, templateBmp, primitiveDetection, matcher, step, sessionId, stepOutcomes, ref totalAccepted, cancelCycleTracker, ct);
+              if (detected) {
+                Log.TapRetryDetected(_logger, step.Order, cancelCycleTracker);
+                break;
+              }
+              Log.TapRetryNotDetected(_logger, step.Order, cancelCycleTracker);
+            }
+
+            if (!detected) {
+              Log.TapRetryExhausted(_logger, step.Order, retryCount);
+              stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_detection_failed", $"detection_failed_after_{retryCount}_retries", null, null));
+            }
           }
-
-          if (!primitiveAction.Args.TryGetValue("x", out var xVal) || !primitiveAction.Args.TryGetValue("y", out var yVal)) {
-            Log.DetectionSkip(_logger, "primitive_tap_coordinates_missing");
-            stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_invalid_config", "primitive_tap_coordinates_missing", null, null));
-            continue;
-          }
-
-          var x = Convert.ToInt32(xVal, CultureInfo.InvariantCulture);
-          var y = Convert.ToInt32(yVal, CultureInfo.InvariantCulture);
-          if (x < 0 || y < 0 || x >= screenshotBmp.Width || y >= screenshotBmp.Height) {
-            Log.DetectionSkip(_logger, "primitive_tap_invalid_target");
-            stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_invalid_target", "primitive_tap_invalid_target", new PrimitiveTapResolvedPoint(x, y), null));
-            continue;
-          }
-
-          var sessionInput = new GameBot.Emulator.Session.InputAction("tap", new Dictionary<string, object>(primitiveAction.Args), null, null);
-          var accepted = await _sessions.SendInputsAsync(sessionId, new[] { sessionInput }, ct).ConfigureAwait(false);
-          totalAccepted += accepted;
-          var detectionConfidence = primitiveAction.Args.TryGetValue("confidence", out var confidenceVal)
-            ? Convert.ToDouble(confidenceVal, CultureInfo.InvariantCulture)
-            : (double?)null;
-          stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", null, new PrimitiveTapResolvedPoint(x, y), detectionConfidence));
+        }
+        catch (OperationCanceledException) {
+          Log.TapRetryCancelled(_logger, step.Order, cancelCycleTracker);
+          stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "cancelled", $"cancelled_during_retry_{cancelCycleTracker}", null, null));
         }
         catch (Exception ex) {
           Log.DetectionError(_logger, ex);
@@ -299,6 +288,72 @@ internal sealed class CommandExecutor : ICommandExecutor {
 
     visited.Remove(commandId);
     return totalAccepted;
+  }
+
+  /// <summary>
+  /// Attempts a single screenshot-fetch → template-match → coordinate-resolve → tap cycle.
+  /// Returns true if detection succeeded and the tap was sent; false otherwise.
+  /// On success, appends the outcome to <paramref name="stepOutcomes"/> and increments <paramref name="totalAccepted"/>.
+  /// </summary>
+  private bool TryDetectAndTap(
+    GameBot.Domain.Triggers.Evaluators.IScreenSource screenSrc,
+    System.Drawing.Bitmap templateBmp,
+    DetectionTarget primitiveDetection,
+    GameBot.Domain.Vision.ITemplateMatcher matcher,
+    CommandStep step,
+    string sessionId,
+    List<PrimitiveTapStepOutcome> stepOutcomes,
+    ref int totalAccepted,
+    int retryAttempt,
+    CancellationToken ct)
+  {
+    var screenshotBmp = screenSrc.GetLatestScreenshot();
+    if (screenshotBmp is null) return false;
+
+    using var template = new System.Drawing.Bitmap(templateBmp);
+    using var screenMs = new System.IO.MemoryStream();
+    using var templateMs = new System.IO.MemoryStream();
+    screenshotBmp.Save(screenMs, System.Drawing.Imaging.ImageFormat.Png);
+    template.Save(templateMs, System.Drawing.Imaging.ImageFormat.Png);
+    using var screenMat = OpenCvSharp.Mat.FromImageData(screenMs.ToArray(), OpenCvSharp.ImreadModes.Color);
+    using var templateMat = OpenCvSharp.Mat.FromImageData(templateMs.ToArray(), OpenCvSharp.ImreadModes.Color);
+
+    var adapter = new GameBot.Domain.Services.ActionExecutionAdapter(matcher);
+    var primitiveAction = new GameBot.Domain.Actions.InputAction {
+      Type = "tap",
+      Args = new Dictionary<string, object> { ["x"] = 0, ["y"] = 0 }
+    };
+
+    var ok = adapter.TryApplyDetectionCoordinates(
+      primitiveAction,
+      primitiveDetection,
+      screenMat,
+      templateMat,
+      primitiveDetection.Confidence,
+      out var err,
+      DetectionSelectionStrategy.HighestConfidence);
+
+    if (!ok || err is not null) return false;
+
+    if (!primitiveAction.Args.TryGetValue("x", out var xVal) || !primitiveAction.Args.TryGetValue("y", out var yVal))
+      return false;
+
+    var x = Convert.ToInt32(xVal, CultureInfo.InvariantCulture);
+    var y = Convert.ToInt32(yVal, CultureInfo.InvariantCulture);
+    if (x < 0 || y < 0 || x >= screenshotBmp.Width || y >= screenshotBmp.Height)
+      return false;
+
+    var sessionInput = new GameBot.Emulator.Session.InputAction("tap", new Dictionary<string, object>(primitiveAction.Args), null, null);
+    var accepted = _sessions.SendInputsAsync(sessionId, new[] { sessionInput }, ct).GetAwaiter().GetResult();
+    totalAccepted += accepted;
+
+    var detectionConfidence = primitiveAction.Args.TryGetValue("confidence", out var confidenceVal)
+      ? Convert.ToDouble(confidenceVal, CultureInfo.InvariantCulture)
+      : (double?)null;
+
+    var reason = retryAttempt > 0 ? $"detected_after_{retryAttempt}_retries" : null;
+    stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", reason, new PrimitiveTapResolvedPoint(x, y), detectionConfidence));
+    return true;
   }
 
   private async Task<string> ResolveSessionIdAsync(string? sessionId, string commandId, CancellationToken ct) {
@@ -358,4 +413,19 @@ internal static partial class Log {
 
   [LoggerMessage(EventId = 6008, Level = LogLevel.Warning, Message = "No connect-to-game context found for command {CommandId} to resolve session.")]
   public static partial void SessionContextMissing(ILogger logger, string CommandId);
+
+  [LoggerMessage(EventId = 6009, Level = LogLevel.Debug, Message = "PrimitiveTap step {StepOrder}: waiting {WaitMs}ms before retry cycle {Cycle}.")]
+  public static partial void TapRetryWaiting(ILogger logger, int StepOrder, int WaitMs, int Cycle);
+
+  [LoggerMessage(EventId = 6010, Level = LogLevel.Information, Message = "PrimitiveTap step {StepOrder}: target detected on cycle {Cycle}.")]
+  public static partial void TapRetryDetected(ILogger logger, int StepOrder, int Cycle);
+
+  [LoggerMessage(EventId = 6011, Level = LogLevel.Debug, Message = "PrimitiveTap step {StepOrder}: target not detected on cycle {Cycle}.")]
+  public static partial void TapRetryNotDetected(ILogger logger, int StepOrder, int Cycle);
+
+  [LoggerMessage(EventId = 6012, Level = LogLevel.Warning, Message = "PrimitiveTap step {StepOrder}: target not detected after {TotalCycles} retry cycles.")]
+  public static partial void TapRetryExhausted(ILogger logger, int StepOrder, int TotalCycles);
+
+  [LoggerMessage(EventId = 6013, Level = LogLevel.Information, Message = "PrimitiveTap step {StepOrder}: cancelled during retry cycle {Cycle}.")]
+  public static partial void TapRetryCancelled(ILogger logger, int StepOrder, int Cycle);
 }

--- a/src/GameBot.Service/Services/ConfigSnapshotService.cs
+++ b/src/GameBot.Service/Services/ConfigSnapshotService.cs
@@ -255,6 +255,9 @@ internal sealed class ConfigSnapshotService : IConfigSnapshotService, IDisposabl
       ["GAMEBOT_BIND_HOST"] = installerBindHost,
       ["GAMEBOT_PORT"] = installerPort,
       ["GAMEBOT_LOOP_MAX_ITERATIONS"] = 1000,
+      ["GAMEBOT_CAPTURE_INTERVAL_MS"] = 500,
+      ["GAMEBOT_TAP_RETRY_COUNT"] = 3,
+      ["GAMEBOT_TAP_RETRY_PROGRESSION"] = 1.0,
 
       // ASP.NET Core configuration env keys and their documented defaults/effective values
       ["Service__Storage__Root"] = _storageRoot,

--- a/src/GameBot.Service/Services/IConfigApplier.cs
+++ b/src/GameBot.Service/Services/IConfigApplier.cs
@@ -1,3 +1,4 @@
+using GameBot.Domain.Config;
 using GameBot.Service.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -10,9 +11,16 @@ internal interface IConfigApplier {
 
 internal sealed class ConfigApplier : IConfigApplier {
   private readonly IOptionsMonitorCache<GameBot.Service.Hosted.TriggerWorkerOptions> _triggerOptionsCache;
+  private readonly AppConfig _appConfig;
+  private readonly GameBot.Emulator.Session.BackgroundScreenCaptureService? _captureService;
 
-  public ConfigApplier(IOptionsMonitorCache<GameBot.Service.Hosted.TriggerWorkerOptions> triggerOptionsCache) {
+  public ConfigApplier(
+      IOptionsMonitorCache<GameBot.Service.Hosted.TriggerWorkerOptions> triggerOptionsCache,
+      AppConfig appConfig,
+      GameBot.Emulator.Session.BackgroundScreenCaptureService? captureService = null) {
     _triggerOptionsCache = triggerOptionsCache;
+    _appConfig = appConfig;
+    _captureService = captureService;
   }
 
   private static LogLevel ParseLogLevel(string? v, LogLevel @default) {
@@ -39,6 +47,17 @@ internal sealed class ConfigApplier : IConfigApplier {
     // Apply debug options
     DynamicDebugOptions.DumpImages = GetBool(snapshot, "GAMEBOT_DEBUG_DUMP_IMAGES", false);
 
+    // Apply AppConfig runtime-mutable properties
+    _appConfig.LoopMaxIterations = Math.Max(1, GetInt(snapshot, "GAMEBOT_LOOP_MAX_ITERATIONS", 1000));
+    _appConfig.CaptureIntervalMs = Math.Max(50, GetInt(snapshot, "GAMEBOT_CAPTURE_INTERVAL_MS", 500));
+    _appConfig.TapRetryCount = Math.Max(0, GetInt(snapshot, "GAMEBOT_TAP_RETRY_COUNT", 3));
+    _appConfig.TapRetryProgression = GetDouble(snapshot, "GAMEBOT_TAP_RETRY_PROGRESSION", 1.0) is var prog && prog > 0 ? prog : 1.0;
+    _appConfig.AdbRetries = Math.Max(0, GetInt(snapshot, "GAMEBOT_ADB_RETRIES", 2));
+    _appConfig.AdbRetryDelayMs = Math.Max(0, GetInt(snapshot, "GAMEBOT_ADB_RETRY_DELAY_MS", 100));
+
+    // Propagate capture interval to active background capture loops
+    _captureService?.UpdateCaptureInterval(_appConfig.CaptureIntervalMs);
+
     // Apply Trigger worker options (OptionsMonitor will observe cache changes)
     var opts = new GameBot.Service.Hosted.TriggerWorkerOptions();
     opts.IntervalSeconds = GetInt(snapshot, "Service__Triggers__Worker__IntervalSeconds", 2);
@@ -52,6 +71,11 @@ internal sealed class ConfigApplier : IConfigApplier {
 
   private static int GetInt(ConfigurationSnapshot snap, string key, int @default) {
     return snap.Parameters.TryGetValue(key, out var p) && p.Value is not null && int.TryParse(p.Value.ToString(), out var v)
+        ? v : @default;
+  }
+  private static double GetDouble(ConfigurationSnapshot snap, string key, double @default) {
+    return snap.Parameters.TryGetValue(key, out var p) && p.Value is not null &&
+        double.TryParse(p.Value.ToString(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v)
         ? v : @default;
   }
   private static bool GetBool(ConfigurationSnapshot snap, string key, bool @default) {

--- a/tests/integration/Commands/PrimitiveTapExecutionIntegrationTests.cs
+++ b/tests/integration/Commands/PrimitiveTapExecutionIntegrationTests.cs
@@ -197,4 +197,71 @@ public sealed class PrimitiveTapExecutionIntegrationTests : IDisposable {
     outcomes[0].GetProperty("status").GetString().Should().Be("skipped_invalid_config");
     outcomes[0].GetProperty("reason").GetString().Should().Be("template_not_found");
   }
+
+  [Fact]
+  public async Task ForceExecutePrimitiveTapWithRetryCountZeroSucceedsOnFirstDetection() {
+    // Set retry count to 0 — only the initial detection check, no retries.
+    // The 1x1 template matches itself, so detection should succeed on the initial check.
+    var prevRetryCount = Environment.GetEnvironmentVariable("GAMEBOT_TAP_RETRY_COUNT");
+    var prevCaptureInterval = Environment.GetEnvironmentVariable("GAMEBOT_CAPTURE_INTERVAL_MS");
+    try {
+      Environment.SetEnvironmentVariable("GAMEBOT_TAP_RETRY_COUNT", "0");
+      Environment.SetEnvironmentVariable("GAMEBOT_CAPTURE_INTERVAL_MS", "50");
+
+      using var app = new WebApplicationFactory<Program>();
+      var client = app.CreateClient();
+      client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+      var uploadResp = await client.PostAsJsonAsync(new Uri("/api/images", UriKind.Relative), new { id = "retry_img", data = OneByOnePngBase64 });
+      uploadResp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+      var gameResp = await client.PostAsJsonAsync(new Uri("/api/games", UriKind.Relative), new { name = "RetryZeroGame", description = "desc" });
+      gameResp.EnsureSuccessStatusCode();
+      var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+      var gameId = game!["id"]!.ToString();
+
+      var commandReq = new {
+        name = "RetryZeroCmd",
+        triggerId = (string?)null,
+        steps = new[] {
+          new {
+            type = "PrimitiveTap",
+            order = 0,
+            primitiveTap = new {
+              detectionTarget = new {
+                referenceImageId = "retry_img",
+                confidence = 0.99,
+                offsetX = 0,
+                offsetY = 0,
+                selectionStrategy = "HighestConfidence"
+              }
+            }
+          }
+        }
+      };
+
+      var commandResp = await client.PostAsJsonAsync(new Uri("/api/commands", UriKind.Relative), commandReq);
+      commandResp.EnsureSuccessStatusCode();
+      var command = await commandResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+      var commandId = command!["id"]!.ToString();
+
+      var sessionResp = await client.PostAsJsonAsync(new Uri("/api/sessions", UriKind.Relative), new { gameId });
+      sessionResp.EnsureSuccessStatusCode();
+      var session = await sessionResp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+      var sessionId = session!["id"]!.ToString();
+
+      var execResp = await client.PostAsync(new Uri($"/api/commands/{commandId}/force-execute?sessionId={sessionId}", UriKind.Relative), null);
+      execResp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+      using var doc = await System.Text.Json.JsonDocument.ParseAsync(await execResp.Content.ReadAsStreamAsync());
+      doc.RootElement.GetProperty("accepted").GetInt32().Should().Be(1);
+      var outcomes = doc.RootElement.GetProperty("stepOutcomes");
+      outcomes.GetArrayLength().Should().Be(1);
+      outcomes[0].GetProperty("status").GetString().Should().Be("executed");
+    }
+    finally {
+      Environment.SetEnvironmentVariable("GAMEBOT_TAP_RETRY_COUNT", prevRetryCount);
+      Environment.SetEnvironmentVariable("GAMEBOT_CAPTURE_INTERVAL_MS", prevCaptureInterval);
+    }
+  }
 }

--- a/tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs
+++ b/tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs
@@ -1,34 +1,62 @@
 using System.Collections.ObjectModel;
+using System.Drawing;
+using System.Drawing.Imaging;
 using FluentAssertions;
 using GameBot.Domain.Commands;
+using GameBot.Domain.Config;
 using GameBot.Domain.Services;
 using GameBot.Domain.Sessions;
 using GameBot.Domain.Triggers;
+using GameBot.Domain.Triggers.Evaluators;
+using GameBot.Domain.Vision;
 using GameBot.Emulator.Session;
 using GameBot.Service.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using OpenCvSharp;
 using Xunit;
 
 namespace GameBot.UnitTests.Commands;
 
 public sealed class CommandExecutorPrimitiveTapTests {
-  [Fact]
-  public async Task ForceExecuteDetailedAsyncReturnsSkippedInvalidConfigWhenDetectionServicesUnavailable() {
-    var command = new Command {
-      Id = "cmd-primitive",
-      Name = "Primitive",
-      TriggerId = null,
-      Steps = new Collection<CommandStep> {
-        new() {
-          Type = CommandStepType.PrimitiveTap,
-          TargetId = string.Empty,
-          Order = 0,
-          PrimitiveTap = new PrimitiveTapConfig {
-            DetectionTarget = new DetectionTarget("img-1", 0.9, 0, 0, DetectionSelectionStrategy.HighestConfidence)
-          }
+  private static Bitmap CreateOneByOneBitmap() {
+    var bmp = new Bitmap(1, 1);
+    bmp.SetPixel(0, 0, Color.Red);
+    return bmp;
+  }
+
+  private static Command CreatePrimitiveTapCommand(string commandId = "cmd-primitive", string imageId = "img-1") => new() {
+    Id = commandId,
+    Name = "Primitive",
+    TriggerId = null,
+    Steps = new Collection<CommandStep> {
+      new() {
+        Type = CommandStepType.PrimitiveTap,
+        TargetId = string.Empty,
+        Order = 0,
+        PrimitiveTap = new PrimitiveTapConfig {
+          DetectionTarget = new DetectionTarget(imageId, 0.9, 0, 0, DetectionSelectionStrategy.HighestConfidence)
         }
       }
-    };
+    }
+  };
+
+  private static Command CreatePrimitiveTapCommandNoDetection(string commandId = "cmd-no-detect") => new() {
+    Id = commandId,
+    Name = "NoDetect",
+    TriggerId = null,
+    Steps = new Collection<CommandStep> {
+      new() {
+        Type = CommandStepType.PrimitiveTap,
+        TargetId = string.Empty,
+        Order = 0,
+        PrimitiveTap = null
+      }
+    }
+  };
+
+  [Fact]
+  public async Task ForceExecuteDetailedAsyncReturnsSkippedInvalidConfigWhenDetectionServicesUnavailable() {
+    var command = CreatePrimitiveTapCommand();
 
     var executor = new CommandExecutor(
       new CommandRepoStub(command),
@@ -47,6 +75,297 @@ public sealed class CommandExecutorPrimitiveTapTests {
     result.StepOutcomes[0].Status.Should().Be("skipped_invalid_config");
     result.StepOutcomes[0].Reason.Should().Be("services_unavailable");
   }
+
+  [Fact]
+  public async Task PrimitiveTapDetectsOnFirstAttemptAfterInitialWait() {
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    // Screen source always returns a bitmap (detection succeeds on 1st attempt)
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var matcher = new TemplateMatcherStub(new[] { new TemplateMatch(new BoundingBox(0, 0, 1, 1), 0.95) });
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 3, TapRetryProgression = 1.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.Accepted.Should().Be(1);
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("executed");
+    result.StepOutcomes[0].Reason.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task PrimitiveTapDetectsOnThirdAttemptAfterRetries() {
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    // Return no match on attempts 1 and 2, match on attempt 3
+    var matcher = new TemplateMatcherStub(new[] { new TemplateMatch(new BoundingBox(0, 0, 1, 1), 0.95) }, failCount: 2);
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 3, TapRetryProgression = 1.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.Accepted.Should().Be(1);
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("executed");
+    result.StepOutcomes[0].Reason.Should().Be("detected_after_2_retries");
+  }
+
+  [Fact]
+  public async Task PrimitiveTapExhaustsRetriesAndFails() {
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    // Never match — all attempts fail
+    var matcher = new TemplateMatcherStub(Array.Empty<TemplateMatch>());
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 3, TapRetryProgression = 1.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("skipped_detection_failed");
+    result.StepOutcomes[0].Reason.Should().Be("detection_failed_after_3_retries");
+  }
+
+  [Fact]
+  public async Task PrimitiveTapCancellationDuringWaitReportsCancelled() {
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    // Never match, so the loop keeps going until cancelled
+    var matcher = new TemplateMatcherStub(Array.Empty<TemplateMatch>());
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 100, TapRetryProgression = 1.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    using var cts = new CancellationTokenSource();
+    cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, cts.Token);
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("cancelled");
+    result.StepOutcomes[0].Reason.Should().StartWith("cancelled_during_retry_");
+  }
+
+  [Fact]
+  public async Task PrimitiveTapCountZeroSingleCheckNoRetries() {
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    // No match — with COUNT=0, should fail immediately after single check
+    var matcher = new TemplateMatcherStub(Array.Empty<TemplateMatch>());
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 0, TapRetryProgression = 1.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("skipped_detection_failed");
+    result.StepOutcomes[0].Reason.Should().Be("detection_failed_after_0_retries");
+  }
+
+  [Fact]
+  public async Task PrimitiveTapWithoutDetectionTargetIsUnaffectedByRetryLogic() {
+    var command = CreatePrimitiveTapCommandNoDetection();
+
+    // Use the full constructor with detection services — the lack of DetectionTarget should
+    // make the retry loop irrelevant and fall through to the existing skip behaviour.
+    using var bmp = CreateOneByOneBitmap();
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub();
+    var matcher = new TemplateMatcherStub(Array.Empty<TemplateMatch>());
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 3 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("skipped_invalid_config");
+    result.StepOutcomes[0].Reason.Should().Be("primitive_tap_missing_detection");
+  }
+
+  [Fact]
+  public async Task PrimitiveTapProgressionDoublesWaitTimeBetweenRetries() {
+    // PROGRESSION=2, WAIT_TIME=100, COUNT=3 — never detect so all retries are exercised.
+    // Expected total waits: initial 100ms + retry waits 100ms + 200ms + 400ms = 800ms total.
+    // With PROGRESSION=1, total = 100 + 100 + 100 + 100 = 400ms.
+    // Assert total time is meaningfully greater with PROGRESSION=2.
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    var matcher = new TemplateMatcherStub(Array.Empty<TemplateMatch>());
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var config = new AppConfig { CaptureIntervalMs = 100, TapRetryCount = 3, TapRetryProgression = 2.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+    sw.Stop();
+
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("skipped_detection_failed");
+    result.StepOutcomes[0].Reason.Should().Be("detection_failed_after_3_retries");
+    // With progression=2: 100 + 100 + 200 + 400 = 800ms minimum
+    // Allow generous margin but it should be clearly > 400ms (what progression=1 would take)
+    sw.ElapsedMilliseconds.Should().BeGreaterThan(600);
+  }
+
+  [Fact]
+  public async Task PrimitiveTapProgressionOneYieldsConstantIntervals() {
+    // PROGRESSION=1 (default), WAIT_TIME=100, COUNT=3 — never detect.
+    // Expected total: 100 + 100 + 100 + 100 = 400ms, all equal intervals.
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    var matcher = new TemplateMatcherStub(Array.Empty<TemplateMatch>());
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var config = new AppConfig { CaptureIntervalMs = 100, TapRetryCount = 3, TapRetryProgression = 1.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+    sw.Stop();
+
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("skipped_detection_failed");
+    result.StepOutcomes[0].Reason.Should().Be("detection_failed_after_3_retries");
+    // With progression=1: 100 + 100 + 100 + 100 = 400ms minimum
+    // Should be clearly < 800ms (what progression=2 would take)
+    sw.ElapsedMilliseconds.Should().BeGreaterThan(300);
+    sw.ElapsedMilliseconds.Should().BeLessThan(800);
+  }
+
+  [Fact]
+  public async Task PrimitiveTapInvalidProgressionFallsBackToConstant() {
+    // AppConfig with invalid progression (0) — should fall back to 1.0 at wiring time.
+    // But at domain level, TapRetryProgression = 0 directly. The fallback is in Program.cs.
+    // Here we test that the retry loop handles progression=1.0 (the default) correctly.
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    var matcher = new TemplateMatcherStub(Array.Empty<TemplateMatch>());
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    // Use default AppConfig which has TapRetryProgression=1.0
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 2 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new ActionRepoStub(),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.StepOutcomes.Should().HaveCount(1);
+    result.StepOutcomes[0].Status.Should().Be("skipped_detection_failed");
+    result.StepOutcomes[0].Reason.Should().Be("detection_failed_after_2_retries");
+  }
+
+  #region Test stubs
 
   private sealed class CommandRepoStub : ICommandRepository {
     private readonly Command _command;
@@ -84,4 +403,35 @@ public sealed class CommandExecutorPrimitiveTapTests {
     public Task<int> SendInputsAsync(string id, IEnumerable<GameBot.Emulator.Session.InputAction> actions, CancellationToken ct = default) => Task.FromResult(actions.Count());
     public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
   }
+
+  private sealed class ScreenSourceStub : IScreenSource {
+    private readonly Bitmap? _bitmap;
+    public ScreenSourceStub(Bitmap? bitmap) => _bitmap = bitmap;
+    public Bitmap? GetLatestScreenshot() => _bitmap;
+  }
+
+  private sealed class ReferenceImageStoreStub : IReferenceImageStore {
+    private readonly Dictionary<string, Bitmap> _images = new(StringComparer.OrdinalIgnoreCase);
+    public ReferenceImageStoreStub(params (string Id, Bitmap Bmp)[] images) { foreach (var (id, bmp) in images) _images[id] = bmp; }
+    public bool TryGet(string id, out Bitmap bitmap) { if (_images.TryGetValue(id, out var b)) { bitmap = b; return true; } bitmap = null!; return false; }
+    public void AddOrUpdate(string id, Bitmap bitmap) => _images[id] = bitmap;
+    public bool Exists(string id) => _images.ContainsKey(id);
+    public bool Delete(string id) => _images.Remove(id);
+  }
+
+  private sealed class TemplateMatcherStub : ITemplateMatcher {
+    private readonly TemplateMatch[] _matches;
+    private int _callCount;
+    private readonly int _failCount;
+    public TemplateMatcherStub(TemplateMatch[] matches, int failCount = 0) { _matches = matches; _failCount = failCount; }
+    public List<int> WaitTimesObserved { get; } = new();
+    public Task<TemplateMatchResult> MatchAllAsync(Mat screenshot, Mat templateMat, TemplateMatcherConfig config, CancellationToken cancellationToken = default) {
+      _callCount++;
+      if (_callCount <= _failCount)
+        return Task.FromResult(new TemplateMatchResult(Array.Empty<TemplateMatch>(), false));
+      return Task.FromResult(new TemplateMatchResult(_matches, false));
+    }
+  }
+
+  #endregion
 }

--- a/tests/unit/Config/AppConfigValidationTests.cs
+++ b/tests/unit/Config/AppConfigValidationTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using GameBot.Domain.Config;
+using Xunit;
+
+namespace GameBot.UnitTests.Config;
+
+public sealed class AppConfigValidationTests
+{
+    [Fact]
+    public void DefaultCaptureIntervalMsIsFiveHundred()
+    {
+        var config = new AppConfig();
+        config.CaptureIntervalMs.Should().Be(500);
+    }
+
+    [Fact]
+    public void DefaultTapRetryCountIsThree()
+    {
+        var config = new AppConfig();
+        config.TapRetryCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void DefaultTapRetryProgressionIsOne()
+    {
+        var config = new AppConfig();
+        config.TapRetryProgression.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void CaptureIntervalMsCanBeSetToCustomValue()
+    {
+        var config = new AppConfig { CaptureIntervalMs = 200 };
+        config.CaptureIntervalMs.Should().Be(200);
+    }
+
+    [Fact]
+    public void TapRetryCountCanBeSetToZero()
+    {
+        var config = new AppConfig { TapRetryCount = 0 };
+        config.TapRetryCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void TapRetryProgressionCanBeSetToCustomValue()
+    {
+        var config = new AppConfig { TapRetryProgression = 2.5 };
+        config.TapRetryProgression.Should().Be(2.5);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **wait-and-retry loop** to primitive tap actions so they wait for image detection before executing, and makes **all mutable configuration variables propagate dynamically** at runtime without requiring a service restart.

## Tap Wait-and-Retry (036)

- Before tapping, the system waits `CaptureIntervalMs` then checks for the detection target
- If not found, retries up to `TapRetryCount` times with configurable backoff (`TapRetryProgression` multiplier)
- New `AppConfig` properties: `CaptureIntervalMs` (500), `TapRetryCount` (3), `TapRetryProgression` (1.0)
- Structured logging via `[LoggerMessage]` for all retry phases (EventIds 6009-6013)
- Full TDD: 16 new tests (unit + integration) covering first-attempt, retry, exhaustion, cancellation, and progression scenarios

## Dynamic Runtime Config

Previously, config changes made via the UI Configuration page required a restart. Now `ConfigApplier.Apply()` propagates these variables to the running service immediately:

| Variable | Consumer |
|---|---|
| `GAMEBOT_LOOP_MAX_ITERATIONS` | SequenceRunner (per-loop) |
| `GAMEBOT_CAPTURE_INTERVAL_MS` | CommandExecutor (per-tap) + BackgroundScreenCaptureService (active loops) |
| `GAMEBOT_TAP_RETRY_COUNT` | CommandExecutor (per-tap) |
| `GAMEBOT_TAP_RETRY_PROGRESSION` | CommandExecutor (per-tap) |
| `GAMEBOT_ADB_RETRIES` | SessionManager (per-ADB operation) |
| `GAMEBOT_ADB_RETRY_DELAY_MS` | SessionManager (per-ADB operation) |

Key changes:
- `AppConfig` properties changed from `init` to `set`
- `BackgroundScreenCaptureService` + `SessionCaptureLoop` use `volatile` interval fields with `UpdateCaptureInterval()` for live updates
- `SessionManager` reads ADB retry config from `AppConfig` instead of env vars at construction time

## Test Results

505 tests (281 unit + 54 contract + 170 integration), 0 failures, 0 warnings.