### PR TITLE
Fix sequence step name round-trip and execution log command identity

### DIFF
--- a/.claude/skills/speckit-analyze/SKILL.md
+++ b/.claude/skills/speckit-analyze/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: "speckit-analyze"
+description: "Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation."
+argument-hint: "Optional focus areas for analysis"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/analyze.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before analysis)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit-tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit-analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit-implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit-specify with refinement", "Run /speckit-plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Check for extension hooks
+
+After reporting, check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.claude/skills/speckit-checklist/SKILL.md
+++ b/.claude/skills/speckit-checklist/SKILL.md
@@ -1,0 +1,372 @@
+---
+name: "speckit-checklist"
+description: "Generate a custom checklist for the current feature based on user requirements."
+argument-hint: "Domain or focus area for the checklist"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/checklist.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before checklist generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Execution Steps.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit-checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"
+
+## Post-Execution Checks
+
+**Check for extension hooks (after checklist generation)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.claude/skills/speckit-clarify/SKILL.md
+++ b/.claude/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: "speckit-clarify"
+description: "Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec."
+argument-hint: "Optional areas to clarify in the spec"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/clarify.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before clarification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit-plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit-specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 5 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. **Re-validate Spec Quality Checklist** (if it exists):
+   - Check if `FEATURE_DIR/checklists/requirements.md` exists.
+   - If it does NOT exist, skip this step silently.
+   - If it exists:
+     1. Read the checklist file.
+     2. Identify all GitHub task-list checkbox lines — lines matching `- [ ]`, `- [x]`, or `- [X]` (case-insensitive, tolerant of leading whitespace for nested items) outside of code fences. Ignore all other content (headings, notes, non-checkbox bullets, metadata).
+     3. For each checkbox line, record its current marker state (checked or unchecked) and item text into a before-snapshot list.
+     4. Re-evaluate each checkbox item against the **updated** spec (the version just saved in step 7).
+     5. For each checkbox item, update only if the checked/unchecked state actually changes:
+        - If the item now passes and was unchecked: change `[ ]` to `[x]`.
+        - If the item now fails and was checked: change `[x]`/`[X]` to `[ ]`.
+        - If the state is unchanged: leave the marker as-is (preserve existing case to avoid cosmetic diffs).
+     6. Save the updated checklist file. **Only toggle the `[ ]`/`[x]` marker portion of checkbox lines whose state changed.** All other file content — headings, metadata, notes, line ordering, whitespace — must remain unchanged to avoid noisy diffs.
+     7. Compare the before-snapshot with the current state to compute three lists for the Completion Report:
+        - **Newly passing**: items that changed from unchecked to checked.
+        - **Regressions**: items that changed from checked to unchecked.
+        - **Still unchecked**: items that remain unchecked.
+     8. Record the before/after pass counts as checked/total checkbox items (e.g., "12/16 → 15/16 items passing").
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit-specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_clarify`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_clarify` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Report completion (after questioning loop ends or early termination):
+- Number of questions asked & answered.
+- Path to updated spec.
+- Sections touched (list names).
+- Spec quality checklist status (if `FEATURE_DIR/checklists/requirements.md` was re-validated): show before/after pass counts (e.g., "Spec Quality Checklist: 12/16 → 15/16 items passing") and list any items that changed state — both newly checked (unchecked → checked) and any regressions (checked → unchecked). If any items remain unchecked, list them as areas needing attention.
+- Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+- If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit-plan` or run `/speckit-clarify` again later post-plan.
+- Suggested next command.
+
+## Done When
+
+- [ ] Spec ambiguities identified and clarifications integrated into spec file
+- [ ] Spec quality checklist re-validated against updated spec (if `FEATURE_DIR/checklists/requirements.md` exists)
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with questions answered, sections touched, checklist status, and coverage summary

--- a/.claude/skills/speckit-constitution/SKILL.md
+++ b/.claude/skills/speckit-constitution/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: "speckit-constitution"
+description: "Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync."
+argument-hint: "Principles or values for the project constitution"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/constitution.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before constitution update)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after constitution update)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: speckit-git-commit
+description: Auto-commit changes after a Spec Kit command completes
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.commit.md
+---
+
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.claude/skills/speckit-git-feature/SKILL.md
+++ b/.claude/skills/speckit-git-feature/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: speckit-git-feature
+description: Create a feature branch with sequential or timestamp numbering
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.feature.md
+---
+
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `/speckit-specify` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.claude/skills/speckit-git-initialize/SKILL.md
+++ b/.claude/skills/speckit-git-initialize/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-initialize
+description: Initialize a Git repository with an initial commit
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.initialize.md
+---
+
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `[OK] Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.claude/skills/speckit-git-remote/SKILL.md
+++ b/.claude/skills/speckit-git-remote/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: speckit-git-remote
+description: Detect Git remote URL for GitHub integration
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.remote.md
+---
+
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.claude/skills/speckit-git-validate/SKILL.md
+++ b/.claude/skills/speckit-git-validate/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-validate
+description: Validate current branch follows feature branch naming conventions
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.validate.md
+---
+
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.claude/skills/speckit-implement/SKILL.md
+++ b/.claude/skills/speckit-implement/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: "speckit-implement"
+description: "Execute the implementation plan by processing and executing all tasks defined in tasks.md"
+argument-hint: "Optional implementation guidance or task filter"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/implement.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read .specify/memory/constitution.md for governance constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit-tasks` first to regenerate the task list.
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_implement`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_implement` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Report final status with summary of completed work.
+
+## Done When
+
+- [ ] All tasks in tasks.md completed and marked `[X]`
+- [ ] Implementation validated against specification, plan, and test coverage
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with summary of completed work

--- a/.claude/skills/speckit-plan/SKILL.md
+++ b/.claude/skills/speckit-plan/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: "speckit-plan"
+description: "Execute the implementation planning workflow using the plan template to generate design artifacts."
+argument-hint: "Optional guidance for the planning phase"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/plan.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/setup-plan.ps1 -Json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_plan`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_plan` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
+
+3. **Agent context update**:
+   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `CLAUDE.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
+
+**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
+
+## Key rules
+
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation and agent context files
+- ERROR on gate failures or unresolved clarifications
+
+## Done When
+
+- [ ] Plan workflow executed and design artifacts generated
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with branch, plan path, and generated artifacts

--- a/.claude/skills/speckit-specify/SKILL.md
+++ b/.claude/skills/speckit-specify/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: "speckit-specify"
+description: "Create or update the feature specification from a natural language feature description."
+argument-hint: "Describe the feature you want to specify"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/specify.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+The text the user typed after `/speckit-specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran successfully in the Pre-Execution Checks above, it will have created/switched to a git branch and output JSON containing `BRANCH_NAME` and `FEATURE_NUM`. Note these values for reference, but the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
+
+3. **Create the spec feature directory**:
+
+   Specs live under the default `specs/` directory unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
+   2. Otherwise, auto-generate it under `specs/`:
+      - Check `.specify/init-options.json` for `branch_numbering`
+      - If `"timestamp"`: prefix is `YYYYMMDD-HHMMSS` (current timestamp)
+      - If `"sequential"` or absent: prefix is `NNN` (next available 3-digit number after scanning existing directories in `specs/`)
+      - Construct the directory name: `<prefix>-<short-name>` (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Copy `.specify/templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist the resolved path to `.specify/feature.json`:
+     ```json
+     {
+       "feature_directory": "<resolved feature dir>"
+     }
+     ```
+     Write the actual resolved directory path value (for example, `specs/003-user-auth`), not the literal string `SPECIFY_FEATURE_DIRECTORY`.
+     This allows downstream commands (`/speckit-plan`, `/speckit-tasks`, etc.) to locate the feature directory without relying on git branch name conventions.
+
+   **IMPORTANT**:
+   - You must only create one feature per `/speckit-specify` invocation
+   - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
+   - The spec directory and file are always created by this command, never by the hook
+
+4. Load `.specify/templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
+    1. Parse user description from arguments
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to the Mandatory Post-Execution Hooks section
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_specify`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_specify` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Report completion to the user with:
+- `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
+- `SPEC_FILE` — the spec file path
+- Checklist results summary
+- Readiness for the next phase (`/speckit-clarify` or `/speckit-plan`)
+
+**NOTE:** Branch creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)
+
+## Done When
+
+- [ ] Specification written to `SPEC_FILE` and validated against quality checklist
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with feature directory, spec file path, and checklist results

--- a/.claude/skills/speckit-tasks/SKILL.md
+++ b/.claude/skills/speckit-tasks/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: "speckit-tasks"
+description: "Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts."
+argument-hint: "Optional task generation constraints"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/tasks.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/setup-tasks.ps1 -Json` from repo root and parse FEATURE_DIR, TASKS_TEMPLATE, and AVAILABLE_DOCS list. `FEATURE_DIR` and `TASKS_TEMPLATE` must be absolute paths when provided. `AVAILABLE_DOCS` is a list of document names/relative paths available under `FEATURE_DIR` (for example `research.md` or `contracts/`). For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map interface contracts to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Read the tasks template from TASKS_TEMPLATE (from the JSON output above) and use it as structure. If TASKS_TEMPLATE is empty, fall back to `.specify/templates/tasks-template.md`. Fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+## Mandatory Post-Execution Hooks
+
+**You MUST complete this section before reporting completion to the user.**
+
+Check if `.specify/extensions.yml` exists in the project root.
+- If it does not exist, or no hooks are registered under `hooks.after_tasks`, skip to the Completion Report.
+- If it exists, read it and look for entries under the `hooks.after_tasks` key.
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue to the Completion Report.
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Mandatory hook** (`optional: false`) — **You MUST emit `EXECUTE_COMMAND:` for each mandatory hook**:
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+
+## Completion Report
+
+Output path to generated tasks.md and summary:
+- Total task count
+- Task count per user story
+- Parallel opportunities identified
+- Independent test criteria for each story
+- Suggested MVP scope (typically just User Story 1)
+- Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Interfaces/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Done When
+
+- [ ] tasks.md generated with all phases, task IDs, and file paths
+- [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
+- [ ] Completion reported to user with task count, story breakdown, and MVP scope

--- a/.claude/skills/speckit-taskstoissues/SKILL.md
+++ b/.claude/skills/speckit-taskstoissues/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: "speckit-taskstoissues"
+description: "Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts."
+argument-hint: "Optional filter or label for GitHub issues"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/taskstoissues.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -25,6 +25,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - File-backed JSON under `data/` (notably `data/commands`, `data/commands/sequences`, `data/config`); Action storage removed from authored model (001-primitive-actions-refactor)
 - C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (web UI) + ASP.NET Core Minimal API, existing `GameBot.Domain` command/action/logging models, `CommandExecutor`, existing detection pipeline (`IReferenceImageStore`, `IScreenSource`, `ITemplateMatcher`), existing web-ui command authoring and execution-log APIs (001-wait-for-image)
 - Existing file-backed JSON command repository under `data/commands` and existing file-backed execution-log repository under `data/execution-logs`; no new persistence store (001-wait-for-image)
+- Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence repository and runner, existing execution-log service, React/Vite authoring UI, existing command repository contracts (001-fix-sequence-step-names)
+- File-backed JSON under `data/commands/sequences`, `data/commands`, and `data/execution-logs` (001-fix-sequence-step-names)
 
 - Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence/command services, existing image detection pipeline, existing execution-log services/repositories, React 18 + Vite 5 UI stack (030-sequence-conditional-logic)
 
@@ -45,9 +47,9 @@ npm test; npm run lint
 Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18: Follow standard conventions
 
 ## Recent Changes
+- 001-fix-sequence-step-names: Added Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence repository and runner, existing execution-log service, React/Vite authoring UI, existing command repository contracts
 - 001-wait-for-image: Added C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (web UI) + ASP.NET Core Minimal API, existing `GameBot.Domain` command/action/logging models, `CommandExecutor`, existing detection pipeline (`IReferenceImageStore`, `IScreenSource`, `ITemplateMatcher`), existing web-ui command authoring and execution-log APIs
 - 001-primitive-actions-refactor: Added Backend C# 13 / .NET 9; Frontend TypeScript ES2020 / React 18 (Vite 5) + ASP.NET Core Minimal API, GameBot.Domain repositories/services, System.Text.Json, existing OpenCvSharp/ADB/session services, React + existing web-ui toolchain
-- 001-sequence-random-delay: Added C# 13 / .NET 9 (backend service/domain), TypeScript ES2020 / React 18 (authoring consumer) + ASP.NET Core Minimal API, existing `GameBot.Domain` command/sequence models and `SequenceRunner`, existing file-backed repositories, Swagger/OpenAPI generation in `GameBot.Service`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.github/agents/speckit.git.commit.agent.md
+++ b/.github/agents/speckit.git.commit.agent.md
@@ -1,0 +1,51 @@
+---
+description: Auto-commit changes after a Spec Kit command completes
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.github/agents/speckit.git.feature.agent.md
+++ b/.github/agents/speckit.git.feature.agent.md
@@ -1,0 +1,70 @@
+---
+description: Create a feature branch with sequential or timestamp numbering
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `/speckit.specify` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.github/agents/speckit.git.initialize.agent.md
+++ b/.github/agents/speckit.git.initialize.agent.md
@@ -1,0 +1,52 @@
+---
+description: Initialize a Git repository with an initial commit
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `[OK] Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.github/agents/speckit.git.remote.agent.md
+++ b/.github/agents/speckit.git.remote.agent.md
@@ -1,0 +1,48 @@
+---
+description: Detect Git remote URL for GitHub integration
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.github/agents/speckit.git.validate.agent.md
+++ b/.github/agents/speckit.git.validate.agent.md
@@ -1,0 +1,52 @@
+---
+description: Validate current branch follows feature branch naming conventions
+---
+
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.github/prompts/speckit.git.commit.prompt.md
+++ b/.github/prompts/speckit.git.commit.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.commit
+---

--- a/.github/prompts/speckit.git.feature.prompt.md
+++ b/.github/prompts/speckit.git.feature.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.feature
+---

--- a/.github/prompts/speckit.git.initialize.prompt.md
+++ b/.github/prompts/speckit.git.initialize.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.initialize
+---

--- a/.github/prompts/speckit.git.remote.prompt.md
+++ b/.github/prompts/speckit.git.remote.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.remote
+---

--- a/.github/prompts/speckit.git.validate.prompt.md
+++ b/.github/prompts/speckit.git.validate.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.git.validate
+---

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -1,0 +1,149 @@
+installed:
+- git
+settings:
+  auto_execute_hooks: true
+hooks:
+  before_constitution:
+  - extension: git
+    command: speckit.git.initialize
+    enabled: true
+    optional: false
+    prompt: Execute speckit.git.initialize?
+    description: Initialize Git repository before constitution setup
+    condition: null
+  before_specify:
+  - extension: git
+    command: speckit.git.feature
+    enabled: true
+    optional: false
+    prompt: Execute speckit.git.feature?
+    description: Create feature branch before specification
+    condition: null
+  before_clarify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before clarification?
+    description: Auto-commit before spec clarification
+    condition: null
+  before_plan:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before planning?
+    description: Auto-commit before implementation planning
+    condition: null
+  before_tasks:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before task generation?
+    description: Auto-commit before task generation
+    condition: null
+  before_implement:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before implementation?
+    description: Auto-commit before implementation
+    condition: null
+  before_checklist:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before checklist?
+    description: Auto-commit before checklist generation
+    condition: null
+  before_analyze:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before analysis?
+    description: Auto-commit before analysis
+    condition: null
+  before_taskstoissues:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before issue sync?
+    description: Auto-commit before tasks-to-issues conversion
+    condition: null
+  after_constitution:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit constitution changes?
+    description: Auto-commit after constitution update
+    condition: null
+  after_specify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit specification changes?
+    description: Auto-commit after specification
+    condition: null
+  after_clarify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit clarification changes?
+    description: Auto-commit after spec clarification
+    condition: null
+  after_plan:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit plan changes?
+    description: Auto-commit after implementation planning
+    condition: null
+  after_tasks:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit task changes?
+    description: Auto-commit after task generation
+    condition: null
+  after_implement:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit implementation changes?
+    description: Auto-commit after implementation
+    condition: null
+  after_checklist:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit checklist changes?
+    description: Auto-commit after checklist generation
+    condition: null
+  after_analyze:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit analysis results?
+    description: Auto-commit after analysis
+    condition: null
+  after_taskstoissues:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit after syncing issues?
+    description: Auto-commit after tasks-to-issues conversion
+    condition: null

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1.0",
+  "extensions": {
+    "git": {
+      "version": "1.0.0",
+      "source": "local",
+      "manifest_hash": "sha256:9731aa8143a72fbebfdb440f155038ab42642517c2b2bdbbf67c8fdbe076ed79",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "claude": [
+          "speckit.git.feature",
+          "speckit.git.validate",
+          "speckit.git.remote",
+          "speckit.git.initialize",
+          "speckit.git.commit"
+        ],
+        "copilot": [
+          "speckit.git.feature",
+          "speckit.git.validate",
+          "speckit.git.remote",
+          "speckit.git.initialize",
+          "speckit.git.commit"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-05-29T14:21:39.859474+00:00"
+    }
+  }
+}

--- a/.specify/extensions/git/README.md
+++ b/.specify/extensions/git/README.md
@@ -1,0 +1,100 @@
+# Git Branching Workflow Extension
+
+Git repository initialization, feature branch creation, numbering (sequential/timestamp), validation, remote detection, and auto-commit for Spec Kit.
+
+## Overview
+
+This extension provides Git operations as an optional, self-contained module. It manages:
+
+- **Repository initialization** with configurable commit messages
+- **Feature branch creation** with sequential (`001-feature-name`) or timestamp (`20260319-143022-feature-name`) numbering
+- **Branch validation** to ensure branches follow naming conventions
+- **Git remote detection** for GitHub integration (e.g., issue creation)
+- **Auto-commit** after core commands (configurable per-command with custom messages)
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `speckit.git.initialize` | Initialize a Git repository with a configurable commit message |
+| `speckit.git.feature` | Create a feature branch with sequential or timestamp numbering |
+| `speckit.git.validate` | Validate current branch follows feature branch naming conventions |
+| `speckit.git.remote` | Detect Git remote URL for GitHub integration |
+| `speckit.git.commit` | Auto-commit changes (configurable per-command enable/disable and messages) |
+
+## Hooks
+
+| Event | Command | Optional | Description |
+|-------|---------|----------|-------------|
+| `before_constitution` | `speckit.git.initialize` | No | Init git repo before constitution |
+| `before_specify` | `speckit.git.feature` | No | Create feature branch before specification |
+| `before_clarify` | `speckit.git.commit` | Yes | Commit outstanding changes before clarification |
+| `before_plan` | `speckit.git.commit` | Yes | Commit outstanding changes before planning |
+| `before_tasks` | `speckit.git.commit` | Yes | Commit outstanding changes before task generation |
+| `before_implement` | `speckit.git.commit` | Yes | Commit outstanding changes before implementation |
+| `before_checklist` | `speckit.git.commit` | Yes | Commit outstanding changes before checklist |
+| `before_analyze` | `speckit.git.commit` | Yes | Commit outstanding changes before analysis |
+| `before_taskstoissues` | `speckit.git.commit` | Yes | Commit outstanding changes before issue sync |
+| `after_constitution` | `speckit.git.commit` | Yes | Auto-commit after constitution update |
+| `after_specify` | `speckit.git.commit` | Yes | Auto-commit after specification |
+| `after_clarify` | `speckit.git.commit` | Yes | Auto-commit after clarification |
+| `after_plan` | `speckit.git.commit` | Yes | Auto-commit after planning |
+| `after_tasks` | `speckit.git.commit` | Yes | Auto-commit after task generation |
+| `after_implement` | `speckit.git.commit` | Yes | Auto-commit after implementation |
+| `after_checklist` | `speckit.git.commit` | Yes | Auto-commit after checklist |
+| `after_analyze` | `speckit.git.commit` | Yes | Auto-commit after analysis |
+| `after_taskstoissues` | `speckit.git.commit` | Yes | Auto-commit after issue sync |
+
+## Configuration
+
+Configuration is stored in `.specify/extensions/git/git-config.yml`:
+
+```yaml
+# Branch numbering strategy: "sequential" or "timestamp"
+branch_numbering: sequential
+
+# Custom commit message for git init
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit per command (all disabled by default)
+# Example: enable auto-commit after specify
+auto_commit:
+  default: false
+  after_specify:
+    enabled: true
+    message: "[Spec Kit] Add specification"
+```
+
+## Installation
+
+```bash
+# Install the bundled git extension (no network required)
+specify extension add git
+```
+
+## Disabling
+
+```bash
+# Disable the git extension (spec creation continues without branching)
+specify extension disable git
+
+# Re-enable it
+specify extension enable git
+```
+
+## Graceful Degradation
+
+When Git is not installed or the directory is not a Git repository:
+- Spec directories are still created under `specs/`
+- Branch creation is skipped with a warning
+- Branch validation is skipped with a warning
+- Remote detection returns empty results
+
+## Scripts
+
+The extension bundles cross-platform scripts:
+
+- `scripts/bash/create-new-feature.sh` — Bash implementation
+- `scripts/bash/git-common.sh` — Shared Git utilities (Bash)
+- `scripts/powershell/create-new-feature.ps1` — PowerShell implementation
+- `scripts/powershell/git-common.ps1` — Shared Git utilities (PowerShell)

--- a/.specify/extensions/git/commands/speckit.git.commit.md
+++ b/.specify/extensions/git/commands/speckit.git.commit.md
@@ -1,0 +1,48 @@
+---
+description: "Auto-commit changes after a Spec Kit command completes"
+---
+
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.specify/extensions/git/commands/speckit.git.feature.md
+++ b/.specify/extensions/git/commands/speckit.git.feature.md
@@ -1,0 +1,67 @@
+---
+description: "Create a feature branch with sequential or timestamp numbering"
+---
+
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `__SPECKIT_COMMAND_SPECIFY__` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.specify/extensions/git/commands/speckit.git.initialize.md
+++ b/.specify/extensions/git/commands/speckit.git.initialize.md
@@ -1,0 +1,49 @@
+---
+description: "Initialize a Git repository with an initial commit"
+---
+
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `[OK] Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.specify/extensions/git/commands/speckit.git.remote.md
+++ b/.specify/extensions/git/commands/speckit.git.remote.md
@@ -1,0 +1,45 @@
+---
+description: "Detect Git remote URL for GitHub integration"
+---
+
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.specify/extensions/git/commands/speckit.git.validate.md
+++ b/.specify/extensions/git/commands/speckit.git.validate.md
@@ -1,0 +1,49 @@
+---
+description: "Validate current branch follows feature branch naming conventions"
+---
+
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.specify/extensions/git/config-template.yml
+++ b/.specify/extensions/git/config-template.yml
@@ -1,0 +1,62 @@
+# Git Branching Workflow Extension Configuration
+# Copied to .specify/extensions/git/git-config.yml on install
+
+# Branch numbering strategy: "sequential" (001, 002, ...) or "timestamp" (YYYYMMDD-HHMMSS)
+branch_numbering: sequential
+
+# Commit message used by `git commit` during repository initialization
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit before/after core commands.
+# Set "default" to enable for all commands, then override per-command.
+# Each key can be true/false. Message is customizable per-command.
+auto_commit:
+  default: false
+  before_clarify:
+    enabled: false
+    message: "[Spec Kit] Save progress before clarification"
+  before_plan:
+    enabled: false
+    message: "[Spec Kit] Save progress before planning"
+  before_tasks:
+    enabled: false
+    message: "[Spec Kit] Save progress before task generation"
+  before_implement:
+    enabled: false
+    message: "[Spec Kit] Save progress before implementation"
+  before_checklist:
+    enabled: false
+    message: "[Spec Kit] Save progress before checklist"
+  before_analyze:
+    enabled: false
+    message: "[Spec Kit] Save progress before analysis"
+  before_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Save progress before issue sync"
+  after_constitution:
+    enabled: false
+    message: "[Spec Kit] Add project constitution"
+  after_specify:
+    enabled: false
+    message: "[Spec Kit] Add specification"
+  after_clarify:
+    enabled: false
+    message: "[Spec Kit] Clarify specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+  after_tasks:
+    enabled: false
+    message: "[Spec Kit] Add tasks"
+  after_implement:
+    enabled: false
+    message: "[Spec Kit] Implementation progress"
+  after_checklist:
+    enabled: false
+    message: "[Spec Kit] Add checklist"
+  after_analyze:
+    enabled: false
+    message: "[Spec Kit] Add analysis report"
+  after_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Sync tasks to issues"

--- a/.specify/extensions/git/extension.yml
+++ b/.specify/extensions/git/extension.yml
@@ -1,0 +1,140 @@
+schema_version: "1.0"
+
+extension:
+  id: git
+  name: "Git Branching Workflow"
+  version: "1.0.0"
+  description: "Feature branch creation, numbering (sequential/timestamp), validation, and Git remote detection"
+  author: spec-kit-core
+  repository: https://github.com/github/spec-kit
+  license: MIT
+
+requires:
+  speckit_version: ">=0.2.0"
+  tools:
+    - name: git
+      required: false
+
+provides:
+  commands:
+    - name: speckit.git.feature
+      file: commands/speckit.git.feature.md
+      description: "Create a feature branch with sequential or timestamp numbering"
+    - name: speckit.git.validate
+      file: commands/speckit.git.validate.md
+      description: "Validate current branch follows feature branch naming conventions"
+    - name: speckit.git.remote
+      file: commands/speckit.git.remote.md
+      description: "Detect Git remote URL for GitHub integration"
+    - name: speckit.git.initialize
+      file: commands/speckit.git.initialize.md
+      description: "Initialize a Git repository with an initial commit"
+    - name: speckit.git.commit
+      file: commands/speckit.git.commit.md
+      description: "Auto-commit changes after a Spec Kit command completes"
+
+  config:
+    - name: "git-config.yml"
+      template: "config-template.yml"
+      description: "Git branching configuration"
+      required: false
+
+hooks:
+  before_constitution:
+    command: speckit.git.initialize
+    optional: false
+    description: "Initialize Git repository before constitution setup"
+  before_specify:
+    command: speckit.git.feature
+    optional: false
+    description: "Create feature branch before specification"
+  before_clarify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before clarification?"
+    description: "Auto-commit before spec clarification"
+  before_plan:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before planning?"
+    description: "Auto-commit before implementation planning"
+  before_tasks:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before task generation?"
+    description: "Auto-commit before task generation"
+  before_implement:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before implementation?"
+    description: "Auto-commit before implementation"
+  before_checklist:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before checklist?"
+    description: "Auto-commit before checklist generation"
+  before_analyze:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before analysis?"
+    description: "Auto-commit before analysis"
+  before_taskstoissues:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before issue sync?"
+    description: "Auto-commit before tasks-to-issues conversion"
+  after_constitution:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit constitution changes?"
+    description: "Auto-commit after constitution update"
+  after_specify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit specification changes?"
+    description: "Auto-commit after specification"
+  after_clarify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit clarification changes?"
+    description: "Auto-commit after spec clarification"
+  after_plan:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit plan changes?"
+    description: "Auto-commit after implementation planning"
+  after_tasks:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit task changes?"
+    description: "Auto-commit after task generation"
+  after_implement:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit implementation changes?"
+    description: "Auto-commit after implementation"
+  after_checklist:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit checklist changes?"
+    description: "Auto-commit after checklist generation"
+  after_analyze:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit analysis results?"
+    description: "Auto-commit after analysis"
+  after_taskstoissues:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit after syncing issues?"
+    description: "Auto-commit after tasks-to-issues conversion"
+
+tags:
+  - "git"
+  - "branching"
+  - "workflow"
+
+config:
+  defaults:
+    branch_numbering: sequential
+    init_commit_message: "[Spec Kit] Initial commit"

--- a/.specify/extensions/git/git-config.yml
+++ b/.specify/extensions/git/git-config.yml
@@ -1,0 +1,62 @@
+# Git Branching Workflow Extension Configuration
+# Copied to .specify/extensions/git/git-config.yml on install
+
+# Branch numbering strategy: "sequential" (001, 002, ...) or "timestamp" (YYYYMMDD-HHMMSS)
+branch_numbering: sequential
+
+# Commit message used by `git commit` during repository initialization
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit before/after core commands.
+# Set "default" to enable for all commands, then override per-command.
+# Each key can be true/false. Message is customizable per-command.
+auto_commit:
+  default: false
+  before_clarify:
+    enabled: false
+    message: "[Spec Kit] Save progress before clarification"
+  before_plan:
+    enabled: false
+    message: "[Spec Kit] Save progress before planning"
+  before_tasks:
+    enabled: false
+    message: "[Spec Kit] Save progress before task generation"
+  before_implement:
+    enabled: false
+    message: "[Spec Kit] Save progress before implementation"
+  before_checklist:
+    enabled: false
+    message: "[Spec Kit] Save progress before checklist"
+  before_analyze:
+    enabled: false
+    message: "[Spec Kit] Save progress before analysis"
+  before_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Save progress before issue sync"
+  after_constitution:
+    enabled: false
+    message: "[Spec Kit] Add project constitution"
+  after_specify:
+    enabled: false
+    message: "[Spec Kit] Add specification"
+  after_clarify:
+    enabled: false
+    message: "[Spec Kit] Clarify specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+  after_tasks:
+    enabled: false
+    message: "[Spec Kit] Add tasks"
+  after_implement:
+    enabled: false
+    message: "[Spec Kit] Implementation progress"
+  after_checklist:
+    enabled: false
+    message: "[Spec Kit] Add checklist"
+  after_analyze:
+    enabled: false
+    message: "[Spec Kit] Add analysis report"
+  after_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Sync tasks to issues"

--- a/.specify/extensions/git/scripts/bash/auto-commit.sh
+++ b/.specify/extensions/git/scripts/bash/auto-commit.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Git extension: auto-commit.sh
+# Automatically commit changes after a Spec Kit command completes.
+# Checks per-command config keys in git-config.yml before committing.
+#
+# Usage: auto-commit.sh <event_name>
+#   e.g.: auto-commit.sh after_specify
+
+set -e
+
+EVENT_NAME="${1:-}"
+if [ -z "$EVENT_NAME" ]; then
+    echo "Usage: $0 <event_name>" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+REPO_ROOT=$(_find_project_root "$SCRIPT_DIR") || REPO_ROOT="$(pwd)"
+cd "$REPO_ROOT"
+
+# Check if git is available
+if ! command -v git >/dev/null 2>&1; then
+    echo "[specify] Warning: Git not found; skipped auto-commit" >&2
+    exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "[specify] Warning: Not a Git repository; skipped auto-commit" >&2
+    exit 0
+fi
+
+# Read per-command config from git-config.yml
+_config_file="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+_enabled=false
+_commit_msg=""
+
+if [ -f "$_config_file" ]; then
+    # Parse the auto_commit section for this event.
+    # Look for auto_commit.<event_name>.enabled and .message
+    # Also check auto_commit.default as fallback.
+    _in_auto_commit=false
+    _in_event=false
+    _default_enabled=false
+
+    while IFS= read -r _line; do
+        # Detect auto_commit: section
+        if echo "$_line" | grep -q '^auto_commit:'; then
+            _in_auto_commit=true
+            _in_event=false
+            continue
+        fi
+
+        # Exit auto_commit section on next top-level key
+        if $_in_auto_commit && echo "$_line" | grep -Eq '^[a-z]'; then
+            break
+        fi
+
+        if $_in_auto_commit; then
+            # Check default key
+            if echo "$_line" | grep -Eq "^[[:space:]]+default:[[:space:]]"; then
+                _val=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                [ "$_val" = "true" ] && _default_enabled=true
+            fi
+
+            # Detect our event subsection
+            if echo "$_line" | grep -Eq "^[[:space:]]+${EVENT_NAME}:"; then
+                _in_event=true
+                continue
+            fi
+
+            # Inside our event subsection
+            if $_in_event; then
+                # Exit on next sibling key (same indent level as event name)
+                if echo "$_line" | grep -Eq '^[[:space:]]{2}[a-z]' && ! echo "$_line" | grep -Eq '^[[:space:]]{4}'; then
+                    _in_event=false
+                    continue
+                fi
+                if echo "$_line" | grep -Eq '[[:space:]]+enabled:'; then
+                    _val=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                    [ "$_val" = "true" ] && _enabled=true
+                    [ "$_val" = "false" ] && _enabled=false
+                fi
+                if echo "$_line" | grep -Eq '[[:space:]]+message:'; then
+                    _commit_msg=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | sed 's/^["'\'']//' | sed 's/["'\'']*$//')
+                fi
+            fi
+        fi
+    done < "$_config_file"
+
+    # If event-specific key not found, use default
+    if [ "$_enabled" = "false" ] && [ "$_default_enabled" = "true" ]; then
+        # Only use default if the event wasn't explicitly set to false
+        # Check if event section existed at all
+        if ! grep -q "^[[:space:]]*${EVENT_NAME}:" "$_config_file" 2>/dev/null; then
+            _enabled=true
+        fi
+    fi
+else
+    # No config file — auto-commit disabled by default
+    exit 0
+fi
+
+if [ "$_enabled" != "true" ]; then
+    exit 0
+fi
+
+# Check if there are changes to commit
+if git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet 2>/dev/null && [ -z "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+    echo "[specify] No changes to commit after $EVENT_NAME" >&2
+    exit 0
+fi
+
+# Derive a human-readable command name from the event
+# e.g., after_specify -> specify, before_plan -> plan
+_command_name=$(echo "$EVENT_NAME" | sed 's/^after_//' | sed 's/^before_//')
+_phase=$(echo "$EVENT_NAME" | grep -q '^before_' && echo 'before' || echo 'after')
+
+# Use custom message if configured, otherwise default
+if [ -z "$_commit_msg" ]; then
+    _commit_msg="[Spec Kit] Auto-commit ${_phase} ${_command_name}"
+fi
+
+# Stage and commit
+_git_out=$(git add . 2>&1) || { echo "[specify] Error: git add failed: $_git_out" >&2; exit 1; }
+_git_out=$(git commit -q -m "$_commit_msg" 2>&1) || { echo "[specify] Error: git commit failed: $_git_out" >&2; exit 1; }
+
+echo "[OK] Changes committed ${_phase} ${_command_name}" >&2

--- a/.specify/extensions/git/scripts/bash/create-new-feature.sh
+++ b/.specify/extensions/git/scripts/bash/create-new-feature.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+# Git extension: create-new-feature.sh
+# Adapted from core scripts/bash/create-new-feature.sh for extension layout.
+# Sources common.sh from the project's installed scripts, falling back to
+# git-common.sh for minimal git helpers.
+
+set -e
+
+JSON_MODE=false
+DRY_RUN=false
+ALLOW_EXISTING=false
+SHORT_NAME=""
+BRANCH_NUMBER=""
+USE_TIMESTAMP=false
+ARGS=()
+i=1
+while [ $i -le $# ]; do
+    arg="${!i}"
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --allow-existing-branch)
+            ALLOW_EXISTING=true
+            ;;
+        --short-name)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            SHORT_NAME="$next_arg"
+            ;;
+        --number)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            BRANCH_NUMBER="$next_arg"
+            if [[ ! "$BRANCH_NUMBER" =~ ^[0-9]+$ ]]; then
+                echo 'Error: --number must be a non-negative integer' >&2
+                exit 1
+            fi
+            ;;
+        --timestamp)
+            USE_TIMESTAMP=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] <feature_description>"
+            echo ""
+            echo "Options:"
+            echo "  --json              Output in JSON format"
+            echo "  --dry-run           Compute branch name without creating the branch"
+            echo "  --allow-existing-branch  Switch to branch if it already exists instead of failing"
+            echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
+            echo "  --number N          Specify branch number manually (overrides auto-detection)"
+            echo "  --timestamp         Use timestamp prefix (YYYYMMDD-HHMMSS) instead of sequential numbering"
+            echo "  --help, -h          Show this help message"
+            echo ""
+            echo "Environment variables:"
+            echo "  GIT_BRANCH_NAME     Use this exact branch name, bypassing all prefix/suffix generation"
+            echo ""
+            echo "Examples:"
+            echo "  $0 'Add user authentication system' --short-name 'user-auth'"
+            echo "  $0 'Implement OAuth2 integration for API' --number 5"
+            echo "  $0 --timestamp --short-name 'user-auth' 'Add user authentication'"
+            echo "  GIT_BRANCH_NAME=my-branch $0 'feature description'"
+            exit 0
+            ;;
+        *)
+            ARGS+=("$arg")
+            ;;
+    esac
+    i=$((i + 1))
+done
+
+FEATURE_DESCRIPTION="${ARGS[*]}"
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Usage: $0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] <feature_description>" >&2
+    exit 1
+fi
+
+# Trim whitespace and validate description is not empty
+FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Error: Feature description cannot be empty or contain only whitespace" >&2
+    exit 1
+fi
+
+# Function to get highest number from specs directory
+get_highest_from_specs() {
+    local specs_dir="$1"
+    local highest=0
+
+    if [ -d "$specs_dir" ]; then
+        for dir in "$specs_dir"/*; do
+            [ -d "$dir" ] || continue
+            dirname=$(basename "$dir")
+            # Match sequential prefixes (>=3 digits), but skip timestamp dirs.
+            if echo "$dirname" | grep -Eq '^[0-9]{3,}-' && ! echo "$dirname" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+                number=$(echo "$dirname" | grep -Eo '^[0-9]+')
+                number=$((10#$number))
+                if [ "$number" -gt "$highest" ]; then
+                    highest=$number
+                fi
+            fi
+        done
+    fi
+
+    echo "$highest"
+}
+
+# Function to get highest number from git branches
+get_highest_from_branches() {
+    git branch -a 2>/dev/null | sed 's/^[* ]*//; s|^remotes/[^/]*/||' | _extract_highest_number
+}
+
+# Extract the highest sequential feature number from a list of ref names (one per line).
+_extract_highest_number() {
+    local highest=0
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        if echo "$name" | grep -Eq '^[0-9]{3,}-' && ! echo "$name" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+            number=$(echo "$name" | grep -Eo '^[0-9]+' || echo "0")
+            number=$((10#$number))
+            if [ "$number" -gt "$highest" ]; then
+                highest=$number
+            fi
+        fi
+    done
+    echo "$highest"
+}
+
+# Function to get highest number from remote branches without fetching (side-effect-free)
+get_highest_from_remote_refs() {
+    local highest=0
+
+    for remote in $(git remote 2>/dev/null); do
+        local remote_highest
+        remote_highest=$(GIT_TERMINAL_PROMPT=0 git ls-remote --heads "$remote" 2>/dev/null | sed 's|.*refs/heads/||' | _extract_highest_number)
+        if [ "$remote_highest" -gt "$highest" ]; then
+            highest=$remote_highest
+        fi
+    done
+
+    echo "$highest"
+}
+
+# Function to check existing branches and return next available number.
+check_existing_branches() {
+    local specs_dir="$1"
+    local skip_fetch="${2:-false}"
+
+    if [ "$skip_fetch" = true ]; then
+        local highest_remote=$(get_highest_from_remote_refs)
+        local highest_branch=$(get_highest_from_branches)
+        if [ "$highest_remote" -gt "$highest_branch" ]; then
+            highest_branch=$highest_remote
+        fi
+    else
+        git fetch --all --prune >/dev/null 2>&1 || true
+        local highest_branch=$(get_highest_from_branches)
+    fi
+
+    local highest_spec=$(get_highest_from_specs "$specs_dir")
+
+    local max_num=$highest_branch
+    if [ "$highest_spec" -gt "$max_num" ]; then
+        max_num=$highest_spec
+    fi
+
+    echo $((max_num + 1))
+}
+
+# Function to clean and format a branch name
+clean_branch_name() {
+    local name="$1"
+    echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
+}
+
+# ---------------------------------------------------------------------------
+# Source common.sh for resolve_template, json_escape, get_repo_root, has_git.
+#
+# Search locations in priority order:
+#  1. .specify/scripts/bash/common.sh under the project root (installed project)
+#  2. scripts/bash/common.sh under the project root (source checkout fallback)
+#  3. git-common.sh next to this script (minimal fallback — lacks resolve_template)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find project root by walking up from the script location
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+_common_loaded=false
+_PROJECT_ROOT=$(_find_project_root "$SCRIPT_DIR") || true
+
+if [ -n "$_PROJECT_ROOT" ] && [ -f "$_PROJECT_ROOT/.specify/scripts/bash/common.sh" ]; then
+    source "$_PROJECT_ROOT/.specify/scripts/bash/common.sh"
+    _common_loaded=true
+elif [ -n "$_PROJECT_ROOT" ] && [ -f "$_PROJECT_ROOT/scripts/bash/common.sh" ]; then
+    source "$_PROJECT_ROOT/scripts/bash/common.sh"
+    _common_loaded=true
+elif [ -f "$SCRIPT_DIR/git-common.sh" ]; then
+    source "$SCRIPT_DIR/git-common.sh"
+    _common_loaded=true
+fi
+
+if [ "$_common_loaded" != "true" ]; then
+    echo "Error: Could not locate common.sh or git-common.sh. Please ensure the Specify core scripts are installed." >&2
+    exit 1
+fi
+
+# Resolve repository root
+if type get_repo_root >/dev/null 2>&1; then
+    REPO_ROOT=$(get_repo_root)
+elif git rev-parse --show-toplevel >/dev/null 2>&1; then
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+elif [ -n "$_PROJECT_ROOT" ]; then
+    REPO_ROOT="$_PROJECT_ROOT"
+else
+    echo "Error: Could not determine repository root." >&2
+    exit 1
+fi
+
+# Check if git is available at this repo root
+if type has_git >/dev/null 2>&1; then
+    if has_git "$REPO_ROOT"; then
+        HAS_GIT=true
+    else
+        HAS_GIT=false
+    fi
+elif git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    HAS_GIT=true
+else
+    HAS_GIT=false
+fi
+
+cd "$REPO_ROOT"
+
+SPECS_DIR="$REPO_ROOT/specs"
+
+# Function to generate branch name with stop word filtering
+generate_branch_name() {
+    local description="$1"
+
+    local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
+
+    local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
+
+    local meaningful_words=()
+    for word in $clean_name; do
+        [ -z "$word" ] && continue
+        if ! echo "$word" | grep -qiE "$stop_words"; then
+            if [ ${#word} -ge 3 ]; then
+                meaningful_words+=("$word")
+            elif echo "$description" | grep -qw -- "${word^^}"; then
+                meaningful_words+=("$word")
+            fi
+        fi
+    done
+
+    if [ ${#meaningful_words[@]} -gt 0 ]; then
+        local max_words=3
+        if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
+
+        local result=""
+        local count=0
+        for word in "${meaningful_words[@]}"; do
+            if [ $count -ge $max_words ]; then break; fi
+            if [ -n "$result" ]; then result="$result-"; fi
+            result="$result$word"
+            count=$((count + 1))
+        done
+        echo "$result"
+    else
+        local cleaned=$(clean_branch_name "$description")
+        echo "$cleaned" | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
+    fi
+}
+
+# Check for GIT_BRANCH_NAME env var override (exact branch name, no prefix/suffix)
+if [ -n "${GIT_BRANCH_NAME:-}" ]; then
+    BRANCH_NAME="$GIT_BRANCH_NAME"
+    # Extract FEATURE_NUM from the branch name if it starts with a numeric prefix
+    # Check timestamp pattern first (YYYYMMDD-HHMMSS-) since it also matches the simpler ^[0-9]+ pattern
+    if echo "$BRANCH_NAME" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+        FEATURE_NUM=$(echo "$BRANCH_NAME" | grep -Eo '^[0-9]{8}-[0-9]{6}')
+        BRANCH_SUFFIX="${BRANCH_NAME#${FEATURE_NUM}-}"
+    elif echo "$BRANCH_NAME" | grep -Eq '^[0-9]+-'; then
+        FEATURE_NUM=$(echo "$BRANCH_NAME" | grep -Eo '^[0-9]+')
+        BRANCH_SUFFIX="${BRANCH_NAME#${FEATURE_NUM}-}"
+    else
+        FEATURE_NUM="$BRANCH_NAME"
+        BRANCH_SUFFIX="$BRANCH_NAME"
+    fi
+else
+    # Generate branch name
+    if [ -n "$SHORT_NAME" ]; then
+        BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
+    else
+        BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
+    fi
+
+    # Warn if --number and --timestamp are both specified
+    if [ "$USE_TIMESTAMP" = true ] && [ -n "$BRANCH_NUMBER" ]; then
+        >&2 echo "[specify] Warning: --number is ignored when --timestamp is used"
+        BRANCH_NUMBER=""
+    fi
+
+    # Determine branch prefix
+    if [ "$USE_TIMESTAMP" = true ]; then
+        FEATURE_NUM=$(date +%Y%m%d-%H%M%S)
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    else
+        if [ -z "$BRANCH_NUMBER" ]; then
+            if [ "$DRY_RUN" = true ] && [ "$HAS_GIT" = true ]; then
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR" true)
+            elif [ "$DRY_RUN" = true ]; then
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            elif [ "$HAS_GIT" = true ]; then
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+            else
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            fi
+        fi
+
+        FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    fi
+fi
+
+# GitHub enforces a 244-byte limit on branch names
+MAX_BRANCH_LENGTH=244
+_byte_length() { printf '%s' "$1" | LC_ALL=C wc -c | tr -d ' '; }
+BRANCH_BYTE_LEN=$(_byte_length "$BRANCH_NAME")
+if [ -n "${GIT_BRANCH_NAME:-}" ] && [ "$BRANCH_BYTE_LEN" -gt $MAX_BRANCH_LENGTH ]; then
+    >&2 echo "Error: GIT_BRANCH_NAME must be 244 bytes or fewer in UTF-8. Provided value is ${BRANCH_BYTE_LEN} bytes."
+    exit 1
+elif [ "$BRANCH_BYTE_LEN" -gt $MAX_BRANCH_LENGTH ]; then
+    PREFIX_LENGTH=$(( ${#FEATURE_NUM} + 1 ))
+    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - PREFIX_LENGTH))
+
+    TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
+    TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
+
+    ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
+    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+
+    >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
+    >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
+    >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
+fi
+
+if [ "$DRY_RUN" != true ]; then
+    if [ "$HAS_GIT" = true ]; then
+        branch_create_error=""
+        if ! branch_create_error=$(git checkout -q -b "$BRANCH_NAME" 2>&1); then
+            current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+            if git branch --list "$BRANCH_NAME" | grep -q .; then
+                if [ "$ALLOW_EXISTING" = true ]; then
+                    if [ "$current_branch" = "$BRANCH_NAME" ]; then
+                        :
+                    elif ! switch_branch_error=$(git checkout -q "$BRANCH_NAME" 2>&1); then
+                        >&2 echo "Error: Failed to switch to existing branch '$BRANCH_NAME'. Please resolve any local changes or conflicts and try again."
+                        if [ -n "$switch_branch_error" ]; then
+                            >&2 printf '%s\n' "$switch_branch_error"
+                        fi
+                        exit 1
+                    fi
+                elif [ "$USE_TIMESTAMP" = true ]; then
+                    >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Rerun to get a new timestamp or use a different --short-name."
+                    exit 1
+                else
+                    >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+                    exit 1
+                fi
+            else
+                >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'."
+                if [ -n "$branch_create_error" ]; then
+                    >&2 printf '%s\n' "$branch_create_error"
+                else
+                    >&2 echo "Please check your git configuration and try again."
+                fi
+                exit 1
+            fi
+        fi
+    else
+        >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    fi
+
+    printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2
+fi
+
+if $JSON_MODE; then
+    if command -v jq >/dev/null 2>&1; then
+        if [ "$DRY_RUN" = true ]; then
+            jq -cn \
+                --arg branch_name "$BRANCH_NAME" \
+                --arg feature_num "$FEATURE_NUM" \
+                '{BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num,DRY_RUN:true}'
+        else
+            jq -cn \
+                --arg branch_name "$BRANCH_NAME" \
+                --arg feature_num "$FEATURE_NUM" \
+                '{BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num}'
+        fi
+    else
+        if type json_escape >/dev/null 2>&1; then
+            _je_branch=$(json_escape "$BRANCH_NAME")
+            _je_num=$(json_escape "$FEATURE_NUM")
+        else
+            _je_branch="$BRANCH_NAME"
+            _je_num="$FEATURE_NUM"
+        fi
+        if [ "$DRY_RUN" = true ]; then
+            printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","DRY_RUN":true}\n' "$_je_branch" "$_je_num"
+        else
+            printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s"}\n' "$_je_branch" "$_je_num"
+        fi
+    fi
+else
+    echo "BRANCH_NAME: $BRANCH_NAME"
+    echo "FEATURE_NUM: $FEATURE_NUM"
+    if [ "$DRY_RUN" != true ]; then
+        printf '# To persist in your shell: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME"
+    fi
+fi

--- a/.specify/extensions/git/scripts/bash/git-common.sh
+++ b/.specify/extensions/git/scripts/bash/git-common.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Git-specific common functions for the git extension.
+# Extracted from scripts/bash/common.sh — contains only git-specific
+# branch validation and detection logic.
+
+# Check if we have git available at the repo root
+has_git() {
+    local repo_root="${1:-$(pwd)}"
+    { [ -d "$repo_root/.git" ] || [ -f "$repo_root/.git" ]; } && \
+        command -v git >/dev/null 2>&1 && \
+        git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# Strip a single optional path segment (e.g. gitflow "feat/004-name" -> "004-name").
+# Only when the full name is exactly two slash-free segments; otherwise returns the raw name.
+spec_kit_effective_branch_name() {
+    local raw="$1"
+    if [[ "$raw" =~ ^([^/]+)/([^/]+)$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[2]}"
+    else
+        printf '%s\n' "$raw"
+    fi
+}
+
+# Validate that a branch name matches the expected feature branch pattern.
+# Accepts sequential (###-* with >=3 digits) or timestamp (YYYYMMDD-HHMMSS-*) formats.
+# Logic aligned with scripts/bash/common.sh check_feature_branch after effective-name normalization.
+check_feature_branch() {
+    local raw="$1"
+    local has_git_repo="$2"
+
+    # For non-git repos, we can't enforce branch naming but still provide output
+    if [[ "$has_git_repo" != "true" ]]; then
+        echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
+        return 0
+    fi
+
+    local branch
+    branch=$(spec_kit_effective_branch_name "$raw")
+
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
+    local is_sequential=false
+    if [[ "$branch" =~ ^[0-9]{3,}- ]] && [[ ! "$branch" =~ ^[0-9]{7}-[0-9]{6}- ]] && [[ ! "$branch" =~ ^[0-9]{7,8}-[0-9]{6}$ ]]; then
+        is_sequential=true
+    fi
+    if [[ "$is_sequential" != "true" ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+        echo "ERROR: Not on a feature branch. Current branch: $raw" >&2
+        echo "Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name" >&2
+        return 1
+    fi
+
+    return 0
+}

--- a/.specify/extensions/git/scripts/bash/initialize-repo.sh
+++ b/.specify/extensions/git/scripts/bash/initialize-repo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Git extension: initialize-repo.sh
+# Initialize a Git repository with an initial commit.
+# Customizable — replace this script to add .gitignore templates,
+# default branch config, git-flow, LFS, signing, etc.
+
+set -e
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find project root
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+REPO_ROOT=$(_find_project_root "$SCRIPT_DIR") || REPO_ROOT="$(pwd)"
+cd "$REPO_ROOT"
+
+# Read commit message from extension config, fall back to default
+COMMIT_MSG="[Spec Kit] Initial commit"
+_config_file="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+if [ -f "$_config_file" ]; then
+    _msg=$(grep '^init_commit_message:' "$_config_file" 2>/dev/null | sed 's/^init_commit_message:[[:space:]]*//' | sed 's/^["'\'']//' | sed 's/["'\'']*$//')
+    if [ -n "$_msg" ]; then
+        COMMIT_MSG="$_msg"
+    fi
+fi
+
+# Check if git is available
+if ! command -v git >/dev/null 2>&1; then
+    echo "[specify] Warning: Git not found; skipped repository initialization" >&2
+    exit 0
+fi
+
+# Check if already a git repo
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "[specify] Git repository already initialized; skipping" >&2
+    exit 0
+fi
+
+# Initialize
+_git_out=$(git init -q 2>&1) || { echo "[specify] Error: git init failed: $_git_out" >&2; exit 1; }
+_git_out=$(git add . 2>&1) || { echo "[specify] Error: git add failed: $_git_out" >&2; exit 1; }
+_git_out=$(git commit --allow-empty -q -m "$COMMIT_MSG" 2>&1) || { echo "[specify] Error: git commit failed: $_git_out" >&2; exit 1; }
+
+echo "✓ Git repository initialized" >&2

--- a/.specify/extensions/git/scripts/powershell/auto-commit.ps1
+++ b/.specify/extensions/git/scripts/powershell/auto-commit.ps1
@@ -1,0 +1,169 @@
+#!/usr/bin/env pwsh
+# Git extension: auto-commit.ps1
+# Automatically commit changes after a Spec Kit command completes.
+# Checks per-command config keys in git-config.yml before committing.
+#
+# Usage: auto-commit.ps1 <event_name>
+#   e.g.: auto-commit.ps1 after_specify
+param(
+    [Parameter(Position = 0, Mandatory = $true)]
+    [string]$EventName
+)
+$ErrorActionPreference = 'Stop'
+
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$repoRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+if (-not $repoRoot) { $repoRoot = Get-Location }
+Set-Location $repoRoot
+
+# Check if git is available
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Warning "[specify] Warning: Git not found; skipped auto-commit"
+    exit 0
+}
+
+# Temporarily relax ErrorActionPreference so git stderr warnings
+# (e.g. CRLF notices on Windows) do not become terminating errors.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    $isRepo = $LASTEXITCODE -eq 0
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+if (-not $isRepo) {
+    Write-Warning "[specify] Warning: Not a Git repository; skipped auto-commit"
+    exit 0
+}
+
+# Read per-command config from git-config.yml
+$configFile = Join-Path $repoRoot ".specify/extensions/git/git-config.yml"
+$enabled = $false
+$commitMsg = ""
+
+if (Test-Path $configFile) {
+    # Parse YAML to find auto_commit section
+    $inAutoCommit = $false
+    $inEvent = $false
+    $defaultEnabled = $false
+
+    foreach ($line in Get-Content $configFile) {
+        # Detect auto_commit: section
+        if ($line -match '^auto_commit:') {
+            $inAutoCommit = $true
+            $inEvent = $false
+            continue
+        }
+
+        # Exit auto_commit section on next top-level key
+        if ($inAutoCommit -and $line -match '^[a-z]') {
+            break
+        }
+
+        if ($inAutoCommit) {
+            # Check default key
+            if ($line -match '^\s+default:\s*(.+)$') {
+                $val = $matches[1].Trim().ToLower()
+                if ($val -eq 'true') { $defaultEnabled = $true }
+            }
+
+            # Detect our event subsection
+            if ($line -match "^\s+${EventName}:") {
+                $inEvent = $true
+                continue
+            }
+
+            # Inside our event subsection
+            if ($inEvent) {
+                # Exit on next sibling key (2-space indent, not 4+)
+                if ($line -match '^\s{2}[a-z]' -and $line -notmatch '^\s{4}') {
+                    $inEvent = $false
+                    continue
+                }
+                if ($line -match '\s+enabled:\s*(.+)$') {
+                    $val = $matches[1].Trim().ToLower()
+                    if ($val -eq 'true') { $enabled = $true }
+                    if ($val -eq 'false') { $enabled = $false }
+                }
+                if ($line -match '\s+message:\s*(.+)$') {
+                    $commitMsg = $matches[1].Trim() -replace '^["'']' -replace '["'']$'
+                }
+            }
+        }
+    }
+
+    # If event-specific key not found, use default
+    if (-not $enabled -and $defaultEnabled) {
+        $hasEventKey = Select-String -Path $configFile -Pattern "^\s*${EventName}:" -Quiet
+        if (-not $hasEventKey) {
+            $enabled = $true
+        }
+    }
+} else {
+    # No config file -- auto-commit disabled by default
+    exit 0
+}
+
+if (-not $enabled) {
+    exit 0
+}
+
+# Check if there are changes to commit
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    git diff --quiet HEAD 2>$null; $d1 = $LASTEXITCODE
+    git diff --cached --quiet 2>$null; $d2 = $LASTEXITCODE
+    $untracked = git ls-files --others --exclude-standard 2>$null
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+
+if ($d1 -eq 0 -and $d2 -eq 0 -and -not $untracked) {
+    Write-Host "[specify] No changes to commit after $EventName" -ForegroundColor DarkGray
+    exit 0
+}
+
+# Derive a human-readable command name from the event
+$commandName = $EventName -replace '^after_', '' -replace '^before_', ''
+$phase = if ($EventName -match '^before_') { 'before' } else { 'after' }
+
+# Use custom message if configured, otherwise default
+if (-not $commitMsg) {
+    $commitMsg = "[Spec Kit] Auto-commit $phase $commandName"
+}
+
+# Stage and commit
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate,
+# while still allowing redirected error output to be captured for diagnostics.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    $out = git add . 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
+    $out = git commit -q -m $commitMsg 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
+} catch {
+    Write-Warning "[specify] Error: $_"
+    exit 1
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+
+Write-Host "[OK] Changes committed $phase $commandName"

--- a/.specify/extensions/git/scripts/powershell/create-new-feature.ps1
+++ b/.specify/extensions/git/scripts/powershell/create-new-feature.ps1
@@ -1,0 +1,403 @@
+#!/usr/bin/env pwsh
+# Git extension: create-new-feature.ps1
+# Adapted from core scripts/powershell/create-new-feature.ps1 for extension layout.
+# Sources common.ps1 from the project's installed scripts, falling back to
+# git-common.ps1 for minimal git helpers.
+[CmdletBinding()]
+param(
+    [switch]$Json,
+    [switch]$AllowExistingBranch,
+    [switch]$DryRun,
+    [string]$ShortName,
+    [Parameter()]
+    [long]$Number = 0,
+    [switch]$Timestamp,
+    [switch]$Help,
+    [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+    [string[]]$FeatureDescription
+)
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Write-Host "Usage: ./create-new-feature.ps1 [-Json] [-DryRun] [-AllowExistingBranch] [-ShortName <name>] [-Number N] [-Timestamp] <feature description>"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Json               Output in JSON format"
+    Write-Host "  -DryRun             Compute branch name without creating the branch"
+    Write-Host "  -AllowExistingBranch  Switch to branch if it already exists instead of failing"
+    Write-Host "  -ShortName <name>   Provide a custom short name (2-4 words) for the branch"
+    Write-Host "  -Number N           Specify branch number manually (overrides auto-detection)"
+    Write-Host "  -Timestamp          Use timestamp prefix (YYYYMMDD-HHMMSS) instead of sequential numbering"
+    Write-Host "  -Help               Show this help message"
+    Write-Host ""
+    Write-Host "Environment variables:"
+    Write-Host "  GIT_BRANCH_NAME     Use this exact branch name, bypassing all prefix/suffix generation"
+    Write-Host ""
+    exit 0
+}
+
+if (-not $FeatureDescription -or $FeatureDescription.Count -eq 0) {
+    Write-Error "Usage: ./create-new-feature.ps1 [-Json] [-DryRun] [-AllowExistingBranch] [-ShortName <name>] [-Number N] [-Timestamp] <feature description>"
+    exit 1
+}
+
+$featureDesc = ($FeatureDescription -join ' ').Trim()
+
+if ([string]::IsNullOrWhiteSpace($featureDesc)) {
+    Write-Error "Error: Feature description cannot be empty or contain only whitespace"
+    exit 1
+}
+
+function Get-HighestNumberFromSpecs {
+    param([string]$SpecsDir)
+
+    [long]$highest = 0
+    if (Test-Path $SpecsDir) {
+        Get-ChildItem -Path $SpecsDir -Directory | ForEach-Object {
+            if ($_.Name -match '^(\d{3,})-' -and $_.Name -notmatch '^\d{8}-\d{6}-') {
+                [long]$num = 0
+                if ([long]::TryParse($matches[1], [ref]$num) -and $num -gt $highest) {
+                    $highest = $num
+                }
+            }
+        }
+    }
+    return $highest
+}
+
+function Get-HighestNumberFromNames {
+    param([string[]]$Names)
+
+    [long]$highest = 0
+    foreach ($name in $Names) {
+        if ($name -match '^(\d{3,})-' -and $name -notmatch '^\d{8}-\d{6}-') {
+            [long]$num = 0
+            if ([long]::TryParse($matches[1], [ref]$num) -and $num -gt $highest) {
+                $highest = $num
+            }
+        }
+    }
+    return $highest
+}
+
+function Get-HighestNumberFromBranches {
+    param()
+
+    try {
+        $branches = git branch -a 2>$null
+        if ($LASTEXITCODE -eq 0 -and $branches) {
+            $cleanNames = $branches | ForEach-Object {
+                $_.Trim() -replace '^\*?\s+', '' -replace '^remotes/[^/]+/', ''
+            }
+            return Get-HighestNumberFromNames -Names $cleanNames
+        }
+    } catch {
+        Write-Verbose "Could not check Git branches: $_"
+    }
+    return 0
+}
+
+function Get-HighestNumberFromRemoteRefs {
+    [long]$highest = 0
+    try {
+        $remotes = git remote 2>$null
+        if ($remotes) {
+            foreach ($remote in $remotes) {
+                $env:GIT_TERMINAL_PROMPT = '0'
+                $refs = git ls-remote --heads $remote 2>$null
+                $env:GIT_TERMINAL_PROMPT = $null
+                if ($LASTEXITCODE -eq 0 -and $refs) {
+                    $refNames = $refs | ForEach-Object {
+                        if ($_ -match 'refs/heads/(.+)$') { $matches[1] }
+                    } | Where-Object { $_ }
+                    $remoteHighest = Get-HighestNumberFromNames -Names $refNames
+                    if ($remoteHighest -gt $highest) { $highest = $remoteHighest }
+                }
+            }
+        }
+    } catch {
+        Write-Verbose "Could not query remote refs: $_"
+    }
+    return $highest
+}
+
+function Get-NextBranchNumber {
+    param(
+        [string]$SpecsDir,
+        [switch]$SkipFetch
+    )
+
+    if ($SkipFetch) {
+        $highestBranch = Get-HighestNumberFromBranches
+        $highestRemote = Get-HighestNumberFromRemoteRefs
+        $highestBranch = [Math]::Max($highestBranch, $highestRemote)
+    } else {
+        try {
+            git fetch --all --prune 2>$null | Out-Null
+        } catch { }
+        $highestBranch = Get-HighestNumberFromBranches
+    }
+
+    $highestSpec = Get-HighestNumberFromSpecs -SpecsDir $SpecsDir
+    $maxNum = [Math]::Max($highestBranch, $highestSpec)
+    return $maxNum + 1
+}
+
+function ConvertTo-CleanBranchName {
+    param([string]$Name)
+    return $Name.ToLower() -replace '[^a-z0-9]', '-' -replace '-{2,}', '-' -replace '^-', '' -replace '-$', ''
+}
+
+# ---------------------------------------------------------------------------
+# Source common.ps1 from the project's installed scripts.
+# Search locations in priority order:
+#  1. .specify/scripts/powershell/common.ps1 under the project root
+#  2. scripts/powershell/common.ps1 under the project root (source checkout)
+#  3. git-common.ps1 next to this script (minimal fallback)
+# ---------------------------------------------------------------------------
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$projectRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+$commonLoaded = $false
+
+if ($projectRoot) {
+    $candidates = @(
+        (Join-Path $projectRoot ".specify/scripts/powershell/common.ps1"),
+        (Join-Path $projectRoot "scripts/powershell/common.ps1")
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            . $candidate
+            $commonLoaded = $true
+            break
+        }
+    }
+}
+
+if (-not $commonLoaded -and (Test-Path "$PSScriptRoot/git-common.ps1")) {
+    . "$PSScriptRoot/git-common.ps1"
+    $commonLoaded = $true
+}
+
+if (-not $commonLoaded) {
+    throw "Unable to locate common script file. Please ensure the Specify core scripts are installed."
+}
+
+# Resolve repository root
+if (Get-Command Get-RepoRoot -ErrorAction SilentlyContinue) {
+    $repoRoot = Get-RepoRoot
+} elseif ($projectRoot) {
+    $repoRoot = $projectRoot
+} else {
+    throw "Could not determine repository root."
+}
+
+# Check if git is available
+if (Get-Command Test-HasGit -ErrorAction SilentlyContinue) {
+    # Call without parameters for compatibility with core common.ps1 (no -RepoRoot param)
+    # and git-common.ps1 (has -RepoRoot param with default).
+    $hasGit = Test-HasGit
+} else {
+    try {
+        git -C $repoRoot rev-parse --is-inside-work-tree 2>$null | Out-Null
+        $hasGit = ($LASTEXITCODE -eq 0)
+    } catch {
+        $hasGit = $false
+    }
+}
+
+Set-Location $repoRoot
+
+$specsDir = Join-Path $repoRoot 'specs'
+
+function Get-BranchName {
+    param([string]$Description)
+
+    $stopWords = @(
+        'i', 'a', 'an', 'the', 'to', 'for', 'of', 'in', 'on', 'at', 'by', 'with', 'from',
+        'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had',
+        'do', 'does', 'did', 'will', 'would', 'should', 'could', 'can', 'may', 'might', 'must', 'shall',
+        'this', 'that', 'these', 'those', 'my', 'your', 'our', 'their',
+        'want', 'need', 'add', 'get', 'set'
+    )
+
+    $cleanName = $Description.ToLower() -replace '[^a-z0-9\s]', ' '
+    $words = $cleanName -split '\s+' | Where-Object { $_ }
+
+    $meaningfulWords = @()
+    foreach ($word in $words) {
+        if ($stopWords -contains $word) { continue }
+        if ($word.Length -ge 3) {
+            $meaningfulWords += $word
+        } elseif ($Description -match "\b$($word.ToUpper())\b") {
+            $meaningfulWords += $word
+        }
+    }
+
+    if ($meaningfulWords.Count -gt 0) {
+        $maxWords = if ($meaningfulWords.Count -eq 4) { 4 } else { 3 }
+        $result = ($meaningfulWords | Select-Object -First $maxWords) -join '-'
+        return $result
+    } else {
+        $result = ConvertTo-CleanBranchName -Name $Description
+        $fallbackWords = ($result -split '-') | Where-Object { $_ } | Select-Object -First 3
+        return [string]::Join('-', $fallbackWords)
+    }
+}
+
+# Check for GIT_BRANCH_NAME env var override (exact branch name, no prefix/suffix)
+if ($env:GIT_BRANCH_NAME) {
+    $branchName = $env:GIT_BRANCH_NAME
+    # Check 244-byte limit (UTF-8) for override names
+    $branchNameUtf8ByteCount = [System.Text.Encoding]::UTF8.GetByteCount($branchName)
+    if ($branchNameUtf8ByteCount -gt 244) {
+        throw "GIT_BRANCH_NAME must be 244 bytes or fewer in UTF-8. Provided value is $branchNameUtf8ByteCount bytes; please supply a shorter override branch name."
+    }
+    # Extract FEATURE_NUM from the branch name if it starts with a numeric prefix
+    # Check timestamp pattern first (YYYYMMDD-HHMMSS-) since it also matches the simpler ^\d+ pattern
+    if ($branchName -match '^(\d{8}-\d{6})-') {
+        $featureNum = $matches[1]
+    } elseif ($branchName -match '^(\d+)-') {
+        $featureNum = $matches[1]
+    } else {
+        $featureNum = $branchName
+    }
+} else {
+    if ($ShortName) {
+        $branchSuffix = ConvertTo-CleanBranchName -Name $ShortName
+    } else {
+        $branchSuffix = Get-BranchName -Description $featureDesc
+    }
+
+    if ($Timestamp -and $Number -ne 0) {
+        Write-Warning "[specify] Warning: -Number is ignored when -Timestamp is used"
+        $Number = 0
+    }
+
+    if ($Timestamp) {
+        $featureNum = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $branchName = "$featureNum-$branchSuffix"
+    } else {
+        if ($Number -eq 0) {
+            if ($DryRun -and $hasGit) {
+                $Number = Get-NextBranchNumber -SpecsDir $specsDir -SkipFetch
+            } elseif ($DryRun) {
+                $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+            } elseif ($hasGit) {
+                $Number = Get-NextBranchNumber -SpecsDir $specsDir
+            } else {
+                $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+            }
+        }
+
+        $featureNum = ('{0:000}' -f $Number)
+        $branchName = "$featureNum-$branchSuffix"
+    }
+}
+
+$maxBranchLength = 244
+if ($branchName.Length -gt $maxBranchLength) {
+    $prefixLength = $featureNum.Length + 1
+    $maxSuffixLength = $maxBranchLength - $prefixLength
+
+    $truncatedSuffix = $branchSuffix.Substring(0, [Math]::Min($branchSuffix.Length, $maxSuffixLength))
+    $truncatedSuffix = $truncatedSuffix -replace '-$', ''
+
+    $originalBranchName = $branchName
+    $branchName = "$featureNum-$truncatedSuffix"
+
+    Write-Warning "[specify] Branch name exceeded GitHub's 244-byte limit"
+    Write-Warning "[specify] Original: $originalBranchName ($($originalBranchName.Length) bytes)"
+    Write-Warning "[specify] Truncated to: $branchName ($($branchName.Length) bytes)"
+}
+
+if (-not $DryRun) {
+    if ($hasGit) {
+        $branchCreated = $false
+        $branchCreateError = ''
+        try {
+            $branchCreateError = git checkout -q -b $branchName 2>&1 | Out-String
+            if ($LASTEXITCODE -eq 0) {
+                $branchCreated = $true
+            }
+        } catch {
+            $branchCreateError = $_.Exception.Message
+        }
+
+        if (-not $branchCreated) {
+            $currentBranch = ''
+            try { $currentBranch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
+            $existingBranch = git branch --list $branchName 2>$null
+            if ($existingBranch) {
+                if ($AllowExistingBranch) {
+                    if ($currentBranch -eq $branchName) {
+                        # Already on the target branch
+                    } else {
+                        $switchBranchError = git checkout -q $branchName 2>&1 | Out-String
+                        if ($LASTEXITCODE -ne 0) {
+                            if ($switchBranchError) {
+                                Write-Error "Error: Branch '$branchName' exists but could not be checked out.`n$($switchBranchError.Trim())"
+                            } else {
+                                Write-Error "Error: Branch '$branchName' exists but could not be checked out. Resolve any uncommitted changes or conflicts and try again."
+                            }
+                            exit 1
+                        }
+                    }
+                } elseif ($Timestamp) {
+                    Write-Error "Error: Branch '$branchName' already exists. Rerun to get a new timestamp or use a different -ShortName."
+                    exit 1
+                } else {
+                    Write-Error "Error: Branch '$branchName' already exists. Please use a different feature name or specify a different number with -Number."
+                    exit 1
+                }
+            } else {
+                if ($branchCreateError) {
+                    Write-Error "Error: Failed to create git branch '$branchName'.`n$($branchCreateError.Trim())"
+                } else {
+                    Write-Error "Error: Failed to create git branch '$branchName'. Please check your git configuration and try again."
+                }
+                exit 1
+            }
+        }
+    } else {
+        if ($Json) {
+            [Console]::Error.WriteLine("[specify] Warning: Git repository not detected; skipped branch creation for $branchName")
+        } else {
+            Write-Warning "[specify] Warning: Git repository not detected; skipped branch creation for $branchName"
+        }
+    }
+
+    $env:SPECIFY_FEATURE = $branchName
+}
+
+if ($Json) {
+    $obj = [PSCustomObject]@{
+        BRANCH_NAME = $branchName
+        FEATURE_NUM = $featureNum
+        HAS_GIT = $hasGit
+    }
+    if ($DryRun) {
+        $obj | Add-Member -NotePropertyName 'DRY_RUN' -NotePropertyValue $true
+    }
+    $obj | ConvertTo-Json -Compress
+} else {
+    Write-Output "BRANCH_NAME: $branchName"
+    Write-Output "FEATURE_NUM: $featureNum"
+    Write-Output "HAS_GIT: $hasGit"
+    if (-not $DryRun) {
+        Write-Output "SPECIFY_FEATURE environment variable set to: $branchName"
+    }
+}

--- a/.specify/extensions/git/scripts/powershell/git-common.ps1
+++ b/.specify/extensions/git/scripts/powershell/git-common.ps1
@@ -1,0 +1,51 @@
+#!/usr/bin/env pwsh
+# Git-specific common functions for the git extension.
+# Extracted from scripts/powershell/common.ps1 -- contains only git-specific
+# branch validation and detection logic.
+
+function Test-HasGit {
+    param([string]$RepoRoot = (Get-Location))
+    try {
+        if (-not (Test-Path (Join-Path $RepoRoot '.git'))) { return $false }
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) { return $false }
+        git -C $RepoRoot rev-parse --is-inside-work-tree 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+function Get-SpecKitEffectiveBranchName {
+    param([string]$Branch)
+    if ($Branch -match '^([^/]+)/([^/]+)$') {
+        return $Matches[2]
+    }
+    return $Branch
+}
+
+function Test-FeatureBranch {
+    param(
+        [string]$Branch,
+        [bool]$HasGit = $true
+    )
+
+    # For non-git repos, we can't enforce branch naming but still provide output
+    if (-not $HasGit) {
+        Write-Warning "[specify] Warning: Git repository not detected; skipped branch validation"
+        return $true
+    }
+
+    $raw = $Branch
+    $Branch = Get-SpecKitEffectiveBranchName $raw
+
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
+    $hasMalformedTimestamp = ($Branch -match '^[0-9]{7}-[0-9]{6}-') -or ($Branch -match '^(?:\d{7}|\d{8})-\d{6}$')
+    $isSequential = ($Branch -match '^[0-9]{3,}-') -and (-not $hasMalformedTimestamp)
+    if (-not $isSequential -and $Branch -notmatch '^\d{8}-\d{6}-') {
+        [Console]::Error.WriteLine("ERROR: Not on a feature branch. Current branch: $raw")
+        [Console]::Error.WriteLine("Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name")
+        return $false
+    }
+    return $true
+}

--- a/.specify/extensions/git/scripts/powershell/initialize-repo.ps1
+++ b/.specify/extensions/git/scripts/powershell/initialize-repo.ps1
@@ -1,0 +1,69 @@
+#!/usr/bin/env pwsh
+# Git extension: initialize-repo.ps1
+# Initialize a Git repository with an initial commit.
+# Customizable -- replace this script to add .gitignore templates,
+# default branch config, git-flow, LFS, signing, etc.
+$ErrorActionPreference = 'Stop'
+
+# Find project root
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$repoRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+if (-not $repoRoot) { $repoRoot = Get-Location }
+Set-Location $repoRoot
+
+# Read commit message from extension config, fall back to default
+$commitMsg = "[Spec Kit] Initial commit"
+$configFile = Join-Path $repoRoot ".specify/extensions/git/git-config.yml"
+if (Test-Path $configFile) {
+    foreach ($line in Get-Content $configFile) {
+        if ($line -match '^init_commit_message:\s*(.+)$') {
+            $val = $matches[1].Trim() -replace '^["'']' -replace '["'']$'
+            if ($val) { $commitMsg = $val }
+            break
+        }
+    }
+}
+
+# Check if git is available
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Warning "[specify] Warning: Git not found; skipped repository initialization"
+    exit 0
+}
+
+# Check if already a git repo
+try {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Warning "[specify] Git repository already initialized; skipping"
+        exit 0
+    }
+} catch { }
+
+# Initialize
+try {
+    $out = git init -q 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git init failed: $out" }
+    $out = git add . 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
+    $out = git commit --allow-empty -q -m $commitMsg 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
+} catch {
+    Write-Warning "[specify] Error: $_"
+    exit 1
+}
+
+Write-Host "[OK] Git repository initialized"

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,10 @@
+{
+  "ai": "claude",
+  "ai_skills": true,
+  "branch_numbering": "sequential",
+  "context_file": "CLAUDE.md",
+  "here": true,
+  "integration": "claude",
+  "script": "ps",
+  "speckit_version": "0.8.18.dev0"
+}

--- a/.specify/integration.json
+++ b/.specify/integration.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.8.18.dev0",
+  "integration_state_schema": 1,
+  "installed_integrations": [
+    "claude"
+  ],
+  "integration_settings": {
+    "claude": {
+      "script": "ps",
+      "invoke_separator": "-"
+    }
+  },
+  "integration": "claude",
+  "default_integration": "claude"
+}

--- a/.specify/integrations/claude.manifest.json
+++ b/.specify/integrations/claude.manifest.json
@@ -1,0 +1,16 @@
+{
+  "integration": "claude",
+  "version": "0.8.18.dev0",
+  "installed_at": "2026-05-29T14:21:39.338103+00:00",
+  "files": {
+    ".claude/skills/speckit-analyze/SKILL.md": "adb9c4baed1d0e27cebd08e506a7247c1357ee721b6ea340201553d5792e6c8a",
+    ".claude/skills/speckit-checklist/SKILL.md": "812b2a102310470141b313670a51e7f33fe4f673a3b8c3d97ddff4abce2e5fbd",
+    ".claude/skills/speckit-clarify/SKILL.md": "a882626090ba6bfc8fb5a7dfba42b537807a3acfdbecfdae76dd66a45a4ab955",
+    ".claude/skills/speckit-constitution/SKILL.md": "c1a044aba243ca6aff627fb5e4404feb6f1108d4f7dd174631bee3ae477d6c15",
+    ".claude/skills/speckit-implement/SKILL.md": "97a339450a2a81cb63d17cac84e8fdca6be07f0e66c37bcdca6ee87cf1f8d9f2",
+    ".claude/skills/speckit-plan/SKILL.md": "3b58fdd3a355ea4904cb8630b7605bb3209430d8fe91bb5d320fdb732a0cc11e",
+    ".claude/skills/speckit-specify/SKILL.md": "4cb1cb21f598288859e84cbf29052c1c41f213a2ca42b79b3a6d6293dde99d02",
+    ".claude/skills/speckit-tasks/SKILL.md": "9acb3cd58a594a0e5a0bad3a62e315cd8a464d3eb2a7acebe404c21e40625b7e",
+    ".claude/skills/speckit-taskstoissues/SKILL.md": "ccacc12041d1e27d3afffc7a189ac3d17444836e10eeb4e128b272b5e8ae45cb"
+  }
+}

--- a/.specify/integrations/speckit.manifest.json
+++ b/.specify/integrations/speckit.manifest.json
@@ -1,0 +1,8 @@
+{
+  "integration": "speckit",
+  "version": "0.8.18.dev0",
+  "installed_at": "2026-05-29T14:21:39.397516+00:00",
+  "files": {
+    ".specify/scripts/powershell/setup-tasks.ps1": "b7ec75a3aea607150294a900f0826b405064e92f8542823e3a2f2ab097f49d8d"
+  }
+}

--- a/.specify/scripts/powershell/setup-tasks.ps1
+++ b/.specify/scripts/powershell/setup-tasks.ps1
@@ -1,0 +1,74 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [switch]$Json,
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Write-Output "Usage: setup-tasks.ps1 [-Json] [-Help]"
+    exit 0
+}
+
+# Source common functions
+. "$PSScriptRoot/common.ps1"
+
+# Get feature paths and validate branch
+$paths = Get-FeaturePathsEnv
+
+# If feature.json pins an existing feature directory, branch naming is not required.
+if (-not (Test-FeatureJsonMatchesFeatureDir -RepoRoot $paths.REPO_ROOT -ActiveFeatureDir $paths.FEATURE_DIR)) {
+    if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) {
+        exit 1
+    }
+}
+
+if (-not (Test-Path $paths.IMPL_PLAN -PathType Leaf)) {
+    [Console]::Error.WriteLine("ERROR: plan.md not found in $($paths.FEATURE_DIR)")
+    [Console]::Error.WriteLine("Run /speckit-plan first to create the implementation plan.")
+    exit 1
+}
+
+if (-not (Test-Path $paths.FEATURE_SPEC -PathType Leaf)) {
+    [Console]::Error.WriteLine("ERROR: spec.md not found in $($paths.FEATURE_DIR)")
+    [Console]::Error.WriteLine("Run /speckit-specify first to create the feature structure.")
+    exit 1
+}
+
+# Build available docs list
+$docs = @()
+if (Test-Path $paths.RESEARCH) { $docs += 'research.md' }
+if (Test-Path $paths.DATA_MODEL) { $docs += 'data-model.md' }
+if ((Test-Path $paths.CONTRACTS_DIR) -and (Get-ChildItem -Path $paths.CONTRACTS_DIR -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+    $docs += 'contracts/'
+}
+if (Test-Path $paths.QUICKSTART) { $docs += 'quickstart.md' }
+
+# Resolve tasks template through override stack
+$tasksTemplate = Resolve-Template -TemplateName 'tasks-template' -RepoRoot $paths.REPO_ROOT
+if (-not $tasksTemplate -or -not (Test-Path -LiteralPath $tasksTemplate -PathType Leaf)) {
+    $expectedCoreTemplate = Join-Path $paths.REPO_ROOT '.specify/templates/tasks-template.md'
+    [Console]::Error.WriteLine("ERROR: Tasks template not found for repository root: $($paths.REPO_ROOT)`nTemplate resolution order: overrides -> presets -> extensions -> core.`nExpected shared/core template location: $expectedCoreTemplate`nTo continue, verify whether 'tasks-template.md' is available in '.specify/templates/overrides/', preset templates, extension templates, or restore the shared/core templates (for example by re-running 'specify init') so that '.specify/templates/tasks-template.md' exists.")
+    exit 1
+}
+$tasksTemplate = (Resolve-Path -LiteralPath $tasksTemplate).Path
+
+# Output results
+if ($Json) {
+    [PSCustomObject]@{
+        FEATURE_DIR    = $paths.FEATURE_DIR
+        AVAILABLE_DOCS = $docs
+        TASKS_TEMPLATE = $tasksTemplate
+    } | ConvertTo-Json -Compress
+} else {
+    Write-Output "FEATURE_DIR: $($paths.FEATURE_DIR)"
+    Write-Output "TASKS_TEMPLATE: $(if ($tasksTemplate) { $tasksTemplate } else { 'not found' })"
+    Write-Output "AVAILABLE_DOCS:"
+    Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Out-Null
+    Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Out-Null
+    Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Out-Null
+    Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Out-Null
+}

--- a/.specify/workflows/speckit/workflow.yml
+++ b/.specify/workflows/speckit/workflow.yml
@@ -1,0 +1,77 @@
+schema_version: "1.0"
+workflow:
+  id: "speckit"
+  name: "Full SDD Cycle"
+  version: "1.0.0"
+  author: "GitHub"
+  description: "Runs specify → plan → tasks → implement with review gates"
+
+requires:
+  # 0.8.5 is the first release with engine-side resolution of the
+  # ``integration: "auto"`` default. Older versions would treat "auto"
+  # as a literal integration key and fail at dispatch.
+  speckit_version: ">=0.8.5"
+  integrations:
+    # The four commands below (specify, plan, tasks, implement) are core
+    # spec-kit commands provided by every integration. The list here is an
+    # advisory, non-exhaustive compatibility hint following the documented
+    # ``any: [...]`` schema -- it is NOT a closed set. The workflow runs
+    # against any integration the project was initialized with, including
+    # ones not listed below, as long as that integration provides the four
+    # core commands referenced in ``steps``.
+    any:
+      - "claude"
+      - "copilot"
+      - "gemini"
+      - "opencode"
+
+inputs:
+  spec:
+    type: string
+    required: true
+    prompt: "Describe what you want to build"
+  integration:
+    type: string
+    default: "auto"
+    prompt: "Integration to use (e.g. claude, copilot, gemini; 'auto' uses the project's initialized integration)"
+  scope:
+    type: string
+    default: "full"
+    enum: ["full", "backend-only", "frontend-only"]
+
+steps:
+  - id: specify
+    command: speckit.specify
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-spec
+    type: gate
+    message: "Review the generated spec before planning."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: plan
+    command: speckit.plan
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-plan
+    type: gate
+    message: "Review the plan before generating tasks."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: tasks
+    command: speckit.tasks
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: implement
+    command: speckit.implement
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"

--- a/.specify/workflows/workflow-registry.json
+++ b/.specify/workflows/workflow-registry.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0",
+  "workflows": {
+    "speckit": {
+      "name": "Full SDD Cycle",
+      "version": "1.0.0",
+      "description": "Runs specify \u2192 plan \u2192 tasks \u2192 implement with review gates",
+      "source": "bundled",
+      "installed_at": "2026-05-29T14:21:40.011938+00:00",
+      "updated_at": "2026-05-29T14:21:40.011951+00:00"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Sequence step command names are now preserved across save/reopen cycles (`001-fix-sequence-step-names`)
+  - Reopening a saved sequence restores each step's selected command and user-visible label without reverting to "Select command".
+  - Execution-log detail entries now identify both the step label and the command name that ran, making logs operator-readable.
+  - When a referenced command is deleted after a sequence was saved, the affected step shows the last-saved command name as unresolved instead of appearing blank; other steps in the same sequence are unaffected.
+
 ### Added
 - Wait For Image primitive action (001-wait-for-image)
   - Added `WaitForImage` as an authorable step in both command and sequence flows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read the current plan
+<!-- SPECKIT END -->

--- a/docs/perf-checklist.md
+++ b/docs/perf-checklist.md
@@ -50,6 +50,16 @@ Reporting
 - Assessment:
 	- Both write and query p95 latencies are comfortably below the `< 200 ms` target.
 
+## Sequence Step Command Reference Performance Note (2026-05-29)
+
+- Feature: Preserve Sequence Step Command Names (`001-fix-sequence-step-names`)
+- Sequence load/save with `commandReference` enrichment adds a single `ICommandRepository.ListAsync` call per create/update/patch request (same overhead regardless of step count). This is O(n_commands) not O(n_steps).
+- Validation: Backend full suite `547 tests passed` in ~36s, indistinguishable from pre-fix baseline.
+- 50-step sequence estimate: step enrichment is O(50) dictionary lookups against the already-fetched command map — no measurable latency addition expected.
+- Execution-log enrichment (`commandNamesById`) issues one `GetAsync` per unique command referenced in the log, not per step entry.
+- No new persistence stores or network calls introduced. File-backed JSON serialization automatically includes `commandReference` fields.
+- Assessment: No regression risk on existing `< 200 ms` sequence API p95 budget or log-detail render targets.
+
 ## WaitForImage Runtime/Logging Evidence (2026-05-28)
 
 - Targeted runtime verification command:

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -188,6 +188,31 @@
 	- Security gate records explicit SAST/dependency and secret-scan results.
 	- Lint/format and static-analysis gates run as explicit blocking checks.
 
+## Sequence Step Command Name Preservation Validation (2026-05-29)
+
+- **Feature**: Preserve Sequence Step Command Names (`001-fix-sequence-step-names`)
+- **Backend full-suite verification**:
+  - Command: `dotnet test -c Debug --logger trx`
+  - Result: `547 passed, 0 failed` (61 contract, 294 unit, 192 integration).
+- **Web UI verification**:
+  - Command: `npm run test -- --no-coverage` (from `src/web-ui`).
+  - Result: `55 suites passed`, `204 tests passed`, `0 failed`.
+- **Lint verification**:
+  - ESLint on touched frontend files: `0 errors, 0 warnings` (fixed pre-existing `react-hooks/exhaustive-deps` warning in `SequencesPage.tsx`).
+  - `dotnet build -c Debug`: `0 errors, 0 warnings`.
+- **Security verification**:
+  - Auth token read from config/environment — no hardcoded secrets in touched files.
+  - Frontend: no credential strings in touched service/page files.
+- **Coverage (touched-area)**:
+  - New contract test: `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`
+  - New integration tests: `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`, `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`, `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`
+  - New unit test: `tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs`
+  - New web UI tests: `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`, `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
+- **User stories delivered**:
+  - US1: Sequences reopen with preserved per-step command selections and labels.
+  - US2: Execution-log detail entries include both step label and command name for command-backed steps.
+  - US3: Deleted/missing commands appear as unresolved with their last-saved name; valid steps remain intact on resave.
+
 ## WaitForImage Final Validation (2026-05-28)
 
 - **Backend full-suite verification**:

--- a/specs/001-fix-sequence-step-names/checklists/requirements.md
+++ b/specs/001-fix-sequence-step-names/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Preserve Sequence Step Command Names
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-29  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated on 2026-05-29 against the initial draft in [spec.md](../spec.md).
+- No clarification questions were required; reasonable defaults were documented in the assumptions section.

--- a/specs/001-fix-sequence-step-names/contracts/sequence-step-roundtrip.openapi.yaml
+++ b/specs/001-fix-sequence-step-names/contracts/sequence-step-roundtrip.openapi.yaml
@@ -1,0 +1,284 @@
+openapi: 3.0.3
+info:
+  title: Sequence Step Round-Trip Contract
+  version: 1.0.0
+  description: Contract fragment for sequence step persistence, authoring reload, and execution-log detail behavior.
+paths:
+  /api/sequences:
+    post:
+      summary: Create a sequence using per-step authoring payload.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SequenceUpsertRequest'
+      responses:
+        '201':
+          description: Sequence created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceResponse'
+  /api/sequences/{sequenceId}:
+    get:
+      summary: Load a saved sequence for authoring.
+      parameters:
+        - in: path
+          name: sequenceId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Sequence returned with persisted per-step details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceResponse'
+    put:
+      summary: Replace a saved sequence with per-step authoring payload.
+      parameters:
+        - in: path
+          name: sequenceId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SequenceUpsertRequest'
+      responses:
+        '200':
+          description: Sequence updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceResponse'
+        '409':
+          description: Optimistic concurrency conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceSaveConflict'
+    patch:
+      summary: Patch a saved sequence with per-step authoring payload.
+      parameters:
+        - in: path
+          name: sequenceId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SequenceUpsertRequest'
+      responses:
+        '200':
+          description: Sequence patched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceResponse'
+        '409':
+          description: Optimistic concurrency conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceSaveConflict'
+  /api/execution-logs/{executionId}:
+    get:
+      summary: Retrieve detailed execution log projection for a sequence run.
+      parameters:
+        - in: path
+          name: executionId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Execution log detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionLogDetail'
+components:
+  schemas:
+    SequenceUpsertRequest:
+      type: object
+      required:
+        - name
+        - version
+        - steps
+      properties:
+        name:
+          type: string
+        version:
+          type: integer
+        interStepDelayRangeMs:
+          type: object
+          nullable: true
+          properties:
+            min:
+              type: integer
+            max:
+              type: integer
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/SequenceLinearStep'
+    SequenceResponse:
+      type: object
+      required:
+        - id
+        - name
+        - version
+        - steps
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        version:
+          type: integer
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/SequenceLinearStep'
+    SequenceLinearStep:
+      type: object
+      required:
+        - stepId
+      properties:
+        stepId:
+          type: string
+        label:
+          type: string
+          nullable: true
+        stepType:
+          type: string
+          enum:
+            - Action
+            - Loop
+            - Break
+        primitiveAction:
+          $ref: '#/components/schemas/PrimitiveAction'
+        action:
+          $ref: '#/components/schemas/LegacyAction'
+        condition:
+          $ref: '#/components/schemas/SequenceCondition'
+        commandReference:
+          $ref: '#/components/schemas/CommandReferenceView'
+    PrimitiveAction:
+      type: object
+      required:
+        - type
+        - payload
+      properties:
+        type:
+          type: string
+        schemaVersion:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
+    LegacyAction:
+      type: object
+      required:
+        - type
+        - parameters
+      properties:
+        type:
+          type: string
+        parameters:
+          type: object
+          additionalProperties: true
+    SequenceCondition:
+      type: object
+      nullable: true
+      properties:
+        type:
+          type: string
+        negate:
+          type: boolean
+    CommandReferenceView:
+      type: object
+      nullable: true
+      properties:
+        commandId:
+          type: string
+        commandNameSnapshot:
+          type: string
+          nullable: true
+        resolutionStatus:
+          type: string
+          enum:
+            - resolved
+            - unresolved
+            - blank
+        unresolvedMessage:
+          type: string
+          nullable: true
+    SequenceSaveConflict:
+      type: object
+      required:
+        - sequenceId
+        - currentVersion
+        - message
+      properties:
+        sequenceId:
+          type: string
+        currentVersion:
+          type: integer
+        message:
+          type: string
+    ExecutionLogDetail:
+      type: object
+      required:
+        - executionId
+        - summary
+        - stepOutcomes
+      properties:
+        executionId:
+          type: string
+        summary:
+          type: string
+        stepOutcomes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExecutionLogStepOutcome'
+    ExecutionLogStepOutcome:
+      type: object
+      required:
+        - stepName
+        - status
+        - message
+      properties:
+        sequenceId:
+          type: string
+          nullable: true
+        sequenceLabel:
+          type: string
+          nullable: true
+        stepId:
+          type: string
+          nullable: true
+        stepLabel:
+          type: string
+          nullable: true
+        stepName:
+          type: string
+          description: Human-readable authoring step label used by the UI detail surface.
+        commandName:
+          type: string
+          nullable: true
+          description: Present for command-backed sequence steps and used in operator-facing messages.
+        status:
+          type: string
+        message:
+          type: string
+          description: Command-backed step messages include both the step label and command name.

--- a/specs/001-fix-sequence-step-names/data-model.md
+++ b/specs/001-fix-sequence-step-names/data-model.md
@@ -1,0 +1,93 @@
+# Data Model: Preserve Sequence Step Command Names
+
+## Entity: PersistedSequenceStep
+
+- Purpose: Canonical saved representation of a linear sequence step used by authoring round-trip and runtime execution.
+- Fields:
+  - `stepId` (string, required, immutable within a sequence)
+  - `label` (string, optional but preserved when supplied)
+  - `stepType` (enum: `Action`, `Loop`, `Break`; defaults to `Action`)
+  - `primitiveAction` (object, optional)
+  - `action` (object, optional for compatibility)
+  - `condition` (object, optional)
+  - `loop` (object, optional)
+  - `body` (`PersistedSequenceStep[]`, optional for loop steps)
+  - `breakCondition` (object, optional)
+- Validation rules:
+  - `stepId` values are unique within a sequence.
+  - Command-backed action steps preserve command reference fields across save and reload.
+  - Loop and break-only fields are omitted for non-matching step types.
+
+## Entity: CommandReference
+
+- Purpose: The executable command target associated with a sequence step.
+- Fields:
+  - `commandId` (string, required for command-backed steps)
+  - `commandNameSnapshot` (string, optional but persisted when known)
+- Validation rules:
+  - `commandId` is stable across save/load unless the user explicitly changes the step.
+  - `commandNameSnapshot` mirrors the selected command's display name at save time when the command exists.
+
+## Entity: UnresolvedCommandReference
+
+- Purpose: A saved command reference whose target command can no longer be resolved from the command repository.
+- Fields:
+  - `commandId` (string, required)
+  - `commandNameSnapshot` (string, optional)
+  - `resolutionStatus` (enum: `resolved`, `unresolved`; required)
+  - `displayState` (enum: `assigned`, `unresolved`, `blank`; required)
+- Validation rules:
+  - `displayState=unresolved` is used only when saved command data exists but live command lookup fails.
+  - `displayState=blank` is used only when no command was intentionally assigned.
+
+## Entity: SequenceAuthoringViewModel
+
+- Purpose: UI-facing projection of a saved step used to populate authoring controls.
+- Fields:
+  - `stepId` (string, required)
+  - `stepLabel` (string, required display identity)
+  - `selectedCommandId` (string, optional)
+  - `selectedCommandName` (string, optional)
+  - `commandResolutionStatus` (enum: `resolved`, `unresolved`, `blank`; required)
+  - `unresolvedMessage` (string, optional)
+- Validation rules:
+  - Resolved steps populate dropdown selection from `selectedCommandId`.
+  - Unresolved steps do not masquerade as blank and surface the snapshot name when present.
+
+## Entity: SequenceExecutionLogStep
+
+- Purpose: Human-readable step-level log representation derived from sequence execution.
+- Fields:
+  - `sequenceId` (string, required)
+  - `sequenceLabel` (string, required)
+  - `stepId` (string, required when known)
+  - `stepLabel` (string, required)
+  - `commandId` (string, optional)
+  - `commandName` (string, optional for command-backed steps)
+  - `stepType` (string, required)
+  - `status` (string, required)
+  - `message` (string, required)
+- Validation rules:
+  - Command-backed step messages include both `stepLabel` and `commandName`.
+  - Non-command steps continue using their existing specialized wording.
+
+## Terminology Note
+
+- `stepLabel` is the canonical authoring-facing display field across persistence, UI reload, and execution logs.
+- Any log-facing "step name" wording refers to this same authoring step label rather than a separate field.
+
+## State Transitions
+
+- Authoring command-reference state: `blank -> resolved -> unresolved -> resolved`
+  - `blank -> resolved`: user selects a command and saves.
+  - `resolved -> unresolved`: saved command id no longer resolves on reload.
+  - `unresolved -> resolved`: command becomes available again or user reassigns the step.
+- Execution-log message state: `step-only wording -> step-plus-command wording`
+  - Applies only to command-backed step log entries after the fix is implemented.
+
+## Relationships
+
+- `PersistedSequenceStep (1) -> (0..1) CommandReference`
+- `CommandReference (1) -> (0..1) UnresolvedCommandReference`
+- `PersistedSequenceStep (1) -> (1) SequenceAuthoringViewModel`
+- `PersistedSequenceStep (1) -> (0..1) SequenceExecutionLogStep`

--- a/specs/001-fix-sequence-step-names/plan.md
+++ b/specs/001-fix-sequence-step-names/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Preserve Sequence Step Command Names
+
+**Branch**: `001-fix-sequence-step-names` | **Date**: 2026-05-29 | **Spec**: `C:\src\GameBot\specs\001-fix-sequence-step-names\spec.md`
+**Input**: Feature specification from `C:\src\GameBot\specs\001-fix-sequence-step-names\spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Repair sequence step round-tripping so saved sequences preserve each step's command association and human-readable identity across backend persistence, authoring UI reload, and execution-log rendering. The design standardizes on the existing per-step sequence payload, adds command-name snapshot support for unresolved references, and enriches sequence execution logs with both the step label and command name.
+
+## Technical Context
+
+**Language/Version**: Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18  
+**Primary Dependencies**: ASP.NET Core Minimal API, existing `GameBot.Domain` sequence repository and runner, existing execution-log service, React/Vite authoring UI, existing command repository contracts  
+**Storage**: File-backed JSON under `data/commands/sequences`, `data/commands`, and `data/execution-logs`  
+**Testing**: `dotnet build -c Debug`; `dotnet test -c Debug --logger trx`; existing contract, integration, unit, and web UI Jest suites for sequence authoring and execution logs  
+**Target Platform**: Windows-hosted backend service and desktop browser authoring UI  
+**Project Type**: Web app (backend + frontend in one repository)  
+**Performance Goals**: No observable regression for sequence create/load/save or execution-log detail rendering; local validation keeps sequence authoring and log-detail operations within existing interactive expectations for sequences up to 50 steps  
+**Constraints**: Preserve backward compatibility for valid saved per-step sequences, distinguish unresolved command references from intentionally blank steps, keep execution-log wording aligned with authoring labels, and avoid introducing new persistence stores or packages  
+**Scale/Scope**: One bug-fix slice spanning sequence API contract handling, file-backed sequence persistence shape, authoring UI mapping, execution-log detail shaping, and targeted regression tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+### Pre-Design Gate Review
+
+- **Code Quality Discipline**: PASS
+  - Scope is limited to existing backend/domain/frontend surfaces already responsible for sequence serialization and execution-log detail projection.
+  - No new projects, frameworks, or persistence technologies are introduced.
+- **Testing Standards**: PASS
+  - Existing regression suites already cover per-step sequence round-trips and execution-log projections; the plan adds bug-specific contract/integration/UI coverage for the missing step-command association and log naming behavior.
+  - Build and tests were executed successfully on 2026-05-29 after clearing an environment process lock.
+- **User Experience Consistency**: PASS
+  - The design preserves current authoring routes and deep links while replacing ambiguous blank states with explicit unresolved states.
+  - Execution logs become more readable without changing the overall execution-log information architecture.
+- **Performance Requirements**: PASS
+  - This is a bounded bug fix with no new hot path; quickstart validation includes a regression check for sequence load/save and log detail rendering on realistic step counts.
+
+### Post-Design Gate Review
+
+- **Code Quality Discipline**: PASS (design keeps serialization, UI mapping, and log enrichment isolated to their owning modules).
+- **Testing Standards**: PASS (research, data model, and contracts identify the exact regression checks required before implementation is complete).
+- **User Experience Consistency**: PASS (design explicitly defines unresolved-reference UI behavior and log wording alignment).
+- **Performance Requirements**: PASS (no new dependency or storage cost is introduced; validation remains focused on existing interactive paths).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-fix-sequence-step-names/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── sequence-step-roundtrip.openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   └── Commands/              # Sequence models and file repository persistence
+├── GameBot.Service/
+│   ├── Program.cs             # Sequence endpoints and execution entrypoints
+│   ├── Endpoints/             # Execution log response shaping
+│   └── Services/ExecutionLog/ # Sequence execution detail projection
+└── web-ui/
+    └── src/
+        ├── pages/             # Sequence authoring UI
+        ├── services/          # Sequence and execution-log DTOs
+        ├── lib/               # Sequence mapping helpers
+        └── types/             # Sequence per-step request/response types
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+```
+
+**Structure Decision**: Keep the fix within existing domain, service, web UI, and test projects. The behavior is controlled by existing sequence and execution-log abstractions, so no structural expansion is required.
+
+## Phase 0: Research Plan
+
+- Confirm the canonical persisted sequence-step shape for authoring round-trips and reject reliance on legacy `string[]` step serialization for this workflow.
+- Define how unresolved command references preserve user-visible identity without inventing replacement commands.
+- Define the minimum execution-log context required to correlate a sequence step with the selected command in the authoring UI.
+- Define the regression-test strategy across API, persistence, UI reload, and execution-log detail projection.
+
+## Phase 1: Design Plan
+
+- Produce `data-model.md` for persisted sequence steps, command reference snapshots, unresolved reference presentation, and enriched execution-log outcomes.
+- Produce `contracts/sequence-step-roundtrip.openapi.yaml` for sequence create/get/update and execution-log detail behavior relevant to this bug fix.
+- Produce `quickstart.md` covering reproduction, verification, unresolved-reference validation, and regression test execution.
+- Update Copilot agent context via `.specify/scripts/powershell/update-agent-context.ps1 -AgentType copilot`.
+
+## Phase 2: Task Planning Approach (for `/speckit.tasks`)
+
+- Split implementation into small vertical slices:
+  1. Backend sequence contract and persistence alignment for per-step command references and snapshots.
+  2. Frontend authoring load/save mapping and unresolved-reference display behavior.
+  3. Sequence execution-log enrichment with step label + command name context.
+  4. Regression tests across contract, integration, unit, and UI layers.
+- Include explicit constitution gate tasks:
+  - Re-run build and all tests.
+  - Verify touched-area coverage stays at or above repository baseline expectations.
+
+## Complexity Tracking
+
+No constitution violations identified; no complexity exemptions required.

--- a/specs/001-fix-sequence-step-names/quickstart.md
+++ b/specs/001-fix-sequence-step-names/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Preserve Sequence Step Command Names
+
+## Preconditions
+
+- Work from `C:\src\GameBot` on branch `001-fix-sequence-step-names`.
+- Ensure no `GameBot.Service` process is holding build outputs before validation.
+- Use the existing command and sequence authoring UI plus execution-log detail page.
+
+## 1. Reproduce the original bug
+
+1. Start the backend and web UI.
+2. Create at least two commands with distinct names.
+3. Create a sequence with multiple command-backed steps using those commands.
+4. Save the sequence, reopen it, and confirm the pre-fix behavior if still present:
+   - command dropdowns revert to `Select command`
+   - step identity is no longer obvious from the saved state
+   - execution logs do not identify the selected command clearly
+
+## 2. Validate sequence authoring round-trip after the fix
+
+1. Create or edit a sequence with at least three steps.
+2. Save the sequence.
+3. Reload the editor for that sequence.
+4. Confirm each step retains:
+   - the same `stepId`
+   - the same selected command
+   - the same user-visible label where applicable
+5. Save again without changes and confirm no command reassignment occurs.
+
+## 3. Validate unresolved command behavior
+
+1. Save a sequence with a command-backed step.
+2. Delete or otherwise make the referenced command unavailable.
+3. Reopen the sequence.
+4. Confirm the affected step:
+   - appears as unresolved rather than blank
+   - shows the last saved command name when available
+   - remains editable without corrupting other steps
+
+## 4. Validate execution-log wording
+
+1. Execute a sequence containing command-backed steps with recognizable step labels and command names.
+2. Open the related execution-log detail view.
+3. Confirm each command-backed step message includes both:
+   - the step label
+   - the command name
+4. Confirm deep links still point to the correct sequence step when the step exists.
+
+## 5. Run required validation commands
+
+```powershell
+dotnet build -c Debug
+dotnet test -c Debug --logger trx
+```
+
+If tests fail, run:
+
+```powershell
+.\scripts\analyze-test-results.ps1
+```
+
+## 6. Targeted regression areas
+
+- Contract tests for sequence create/get/update with per-step payloads
+- Integration tests for saved step metadata round-trips
+- Unit or integration tests for execution-log detail projection
+- Web UI tests for reopening saved sequences and rendering unresolved command states

--- a/specs/001-fix-sequence-step-names/quickstart.md
+++ b/specs/001-fix-sequence-step-names/quickstart.md
@@ -61,7 +61,22 @@ If tests fail, run:
 
 ## 6. Targeted regression areas
 
-- Contract tests for sequence create/get/update with per-step payloads
-- Integration tests for saved step metadata round-trips
-- Unit or integration tests for execution-log detail projection
-- Web UI tests for reopening saved sequences and rendering unresolved command states
+- Contract tests for sequence create/get/update with per-step payloads: `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`
+- Integration tests for saved step metadata round-trips: `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`
+- Integration tests for deleted-command unresolved state: `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`
+- Integration and unit tests for execution-log detail projection: `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`, `tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs`
+- Web UI tests for reopening saved sequences: `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`
+- Web UI tests for unresolved command display: `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
+
+## 7. Verifying unresolved command behavior (automated)
+
+Run the dedicated integration regression:
+
+```powershell
+dotnet test tests/integration/GameBot.IntegrationTests.csproj -c Debug --filter "SequenceMissingCommandReference"
+```
+
+Expected result: 1 test passes, confirming that:
+- A sequence saved with a command reference preserves the command name snapshot even after the command is deleted.
+- The GET response returns `commandReference.isResolved = false` with the original `commandName`.
+- A PATCH that round-trips the unresolved reference keeps the snapshot intact on reload.

--- a/specs/001-fix-sequence-step-names/research.md
+++ b/specs/001-fix-sequence-step-names/research.md
@@ -1,0 +1,41 @@
+# Research: Preserve Sequence Step Command Names
+
+## Decision 1: Canonical authoring round-trip shape
+
+- Decision: Treat the per-step object array (`SequenceLinearStep[]`) as the canonical authoring payload for create/get/update flows, and keep legacy `string[]` handling only as compatibility fallback for older callers.
+- Rationale: The existing frontend already saves and loads rich step objects with `stepId`, `label`, and primitive/action payloads; reducing them to command-id strings drops the data required to reopen steps accurately.
+- Alternatives considered:
+  - Continue normalizing authoring saves to `string[]` command ids (rejected: loses step identity and non-command step metadata).
+  - Remove all legacy support immediately (rejected: unnecessary risk to older stored content or auxiliary callers).
+
+## Decision 2: Persist user-visible command identity with the step
+
+- Decision: Persist a command-name snapshot alongside the step's command reference when the step targets a command.
+- Rationale: The UI cannot show a meaningful unresolved state for deleted or missing commands if it only stores the command id.
+- Alternatives considered:
+  - Resolve command names live only from the command repository (rejected: deleted commands would still appear blank or unknown).
+  - Reuse the step label as the command name source (rejected: step labels and command names serve different purposes and can diverge).
+
+## Decision 3: Unresolved command-reference UX
+
+- Decision: When a saved command id no longer resolves, keep the step intact and expose an explicit unresolved state with the last saved command name when available.
+- Rationale: This matches the clarified spec, distinguishes broken references from intentionally blank steps, and avoids destructive data loss.
+- Alternatives considered:
+  - Show the normal empty `Select command` state (rejected: misleading because it hides that data was previously assigned).
+  - Auto-clear the command reference on load (rejected: corrupts historical authoring data).
+
+## Decision 4: Execution-log step wording
+
+- Decision: Sequence execution-log step entries include both the step label and the selected command name for command-backed steps.
+- Rationale: Operators need a stable authoring-facing step identity and the human-recognizable command that actually ran.
+- Alternatives considered:
+  - Log only the step label (rejected: still ambiguous when step labels are generic or generated).
+  - Log command id instead of command name (rejected: less readable for operators and unnecessary for the clarified requirement).
+
+## Decision 5: Test strategy for the bug fix
+
+- Decision: Cover the fix with one contract/integration round-trip assertion for saved step metadata, one frontend reload assertion for selected command restoration and unresolved state, and one execution-log projection/integration assertion for step label plus command name.
+- Rationale: The bug spans serialization, UI mapping, and log projection; one layer alone cannot prove the behavior end-to-end.
+- Alternatives considered:
+  - UI-only regression coverage (rejected: would miss backend persistence shape regressions).
+  - API-only regression coverage (rejected: would not prove the user-facing editor state or execution-log display wording).

--- a/specs/001-fix-sequence-step-names/spec.md
+++ b/specs/001-fix-sequence-step-names/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Preserve Sequence Step Command Names
+
+**Feature Branch**: `001-fix-sequence-step-names`  
+**Created**: 2026-05-29  
+**Status**: Draft  
+**Input**: User description: "There's a bug (or two - I don't know) I want you to fix. When creating the steps of a sequence, their names appear properly in the UI. However when the sequence is saved and reopened, the step names disappear, the step names are also missing from the execution logs, they appear like \"command: executed — Step 'body-step-2' executed.\" so I don't know which command was that and I cannot even check it in the UI, as UI is showing steps, however all of them show the drop down box with \"Select command\" in them. Can you fix this?"
+
+## Clarifications
+
+### Session 2026-05-29
+
+- Q: What execution log context should be shown for each sequence step run? → A: Log the authoring step label and command name.
+- Q: How should the editor represent a saved step whose command can no longer be resolved? → A: Show an unresolved state with the last saved command name when available.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reopen a Sequence Without Losing Step Identity (Priority: P1)
+
+As a sequence author, I can save a sequence and reopen it later without losing the command selected for each step, so I can continue editing with confidence.
+
+**Why this priority**: Losing the selected command after save makes saved sequences unreliable and prevents further editing.
+
+**Independent Test**: Create a sequence with multiple named steps that reference different commands, save it, reopen it, and confirm each step still shows the correct command selection and label.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence author has assigned commands to sequence steps, **When** the sequence is saved and reopened, **Then** each step shows the same command selection that was saved.
+2. **Given** a saved sequence contains multiple steps with different commands, **When** the author returns to the sequence editor, **Then** no step reverts to an empty "Select command" state unless that step was intentionally left unassigned.
+
+---
+
+### User Story 2 - Identify Executed Commands in Logs (Priority: P2)
+
+As an operator reviewing execution history, I can tell which command each sequence step ran, so I can understand what happened without cross-referencing internal step identifiers.
+
+**Why this priority**: Execution logs are part of troubleshooting and auditability; internal step identifiers alone do not provide enough context.
+
+**Independent Test**: Execute a sequence with named steps and inspect the resulting execution log entries to confirm they include the user-recognizable command identity for each executed step.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence step runs a selected command, **When** the execution is logged, **Then** the log entry includes both the step label and the command name so an operator can match it to the authoring UI.
+2. **Given** a sequence contains repeated or similar step labels, **When** execution logs are reviewed, **Then** each logged step still includes the command name needed to distinguish what was executed.
+
+---
+
+### User Story 3 - Preserve Existing Sequences During Repair (Priority: P3)
+
+As a user with previously saved sequences, I can reopen existing sequences without data loss or unexpected reassignment, so the fix does not force me to rebuild working automations.
+
+**Why this priority**: A fix that only helps newly created sequences would leave existing saved content broken and reduce trust in the editor.
+
+**Independent Test**: Open a sequence saved before the fix, verify the editor shows any recoverable command associations correctly, and verify sequences with already-valid step associations remain unchanged after save.
+
+**Acceptance Scenarios**:
+
+1. **Given** a previously saved sequence already contains valid step-to-command associations, **When** it is opened and saved again, **Then** those associations remain intact.
+2. **Given** a previously saved sequence has missing or unresolved step associations, **When** it is opened, **Then** the system preserves remaining valid data and shows an unresolved state that includes the last saved command name when available without corrupting other steps.
+
+### Edge Cases
+
+- What happens when a saved step references a command that has since been deleted or is no longer available? The editor must preserve the step record and show an unresolved state with the last saved command name when available.
+- How does the system handle multiple steps that point to the same command? Each step must retain its own identity while still showing the shared command correctly.
+- What happens when a sequence is saved with a mix of assigned and intentionally unassigned steps? Only intentionally unassigned steps may appear empty when reopened.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST persist the command association for each sequence step so the same association is available when the sequence is reopened.
+- **FR-002**: The sequence editor MUST display the saved command selection for each step when loading an existing sequence.
+- **FR-003**: The system MUST preserve each step's user-visible name independently from the command associated with that step.
+- **FR-004**: The system MUST distinguish between a step that was intentionally left without a command and a step whose saved command association failed to load.
+- **FR-004a**: When a saved command association cannot be resolved, the sequence editor MUST show an unresolved state rather than the same empty state used for an intentionally unassigned step.
+- **FR-004b**: When available from saved data, the unresolved state MUST include the last saved command name.
+- **FR-005**: The system MUST include both the sequence step label and the selected command name in step execution logs.
+- **FR-006**: The system MUST keep execution log wording consistent with the command selection shown in the sequence editor for the same step.
+- **FR-007**: The system MUST preserve valid step-to-command associations when loading and re-saving sequences created before this fix.
+- **FR-008**: The system MUST avoid reassigning a step to a different command unless the user explicitly changes that step in the editor.
+
+### Key Entities *(include if feature involves data)*
+
+- **Sequence Step**: A saved step within a sequence, including its own identity, display name, ordering, and associated command reference.
+- **Command Reference**: The saved link from a sequence step to a command that should appear in the editor and be used during execution.
+- **Unresolved Command Reference**: A saved step-to-command association whose target command cannot currently be loaded, but whose last known command name may still be shown to the user.
+- **Execution Log Entry**: A human-readable record of step execution that includes the step label and command name a user recognizes in authoring.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In validation of saved sequences containing assigned steps, 100% of step-command selections remain visible after save and reopen.
+- **SC-002**: In execution log review for validated sequence runs, 100% of step-executed entries include both the step label and the user-recognizable command name instead of only an internal step identifier.
+- **SC-003**: Users can reopen and verify the command mapping of a five-step sequence in under 30 seconds without guessing which step maps to which command.
+- **SC-004**: Previously valid saved sequences continue to reopen without losing any existing step-command associations during regression validation.
+- **SC-005**: In validation of sequences with deleted or missing commands, 100% of unresolved steps are shown as unresolved rather than as intentionally blank, and include the last saved command name when that data exists.
+
+## Assumptions
+
+- Sequence steps already have a distinct saved identity and order separate from the command they invoke.
+- Command names shown in the authoring UI are the same names users expect to see reflected in execution history.
+- Existing sequences with truly missing command references should remain editable, but the fix should not invent replacements for data that no longer exists.

--- a/specs/001-fix-sequence-step-names/tasks.md
+++ b/specs/001-fix-sequence-step-names/tasks.md
@@ -17,7 +17,7 @@
 
 **Purpose**: Establish the baseline reproduction and validation flow before code changes
 
-- [ ] T001 Run the baseline validation and reproduction steps documented in `specs/001-fix-sequence-step-names/quickstart.md`
+- [X] T001 Run the baseline validation and reproduction steps documented in `specs/001-fix-sequence-step-names/quickstart.md`
 - [X] T002 [P] Reproduce the saved-step and execution-log regressions from `specs/001-fix-sequence-step-names/quickstart.md` against `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/pages/ExecutionLogs.tsx`
 
 ---
@@ -112,13 +112,13 @@
 
 **Purpose**: Final verification, cleanup, and documentation touches across stories
 
-- [ ] T024 [P] Update verification guidance and unresolved-command checks in `specs/001-fix-sequence-step-names/quickstart.md`
-- [ ] T025 Run `dotnet build -c Debug` and `dotnet test -c Debug --logger trx` using `specs/001-fix-sequence-step-names/quickstart.md`, then run `scripts/analyze-test-results.ps1` if failures occur
-- [ ] T026 Verify touched-area regression coverage across `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`, `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`, `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`, `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`, `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`, and `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
-- [ ] T027 [P] Run lint and static analysis for touched backend and frontend files including `src/GameBot.Service/Program.cs`, `src/GameBot.Domain/Commands/SequenceStep.cs`, `src/GameBot.Domain/Commands/FileSequenceRepository.cs`, `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs`, and `src/web-ui/src/pages/SequencesPage.tsx`
-- [ ] T028 [P] Run security and secret-scan verification for touched files including `src/GameBot.Service/Program.cs`, `src/GameBot.Domain/Commands/FileSequenceRepository.cs`, `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs`, and `src/web-ui/src/pages/SequencesPage.tsx`, then record the result in implementation notes or PR evidence
-- [ ] T029 [P] Validate sequence load/save and execution-log detail responsiveness for a 50-step sequence using `specs/001-fix-sequence-step-names/quickstart.md`, then record a perf note in `docs/perf-checklist.md`
-- [ ] T030 [P] Add a user-visible fix note to `CHANGELOG.md` and update affected validation guidance in `docs/validation.md`
+- [X] T024 [P] Update verification guidance and unresolved-command checks in `specs/001-fix-sequence-step-names/quickstart.md`
+- [X] T025 Run `dotnet build -c Debug` and `dotnet test -c Debug --logger trx` using `specs/001-fix-sequence-step-names/quickstart.md`, then run `scripts/analyze-test-results.ps1` if failures occur
+- [X] T026 Verify touched-area regression coverage across `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`, `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`, `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`, `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`, `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`, and `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
+- [X] T027 [P] Run lint and static analysis for touched backend and frontend files including `src/GameBot.Service/Program.cs`, `src/GameBot.Domain/Commands/SequenceStep.cs`, `src/GameBot.Domain/Commands/FileSequenceRepository.cs`, `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs`, and `src/web-ui/src/pages/SequencesPage.tsx`
+- [X] T028 [P] Run security and secret-scan verification for touched files including `src/GameBot.Service/Program.cs`, `src/GameBot.Domain/Commands/FileSequenceRepository.cs`, `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs`, and `src/web-ui/src/pages/SequencesPage.tsx`, then record the result in implementation notes or PR evidence
+- [X] T029 [P] Validate sequence load/save and execution-log detail responsiveness for a 50-step sequence using `specs/001-fix-sequence-step-names/quickstart.md`, then record a perf note in `docs/perf-checklist.md`
+- [X] T030 [P] Add a user-visible fix note to `CHANGELOG.md` and update affected validation guidance in `docs/validation.md`
 
 ---
 

--- a/specs/001-fix-sequence-step-names/tasks.md
+++ b/specs/001-fix-sequence-step-names/tasks.md
@@ -1,0 +1,218 @@
+# Tasks: Preserve Sequence Step Command Names
+
+**Input**: Design documents from `/specs/001-fix-sequence-step-names/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Bug-fix regression tests are required by the constitution and are included for each affected user story.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this belongs to (`[US1]`, `[US2]`, `[US3]`)
+- Include exact file paths in each task description
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the baseline reproduction and validation flow before code changes
+
+- [ ] T001 Run the baseline validation and reproduction steps documented in `specs/001-fix-sequence-step-names/quickstart.md`
+- [ ] T002 [P] Reproduce the saved-step and execution-log regressions from `specs/001-fix-sequence-step-names/quickstart.md` against `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/pages/ExecutionLogs.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared sequence-step contract and mapping work required before user story implementation
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Extend the shared sequence step model with command-name snapshot and unresolved-reference support in `src/GameBot.Domain/Commands/SequenceStep.cs`
+- [ ] T004 Persist and reload the new sequence-step command reference fields safely in `src/GameBot.Domain/Commands/FileSequenceRepository.cs`
+- [ ] T005 [P] Align frontend sequence DTOs with the command reference view contract in `src/web-ui/src/types/sequenceFlow.ts` and `src/web-ui/src/services/sequences.ts`
+- [ ] T006 [P] Centralize command reference extraction and fallback mapping in `src/web-ui/src/lib/sequenceMapping.ts`
+
+**Checkpoint**: Shared sequence-step contract and mapping are ready for story-specific work
+
+---
+
+## Phase 3: User Story 1 - Reopen a Sequence Without Losing Step Identity (Priority: P1) 🎯 MVP
+
+**Goal**: Save and reopen sequences without losing each step's selected command or user-visible label
+
+**Independent Test**: Create a multi-step sequence with different command selections, save it, reopen it, and confirm each step still shows the original command and step identity.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T007 [P] [US1] Add a contract regression for per-step command round-tripping in `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`
+- [ ] T008 [P] [US1] Add an integration regression for saved step metadata round-tripping in `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`
+- [ ] T009 [P] [US1] Add a web UI regression for reopening saved sequences with preserved command selections in `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`
+- [ ] T010 [P] [US1] Add an explicit unchanged-resave regression in `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs` that saves, reloads, re-saves unchanged steps, and asserts no step is reassigned to a different command
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Preserve canonical per-step object payloads for sequence create/update/patch in `src/GameBot.Service/Program.cs`
+- [ ] T012 [US1] Populate saved `commandReference` response data for command-backed steps in `src/GameBot.Service/Program.cs`
+- [ ] T013 [US1] Restore saved command selections and step labels on editor load in `src/web-ui/src/pages/SequencesPage.tsx`
+
+**Checkpoint**: User Story 1 is functional when saved sequences reopen with the same step-to-command mappings the author selected
+
+---
+
+## Phase 4: User Story 2 - Identify Executed Commands in Logs (Priority: P2)
+
+**Goal**: Make execution logs identify both the sequence step and the command that actually ran
+
+**Independent Test**: Execute a sequence with labeled steps and confirm the execution-log detail view includes both the step label and command name for each command-backed step.
+
+### Tests for User Story 2 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T014 [P] [US2] Add an execution-log integration regression for step label plus command name in `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`
+- [ ] T015 [P] [US2] Add an execution-log projection unit regression in `tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Enrich sequence execution detail items with command names in `src/GameBot.Service/Program.cs`
+- [ ] T017 [US2] Project command-aware sequence step details through execution-log responses in `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` and `src/GameBot.Service/Models/ExecutionLogs.cs`
+- [ ] T018 [US2] Align execution-log client types and rendering with command-aware step messages in `src/web-ui/src/services/executionLogsApi.ts` and `src/web-ui/src/pages/ExecutionLogs.tsx`
+
+**Checkpoint**: User Story 2 is functional when sequence execution logs identify both the step and the executed command without relying on internal step ids alone
+
+---
+
+## Phase 5: User Story 3 - Preserve Existing Sequences During Repair (Priority: P3)
+
+**Goal**: Keep existing valid sequences intact while showing deleted or missing commands as unresolved instead of blank
+
+**Independent Test**: Reopen a previously saved sequence after removing one referenced command and confirm valid steps remain intact while the missing command appears as unresolved with its last saved name.
+
+### Tests for User Story 3 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T019 [P] [US3] Add an integration regression for deleted-command unresolved states in `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`
+- [ ] T020 [P] [US3] Add a web UI regression for unresolved saved command display in `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
+
+### Implementation for User Story 3
+
+- [ ] T021 [US3] Return unresolved command-reference metadata when saved command ids no longer resolve in `src/GameBot.Service/Program.cs`
+- [ ] T022 [US3] Render unresolved saved commands with snapshot names in `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/components/SearchableDropdown.tsx`
+- [ ] T023 [US3] Preserve valid assignments and unresolved snapshots during sequence resaves in `src/GameBot.Domain/Commands/FileSequenceRepository.cs` and `src/GameBot.Service/Program.cs`
+
+**Checkpoint**: User Story 3 is functional when existing sequences remain editable and missing commands are shown as unresolved instead of silently cleared
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, cleanup, and documentation touches across stories
+
+- [ ] T024 [P] Update verification guidance and unresolved-command checks in `specs/001-fix-sequence-step-names/quickstart.md`
+- [ ] T025 Run `dotnet build -c Debug` and `dotnet test -c Debug --logger trx` using `specs/001-fix-sequence-step-names/quickstart.md`, then run `scripts/analyze-test-results.ps1` if failures occur
+- [ ] T026 Verify touched-area regression coverage across `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`, `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`, `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`, `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`, `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`, and `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
+- [ ] T027 [P] Run lint and static analysis for touched backend and frontend files including `src/GameBot.Service/Program.cs`, `src/GameBot.Domain/Commands/SequenceStep.cs`, `src/GameBot.Domain/Commands/FileSequenceRepository.cs`, `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs`, and `src/web-ui/src/pages/SequencesPage.tsx`
+- [ ] T028 [P] Run security and secret-scan verification for touched files including `src/GameBot.Service/Program.cs`, `src/GameBot.Domain/Commands/FileSequenceRepository.cs`, `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs`, and `src/web-ui/src/pages/SequencesPage.tsx`, then record the result in implementation notes or PR evidence
+- [ ] T029 [P] Validate sequence load/save and execution-log detail responsiveness for a 50-step sequence using `specs/001-fix-sequence-step-names/quickstart.md`, then record a perf note in `docs/perf-checklist.md`
+- [ ] T030 [P] Add a user-visible fix note to `CHANGELOG.md` and update affected validation guidance in `docs/validation.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; establishes the failing behavior and validation flow.
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories by defining the shared sequence-step contract and mapping.
+- **User Story 1 (Phase 3)**: Depends on Foundational completion.
+- **User Story 2 (Phase 4)**: Depends on Foundational completion.
+- **User Story 3 (Phase 5)**: Depends on Foundational completion.
+- **Polish (Phase 6)**: Depends on the user stories selected for delivery.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No hard dependency on other stories after Foundational.
+- **User Story 2 (P2)**: No hard dependency on User Story 1 after Foundational, but shares the same canonical per-step model.
+- **User Story 3 (P3)**: No hard dependency on User Story 1 after Foundational, but reuses the same command snapshot and mapping surfaces.
+
+### Within Each User Story
+
+- Regression tests MUST be written and observed failing before implementation.
+- Backend contract and persistence changes come before frontend rendering changes.
+- Story validation should be rerun before moving to the next priority slice.
+- No bug-fix story is complete until unchanged step-command mappings are explicitly verified on resave.
+
+### Parallel Opportunities
+
+- T005 and T006 can run in parallel once T003-T004 define the shared model shape.
+- T007, T008, T009, and T010 can run in parallel within User Story 1.
+- T014 and T015 can run in parallel within User Story 2.
+- T019 and T020 can run in parallel within User Story 3.
+- User Stories 2 and 3 can be staffed in parallel after Foundational, though implementation should still validate each story independently.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task T007: Add a contract regression for per-step command round-tripping in tests/contract/Sequences/SequencePerStepConditionsContractTests.cs
+Task T008: Add an integration regression for saved step metadata round-tripping in tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs
+Task T009: Add a web UI regression for reopening saved sequences with preserved command selections in src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
+Task T010: Add an explicit unchanged-resave regression in tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs that asserts no step is reassigned to a different command
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```text
+Task T014: Add an execution-log integration regression for step label plus command name in tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
+Task T015: Add an execution-log projection unit regression in tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```text
+Task T019: Add an integration regression for deleted-command unresolved states in tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs
+Task T020: Add a web UI regression for unresolved saved command display in src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Stop and validate that saved sequences reopen with preserved command selections and labels.
+
+### Incremental Delivery
+
+1. Finish Setup and Foundational to lock the shared sequence-step contract.
+2. Deliver User Story 1 as the MVP bug fix for save/reopen behavior.
+3. Add User Story 2 to make execution logs operator-readable.
+4. Add User Story 3 to preserve existing sequences and unresolved references safely.
+5. Finish with Phase 6 validation and cleanup.
+
+### Parallel Team Strategy
+
+1. One developer completes Foundational backend/domain contract work.
+2. After Foundational, one developer can take User Story 1 while another handles User Story 2 test scaffolding.
+3. User Story 3 can proceed in parallel once the shared contract is stable and the team can validate unresolved-reference UX independently.
+
+---
+
+## Notes
+
+- `[P]` tasks indicate different files and no incomplete dependency on the same slice.
+- Each user story remains independently testable after Foundational is complete.
+- Keep the legacy `string[]` sequence-step path as compatibility fallback only; do not let it overwrite canonical per-step authoring data.
+- Re-run the full validation commands after each story slice that changes backend persistence or execution-log projection.

--- a/specs/001-fix-sequence-step-names/tasks.md
+++ b/specs/001-fix-sequence-step-names/tasks.md
@@ -28,10 +28,10 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T003 Extend the shared sequence step model with command-name snapshot and unresolved-reference support in `src/GameBot.Domain/Commands/SequenceStep.cs`
-- [ ] T004 Persist and reload the new sequence-step command reference fields safely in `src/GameBot.Domain/Commands/FileSequenceRepository.cs`
-- [ ] T005 [P] Align frontend sequence DTOs with the command reference view contract in `src/web-ui/src/types/sequenceFlow.ts` and `src/web-ui/src/services/sequences.ts`
-- [ ] T006 [P] Centralize command reference extraction and fallback mapping in `src/web-ui/src/lib/sequenceMapping.ts`
+- [X] T003 Extend the shared sequence step model with command-name snapshot and unresolved-reference support in `src/GameBot.Domain/Commands/SequenceStep.cs`
+- [X] T004 Persist and reload the new sequence-step command reference fields safely in `src/GameBot.Domain/Commands/FileSequenceRepository.cs`
+- [X] T005 [P] Align frontend sequence DTOs with the command reference view contract in `src/web-ui/src/types/sequenceFlow.ts` and `src/web-ui/src/services/sequences.ts`
+- [X] T006 [P] Centralize command reference extraction and fallback mapping in `src/web-ui/src/lib/sequenceMapping.ts`
 
 **Checkpoint**: Shared sequence-step contract and mapping are ready for story-specific work
 
@@ -54,8 +54,8 @@
 
 ### Implementation for User Story 1
 
-- [ ] T011 [US1] Preserve canonical per-step object payloads for sequence create/update/patch in `src/GameBot.Service/Program.cs`
-- [ ] T012 [US1] Populate saved `commandReference` response data for command-backed steps in `src/GameBot.Service/Program.cs`
+- [X] T011 [US1] Preserve canonical per-step object payloads for sequence create/update/patch in `src/GameBot.Service/Program.cs`
+- [X] T012 [US1] Populate saved `commandReference` response data for command-backed steps in `src/GameBot.Service/Program.cs`
 - [X] T013 [US1] Restore saved command selections and step labels on editor load in `src/web-ui/src/pages/SequencesPage.tsx`
 
 **Checkpoint**: User Story 1 is functional when saved sequences reopen with the same step-to-command mappings the author selected
@@ -95,14 +95,14 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T019 [P] [US3] Add an integration regression for deleted-command unresolved states in `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`
-- [ ] T020 [P] [US3] Add a web UI regression for unresolved saved command display in `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
+- [X] T019 [P] [US3] Add an integration regression for deleted-command unresolved states in `tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs`
+- [X] T020 [P] [US3] Add a web UI regression for unresolved saved command display in `src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx`
 
 ### Implementation for User Story 3
 
-- [ ] T021 [US3] Return unresolved command-reference metadata when saved command ids no longer resolve in `src/GameBot.Service/Program.cs`
-- [ ] T022 [US3] Render unresolved saved commands with snapshot names in `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/components/SearchableDropdown.tsx`
-- [ ] T023 [US3] Preserve valid assignments and unresolved snapshots during sequence resaves in `src/GameBot.Domain/Commands/FileSequenceRepository.cs` and `src/GameBot.Service/Program.cs`
+- [X] T021 [US3] Return unresolved command-reference metadata when saved command ids no longer resolve in `src/GameBot.Service/Program.cs`
+- [X] T022 [US3] Render unresolved saved commands with snapshot names in `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/components/SearchableDropdown.tsx`
+- [X] T023 [US3] Preserve valid assignments and unresolved snapshots during sequence resaves in `src/GameBot.Domain/Commands/FileSequenceRepository.cs` and `src/GameBot.Service/Program.cs`
 
 **Checkpoint**: User Story 3 is functional when existing sequences remain editable and missing commands are shown as unresolved instead of silently cleared
 

--- a/specs/001-fix-sequence-step-names/tasks.md
+++ b/specs/001-fix-sequence-step-names/tasks.md
@@ -18,7 +18,7 @@
 **Purpose**: Establish the baseline reproduction and validation flow before code changes
 
 - [ ] T001 Run the baseline validation and reproduction steps documented in `specs/001-fix-sequence-step-names/quickstart.md`
-- [ ] T002 [P] Reproduce the saved-step and execution-log regressions from `specs/001-fix-sequence-step-names/quickstart.md` against `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/pages/ExecutionLogs.tsx`
+- [X] T002 [P] Reproduce the saved-step and execution-log regressions from `specs/001-fix-sequence-step-names/quickstart.md` against `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/pages/ExecutionLogs.tsx`
 
 ---
 
@@ -47,16 +47,16 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T007 [P] [US1] Add a contract regression for per-step command round-tripping in `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`
-- [ ] T008 [P] [US1] Add an integration regression for saved step metadata round-tripping in `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`
-- [ ] T009 [P] [US1] Add a web UI regression for reopening saved sequences with preserved command selections in `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`
-- [ ] T010 [P] [US1] Add an explicit unchanged-resave regression in `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs` that saves, reloads, re-saves unchanged steps, and asserts no step is reassigned to a different command
+- [X] T007 [P] [US1] Add a contract regression for per-step command round-tripping in `tests/contract/Sequences/SequencePerStepConditionsContractTests.cs`
+- [X] T008 [P] [US1] Add an integration regression for saved step metadata round-tripping in `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs`
+- [X] T009 [P] [US1] Add a web UI regression for reopening saved sequences with preserved command selections in `src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx`
+- [X] T010 [P] [US1] Add an explicit unchanged-resave regression in `tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs` that saves, reloads, re-saves unchanged steps, and asserts no step is reassigned to a different command
 
 ### Implementation for User Story 1
 
 - [ ] T011 [US1] Preserve canonical per-step object payloads for sequence create/update/patch in `src/GameBot.Service/Program.cs`
 - [ ] T012 [US1] Populate saved `commandReference` response data for command-backed steps in `src/GameBot.Service/Program.cs`
-- [ ] T013 [US1] Restore saved command selections and step labels on editor load in `src/web-ui/src/pages/SequencesPage.tsx`
+- [X] T013 [US1] Restore saved command selections and step labels on editor load in `src/web-ui/src/pages/SequencesPage.tsx`
 
 **Checkpoint**: User Story 1 is functional when saved sequences reopen with the same step-to-command mappings the author selected
 
@@ -72,14 +72,14 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T014 [P] [US2] Add an execution-log integration regression for step label plus command name in `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`
-- [ ] T015 [P] [US2] Add an execution-log projection unit regression in `tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs`
+- [X] T014 [P] [US2] Add an execution-log integration regression for step label plus command name in `tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs`
+- [X] T015 [P] [US2] Add an execution-log projection unit regression in `tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T016 [US2] Enrich sequence execution detail items with command names in `src/GameBot.Service/Program.cs`
-- [ ] T017 [US2] Project command-aware sequence step details through execution-log responses in `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` and `src/GameBot.Service/Models/ExecutionLogs.cs`
-- [ ] T018 [US2] Align execution-log client types and rendering with command-aware step messages in `src/web-ui/src/services/executionLogsApi.ts` and `src/web-ui/src/pages/ExecutionLogs.tsx`
+- [X] T016 [US2] Enrich sequence execution detail items with command names in `src/GameBot.Service/Program.cs`
+- [X] T017 [US2] Project command-aware sequence step details through execution-log responses in `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` and `src/GameBot.Service/Models/ExecutionLogs.cs`
+- [X] T018 [US2] Align execution-log client types and rendering with command-aware step messages in `src/web-ui/src/services/executionLogsApi.ts` and `src/web-ui/src/pages/ExecutionLogs.tsx`
 
 **Checkpoint**: User Story 2 is functional when sequence execution logs identify both the step and the executed command without relying on internal step ids alone
 

--- a/src/GameBot.Domain/Commands/SequenceStep.cs
+++ b/src/GameBot.Domain/Commands/SequenceStep.cs
@@ -19,6 +19,11 @@ namespace GameBot.Domain.Commands {
     public Dictionary<string, object?> Parameters { get; } = new();
   }
 
+  public sealed class SequenceCommandReference {
+    public string CommandId { get; set; } = string.Empty;
+    public string? CommandName { get; set; }
+  }
+
   /// <summary>
   /// Minimal step model; detailed validation and behaviors added in US1/US2/US3 phases.
   /// </summary>
@@ -27,6 +32,7 @@ namespace GameBot.Domain.Commands {
     public string StepId { get; set; } = string.Empty;
     public string? Label { get; set; }
     public string CommandId { get; set; } = string.Empty;
+    public SequenceCommandReference? CommandReference { get; set; }
     public SequenceStepType StepType { get; set; } = SequenceStepType.Command;
     public SequenceActionPayload? Action { get; set; }
     public WaitForImageConfig? WaitForImage { get; set; }

--- a/src/GameBot.Domain/Logging/ExecutionLogModels.cs
+++ b/src/GameBot.Domain/Logging/ExecutionLogModels.cs
@@ -57,6 +57,11 @@ public sealed record ExecutionStepOutcome(
   /// Structured wait-for-image details when the step represents a wait primitive.
   /// </summary>
   public WaitForImageDetailAttributes? DetailAttributes { get; init; }
+
+  /// <summary>
+  /// Human-readable command name for command-backed sequence steps when available.
+  /// </summary>
+  public string? CommandName { get; init; }
 }
 
 public sealed record ExecutionDetailItem(

--- a/src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
@@ -151,6 +151,7 @@ internal static class ExecutionLogsEndpoints {
         StepId = step.StepId,
         StepLabel = step.StepLabel,
         StepName = step.StepName,
+        CommandName = step.CommandName,
         StepType = step.StepType,
         Status = step.Status,
         Message = step.Message,

--- a/src/GameBot.Service/Models/ExecutionLogs.cs
+++ b/src/GameBot.Service/Models/ExecutionLogs.cs
@@ -93,6 +93,7 @@ internal sealed class StepOutcomeDetailDto {
   public string? StepId { get; init; }
   public string? StepLabel { get; init; }
   public required string StepName { get; init; }
+  public string? CommandName { get; init; }
   public string? StepType { get; init; }
   public required string Status { get; init; }
   public required string Message { get; init; }

--- a/src/GameBot.Service/Models/SequenceStepContracts.cs
+++ b/src/GameBot.Service/Models/SequenceStepContracts.cs
@@ -32,10 +32,17 @@ internal sealed record SequenceStepContract {
   public string? Label { get; init; }
   public string? StepType { get; init; }
   public PrimitiveActionRequest? PrimitiveAction { get; init; }
+  public SequenceCommandReferenceContract? CommandReference { get; init; }
   public SequenceStepConditionContract? Condition { get; init; }
   public LoopConfigContract? Loop { get; init; }
   public IReadOnlyList<SequenceStepContract>? Body { get; init; }
   public SequenceStepConditionContract? BreakCondition { get; init; }
+}
+
+internal sealed record SequenceCommandReferenceContract {
+  public required string CommandId { get; init; }
+  public string? CommandName { get; init; }
+  public bool? IsResolved { get; init; }
 }
 
 internal sealed record WaitForImagePayloadContract {

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -795,6 +795,7 @@ sequences.MapPost("{sequenceId}/execute", async (
   IImageVisibleConditionAdapter imageVisibleConditionAdapter,
   GameBot.Domain.Images.IImageRepository imageRepository,
   GameBot.Service.Services.ExecutionLog.IExecutionLogService executionLogService,
+  ICommandRepository commandRepository,
   ISequenceRepository sequenceRepository,
   GameBot.Service.Services.ICommandExecutor commandExecutor,
   string sequenceId,
@@ -869,12 +870,27 @@ sequences.MapPost("{sequenceId}/execute", async (
     var sequence = await sequenceRepository.GetAsync(sequenceId).ConfigureAwait(false);
     var sequenceName = sequence?.Name ?? sequenceId;
     var status = string.Equals(res.Status, "Succeeded", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
-    var sequenceStepsByRef = (sequence?.Steps ?? Array.Empty<GameBot.Domain.Commands.SequenceStep>())
+    var flattenedSequenceSteps = FlattenSequenceSteps(sequence?.Steps ?? Array.Empty<GameBot.Domain.Commands.SequenceStep>()).ToArray();
+    var sequenceStepsByRef = flattenedSequenceSteps
       .GroupBy(step => !string.IsNullOrWhiteSpace(step.StepId) ? step.StepId! : step.CommandId, StringComparer.Ordinal)
+      .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+    var sequenceStepsByCommandId = flattenedSequenceSteps
+      .Where(step => !string.IsNullOrWhiteSpace(step.CommandId))
+      .GroupBy(step => step.CommandId, StringComparer.Ordinal)
       .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
     var flowStepsByCommandRef = (sequence?.FlowSteps ?? Array.Empty<GameBot.Domain.Commands.FlowStep>())
       .GroupBy(step => string.IsNullOrWhiteSpace(step.PayloadRef) ? step.StepId : step.PayloadRef!, StringComparer.Ordinal)
       .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+    var commandNamesById = new Dictionary<string, string>(StringComparer.Ordinal);
+    foreach (var commandId in res.Steps
+      .Where(step => step.LoopIterations is null && !string.IsNullOrWhiteSpace(step.CommandId))
+      .Select(step => step.CommandId)
+      .Distinct(StringComparer.Ordinal)) {
+      var command = await commandRepository.GetAsync(commandId, ct).ConfigureAwait(false);
+      if (command is not null && !string.IsNullOrWhiteSpace(command.Name)) {
+        commandNamesById[commandId] = command.Name;
+      }
+    }
 
     var commandSteps = res.Steps.Where(s => s.LoopIterations is null).ToList();
     var detailItems = new List<GameBot.Domain.Logging.ExecutionDetailItem> {
@@ -888,9 +904,9 @@ sequences.MapPost("{sequenceId}/execute", async (
     var stepOrder = 1;
     foreach (var step in res.Steps) {
       flowStepsByCommandRef.TryGetValue(step.CommandId, out var flowStep);
-      sequenceStepsByRef.TryGetValue(step.CommandId, out var sequenceStep);
-      var stepId = flowStep?.StepId ?? step.CommandId;
-      var stepLabel = flowStep?.Label ?? sequenceStep?.Label ?? step.CommandId;
+      sequenceStepsByCommandId.TryGetValue(step.CommandId, out var sequenceStep);
+      var stepId = flowStep?.StepId ?? sequenceStep?.StepId ?? step.CommandId;
+      var stepLabel = flowStep?.Label ?? sequenceStep?.Label ?? sequenceStep?.StepId ?? step.CommandId;
 
       // Loop summary entries are not command executions — emit a loop-type detail instead.
       if (step.LoopIterations is not null) {
@@ -925,6 +941,7 @@ sequences.MapPost("{sequenceId}/execute", async (
       var isWaitForImageStep = waitDetails is not null
         || waitConfig is not null
         || string.Equals(sequenceStep?.Action?.Type, "WaitForImage", StringComparison.OrdinalIgnoreCase);
+      commandNamesById.TryGetValue(step.CommandId, out var commandName);
       var stepType = isWaitForImageStep ? "waitForImage" : "command";
       var imageLoadStatus = waitDetails?.ImageLoadStatus
         ?? (waitConfig?.DetectionTarget is null
@@ -932,9 +949,13 @@ sequences.MapPost("{sequenceId}/execute", async (
           : string.Equals(actionOutcome, "image_unavailable", StringComparison.OrdinalIgnoreCase)
             ? "unavailable"
             : "loaded");
-      var stepDisplayMessage = !string.IsNullOrWhiteSpace(step.Message)
-        ? $"Step '{stepLabel}' {actionOutcome}: {step.Message}"
-        : $"Step '{stepLabel}' {actionOutcome}.";
+      var stepDisplayMessage = isWaitForImageStep || string.IsNullOrWhiteSpace(commandName)
+        ? (!string.IsNullOrWhiteSpace(step.Message)
+          ? $"Step '{stepLabel}' {actionOutcome}: {step.Message}"
+          : $"Step '{stepLabel}' {actionOutcome}.")
+        : (!string.IsNullOrWhiteSpace(step.Message)
+          ? $"Step '{stepLabel}' ran command '{commandName}' with outcome '{actionOutcome}': {step.Message}"
+          : $"Step '{stepLabel}' ran command '{commandName}' with outcome '{actionOutcome}'.");
       detailItems.Add(new GameBot.Domain.Logging.ExecutionDetailItem(
         "step",
         stepDisplayMessage,
@@ -959,7 +980,8 @@ sequences.MapPost("{sequenceId}/execute", async (
           ["sequenceId"] = sequenceId,
           ["sequenceLabel"] = sequenceName,
           ["stepId"] = stepId,
-          ["stepLabel"] = stepLabel
+          ["stepLabel"] = stepLabel,
+          ["commandName"] = isWaitForImageStep ? null : commandName
         },
         "normal"));
     }
@@ -1562,6 +1584,20 @@ static IReadOnlyList<SequenceStep> MapBodySteps(IReadOnlyList<SequenceStepContra
     }
   }
   return result;
+}
+
+static IEnumerable<GameBot.Domain.Commands.SequenceStep> FlattenSequenceSteps(IEnumerable<GameBot.Domain.Commands.SequenceStep> steps) {
+  foreach (var step in steps) {
+    yield return step;
+
+    if (step.Body.Count == 0) {
+      continue;
+    }
+
+    foreach (var child in FlattenSequenceSteps(step.Body)) {
+      yield return child;
+    }
+  }
 }
 
 static WaitForImageConfig? MapWaitForImageConfig(PrimitiveActionRequest? primitiveAction) {

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -553,7 +553,7 @@ app.MapPost("/installer/same-build/decision", (GameBot.Service.Models.SameBuildD
 var sequences = app.MapGroup(ApiRoutes.Sequences).WithTags("Sequences");
 var legacyBranchingErrors = new[] { "entryStepId and links are no longer supported. Use per-step conditions on steps[].condition." };
 
-sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo, SequenceStepValidationService stepValidationService, IImageRepository imageRepository, CancellationToken ct) => {
+sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo, ICommandRepository commandRepository, SequenceStepValidationService stepValidationService, IImageRepository imageRepository, CancellationToken ct) => {
   using var doc = await System.Text.Json.JsonDocument.ParseAsync(http.Body, cancellationToken: ct).ConfigureAwait(false);
   var root = doc.RootElement;
   if (HasLegacyBranchingFields(root)) {
@@ -574,6 +574,7 @@ sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo, Sequenc
     };
 
     var linearSteps = MapToLinearSteps(perStepRequest);
+    await EnrichCommandReferencesAsync(linearSteps, commandRepository, existingSteps: null, ct).ConfigureAwait(false);
     var perStepValidationErrors = await ValidatePerStepForPersistenceAsync(linearSteps, stepValidationService, imageRepository, ct).ConfigureAwait(false);
     if (perStepValidationErrors.Count > 0) {
       return Results.BadRequest(new { message = "Invalid sequence payload", errors = perStepValidationErrors });
@@ -588,7 +589,7 @@ sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo, Sequenc
     perStepSequence.SetSteps(linearSteps);
     perStepSequence.InterStepDelayRangeMs = MapDelayRangeMs(perStepRequest.InterStepDelayRangeMs);
     var createdPerStep = await repo.CreateAsync(perStepSequence).ConfigureAwait(false);
-    return Results.Created(new Uri($"{ApiRoutes.Sequences}/{createdPerStep.Id}", UriKind.Relative), ToSequenceResponse(createdPerStep));
+    return Results.Created(new Uri($"{ApiRoutes.Sequences}/{createdPerStep.Id}", UriKind.Relative), await ToSequenceResponseAsync(createdPerStep, commandRepository, ct).ConfigureAwait(false));
   }
 
   if (isPerStepCandidate && !string.IsNullOrWhiteSpace(perStepRequestError)) {
@@ -610,7 +611,7 @@ sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo, Sequenc
       seq.SetSteps(steps);
     }
     var created = await repo.CreateAsync(seq).ConfigureAwait(false);
-    return Results.Created(new Uri($"{ApiRoutes.Sequences}/{created.Id}", UriKind.Relative), ToSequenceResponse(created));
+    return Results.Created(new Uri($"{ApiRoutes.Sequences}/{created.Id}", UriKind.Relative), await ToSequenceResponseAsync(created, commandRepository, ct).ConfigureAwait(false));
   }
   // Fallback to domain shape
   var seqDomain = JsonSerializer.Deserialize<GameBot.Domain.Commands.CommandSequence>(root);
@@ -623,13 +624,13 @@ sequences.MapPost("", async (HttpRequest http, ISequenceRepository repo, Sequenc
   return Results.Created($"{ApiRoutes.Sequences}/{createdDomain.Id}", createdDomain);
 }).Accepts<System.Text.Json.JsonElement>("application/json").WithName("CreateSequence");
 
-sequences.MapGet("{sequenceId}", async (ISequenceRepository repo, string sequenceId) => {
+sequences.MapGet("{sequenceId}", async (ISequenceRepository repo, ICommandRepository commandRepository, string sequenceId, CancellationToken ct) => {
   var found = await repo.GetAsync(sequenceId).ConfigureAwait(false);
   if (found is null) return Results.NotFound();
-  return Results.Ok(ToSequenceResponse(found));
+  return Results.Ok(await ToSequenceResponseAsync(found, commandRepository, ct).ConfigureAwait(false));
 }).WithName("GetSequence");
 
-sequences.MapPut("{sequenceId}", async (HttpRequest http, ISequenceRepository repo, SequenceStepValidationService stepValidationService, IImageRepository imageRepository, string sequenceId, CancellationToken ct) => {
+sequences.MapPut("{sequenceId}", async (HttpRequest http, ISequenceRepository repo, ICommandRepository commandRepository, SequenceStepValidationService stepValidationService, IImageRepository imageRepository, string sequenceId, CancellationToken ct) => {
   var existing = await repo.GetAsync(sequenceId).ConfigureAwait(false);
   if (existing is null) return Results.NotFound();
   using var doc = await System.Text.Json.JsonDocument.ParseAsync(http.Body, cancellationToken: ct).ConfigureAwait(false);
@@ -659,6 +660,7 @@ sequences.MapPut("{sequenceId}", async (HttpRequest http, ISequenceRepository re
   if (TryReadPerStepRequest(root, out var perStepRequest, out var perStepRequestError) && perStepRequest is not null) {
     existing.Name = string.IsNullOrWhiteSpace(perStepRequest.Name) ? existing.Name : perStepRequest.Name.Trim();
     var linearSteps = MapToLinearSteps(perStepRequest);
+    await EnrichCommandReferencesAsync(linearSteps, commandRepository, existing.Steps, ct).ConfigureAwait(false);
     var perStepValidationErrors = await ValidatePerStepForPersistenceAsync(linearSteps, stepValidationService, imageRepository, ct).ConfigureAwait(false);
     if (perStepValidationErrors.Count > 0) {
       return Results.BadRequest(new { message = "Invalid sequence payload", errors = perStepValidationErrors });
@@ -690,10 +692,10 @@ sequences.MapPut("{sequenceId}", async (HttpRequest http, ISequenceRepository re
   existing.Version += 1;
   existing.UpdatedAt = DateTimeOffset.UtcNow;
   var saved = await repo.UpdateAsync(existing).ConfigureAwait(false);
-  return Results.Ok(ToSequenceResponse(saved));
+  return Results.Ok(await ToSequenceResponseAsync(saved, commandRepository, ct).ConfigureAwait(false));
 }).WithName("UpdateSequence");
 
-sequences.MapPatch("{sequenceId}", async (HttpRequest http, ISequenceRepository repo, SequenceStepValidationService stepValidationService, IImageRepository imageRepository, string sequenceId, CancellationToken ct) => {
+sequences.MapPatch("{sequenceId}", async (HttpRequest http, ISequenceRepository repo, ICommandRepository commandRepository, SequenceStepValidationService stepValidationService, IImageRepository imageRepository, string sequenceId, CancellationToken ct) => {
   var existing = await repo.GetAsync(sequenceId).ConfigureAwait(false);
   if (existing is null) return Results.NotFound();
   using var doc = await System.Text.Json.JsonDocument.ParseAsync(http.Body, cancellationToken: ct).ConfigureAwait(false);
@@ -723,6 +725,7 @@ sequences.MapPatch("{sequenceId}", async (HttpRequest http, ISequenceRepository 
   if (TryReadPerStepRequest(root, out var perStepRequest, out var perStepRequestError) && perStepRequest is not null) {
     existing.Name = string.IsNullOrWhiteSpace(perStepRequest.Name) ? existing.Name : perStepRequest.Name.Trim();
     var linearSteps = MapToLinearSteps(perStepRequest);
+    await EnrichCommandReferencesAsync(linearSteps, commandRepository, existing.Steps, ct).ConfigureAwait(false);
     var perStepValidationErrors = await ValidatePerStepForPersistenceAsync(linearSteps, stepValidationService, imageRepository, ct).ConfigureAwait(false);
     if (perStepValidationErrors.Count > 0) {
       return Results.BadRequest(new { message = "Invalid sequence payload", errors = perStepValidationErrors });
@@ -754,7 +757,7 @@ sequences.MapPatch("{sequenceId}", async (HttpRequest http, ISequenceRepository 
   existing.Version += 1;
   existing.UpdatedAt = DateTimeOffset.UtcNow;
   var saved = await repo.UpdateAsync(existing).ConfigureAwait(false);
-  return Results.Ok(ToSequenceResponse(saved));
+  return Results.Ok(await ToSequenceResponseAsync(saved, commandRepository, ct).ConfigureAwait(false));
 }).WithName("PatchSequence");
 
 sequences.MapPost("{sequenceId}/validate", async (string sequenceId, SequenceFlowUpsertRequestDto request, ISequenceFlowValidator validator, ISequenceRepository repo, SequenceStepValidationService stepValidationService) => {
@@ -1105,7 +1108,12 @@ static string? TryFindVersioningDirectory() {
   return null;
 }
 
-static object ToSequenceResponse(GameBot.Domain.Commands.CommandSequence sequence) {
+static async Task<object> ToSequenceResponseAsync(GameBot.Domain.Commands.CommandSequence sequence, ICommandRepository commandRepository, CancellationToken ct) {
+  var commandLookup = await BuildCommandLookupAsync(commandRepository, ct).ConfigureAwait(false);
+  return ToSequenceResponse(sequence, commandLookup);
+}
+
+static object ToSequenceResponse(GameBot.Domain.Commands.CommandSequence sequence, IReadOnlyDictionary<string, string> commandLookup) {
   if (sequence.FlowSteps.Count > 0 || sequence.FlowLinks.Count > 0) {
     var flowSteps = sequence.FlowSteps.Select(step => new {
       stepId = step.StepId,
@@ -1141,7 +1149,7 @@ static object ToSequenceResponse(GameBot.Domain.Commands.CommandSequence sequenc
       id = sequence.Id,
       name = sequence.Name,
       version = sequence.Version,
-      steps = sequence.Steps.Select(MapStepToDto).ToArray(),
+      steps = sequence.Steps.Select(step => MapStepToDto(step, commandLookup)).ToArray(),
       interStepDelayRangeMs = sequence.InterStepDelayRangeMs is not null
         ? new { min = sequence.InterStepDelayRangeMs.Min, max = sequence.InterStepDelayRangeMs.Max }
         : null
@@ -1199,7 +1207,7 @@ static object? MapPerStepConditionToDto(SequenceStepCondition? condition) {
   };
 }
 
-static object MapStepToDto(SequenceStep step) {
+static object MapStepToDto(SequenceStep step, IReadOnlyDictionary<string, string> commandLookup) {
   var stepType = step.StepType switch {
     SequenceStepType.Loop => "Loop",
     SequenceStepType.Break => "Break",
@@ -1210,6 +1218,7 @@ static object MapStepToDto(SequenceStep step) {
     stepId = step.StepId,
     label = step.Label,
     stepType,
+    commandReference = MapCommandReferenceToDto(step, commandLookup),
     primitiveAction = step.Action is null
       ? null
       : new {
@@ -1219,8 +1228,30 @@ static object MapStepToDto(SequenceStep step) {
       },
     condition = MapPerStepConditionToDto(step.Condition),
     loop = MapLoopConfigToDto(step.Loop),
-    body = step.Body.Count > 0 ? step.Body.Select(MapStepToDto).ToArray() : null,
+    body = step.Body.Count > 0 ? step.Body.Select(child => MapStepToDto(child, commandLookup)).ToArray() : null,
     breakCondition = MapPerStepConditionToDto(step.BreakCondition)
+  };
+}
+
+static object? MapCommandReferenceToDto(SequenceStep step, IReadOnlyDictionary<string, string> commandLookup) {
+  if (!IsCommandBackedStep(step)) {
+    return null;
+  }
+
+  var commandId = step.CommandId?.Trim();
+  if (string.IsNullOrWhiteSpace(commandId)) {
+    return null;
+  }
+
+  commandLookup.TryGetValue(commandId, out var resolvedName);
+  var snapshotName = !string.IsNullOrWhiteSpace(step.CommandReference?.CommandName)
+    ? step.CommandReference!.CommandName!.Trim()
+    : resolvedName;
+
+  return new {
+    commandId,
+    commandName = snapshotName,
+    isResolved = resolvedName is not null
   };
 }
 
@@ -1496,6 +1527,7 @@ static List<SequenceStep> MapToLinearSteps(SequenceUpsertContract request) {
         StepId = step.StepId,
         Label = step.Label,
         CommandId = step.StepId,
+        CommandReference = MapCommandReference(step.CommandReference, step.StepId),
         StepType = SequenceStepType.Action,
         Action = step.PrimitiveAction is not null ? new SequenceActionPayload { Type = step.PrimitiveAction.Type, SchemaVersion = step.PrimitiveAction.SchemaVersion } : null,
         WaitForImage = MapWaitForImageConfig(step.PrimitiveAction),
@@ -1512,6 +1544,7 @@ static List<SequenceStep> MapToLinearSteps(SequenceUpsertContract request) {
             && commandId is not null
             && !string.IsNullOrWhiteSpace(commandId.ToString())) {
           mapped.CommandId = commandId.ToString()!;
+          mapped.CommandReference = MapCommandReference(step.CommandReference, mapped.CommandId);
         }
       }
 
@@ -1564,6 +1597,7 @@ static IReadOnlyList<SequenceStep> MapBodySteps(IReadOnlyList<SequenceStepContra
         StepId = child.StepId,
         Label = child.Label,
         CommandId = child.StepId,
+        CommandReference = MapCommandReference(child.CommandReference, child.StepId),
         StepType = SequenceStepType.Action,
         Action = child.PrimitiveAction is not null ? new SequenceActionPayload { Type = child.PrimitiveAction.Type, SchemaVersion = child.PrimitiveAction.SchemaVersion } : null,
         WaitForImage = MapWaitForImageConfig(child.PrimitiveAction),
@@ -1578,6 +1612,7 @@ static IReadOnlyList<SequenceStep> MapBodySteps(IReadOnlyList<SequenceStepContra
             && cid is not null
             && !string.IsNullOrWhiteSpace(cid.ToString())) {
           mapped.CommandId = cid.ToString()!;
+          mapped.CommandReference = MapCommandReference(child.CommandReference, mapped.CommandId);
         }
       }
       result.Add(mapped);
@@ -1596,6 +1631,81 @@ static IEnumerable<GameBot.Domain.Commands.SequenceStep> FlattenSequenceSteps(IE
 
     foreach (var child in FlattenSequenceSteps(step.Body)) {
       yield return child;
+    }
+  }
+}
+
+static SequenceCommandReference? MapCommandReference(SequenceCommandReferenceContract? contract, string commandId) {
+  var normalizedId = string.IsNullOrWhiteSpace(commandId) ? contract?.CommandId?.Trim() : commandId.Trim();
+  if (string.IsNullOrWhiteSpace(normalizedId)) {
+    return null;
+  }
+
+  var normalizedName = string.IsNullOrWhiteSpace(contract?.CommandName) ? null : contract!.CommandName!.Trim();
+  return new SequenceCommandReference {
+    CommandId = normalizedId,
+    CommandName = normalizedName
+  };
+}
+
+static bool IsCommandBackedStep(SequenceStep step) {
+  return step.StepType != SequenceStepType.Loop
+    && step.StepType != SequenceStepType.Break
+    && string.Equals(step.Action?.Type, ActionTypes.Command, StringComparison.OrdinalIgnoreCase)
+    && !string.IsNullOrWhiteSpace(step.CommandId);
+}
+
+static async Task<IReadOnlyDictionary<string, string>> BuildCommandLookupAsync(ICommandRepository commandRepository, CancellationToken ct) {
+  var commands = await commandRepository.ListAsync(ct).ConfigureAwait(false);
+  return commands
+    .Where(command => !string.IsNullOrWhiteSpace(command.Id))
+    .GroupBy(command => command.Id, StringComparer.OrdinalIgnoreCase)
+    .ToDictionary(group => group.Key, group => group.First().Name, StringComparer.OrdinalIgnoreCase);
+}
+
+static async Task EnrichCommandReferencesAsync(IReadOnlyList<SequenceStep> steps, ICommandRepository commandRepository, IReadOnlyList<SequenceStep>? existingSteps, CancellationToken ct) {
+  var commandLookup = await BuildCommandLookupAsync(commandRepository, ct).ConfigureAwait(false);
+  var existingLookup = FlattenSequenceSteps(existingSteps ?? Array.Empty<SequenceStep>())
+    .Where(step => IsCommandBackedStep(step))
+    .GroupBy(step => step.StepId, StringComparer.OrdinalIgnoreCase)
+    .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+  EnrichCommandReferences(steps, commandLookup, existingLookup);
+}
+
+static void EnrichCommandReferences(IReadOnlyList<SequenceStep> steps, IReadOnlyDictionary<string, string> commandLookup, IReadOnlyDictionary<string, SequenceStep> existingLookup) {
+  foreach (var step in steps) {
+    if (IsCommandBackedStep(step)) {
+      if (commandLookup.TryGetValue(step.CommandId, out var liveName)) {
+        step.CommandReference = new SequenceCommandReference {
+          CommandId = step.CommandId,
+          CommandName = liveName
+        };
+      }
+      else if (!string.IsNullOrWhiteSpace(step.CommandReference?.CommandName)) {
+        step.CommandReference = new SequenceCommandReference {
+          CommandId = step.CommandId,
+          CommandName = step.CommandReference.CommandName!.Trim()
+        };
+      }
+      else if (existingLookup.TryGetValue(step.StepId, out var existingStep)
+               && string.Equals(existingStep.CommandId, step.CommandId, StringComparison.OrdinalIgnoreCase)
+               && !string.IsNullOrWhiteSpace(existingStep.CommandReference?.CommandName)) {
+        step.CommandReference = new SequenceCommandReference {
+          CommandId = step.CommandId,
+          CommandName = existingStep.CommandReference.CommandName!.Trim()
+        };
+      }
+      else {
+        step.CommandReference = new SequenceCommandReference {
+          CommandId = step.CommandId,
+          CommandName = null
+        };
+      }
+    }
+
+    if (step.Body.Count > 0) {
+      EnrichCommandReferences(step.Body, commandLookup, existingLookup);
     }
   }
 }

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -17,6 +17,7 @@ internal sealed record ExecutionLogStepProjection(
   string? StepId,
   string StepLabel,
   string StepName,
+  string? CommandName,
   string StepType,
   string Status,
   string Message,
@@ -238,13 +239,25 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       string.Equals(detail.Kind, "snapshot", StringComparison.OrdinalIgnoreCase) ||
       (detail.Attributes?.ContainsKey("imageUrl") ?? false));
 
-    var stepOutcomes = entry.StepOutcomes
+    var storedOrDerivedStepOutcomes = entry.StepOutcomes.Count > 0
+      ? entry.StepOutcomes
+      : BuildSequenceStepOutcomes(
+        entry.ObjectRef.ObjectId,
+        entry.ObjectRef.DisplayNameSnapshot,
+        new ExecutionLogContext {
+          SequenceId = entry.ObjectRef.ObjectId,
+          SequenceLabel = entry.ObjectRef.DisplayNameSnapshot
+        },
+        entry.Details);
+
+    var stepOutcomes = storedOrDerivedStepOutcomes
       .Select(step => new ExecutionLogStepProjection(
         ResolveSequenceId(entry, step),
         ResolveSequenceLabel(entry, step),
         step.StepId,
         ResolveStepLabel(step),
-        string.IsNullOrWhiteSpace(step.StepType) ? $"Step {step.StepOrder}" : step.StepType,
+        ResolveStepLabel(step),
+        step.CommandName,
         step.StepType,
         step.Outcome,
         step.ReasonText ?? step.ReasonCode ?? "Step completed.",
@@ -285,6 +298,7 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       var resolvedSequenceLabel = TryGetString(attributes, "sequenceLabel") ?? context.SequenceLabel ?? sequenceName;
       var resolvedStepId = TryGetString(attributes, "stepId") ?? context.StepId;
       var resolvedStepLabel = TryGetString(attributes, "stepLabel") ?? context.StepLabel;
+      var resolvedCommandName = TryGetString(attributes, "commandName");
       var appliedDelayMs = TryGetInt(attributes, "appliedDelayMs");
       var conditionTrace = TryGetConditionTrace(attributes, "conditionTrace")
                            ?? BuildConditionTraceFromAttributes(attributes);
@@ -302,6 +316,7 @@ internal sealed class ExecutionLogService : IExecutionLogService {
         resolvedStepLabel,
         conditionTrace,
         appliedDelayMs) {
+        CommandName = resolvedCommandName,
         DetailAttributes = detailAttributes
       });
     }

--- a/src/web-ui/src/components/sequences/LoopBlock.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlock.tsx
@@ -107,7 +107,7 @@ export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, 
                       disabled={disabled}
                       onChange={(e) => {
                         const updated = body.map((s, i) =>
-                          i === index ? { ...s, commandId: e.target.value } as StepEntry : s
+                          i === index ? { ...s, commandId: e.target.value, commandReference: undefined } as StepEntry : s
                         );
                         onChange({ ...loop, body: updated });
                       }}

--- a/src/web-ui/src/pages/ExecutionLogs.tsx
+++ b/src/web-ui/src/pages/ExecutionLogs.tsx
@@ -312,7 +312,7 @@ export const ExecutionLogsPage: React.FC = () => {
               <ul>
                 {detail.stepOutcomes.map((step, index) => (
                   <li key={`${step.stepName}-${index}`}>
-                    <strong>{step.stepName}</strong>: {step.status} — {step.message}
+                    <strong>{step.stepName}</strong>{step.commandName ? ` (${step.commandName})` : ''}: {step.status} — {step.message}
                     <div className="form-hint">
                       Applied delay: {typeof step.appliedDelayMs === 'number' ? `${step.appliedDelayMs} ms` : 'n/a'}
                     </div>

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -13,7 +13,7 @@ import { validatePerStepConditions } from '../lib/validation';
 import { isLinearStepArray, toCommandStepIds, toInterStepDelayRange, toLinearSteps } from '../lib/sequenceMapping';
 import { LoopBlock } from '../components/sequences/LoopBlock';
 import type { LoopStepEntry, BreakStepEntry, StepEntry } from '../types/stepEntry';
-import type { SequenceLinearStep, LoopConfigDto, SequencePrimitiveActionPayload } from '../types/sequenceFlow';
+import type { SequenceLinearStep, LoopConfigDto, SequencePrimitiveActionPayload, SequenceCommandReference } from '../types/sequenceFlow';
 
 type SequenceStep = {
   id: string;
@@ -21,6 +21,7 @@ type SequenceStep = {
   stepType: 'Action' | 'Loop' | 'Break';
   actionType: 'command' | 'WaitForImage';
   commandId: string;
+  commandReference?: SequenceCommandReference;
   waitReferenceImageId: string;
   waitConfidence: string;
   waitTimeoutMs: string;
@@ -51,12 +52,13 @@ const emptyForm: SequenceFormValue = {
   delayMax: ''
 };
 
-const createDefaultStep = (commandId: string, stepId: string): SequenceStep => ({
+const createDefaultStep = (commandId: string, stepId: string, commandReference?: SequenceCommandReference): SequenceStep => ({
   id: makeId(),
   stepId,
   stepType: 'Action',
   actionType: 'command',
   commandId,
+  commandReference,
   waitReferenceImageId: '',
   waitConfidence: '',
   waitTimeoutMs: '1000',
@@ -74,6 +76,7 @@ const createDefaultWaitStep = (stepId: string): SequenceStep => ({
   stepType: 'Action',
   actionType: 'WaitForImage',
   commandId: '',
+  commandReference: undefined,
   waitReferenceImageId: '',
   waitConfidence: '',
   waitTimeoutMs: '1000',
@@ -86,6 +89,69 @@ const createDefaultWaitStep = (stepId: string): SequenceStep => ({
 });
 
 const toStepEntries = (ids?: string[]): SequenceStep[] => (ids ?? []).map((cmdId, index) => createDefaultStep(cmdId, `step-${index + 1}`));
+
+const getUnresolvedCommandLabel = (reference: SequenceCommandReference | undefined, commandId: string): string => {
+  const commandName = reference?.commandName?.trim();
+  return commandName ? `${commandName} (unresolved)` : `${commandId} (unresolved)`;
+};
+
+const getDisplayCommandLabel = (
+  commandId: string,
+  commandReference: SequenceCommandReference | undefined,
+  commandLookup: Map<string, string>
+): string => {
+  const liveLabel = commandLookup.get(commandId);
+  return liveLabel ?? getUnresolvedCommandLabel(commandReference, commandId);
+};
+
+const appendUnresolvedCommandOption = (
+  optionsByValue: Map<string, SearchableOption>,
+  commandId: string,
+  commandReference: SequenceCommandReference | undefined
+) => {
+  const normalizedId = commandId.trim();
+  if (!normalizedId || optionsByValue.has(normalizedId)) {
+    return;
+  }
+
+  optionsByValue.set(normalizedId, {
+    value: normalizedId,
+    label: getUnresolvedCommandLabel(commandReference, normalizedId)
+  });
+};
+
+const collectLoopBodyCommandOptions = (optionsByValue: Map<string, SearchableOption>, body: StepEntry[] | undefined) => {
+  if (!body) {
+    return;
+  }
+
+  for (const entry of body) {
+    if (entry.type === 'Action') {
+      appendUnresolvedCommandOption(optionsByValue, entry.commandId, entry.commandReference);
+      continue;
+    }
+
+    if (entry.type === 'Loop') {
+      collectLoopBodyCommandOptions(optionsByValue, entry.body);
+    }
+  }
+};
+
+const mergeCommandOptionsWithUnresolved = (liveOptions: SearchableOption[], steps: SequenceStep[]): SearchableOption[] => {
+  const optionsByValue = new Map(liveOptions.map((option) => [option.value, option]));
+  for (const step of steps) {
+    if (step.stepType === 'Action' && step.actionType === 'command') {
+      appendUnresolvedCommandOption(optionsByValue, step.commandId, step.commandReference);
+      continue;
+    }
+
+    if (step.stepType === 'Loop' && step.loopEntry) {
+      collectLoopBodyCommandOptions(optionsByValue, step.loopEntry.body);
+    }
+  }
+
+  return Array.from(optionsByValue.values());
+};
 
 const nextGeneratedStepId = (steps: SequenceStep[]): string => {
   const highest = steps.reduce((max, step) => {
@@ -143,6 +209,7 @@ const linearBodyToStepEntries = (body: SequenceLinearStep[]): StepEntry[] => {
       id: makeId(),
       stepId: child.stepId,
       commandId: cmdId,
+      commandReference: child.commandReference ?? undefined,
       conditionType: child.condition?.type === 'imageVisible' ? 'imageVisible'
         : child.condition?.type === 'commandOutcome' ? 'commandOutcome' : 'none',
       conditionNegate: child.condition?.negate ?? false,
@@ -176,7 +243,9 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         id: makeId(),
         stepId: step.stepId,
         stepType: 'Loop' as const,
+        actionType: 'command' as const,
         commandId: '',
+        commandReference: undefined,
         conditionType: 'none' as const,
         conditionNegate: false,
         imageId: '',
@@ -258,7 +327,9 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         id: makeId(),
         stepId: step.stepId,
         stepType: 'Action' as const,
+        actionType: 'command' as const,
         commandId,
+        commandReference: step.commandReference ?? undefined,
         conditionType: 'imageVisible',
         conditionNegate: step.condition.negate ?? false,
         imageId: step.condition.imageId,
@@ -273,7 +344,9 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         id: makeId(),
         stepId: step.stepId,
         stepType: 'Action' as const,
+        actionType: 'command' as const,
         commandId,
+        commandReference: step.commandReference ?? undefined,
         conditionType: 'commandOutcome',
         conditionNegate: step.condition.negate ?? false,
         imageId: '',
@@ -284,10 +357,27 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
     }
 
     return {
-      ...createDefaultStep(commandId, step.stepId),
+      ...createDefaultStep(commandId, step.stepId, step.commandReference ?? undefined),
       stepId: step.stepId
     };
   });
+};
+
+const buildCommandReferencePayload = (commandId: string, commandReference: SequenceCommandReference | undefined) => {
+  if (!commandId.trim()) {
+    return undefined;
+  }
+
+  const commandName = commandReference?.commandName?.trim();
+  if (!commandName && commandReference?.isResolved !== false) {
+    return undefined;
+  }
+
+  return {
+    commandId: commandId.trim(),
+    commandName: commandName || undefined,
+    isResolved: commandReference?.isResolved ?? false
+  };
 };
 
 const buildConditionPayload = (step: SequenceStep) => {
@@ -333,7 +423,7 @@ const bodyEntryToPayloadStep = (entry: StepEntry): SequenceLinearStep => {
     };
   }
   // Action body step
-  const a = entry as { stepId: string; commandId: string; conditionType: string; conditionNegate: boolean; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
+  const a = entry as { stepId: string; commandId: string; commandReference?: SequenceCommandReference; conditionType: string; conditionNegate: boolean; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
   const cond = a.conditionType === 'imageVisible'
     ? { type: 'imageVisible' as const, imageId: a.imageId.trim(), minSimilarity: a.minSimilarity.trim() === '' ? null : Number(a.minSimilarity), negate: a.conditionNegate || undefined }
     : a.conditionType === 'commandOutcome'
@@ -343,6 +433,7 @@ const bodyEntryToPayloadStep = (entry: StepEntry): SequenceLinearStep => {
     stepId: entry.stepId.trim(),
     stepType: 'Action',
     primitiveAction: { type: 'command', schemaVersion: 'v1', payload: { commandId: a.commandId } },
+    commandReference: buildCommandReferencePayload(a.commandId, a.commandReference),
     condition: cond
   };
 };
@@ -399,6 +490,7 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
           commandId: step.commandId
         }
       },
+      commandReference: buildCommandReferencePayload(step.commandId, step.commandReference),
       condition: buildConditionPayload(step)
     };
   });
@@ -458,6 +550,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
   const { confirmNavigate } = useUnsavedChangesPrompt(dirty);
 
   const commandLookup = useMemo(() => new Map(commandOptions.map((o) => [o.value, o.label])), [commandOptions]);
+  const editorCommandOptions = useMemo(() => mergeCommandOptionsWithUnresolved(commandOptions, form.steps), [commandOptions, form.steps]);
   const sequenceRows = useMemo(() => sequences.map((s) => ({ id: s.id, name: s.name, stepCount: s.steps?.length ?? 0 })), [sequences]);
 
   const displayedSequences = useMemo(() => {
@@ -786,7 +879,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 setForm((prev) => ({ ...prev, steps: prev.steps.filter((step) => step.id !== s.id) }));
                 setDirty(true);
               }}
-              commandOptions={commandOptions}
+              commandOptions={editorCommandOptions}
               disabled={submitting || loading}
             />
           ),
@@ -796,11 +889,11 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         id: s.id,
         label: s.actionType === 'WaitForImage'
           ? `Wait for image: ${s.waitReferenceImageId.trim() || 'any image'}`
-          : commandLookup.get(s.commandId) ?? s.commandId,
+          : getDisplayCommandLabel(s.commandId, s.commandReference, commandLookup),
         details: renderStepConditionEditor(s, idx),
       };
     });
-  }, [form.steps, commandOptions, commandLookup, submitting, loading]);
+  }, [form.steps, editorCommandOptions, commandLookup, submitting, loading]);
 
   const validate = (v: SequenceFormValue): Record<string, string> | undefined => {
     const next: Record<string, string> = {};

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { listSequences, SequenceDto, createSequence, getSequence, updateSequence, deleteSequence, isSequenceConflictError } from '../services/sequences';
 import { ConfirmDeleteModal } from '../components/ConfirmDeleteModal';
 import { ApiError } from '../lib/api';
@@ -605,7 +605,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
     setDirty(false);
   };
 
-  const renderStepConditionEditor = (step: SequenceStep, index: number): React.ReactNode => (
+  const renderStepConditionEditor = useCallback((step: SequenceStep, index: number): React.ReactNode => (
     <div className="sequence-step-condition-editor">
       {step.stepType === 'Action' && step.actionType === 'WaitForImage' && (
         <>
@@ -824,7 +824,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         </>
       )}
     </div>
-  );
+  ), [form.steps, submitting, loading]);
 
   const createLoopStep = (loopType: 'count' | 'while' | 'repeatUntil'): SequenceStep => {
     const id = makeId();
@@ -893,7 +893,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         details: renderStepConditionEditor(s, idx),
       };
     });
-  }, [form.steps, editorCommandOptions, commandLookup, submitting, loading]);
+  }, [form.steps, editorCommandOptions, commandLookup, submitting, loading, renderStepConditionEditor]);
 
   const validate = (v: SequenceFormValue): Record<string, string> | undefined => {
     const next: Record<string, string> = {};

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -132,8 +132,11 @@ const linearBodyToStepEntries = (body: SequenceLinearStep[]): StepEntry[] => {
         breakCondition: child.breakCondition ?? undefined
       } satisfies BreakStepEntry;
     }
-    const cmdId = typeof child.action?.parameters?.commandId === 'string'
-      ? child.action.parameters.commandId
+    const primitiveAction = getPrimitiveAction(child);
+    const cmdId = typeof primitiveAction?.payload?.commandId === 'string'
+      ? primitiveAction.payload.commandId
+      : typeof child.action?.parameters?.commandId === 'string'
+        ? child.action.parameters.commandId
       : child.stepId;
     return {
       type: 'Action',

--- a/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
@@ -219,4 +219,82 @@ describe('SequencesPage', () => {
       ]
     }));
   });
+
+  it('preserves loop body command selections when reloading saved primitive actions', async () => {
+    listSequencesMock.mockResolvedValue([{ id: 'seq-loop', name: 'Loop Sequence', steps: [] }] as any);
+    getSequenceMock.mockResolvedValue({
+      id: 'seq-loop',
+      name: 'Loop Sequence',
+      version: 3,
+      steps: [
+        {
+          stepId: 'loop-1',
+          stepType: 'Loop',
+          loop: {
+            loopType: 'count',
+            count: 2,
+            maxIterations: 2
+          },
+          body: [
+            {
+              stepId: 'body-step-1',
+              stepType: 'Action',
+              primitiveAction: {
+                type: 'command',
+                schemaVersion: 'v1',
+                payload: {
+                  commandId: 'c2'
+                }
+              },
+              condition: null
+            }
+          ]
+        }
+      ]
+    } as any);
+    updateSequenceMock.mockResolvedValue({} as any);
+
+    render(<SequencesPage />);
+
+    await screen.findByText('Loop Sequence');
+    fireEvent.click(screen.getByText('Loop Sequence'));
+
+    await screen.findByText('Edit Sequence');
+
+    const bodyCommandSelect = screen.getByTestId('loop-body-command-select') as HTMLSelectElement;
+    expect(bodyCommandSelect.value).toBe('c2');
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(updateSequenceMock).toHaveBeenCalledWith('seq-loop', {
+      name: 'Loop Sequence',
+      version: 3,
+      interStepDelayRangeMs: null,
+      steps: [
+        {
+          stepId: 'loop-1',
+          stepType: 'Loop',
+          loop: {
+            loopType: 'count',
+            count: 2,
+            maxIterations: 2
+          },
+          body: [
+            {
+              stepId: 'body-step-1',
+              stepType: 'Action',
+              primitiveAction: {
+                type: 'command',
+                schemaVersion: 'v1',
+                payload: {
+                  commandId: 'c2'
+                }
+              },
+              condition: null
+            }
+          ]
+        }
+      ]
+    }));
+  });
 });

--- a/src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SequencesPage } from '../SequencesPage';
+import { getSequence, listSequences, updateSequence } from '../../services/sequences';
+import { listCommands } from '../../services/commands';
+
+jest.mock('../../services/sequences');
+jest.mock('../../services/commands');
+
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+const getSequenceMock = getSequence as jest.MockedFunction<typeof getSequence>;
+const updateSequenceMock = updateSequence as jest.MockedFunction<typeof updateSequence>;
+const listCommandsMock = listCommands as jest.MockedFunction<typeof listCommands>;
+
+describe('SequencesPage unresolved commands', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    listSequencesMock.mockResolvedValue([{ id: 'seq-missing', name: 'Missing Command Sequence', steps: [] }] as any);
+    listCommandsMock.mockResolvedValue([
+      { id: 'c1', name: 'Command One' }
+    ] as any);
+  });
+
+  it('shows unresolved saved command names instead of an empty selection and preserves them on save', async () => {
+    getSequenceMock.mockResolvedValue({
+      id: 'seq-missing',
+      name: 'Missing Command Sequence',
+      version: 7,
+      steps: [
+        {
+          stepId: 'step-1',
+          label: 'Deleted command step',
+          stepType: 'Action',
+          primitiveAction: {
+            type: 'command',
+            schemaVersion: 'v1',
+            payload: {
+              commandId: 'missing-cmd'
+            }
+          },
+          commandReference: {
+            commandId: 'missing-cmd',
+            commandName: 'Deleted Command',
+            isResolved: false
+          },
+          condition: null
+        }
+      ]
+    } as any);
+    updateSequenceMock.mockResolvedValue({} as any);
+
+    render(<SequencesPage />);
+
+    await screen.findByText('Missing Command Sequence');
+    fireEvent.click(screen.getByText('Missing Command Sequence'));
+
+    await screen.findByText('Edit Sequence');
+
+    expect(screen.getByText('Deleted Command (unresolved)')).toBeInTheDocument();
+    expect(screen.queryByText('missing-cmd')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(updateSequenceMock).toHaveBeenCalledWith('seq-missing', {
+      name: 'Missing Command Sequence',
+      version: 7,
+      interStepDelayRangeMs: null,
+      steps: [
+        {
+          stepId: 'step-1',
+          stepType: 'Action',
+          primitiveAction: {
+            type: 'command',
+            schemaVersion: 'v1',
+            payload: {
+              commandId: 'missing-cmd'
+            }
+          },
+          commandReference: {
+            commandId: 'missing-cmd',
+            commandName: 'Deleted Command',
+            isResolved: false
+          },
+          condition: null
+        }
+      ]
+    }));
+  });
+});

--- a/src/web-ui/src/services/executionLogsApi.ts
+++ b/src/web-ui/src/services/executionLogsApi.ts
@@ -45,6 +45,7 @@ export type ExecutionLogStepOutcomeDto = {
   stepId?: string;
   stepLabel?: string;
   stepName: string;
+  commandName?: string;
   stepType?: string;
   status: string;
   message: string;

--- a/src/web-ui/src/types/sequenceFlow.ts
+++ b/src/web-ui/src/types/sequenceFlow.ts
@@ -102,6 +102,12 @@ export type SequencePrimitiveActionPayload = {
   payload: Record<string, unknown>;
 };
 
+export type SequenceCommandReference = {
+  commandId: string;
+  commandName?: string | null;
+  isResolved?: boolean | null;
+};
+
 export type LoopConfigDto =
   | { loopType: 'count'; count: number; maxIterations?: number | null }
   | { loopType: 'while'; condition: SequenceStepCondition; maxIterations?: number | null }
@@ -113,6 +119,7 @@ export type SequenceLinearStep = {
   stepType?: 'Action' | 'Loop' | 'Break';
   action?: SequenceActionPayload | null;
   primitiveAction?: SequencePrimitiveActionPayload | null;
+  commandReference?: SequenceCommandReference | null;
   condition?: SequenceStepCondition | null;
   loop?: LoopConfigDto | null;
   body?: SequenceLinearStep[] | null;

--- a/src/web-ui/src/types/stepEntry.ts
+++ b/src/web-ui/src/types/stepEntry.ts
@@ -1,4 +1,4 @@
-import type { SequenceStepCondition } from './sequenceFlow';
+import type { SequenceCommandReference, SequenceStepCondition } from './sequenceFlow';
 
 /** Discriminated union for all step types in the sequence form editor. */
 export type StepEntry =
@@ -11,6 +11,7 @@ export type ActionStepEntry = {
   id: string;
   stepId: string;
   commandId: string;
+  commandReference?: SequenceCommandReference;
   conditionType: 'none' | 'imageVisible' | 'commandOutcome';
   imageId: string;
   minSimilarity: string;

--- a/tests/contract/Sequences/SequencePerStepConditionsContractTests.cs
+++ b/tests/contract/Sequences/SequencePerStepConditionsContractTests.cs
@@ -102,4 +102,54 @@ public sealed class SequencePerStepConditionsContractTests {
     patched.GetProperty("name").GetString().Should().Be("per-step-contract-updated");
     patched.GetProperty("steps")[1].GetProperty("condition").GetProperty("type").GetString().Should().Be("commandOutcome");
   }
+
+  [Fact]
+  public async Task CreateAndGetSequencePreserveLoopBodyCommandReferences() {
+    using var app = CreateFactory();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var createPayload = new {
+      name = "loop-body-command-contract",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "loop-1",
+          label = "Repeat mailbox",
+          stepType = "Loop",
+          loop = new {
+            loopType = "count",
+            count = 2,
+            maxIterations = 2
+          },
+          body = new object[] {
+            new {
+              stepId = "body-step-1",
+              label = "Open mailbox",
+              stepType = "Action",
+              primitiveAction = new {
+                type = "command",
+                schemaVersion = "v1",
+                payload = new { commandId = "cmd-mail" }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var sequenceId = created.GetProperty("id").GetString();
+    sequenceId.Should().NotBeNullOrWhiteSpace();
+    created.GetProperty("steps")[0].GetProperty("body")[0].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("cmd-mail");
+
+    var getResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var fetched = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    fetched.GetProperty("steps")[0].GetProperty("body")[0].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("cmd-mail");
+    fetched.GetProperty("steps")[0].GetProperty("body")[0].GetProperty("stepId").GetString().Should().Be("body-step-1");
+  }
 }

--- a/tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs
@@ -107,7 +107,7 @@ public sealed class SequenceExecutionLoggingIntegrationTests {
       var step = detailDoc.RootElement.GetProperty("stepOutcomes")[0];
 
       step.GetProperty("stepType").GetString().Should().Be("waitForImage");
-      step.GetProperty("stepName").GetString().Should().Be("waitForImage");
+      step.GetProperty("stepName").GetString().Should().Be("Wait for inbox");
       step.GetProperty("status").GetString().Should().Be("timeout_elapsed");
       var detailAttributes = step.GetProperty("detailAttributes");
       detailAttributes.GetProperty("timeoutMs").GetInt32().Should().Be(1800);
@@ -116,6 +116,64 @@ public sealed class SequenceExecutionLoggingIntegrationTests {
       detailAttributes.GetProperty("confidence").GetDouble().Should().Be(0.87);
       detailAttributes.GetProperty("exitCondition").GetString().Should().Be("timeout_elapsed");
       detailAttributes.GetProperty("imageLoadStatus").GetString().Should().Be("loaded");
+    }
+    finally {
+      Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", previousAuthToken);
+    }
+  }
+
+  [Fact]
+  public async Task SequenceExecutionDetailIncludesStepLabelAndCommandNameForCommandBackedSteps() {
+    var previousAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+    try {
+      using var app = new WebApplicationFactory<Program>();
+      var client = app.CreateClient();
+      client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+      var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+      await logService.LogSequenceExecutionAsync(
+        "seq-command-log",
+        "Command Log Sequence",
+        "success",
+        "Sequence completed.",
+        new ExecutionLogContext { Depth = 0, SequenceId = "seq-command-log", SequenceLabel = "Command Log Sequence" },
+        new[] {
+          new ExecutionDetailItem(
+            "step",
+            "Step 'Collect rewards' executed command 'Open Mail'.",
+            new Dictionary<string, object?> {
+              ["stepOrder"] = 1,
+              ["stepType"] = "command",
+              ["status"] = "Succeeded",
+              ["actionOutcome"] = "executed",
+              ["reasonCode"] = "executed",
+              ["sequenceId"] = "seq-command-log",
+              ["sequenceLabel"] = "Command Log Sequence",
+              ["stepId"] = "step-collect",
+              ["stepLabel"] = "Collect rewards",
+              ["commandName"] = "Open Mail"
+            },
+            "normal")
+        }).ConfigureAwait(false);
+
+      var listResp = await client.GetAsync(new Uri("/api/execution-logs?objectType=sequence&objectId=seq-command-log&pageSize=1", UriKind.Relative)).ConfigureAwait(false);
+      listResp.EnsureSuccessStatusCode();
+
+      using var listDoc = JsonDocument.Parse(await listResp.Content.ReadAsStringAsync().ConfigureAwait(false));
+      var id = listDoc.RootElement.GetProperty("items")[0].GetProperty("id").GetString();
+
+      var detailResp = await client.GetAsync(new Uri($"/api/execution-logs/{id}", UriKind.Relative)).ConfigureAwait(false);
+      detailResp.EnsureSuccessStatusCode();
+
+      using var detailDoc = JsonDocument.Parse(await detailResp.Content.ReadAsStringAsync().ConfigureAwait(false));
+      var step = detailDoc.RootElement.GetProperty("stepOutcomes")[0];
+
+      step.GetProperty("stepName").GetString().Should().Be("Collect rewards");
+      step.GetProperty("commandName").GetString().Should().Be("Open Mail");
+      step.GetProperty("message").GetString().Should().Contain("Collect rewards");
+      step.GetProperty("message").GetString().Should().Contain("Open Mail");
     }
     finally {
       Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", previousAuthToken);

--- a/tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs
+++ b/tests/integration/Sequences/PerStepConditionAuthoringRoundTripIntegrationTests.cs
@@ -85,4 +85,178 @@ public sealed class PerStepConditionAuthoringRoundTripIntegrationTests {
     firstCondition.ValueKind.Should().Be(JsonValueKind.Null);
     reloaded.GetProperty("steps")[1].GetProperty("condition").GetProperty("expectedState").GetString().Should().Be("skipped");
   }
+
+  [Fact]
+  public async Task SavedLoopBodyCommandReferencesRoundTripWithoutFallingBackToStepIds() {
+    TestEnvironment.PrepareCleanDataDir();
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+
+    var createPayload = new {
+      name = "loop-roundtrip",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "loop-1",
+          label = "Repeat mailbox",
+          stepType = "Loop",
+          loop = new {
+            loopType = "count",
+            count = 2,
+            maxIterations = 2
+          },
+          body = new object[] {
+            new {
+              stepId = "body-step-1",
+              label = "Open mailbox",
+              stepType = "Action",
+              primitiveAction = new {
+                type = "command",
+                schemaVersion = "v1",
+                payload = new { commandId = "cmd-mail" }
+              }
+            },
+            new {
+              stepId = "body-step-2",
+              label = "Collect rewards",
+              stepType = "Action",
+              primitiveAction = new {
+                type = "command",
+                schemaVersion = "v1",
+                payload = new { commandId = "cmd-rewards" }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var sequenceId = created.GetProperty("id").GetString();
+    sequenceId.Should().NotBeNullOrWhiteSpace();
+
+    var reloadResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    reloadResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var reloaded = await reloadResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+
+    var body = reloaded.GetProperty("steps")[0].GetProperty("body");
+    body[0].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("cmd-mail");
+    body[1].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("cmd-rewards");
+    body[1].GetProperty("stepId").GetString().Should().Be("body-step-2");
+  }
+
+  [Fact]
+  public async Task UnchangedLoopBodyResaveDoesNotReassignCommandsToBodyStepIds() {
+    TestEnvironment.PrepareCleanDataDir();
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+
+    var createPayload = new {
+      name = "loop-unchanged-resave",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "loop-1",
+          label = "Repeat mailbox",
+          stepType = "Loop",
+          loop = new {
+            loopType = "count",
+            count = 2,
+            maxIterations = 2
+          },
+          body = new object[] {
+            new {
+              stepId = "body-step-1",
+              label = "Open mailbox",
+              stepType = "Action",
+              primitiveAction = new {
+                type = "command",
+                schemaVersion = "v1",
+                payload = new { commandId = "cmd-mail" }
+              }
+            },
+            new {
+              stepId = "body-step-2",
+              label = "Collect rewards",
+              stepType = "Action",
+              primitiveAction = new {
+                type = "command",
+                schemaVersion = "v1",
+                payload = new { commandId = "cmd-rewards" }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var sequenceId = created.GetProperty("id").GetString();
+    sequenceId.Should().NotBeNullOrWhiteSpace();
+
+    var getResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var fetched = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+
+    var patchPayload = new {
+      name = fetched.GetProperty("name").GetString(),
+      version = fetched.GetProperty("version").GetInt32(),
+      steps = new object[] {
+        new {
+          stepId = "loop-1",
+          label = "Repeat mailbox",
+          stepType = "Loop",
+          loop = new {
+            loopType = "count",
+            count = 2,
+            maxIterations = 2
+          },
+          body = new object[] {
+            new {
+              stepId = "body-step-1",
+              label = "Open mailbox",
+              stepType = "Action",
+              primitiveAction = new {
+                type = "command",
+                schemaVersion = "v1",
+                payload = new { commandId = fetched.GetProperty("steps")[0].GetProperty("body")[0].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString() }
+              }
+            },
+            new {
+              stepId = "body-step-2",
+              label = "Collect rewards",
+              stepType = "Action",
+              primitiveAction = new {
+                type = "command",
+                schemaVersion = "v1",
+                payload = new { commandId = fetched.GetProperty("steps")[0].GetProperty("body")[1].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString() }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var patchResponse = await client.PatchAsJsonAsync($"/api/sequences/{sequenceId}", patchPayload).ConfigureAwait(false);
+    patchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var reloadResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    reloadResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var reloaded = await reloadResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+
+    var body = reloaded.GetProperty("steps")[0].GetProperty("body");
+    body[0].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("cmd-mail");
+    body[1].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("cmd-rewards");
+    body[1].GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().NotBe("body-step-2");
+  }
 }

--- a/tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs
+++ b/tests/integration/Sequences/SequenceMissingCommandReferenceIntegrationTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Sequences;
+
+public sealed class SequenceMissingCommandReferenceIntegrationTests {
+  private static WebApplicationFactory<Program> CreateFactory() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+    return new WebApplicationFactory<Program>();
+  }
+
+  [Fact]
+  public async Task GetAndResavePreserveUnresolvedCommandSnapshotAfterCommandDeletion() {
+    using var app = CreateFactory();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var commandRepository = app.Services.GetRequiredService<ICommandRepository>();
+    await commandRepository.AddAsync(new Command {
+      Id = "missing-cmd",
+      Name = "Deleted Command"
+    }).ConfigureAwait(false);
+
+    var createPayload = new {
+      name = "missing-command-sequence",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "step-1",
+          label = "Deleted command step",
+          stepType = "Action",
+          primitiveAction = new {
+            type = "command",
+            schemaVersion = "v1",
+            payload = new { commandId = "missing-cmd" }
+          }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var sequenceId = created.GetProperty("id").GetString();
+    sequenceId.Should().NotBeNullOrWhiteSpace();
+
+    await commandRepository.DeleteAsync("missing-cmd").ConfigureAwait(false);
+
+    var getResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var fetched = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+
+    var fetchedStep = fetched.GetProperty("steps")[0];
+    fetchedStep.GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("missing-cmd");
+    fetchedStep.GetProperty("commandReference").GetProperty("commandId").GetString().Should().Be("missing-cmd");
+    fetchedStep.GetProperty("commandReference").GetProperty("commandName").GetString().Should().Be("Deleted Command");
+    fetchedStep.GetProperty("commandReference").GetProperty("isResolved").GetBoolean().Should().BeFalse();
+
+    var patchPayload = new {
+      name = fetched.GetProperty("name").GetString(),
+      version = fetched.GetProperty("version").GetInt32(),
+      steps = new object[] {
+        new {
+          stepId = fetchedStep.GetProperty("stepId").GetString(),
+          label = fetchedStep.GetProperty("label").GetString(),
+          stepType = fetchedStep.GetProperty("stepType").GetString(),
+          primitiveAction = new {
+            type = fetchedStep.GetProperty("primitiveAction").GetProperty("type").GetString(),
+            schemaVersion = fetchedStep.GetProperty("primitiveAction").GetProperty("schemaVersion").GetString(),
+            payload = new {
+              commandId = fetchedStep.GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString()
+            }
+          },
+          commandReference = new {
+            commandId = fetchedStep.GetProperty("commandReference").GetProperty("commandId").GetString(),
+            commandName = fetchedStep.GetProperty("commandReference").GetProperty("commandName").GetString(),
+            isResolved = fetchedStep.GetProperty("commandReference").GetProperty("isResolved").GetBoolean()
+          }
+        }
+      }
+    };
+
+    var patchResponse = await client.PatchAsJsonAsync($"/api/sequences/{sequenceId}", patchPayload).ConfigureAwait(false);
+    patchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var reloadResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    reloadResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var reloaded = await reloadResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+
+    var reloadedStep = reloaded.GetProperty("steps")[0];
+    reloadedStep.GetProperty("primitiveAction").GetProperty("payload").GetProperty("commandId").GetString().Should().Be("missing-cmd");
+    reloadedStep.GetProperty("commandReference").GetProperty("commandName").GetString().Should().Be("Deleted Command");
+    reloadedStep.GetProperty("commandReference").GetProperty("isResolved").GetBoolean().Should().BeFalse();
+  }
+}

--- a/tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs
+++ b/tests/unit/ExecutionLogs/SequenceExecutionLogProjectionTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Xunit;
+
+namespace GameBot.UnitTests.ExecutionLogs;
+
+public sealed class SequenceExecutionLogProjectionTests {
+  [Fact]
+  public void BuildDetailProjectionIncludesCommandNameForCommandBackedSequenceSteps() {
+    var entry = new ExecutionLogEntry {
+      Id = "projection-command-name",
+      ExecutionType = "sequence",
+      FinalStatus = "success",
+      ObjectRef = new ExecutionObjectReference("sequence", "seq-1", "Sequence One"),
+      Navigation = new ExecutionNavigationContext("/authoring/sequences/seq-1", null),
+      Hierarchy = new ExecutionHierarchyContext("projection-command-name", null, 0, null),
+      Summary = "Sequence completed.",
+      Details = new[] {
+        new ExecutionDetailItem(
+          "step",
+          "Step 'Collect rewards' executed command 'Open Mail'.",
+          new Dictionary<string, object?> {
+            ["stepOrder"] = 1,
+            ["stepType"] = "command",
+            ["status"] = "Succeeded",
+            ["actionOutcome"] = "executed",
+            ["sequenceId"] = "seq-1",
+            ["sequenceLabel"] = "Sequence One",
+            ["stepId"] = "step-collect",
+            ["stepLabel"] = "Collect rewards",
+            ["commandName"] = "Open Mail"
+          },
+          "normal")
+      },
+      RetentionExpiresUtc = DateTimeOffset.UtcNow.AddDays(1)
+    };
+
+    var projection = ExecutionLogService.BuildDetailProjection(entry);
+
+    projection.StepOutcomes.Should().ContainSingle();
+    projection.StepOutcomes[0].StepLabel.Should().Be("Collect rewards");
+    projection.StepOutcomes[0].CommandName.Should().Be("Open Mail");
+    projection.StepOutcomes[0].Message.Should().Contain("Collect rewards");
+    projection.StepOutcomes[0].Message.Should().Contain("Open Mail");
+  }
+}


### PR DESCRIPTION
## Summary

- Fixed a bug where sequence step command selections were lost on save/reopen — steps showed \"Select command\" after being reopened because the command name was not persisted in the step contract
- Fixed execution log entries to include the authoring step label and command name instead of bare internal step IDs (e.g. `body-step-2`)
- Added an unresolved-command state in the UI so steps whose saved command no longer exists show the last saved name rather than silently going blank

## Changes

- **Domain/API**: Added `CommandName` field to `SequenceStep` and step contracts for round-trip persistence
- **Backend**: Updated `ExecutionLogService` to log step label + command name; updated `Program.cs` mappings accordingly
- **Frontend**: Updated `SequencesPage`, `LoopBlock`, `stepEntry` types, and `executionLogsApi` to carry and display command name; added unresolved-command UI state
- **Tests**: New integration tests for round-trip, missing-command reference, execution log projection, and per-step conditions; new React component specs

## Test plan

- [ ] Create a sequence with multiple steps referencing different commands, save, reopen — each step retains its command selection
- [ ] Execute the sequence and review execution logs — each entry shows step label and command name
- [ ] Delete a command that a saved step references, reopen the sequence — affected step shows unresolved state with the last saved command name
- [ ] Run `dotnet test` — all integration tests pass
- [ ] Run `npm test` in `src/web-ui` — all component specs pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)