### PR TITLE
Add step management outside loops with DnD reordering (#037)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/037-loop-step-management"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
+at specs/037-loop-step-management/plan.md
 <!-- SPECKIT END -->

--- a/specs/037-loop-step-management/checklists/requirements.md
+++ b/specs/037-loop-step-management/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Sequence Loop Step Management
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Clarification complete (4 questions answered 2026-05-30). Spec is ready for `/speckit-plan`.

--- a/specs/037-loop-step-management/data-model.md
+++ b/specs/037-loop-step-management/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Sequence Loop Step Management
+
+**Branch**: `037-loop-step-management` | **Date**: 2026-05-30
+
+## Existing Types (unchanged)
+
+These types are defined in `src/web-ui/src/types/stepEntry.ts` and remain unmodified by this feature.
+
+### StepEntry (discriminated union)
+
+```
+StepEntry = ActionStepEntry | LoopStepEntry | BreakStepEntry
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | `"Action" \| "Loop" \| "Break"` | Discriminant |
+| `id` | `string` | UUID, unique across the sequence |
+| `stepId` | `string` | Display name / key used by backend |
+
+### LoopStepEntry
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | `"Loop"` | Discriminant |
+| `id` | `string` | Also used as `scopeId` for loop-body DnD scope |
+| `loopType` | `"count" \| "while" \| "repeatUntil"` | |
+| `body` | `StepEntry[]` | Ordered child steps; scoped within this loop |
+
+### SequenceStep (in SequencesPage)
+
+Wrapper that combines `StepEntry` with a `stepType` discriminant and form-level metadata (e.g., `loopEntry`). Not modified by this feature.
+
+---
+
+## New DnD Metadata Type
+
+Used as the `data` payload for `useSortable` / `useDraggable` in dnd-kit. Not persisted — exists only during drag interactions.
+
+### StepDragData
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scopeId` | `string` | `"root"` for top-level steps; `loop.id` for loop-body steps |
+| `type` | `"step"` | Constant discriminant to distinguish from other draggable types |
+
+**Usage**:
+```typescript
+// Top-level step
+useSortable({ id: step.id, data: { scopeId: 'root', type: 'step' } })
+
+// Loop body step
+useSortable({ id: step.id, data: { scopeId: loop.id, type: 'step' } })
+```
+
+---
+
+## Scope Model
+
+| Scope | scopeId value | Who owns SortableContext |
+|-------|--------------|--------------------------|
+| Top-level sequence | `"root"` | `SortableSequenceStepList` |
+| Loop body | `loop.id` (UUID) | `LoopBlock` (modified) |
+
+The single `DndContext` wraps the entire sequence editor in `SequencesPage`. Scope enforcement is done in the `onDragEnd` handler: if `active.data.current.scopeId !== over.data.current.scopeId`, the handler returns without modifying state.
+
+---
+
+## Visual State During Drag
+
+Not a persisted data model — describes transient UI state managed in `SequencesPage`.
+
+| State Variable | Type | Cleared |
+|----------------|------|---------|
+| `activeStepId` | `string \| null` | On `onDragEnd` / `onDragCancel` |
+| `isDragInvalid` | `boolean` | On `onDragEnd` / `onDragCancel` |
+
+`isDragInvalid = true` when the currently hovered drop target has a different `scopeId` than the active item. Passed as prop to `LoopBlock` to apply `loop-block--drop-invalid` CSS class.

--- a/specs/037-loop-step-management/plan.md
+++ b/specs/037-loop-step-management/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan: Sequence Loop Step Management
+
+**Branch**: `037-loop-step-management` | **Date**: 2026-05-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/037-loop-step-management/spec.md`
+
+## Summary
+
+Users cannot currently add steps at the top-level scope of a sequence once a loop has been added, and step reordering uses button-based ↑/↓ controls with no scope enforcement. This feature adds a persistent "Add step" button at the bottom of the sequence editor (appending top-level steps) and replaces the ↑/↓ controls with drag-and-drop reordering (using `@dnd-kit/core` + `@dnd-kit/sortable`) that enforces scope boundaries — top-level steps cannot be dragged into a loop, and loop-body steps cannot be dragged out.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.6.3, React 18.3.1
+**Primary Dependencies**: React 18, `@dnd-kit/core` ^6.x (new), `@dnd-kit/sortable` ^8.x (new), `@dnd-kit/utilities` ^3.x (new)
+**Storage**: N/A — UI-only feature; no backend changes
+**Testing**: Jest 29.7.0 (unit/component), Playwright 1.49.1 (E2E)
+**Target Platform**: Web browser (Chrome/Edge), desktop viewport
+**Project Type**: Web application — React frontend
+**Performance Goals**: Drag-and-drop interactions at 60fps; no perceptible lag for sequences up to 50 steps
+**Constraints**: `ReorderableList` component must remain unchanged (used by `CommandForm` and potentially other views); no changes to backend API or data serialization
+**Scale/Scope**: Single-user authoring session; sequences typically < 20 steps
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Build/CI green | ✅ Pass | No current failures on master |
+| Lint/format clean | ✅ Pass | New code must pass existing ESLint config |
+| Method naming (CamelCase only) | ✅ Pass | New methods must use CamelCase per constitution |
+| Test coverage ≥80% line / ≥70% branch | ⚠️ Required | New components need unit tests; LoopBlock changes need updated tests |
+| Performance goal declared | ✅ Pass | 60fps DnD declared above |
+| No new unused dependencies | ✅ Pass | All three `@dnd-kit` packages are used |
+
+*Post-Phase-1 re-check*: No violations found after design. All gates remain green.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/037-loop-step-management/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+└── tasks.md             ← Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code
+
+```text
+src/web-ui/src/
+├── components/
+│   ├── SortableSequenceStepList.tsx    NEW — DnD-based step list for sequence editors
+│   ├── SortableStepItem.tsx            NEW — useSortable wrapper for individual steps
+│   ├── ReorderableList.tsx             UNCHANGED — button-based, kept for CommandForm etc.
+│   └── sequences/
+│       └── LoopBlock.tsx               MODIFY — replace ↑/↓ with DnD sortable body
+└── pages/
+    └── SequencesPage.tsx               MODIFY — add DndContext, use SortableSequenceStepList,
+                                                  add bottom "Add step" button
+```
+
+**CSS** (wherever global styles live, e.g., `src/web-ui/src/index.css` or a component CSS file):
+- Add `.loop-block--drop-invalid` class for the "not allowed" visual during drag
+
+**Structure Decision**: Web application, frontend only. Backend unchanged.
+
+## Implementation Phases
+
+### Phase 1: New DnD Components
+
+**Goal**: Create `SortableStepItem` and `SortableSequenceStepList` as standalone components.
+
+**`SortableStepItem.tsx`**:
+- Wraps any step with `useSortable({ id, data: { scopeId, type: 'step' } })`
+- Exposes a drag handle (or makes the entire row draggable)
+- Applies `transform` / `transition` styles from `useSortable`
+- Props: `id: string`, `scopeId: string`, `children: React.ReactNode`, `disabled?: boolean`
+
+**`SortableSequenceStepList.tsx`**:
+- Accepts `steps: SequenceStep[]`, `onChange`, `onDelete`, `disabled`
+- Wraps the list in `SortableContext` with `scopeId = "root"` items
+- Renders each step in a `SortableStepItem`
+- For `Loop` steps, renders `LoopBlock` as the item content (same as current `ReorderableList` `details` approach)
+- Does NOT own `DndContext` — that lives in `SequencesPage` to allow cross-component drag events
+
+### Phase 2: Modify LoopBlock for DnD Body
+
+**Goal**: Replace the ↑/↓ reorder buttons inside `LoopBlock` with a sortable body using dnd-kit.
+
+**Changes to `LoopBlock.tsx`**:
+- Remove `move()` helper and `handleBodyReorder()`
+- Wrap `<ol>` body in `SortableContext` with items tagged `scopeId = loop.id`
+- Each body step `<li>` becomes a `SortableStepItem` with `scopeId = loop.id`
+- Remove the ↑ / ↓ `<button>` elements (lines 124–125)
+- Accept `isDropInvalid?: boolean` prop; apply `loop-block--drop-invalid` CSS class to the body div when true
+
+### Phase 3: Update SequencesPage
+
+**Goal**: Wire up `DndContext`, replace `ReorderableList` with `SortableSequenceStepList`, add the persistent "Add step" button.
+
+**Changes to `SequencesPage.tsx`** (both create form ~line 1254 and edit form ~line 1495):
+
+1. **Add state**:
+   ```
+   const [activeStepId, setActiveStepId] = useState<string | null>(null);
+   const [isDragInvalid, setIsDragInvalid] = useState(false);
+   ```
+
+2. **Add `DndContext` wrapping** the step list section:
+   - `onDragStart`: set `activeStepId`
+   - `onDragOver`: compare `active.data.current.scopeId` vs `over?.data.current?.scopeId`; set `isDragInvalid` if different
+   - `onDragEnd`: if scopes match, perform reorder (update `form.steps`); always clear `activeStepId` and `isDragInvalid`
+   - `onDragCancel`: clear both state variables
+
+3. **Replace `<ReorderableList>` with `<SortableSequenceStepList>`** passing `isDragInvalid` through to `LoopBlock`
+
+4. **Add persistent "Add step" button** after `</SortableSequenceStepList>`:
+   - Creates a blank action step (same structure as `handleAddBodyStep` in `LoopBlock`) appended to `form.steps`
+   - `data-testid="add-top-level-step"`
+
+5. **Update form hint** text (line 1268) from `"drag buttons to reorder"` to `"drag steps to reorder"`
+
+### Phase 4: CSS and Visual Feedback
+
+Add to the project's CSS:
+```css
+.loop-block--drop-invalid {
+  outline: 2px solid #d32f2f;
+  opacity: 0.7;
+}
+```
+
+Optionally add a custom `DragOverlay` in `SequencesPage` for a floating "ghost" step label during drag.
+
+### Phase 5: Tests
+
+**Unit tests** (`SortableSequenceStepList.test.tsx`):
+- Renders steps and a loop block
+- Top-level "Add step" button appends a step to the sequence
+- `onDelete` removes the correct step
+
+**Unit tests** (update `LoopBlock.test.tsx`):
+- Existing "Add step inside loop" behavior unchanged
+- ↑/↓ buttons absent in new implementation
+- `isDropInvalid` prop applies the CSS class
+
+**E2E** (`sequences-loop-steps.spec.ts`):
+- User story 1: add a step at the top level when a loop is present → verify step is outside the loop
+- User story 2: drag a top-level step past a loop → verify reorder is correct
+- FR-007/FR-008: attempt to drag a top-level step over a loop body → verify "not allowed" CSS class appears and step stays at top level after release

--- a/specs/037-loop-step-management/quickstart.md
+++ b/specs/037-loop-step-management/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Sequence Loop Step Management
+
+**Branch**: `037-loop-step-management` | **Date**: 2026-05-30
+
+## Prerequisites
+
+- Node.js ≥ 18
+- Existing GameBot development environment set up
+
+## Install New Dependency
+
+From `src/web-ui/`:
+
+```bash
+npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+Expected additions to `package.json` `dependencies`:
+- `@dnd-kit/core` ^6.x
+- `@dnd-kit/sortable` ^8.x
+- `@dnd-kit/utilities` ^3.x
+
+## Run the Dev Server
+
+```bash
+cd src/web-ui
+npm run dev
+```
+
+Open the app, navigate to a sequence, add a loop, then verify:
+1. A persistent "Add step" button appears at the bottom of the step list
+2. Clicking it adds a blank action step at the top level (outside the loop)
+3. Steps can be dragged to reorder within their scope
+4. Dragging a top-level step over the loop interior shows a "not allowed" indicator
+
+## Run Tests
+
+Unit tests:
+```bash
+cd src/web-ui
+npm test
+```
+
+E2E tests (Playwright):
+```bash
+cd src/web-ui
+npx playwright test
+```
+
+Key test files to create/modify:
+- `src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx` (new)
+- `src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx` (modify)
+- `src/web-ui/tests/sequences-loop-steps.spec.ts` (new Playwright E2E)
+
+## Key Files Changed
+
+| File | Change |
+|------|--------|
+| `src/web-ui/src/components/SortableSequenceStepList.tsx` | New — DnD-based step list for sequences |
+| `src/web-ui/src/components/SortableStepItem.tsx` | New — draggable wrapper for individual steps |
+| `src/web-ui/src/components/sequences/LoopBlock.tsx` | Modified — replace ↑/↓ with DnD sortable body |
+| `src/web-ui/src/pages/SequencesPage.tsx` | Modified — add DndContext, SortableSequenceStepList, bottom "Add step" button |
+| `src/web-ui/src/index.css` (or equivalent) | Modified — add `.loop-block--drop-invalid` CSS class |

--- a/specs/037-loop-step-management/research.md
+++ b/specs/037-loop-step-management/research.md
@@ -1,0 +1,69 @@
+# Research: Sequence Loop Step Management
+
+**Branch**: `037-loop-step-management` | **Date**: 2026-05-30
+
+## Decision 1: Drag-and-Drop Library
+
+**Decision**: Use `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities`
+
+**Rationale**:
+- TypeScript-first, composable hooks-based API; no opinionated DOM structure
+- Multiple independent `SortableContext` instances can share one `DndContext` — exactly the pattern needed for scope-constrained reordering (top-level and loop body as separate contexts)
+- Custom `data` payload on draggable items makes scope comparison straightforward in `onDragEnd`
+- Active maintenance, good React 18 compatibility
+
+**Alternatives considered**:
+- **Native HTML5 DnD API**: No third-party cost, but cross-browser inconsistency (Firefox vs Chrome scroll behavior), no built-in sortable helpers, complex visual feedback implementation. Rejected due to implementation complexity for scope constraints.
+- **`react-beautiful-dnd`**: Well-known but officially deprecated. Each `Droppable` is isolated, which actually maps well to scope constraint but the project is unmaintained. Rejected.
+- **`@hello-pangea/dnd`** (maintained fork of react-beautiful-dnd): Viable alternative; similar scope isolation model. Less composable for custom collision detection. Could serve as fallback.
+
+---
+
+## Decision 2: Scope Enforcement Strategy
+
+**Decision**: Tag each draggable step with a `scopeId` string. Validate scope match in `onDragEnd`; apply CSS class on cross-scope `onDragOver`.
+
+**Rationale**:
+- Top-level steps get `scopeId = "root"`. Loop body steps get `scopeId = <loop.id>`.
+- dnd-kit allows arbitrary `data` attached to `useSortable`'s `data` prop, propagated in `active.data.current` and `over.data.current` during drag events.
+- `onDragEnd`: if `active.data.current.scopeId !== over.data.current.scopeId`, return early without reordering.
+- `onDragOver`: compare same fields; if mismatch, add a CSS modifier class (e.g., `loop-block--drop-invalid`) to the target container for the "not allowed" visual.
+- When invalid drop occurs (mouse released over invalid target), dnd-kit automatically keeps the item in its original position — no explicit snap-back code needed.
+
+**Alternatives considered**:
+- **Separate `DndContext` per scope**: Would prevent cross-scope drag entirely at the DnD level (no `over` event across contexts). Simpler but gives no visual feedback during drag; user sees nothing wrong until they release. Rejected in favor of visible "not allowed" indicator.
+- **`modifiers` array**: dnd-kit modifiers restrict pointer movement, not drop targets. Not suited for scope constraints. Rejected.
+
+---
+
+## Decision 3: "Add Step" Button Placement
+
+**Decision**: A single persistent "Add step" button is placed at the very bottom of the step list in `SequencesPage`, below the `SortableSequenceStepList`. Clicking it appends a blank action step to the top-level `form.steps` array.
+
+**Rationale**:
+- User explicitly chose Option A during clarification: bottom-of-sequence, appends to end.
+- Mirrors `LoopBlock`'s existing "Add step" button pattern (scoped to loop bottom) but at the sequence level.
+- No ambiguity about insertion position; always appends.
+
+---
+
+## Decision 4: Coexistence with ReorderableList
+
+**Decision**: Create a new `SortableSequenceStepList` component for sequences. Leave `ReorderableList` unchanged for its other usages (e.g., CommandForm).
+
+**Rationale**:
+- `ReorderableList` is used in at least `CommandForm` with the existing ↑/↓ button model. Modifying it would risk regressions in unrelated UI.
+- `SortableSequenceStepList` is purpose-built for the sequence editor; it accepts `SequenceStep` objects directly (not `ReorderableListItem`) and owns the DnD context.
+- `LoopBlock` gets its own internal sortable body using the same shared `DndContext` (bubbled up from the sequence editor).
+
+---
+
+## Decision 5: Visual "Not Allowed" Indicator
+
+**Decision**: Apply a CSS class to the hovered drop container when a cross-scope drag is detected. Use a red-outline or dimmed styling. On release over invalid target, item snaps back (no-op in `onDragEnd`).
+
+**Rationale**:
+- Standard UX pattern for constrained DnD. The CSS class approach is decoupled — styles can be adjusted without touching logic.
+- dnd-kit's `DragOverlay` component can also render a "forbidden" cursor overlay if desired; adding it is non-breaking.
+
+**Implementation note**: Use a React state variable `isDragInvalid` set in `onDragOver` and cleared in `onDragEnd`/`onDragCancel`. Pass it as a prop to loop blocks to apply the CSS class conditionally.

--- a/specs/037-loop-step-management/spec.md
+++ b/specs/037-loop-step-management/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Sequence Loop Step Management
+
+**Feature Branch**: `037-loop-step-management`  
+**Created**: 2026-05-30  
+**Status**: Draft  
+**Input**: User description: "I want to be able to create new steps in the sequence within the loop as well as outside. Now it works like this: once I add a loop to the sequence, I can only create new steps within this loop. This is OK for starters, and it must be kept, however I cannot add a step after the loop. Once The step is added outside the loop, I also need to be able to move the step before and after the loop, i.e. reordering the steps should work only between the nesting level where the steps are, not moving the steps in and out of the loop just by reordering."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Add Step Outside a Loop (Priority: P1)
+
+A user is authoring a sequence that contains one or more loops. They want to add a step that executes at the top level of the sequence — either before or after a loop — but currently the only "add step" control available targets the inside of the loop. This story covers making it possible to add steps at the top-level sequence scope regardless of whether loops are present.
+
+**Why this priority**: Without this, any sequence that uses a loop is structurally incomplete — the user cannot add post-loop cleanup steps, conditional follow-ups, or any actions that should run after the loop finishes. This is a blocking gap.
+
+**Independent Test**: Can be fully tested by opening a sequence that contains a loop and verifying that an "add step" control exists at the top-level scope (outside the loop), then adding a step and confirming it appears at the top level.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence with a loop and no top-level steps after the loop, **When** the user triggers "add step" at the top-level scope, **Then** a new step is inserted at the top level of the sequence, not inside the loop.
+2. **Given** a sequence where the last element is a loop, **When** the user adds a step using the top-level add control, **Then** the new step appears after the loop in the sequence.
+3. **Given** a sequence with top-level steps both before and after a loop, **When** the user clicks the persistent "Add step" button, **Then** the new step is appended at the end of the top-level scope.
+4. **Given** a sequence containing only a loop (no other top-level steps), **When** the user opens the sequence editor, **Then** a top-level "add step" control is visible and functional.
+
+---
+
+### User Story 2 - Reorder Steps Within the Same Nesting Level (Priority: P2)
+
+A user has a sequence with a mix of top-level steps and at least one loop. They want to reorder the top-level steps — including changing whether a step runs before or after the loop — using the existing reordering controls. They expect that reordering operates only within the same scope: top-level steps can be shuffled among top-level items, and loop steps can be shuffled among loop items, but steps cannot accidentally cross the loop boundary.
+
+**Why this priority**: Once users can add steps at both levels, reordering is the next essential authoring operation. Scope-constrained reordering prevents accidental structural changes and makes the authoring model predictable.
+
+**Independent Test**: Can be fully tested by creating a sequence with two top-level steps and one loop (with its own internal steps), then reordering the top-level steps and verifying that loop contents are unaffected, and that reordering inside the loop does not affect top-level step order.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence with steps [A, Loop, B] at the top level, **When** the user drags step B before the Loop, **Then** the sequence becomes [A, B, Loop] and Loop contents are unchanged.
+2. **Given** a sequence with steps [A, Loop, B] at the top level, **When** the user drags step A after the Loop, **Then** the sequence becomes [Loop, B, A] and Loop contents are unchanged.
+3. **Given** a loop with internal steps [X, Y, Z], **When** the user drags them into the order [Z, X, Y], **Then** the top-level sequence order is unchanged.
+4. **Given** a top-level step being dragged, **When** the user hovers it over the interior of a loop, **Then** the loop interior displays a "not allowed" visual indicator and the step snaps back to its original position on release.
+5. **Given** a loop-interior step being dragged, **When** the user hovers it over a top-level drop target outside the loop, **Then** the top-level drop target displays a "not allowed" visual indicator and the step snaps back to its original position on release.
+
+---
+
+### User Story 3 - Add Steps Inside a Loop (Priority: P3)
+
+A user adds a loop to a sequence and then adds steps inside that loop. This is the currently working behavior and must continue to work without regression.
+
+**Why this priority**: Existing functionality that must be preserved; lower priority because it already works.
+
+**Independent Test**: Can be fully tested by adding a loop to a sequence, then adding multiple steps inside the loop and verifying they are scoped to the loop.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence with a loop, **When** the user uses the in-loop "add step" control, **Then** a new step is added inside the loop, not at the top level.
+2. **Given** a loop with existing internal steps, **When** the user adds another step inside the loop, **Then** the new step is added at the correct position within the loop.
+
+---
+
+### Edge Cases
+
+- What happens when a sequence has only a loop and the user tries to add a top-level step? The add control must still be accessible and functional.
+- What happens when a loop is the first element and the user wants a step before it? The user appends a step using the persistent "Add step" button (which places it at the end of the top-level scope) and then drags it to the desired position before the loop. Direct positional insertion is not supported; the "Add step" button always appends.
+- What happens when a loop is nested inside another loop? **Out of scope for this feature** — nested loops (loop within a loop) are a known limitation and will be addressed in a follow-up feature.
+- How does the system handle reordering when only one step exists at a nesting level? Controls may be disabled or hidden since there is nothing to reorder.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Users MUST be able to add new steps at the top-level sequence scope even when one or more loops exist within the sequence. A persistent "Add step" button MUST appear at the bottom of the sequence editor, always appending a new step at the end of the top-level scope; the existing in-loop "add step" control continues to scope additions to the loop interior.
+- **FR-002**: Users MUST be able to add new steps inside a loop (existing behavior MUST be preserved without regression).
+- **FR-003**: Users MUST be able to reorder steps within the top-level sequence scope, including changing a step's position relative to loops at that level.
+- **FR-004**: Users MUST be able to reorder steps within a loop's scope.
+- **FR-005**: Step reordering MUST be constrained to the nesting level of the step being moved — a step cannot be moved into or out of a loop via reordering controls.
+- **FR-006**: Step reordering uses drag-and-drop. The drag-and-drop interaction MUST prevent a step from being dropped into a drop target that belongs to a different nesting level (i.e., dragging a top-level step cannot drop it inside a loop, and dragging a loop-interior step cannot drop it at the top level).
+- **FR-007**: During a drag operation, invalid drop targets MUST display a visual "not allowed" indicator (such as a cursor change, highlight, or dimming). When a step is released over an invalid drop target, it MUST snap back to its original position.
+
+### Key Entities
+
+- **Sequence**: The top-level ordered list of steps and loop blocks that is executed as a unit.
+- **Loop Block**: A container element within a sequence that holds its own ordered list of steps and repeats them according to loop configuration.
+- **Step**: An individual action item that belongs to exactly one scope — either the top-level sequence or a specific loop block.
+- **Nesting Level**: The scope to which a step belongs (top-level = 0, inside a loop = 1, inside a nested loop = 2, etc.).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can add a step at the top-level scope in a sequence containing at least one loop, without any additional navigation or workarounds.
+- **SC-002**: 100% of drag-and-drop reorder operations produce a result where the dropped step remains at the same nesting level it started at; cross-level drop targets are rejected.
+- **SC-003**: Users can successfully add and reorder steps both inside and outside loops within the same sequence editing session without errors.
+- **SC-004**: The add-step and reorder controls are visually distinct and available at each nesting level, reducing authoring errors related to wrong-level insertion.
+
+## Clarifications
+
+### Session 2026-05-30
+
+- Q: Does scope-constrained step management apply recursively to nested loops (loop-within-a-loop), or only to the first level of nesting? → A: First level only. Nested loops (loop within a loop) are out of scope; this feature covers only a loop directly inside a top-level sequence.
+- Q: Where does the top-level "add step" control appear? → A: A single persistent "Add step" button at the very bottom of the sequence; it always appends a new step at the end of the top-level scope.
+- Q: What mechanism is used for step reordering? → A: Drag-and-drop only. Move-up/move-down buttons are not part of this feature.
+- Q: How does the UI communicate a rejected cross-level drop during drag-and-drop? → A: Visual "not allowed" indicator on invalid drop targets during drag (cursor change, highlight, or dimming); item snaps back to its original position on an invalid drop.
+
+## Assumptions
+
+- The existing loop authoring UI already shows steps inside the loop and provides an "add step" control scoped to the loop interior.
+- "Reordering" means drag-and-drop. Move-up/move-down buttons are not part of this feature.
+- Nested loops (loop within a loop) are **out of scope**. This feature covers exactly one level of nesting: a loop directly inside a top-level sequence. Nested loop support is a known limitation for a follow-up feature.
+- The Loop Block itself is treated as a single item at the top-level scope and can be reordered among other top-level items (moving the whole loop, not its contents).

--- a/specs/037-loop-step-management/tasks.md
+++ b/specs/037-loop-step-management/tasks.md
@@ -1,0 +1,175 @@
+# Tasks: Sequence Loop Step Management
+
+**Input**: Design documents from `specs/037-loop-step-management/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, quickstart.md ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story (US1, US2, US3)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Install new dependency required by US2
+
+- [ ] T001 Install `@dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities` in `src/web-ui/` via `npm install`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared DnD infrastructure types and the drag-item wrapper component that both US2 phases (SortableSequenceStepList and LoopBlock refactor) depend on.
+
+**⚠️ CRITICAL**: T007 and T008 in Phase 4 both depend on T003 being complete.
+
+- [ ] T002 Add `StepDragData` type `{ scopeId: string; type: 'step' }` to `src/web-ui/src/types/stepEntry.ts`
+- [ ] T003 Create `src/web-ui/src/components/SortableStepItem.tsx` — wraps a step row with `useSortable({ id, data: { scopeId, type: 'step' } })`; applies dnd-kit `transform`/`transition` styles; accepts `id: string`, `scopeId: string`, `disabled?: boolean`, `children: React.ReactNode`; renders a visible drag handle (e.g., `⠿` grip icon) so users can see and interact with the drag affordance (addresses SC-004)
+- [ ] T003a Create `src/web-ui/src/components/__tests__/SortableStepItem.test.tsx` — unit tests covering: (a) renders children; (b) renders drag handle icon; (c) applies `transform`/`transition` style from useSortable (mock dnd-kit hooks); (d) applies disabled state correctly; (e) passes `scopeId` and `type: 'step'` in useSortable data (constitution: ≥80% line / ≥70% branch coverage for new module)
+
+**Checkpoint**: Shared drag infrastructure ready — US1 (Phase 3) and US2 (Phase 4) can now proceed.
+
+---
+
+## Phase 3: User Story 1 — Add Step Outside a Loop (Priority: P1) 🎯 MVP
+
+**Goal**: A persistent "Add step" button at the very bottom of the sequence step list always appends a blank action step at the top-level scope, regardless of whether loops are present.
+
+**Independent Test**: Open a sequence containing a loop. Click the new "Add step" button at the bottom. Verify a new blank action step appears at the end of the top-level sequence, not inside the loop. Verify the loop's internal "Add step" button still adds steps inside the loop only.
+
+### Implementation for User Story 1
+
+- [ ] T004 [US1] Add `handleAddTopLevelStep()` function to `SequencesPage.tsx` — creates a blank `SequenceStep` with `stepType: 'Action'` and `actionType: 'command'` (same pattern as `createLoopStep` which returns `SequenceStep`); appends it to `form.steps` via `setForm`; follow existing `nextGeneratedStepId` helper for ID generation
+- [ ] T005 [US1] In `SequencesPage.tsx` create-sequence form section (after the `<ReorderableList>` at ~line 1267), add `<button type="button" data-testid="add-top-level-step" onClick={handleAddTopLevelStep} disabled={submitting || loading}>Add step</button>`
+- [ ] T006 [US1] In `SequencesPage.tsx` edit-sequence form section (after the `<ReorderableList>` at ~line 1495), add the same persistent "Add step" button wired to `handleAddTopLevelStep`
+
+**Checkpoint**: US1 is fully functional. User can now add top-level steps when a loop is present. Test independently before proceeding to US2.
+
+---
+
+## Phase 4: User Story 2 — Scope-Constrained DnD Reordering (Priority: P2)
+
+**Goal**: Replace the ↑/↓ button-based reordering with drag-and-drop. Top-level steps can be dragged to reorder among top-level items (including past loop blocks). Loop-body steps can be dragged to reorder within the loop. Cross-scope drops are rejected with a visual "not allowed" indicator.
+
+**Independent Test**: In a sequence with top-level steps [A, Loop, B]: (1) drag step B before the Loop — sequence becomes [A, B, Loop]; (2) attempt to drag a top-level step into the loop body — a "not allowed" visual appears and the step snaps back; (3) drag loop-body steps to reorder — top-level order is unchanged.
+
+### Implementation for User Story 2
+
+- [ ] T007 [P] [US2] Create `src/web-ui/src/components/SortableSequenceStepList.tsx` — accepts `steps: SequenceStep[]`, `onDelete`, `disabled`, `isDragInvalid: boolean` (no `onChange` — reordering is handled entirely by `DndContext.onDragEnd` in `SequencesPage`, not by this component); wraps items in a `SortableContext` (ids = step ids, each with `scopeId = "root"` in data); renders each step in a `SortableStepItem`; for Loop steps renders `LoopBlock` as child content and passes `isDragInvalid` as `isDropInvalid` to `LoopBlock`; does NOT own `DndContext` (that lives in SequencesPage)
+- [ ] T008 [US2] Refactor `src/web-ui/src/components/sequences/LoopBlock.tsx` — remove the `move()` helper and `handleBodyReorder()` function; remove the ↑/↓ `<button>` elements (lines 124–125); wrap the `<ol>` body in a `SortableContext` (ids = body step ids, `scopeId = loop.id`); render each body step `<li>` inside a `SortableStepItem` with `scopeId={loop.id}`; preserve `handleAddBodyStep`, `handleAddBreakStep`, and their buttons unchanged; add `isDropInvalid?: boolean` prop; apply CSS class `loop-block--drop-invalid` to the `loop-block__body` div when `isDropInvalid` is true
+- [ ] T009 [US2] Add `activeStepId: string | null` and `isDragInvalid: boolean` state to `SequencesPage.tsx`; implement `handleDragStart`, `handleDragEnd`, `handleDragOver`, `handleDragCancel` handlers: `handleDragStart` sets `activeStepId`; `handleDragEnd` compares `active.data.current.scopeId` vs `over?.data.current?.scopeId` — if matching, performs reorder in `form.steps` via array splice; always clears both state vars; `handleDragCancel` clears both state vars; `handleDragOver` sets `isDragInvalid = true` when active and over scopes differ
+- [ ] T010 [US2] Wrap the step list section in `SequencesPage.tsx` create-sequence form in `<DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragOver={handleDragOver} onDragCancel={handleDragCancel}>`; replace `<ReorderableList ... />` (~line 1254) with `<SortableSequenceStepList steps={form.steps} onDelete={(item) => { setForm(prev => ({ ...prev, steps: prev.steps.filter(s => s.id !== item.id) })); setDirty(true); }} disabled={submitting || loading} isDragInvalid={isDragInvalid} />`
+- [ ] T011 [US2] Wrap the step list section in `SequencesPage.tsx` edit-sequence form (~line 1495) in `<DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragOver={handleDragOver} onDragCancel={handleDragCancel}>`; replace `<ReorderableList ... />` with `<SortableSequenceStepList steps={form.steps} onDelete={(item) => { setForm(prev => ({ ...prev, steps: prev.steps.filter(s => s.id !== item.id) })); setDirty(true); }} disabled={submitting || loading} isDragInvalid={isDragInvalid} />`
+- [ ] T012 [P] [US2] Add `.loop-block--drop-invalid { outline: 2px solid #d32f2f; opacity: 0.7; }` CSS rule to the project stylesheet (`src/web-ui/src/index.css` or equivalent)
+
+**Checkpoint**: US2 is fully functional. Drag-and-drop reordering works at both nesting levels. Cross-scope drops are rejected visually. Test independently.
+
+---
+
+## Phase 5: User Story 3 — Preserve In-Loop Step Addition (Priority: P3)
+
+**Goal**: Verify that the LoopBlock refactor in Phase 4 (T008) preserves the existing "Add step" and "Add break" functionality for loop bodies without regression.
+
+**Independent Test**: Add a loop to a sequence. Use the loop's internal "Add step" button. Verify the new step appears inside the loop body. Use "Add break" — verify it adds a break step inside the loop body. Existing LoopBlock unit tests must pass.
+
+### Implementation for User Story 3
+
+- [ ] T013 [US3] Update `src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx` (create file if it doesn't exist) — add/update tests to verify: (a) "Add step" button adds an action step to the loop body; (b) "Add break" button adds a break step; (c) `isDropInvalid=true` prop applies `loop-block--drop-invalid` CSS class; (d) ↑/↓ buttons are absent; existing passing tests remain green
+
+**Checkpoint**: US3 preserved — in-loop step addition works identically to before the refactor.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+- [ ] T014 [P] Update form hint text in `SequencesPage.tsx` — change `"Steps execute in listed order; drag buttons to reorder before saving."` (appears in both create and edit forms) to `"Steps execute in listed order; drag to reorder within the same level."`
+- [ ] T015 Add unit tests for `SortableSequenceStepList.tsx` in `src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx` — cover: renders step list items; `isDragInvalid=true` passes `isDropInvalid=true` to `LoopBlock`; `onDelete` callback fires with the correct step; loop steps render `LoopBlock` as child content
+- [ ] T016 Run `npm test` in `src/web-ui/` and fix any failing tests or coverage regressions introduced by the DnD refactor
+- [ ] T017 [P] Add Playwright E2E test in `src/web-ui/tests/sequences-loop-steps.spec.ts` covering US1 (add step after loop at top level) and US2 (drag step past loop; attempt cross-scope drag and verify snap-back)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 (npm install must complete before importing dnd-kit)
+- **Phase 3 (US1)**: Depends on Phase 2 — but US1 uses only React state, not dnd-kit directly; T004–T006 do not import `SortableStepItem`
+- **Phase 4 (US2)**: Depends on Phase 2 (T003 `SortableStepItem` must exist) — T007 and T008 can run in parallel; T009–T011 depend on T007 and T008
+- **Phase 5 (US3)**: Depends on Phase 4 (T008 LoopBlock refactor must be complete)
+- **Polish**: Depends on Phases 3–5
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on US2 or US3 — can be built and demoed independently after Phase 2
+- **US2 (P2)**: Depends on Phase 2 (SortableStepItem); no dependency on US1
+- **US3 (P3)**: Depends on US2 (T008 LoopBlock refactor)
+
+### Within Phase 4 (US2)
+
+```
+T007 (SortableSequenceStepList) ─┐
+                                  ├── T010 (create form DndContext)
+T008 (LoopBlock DnD refactor) ───┤
+                                  ├── T011 (edit form DndContext)
+T009 (handlers in SequencesPage)─┘
+T012 (CSS) — independent [P]
+```
+
+### Parallel Opportunities
+
+- T007 and T008 can run in parallel (different files, both depend only on T003)
+- T009 (handlers) can be authored in parallel with T007/T008 (no runtime dependency until T010/T011)
+- T012 (CSS) is fully independent and can be done any time after T001
+- T014 (hint text), T015 (unit tests), T017 (E2E tests) can all run in parallel in Polish phase
+
+---
+
+## Parallel Example: Phase 4 (US2)
+
+```
+# After T003 completes, launch these in parallel:
+Task T007: Create SortableSequenceStepList.tsx
+Task T008: Refactor LoopBlock.tsx for DnD
+Task T009: Implement DnD event handlers in SequencesPage.tsx
+Task T012: Add CSS for loop-block--drop-invalid
+
+# After T007, T008, T009 complete:
+Task T010: Wire DndContext into create form (SequencesPage.tsx)
+Task T011: Wire DndContext into edit form (SequencesPage.tsx)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Install deps
+2. Complete Phase 2: Create SortableStepItem (needed later for US2)
+3. Complete Phase 3: US1 (T004–T006) — the "Add step" button
+4. **STOP and VALIDATE**: Verify top-level step addition works in the browser
+5. Demo if ready — this alone resolves the blocking UX gap
+
+### Incremental Delivery
+
+1. Phase 1–3 → **MVP**: Top-level "Add step" button works
+2. Phase 4 (US2) → DnD reordering with scope constraints
+3. Phase 5 (US3) → Regression tests confirming no regression
+4. Polish → Updated hint text, full test suite, E2E coverage
+
+---
+
+## Notes
+
+- [P] tasks = different files, no shared-state dependencies
+- The `ReorderableList` component is intentionally left unchanged (used by `CommandForm`)
+- `SortableStepItem` must not import from `SequencesPage` — it is a generic DnD wrapper
+- `SortableSequenceStepList` must NOT own `DndContext` — only `SequencesPage` does, so cross-component drag events work
+- Scope enforcement lives exclusively in `onDragEnd` in `SequencesPage.tsx` — no scope logic inside individual components
+- `SortableSequenceStepList` has no `onChange` prop — reordering state updates live in `DndContext.onDragEnd` in `SequencesPage` only
+- After T010/T011, the existing `onAdd` prop of `ReorderableList` is no longer called for sequences; the new "Add step" button from Phase 3 takes over that role

--- a/specs/037-loop-step-management/tasks.md
+++ b/specs/037-loop-step-management/tasks.md
@@ -16,7 +16,7 @@
 
 **Purpose**: Install new dependency required by US2
 
-- [ ] T001 Install `@dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities` in `src/web-ui/` via `npm install`
+- [X] T001 Install `@dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities` in `src/web-ui/` via `npm install`
 
 ---
 
@@ -26,9 +26,9 @@
 
 **⚠️ CRITICAL**: T007 and T008 in Phase 4 both depend on T003 being complete.
 
-- [ ] T002 Add `StepDragData` type `{ scopeId: string; type: 'step' }` to `src/web-ui/src/types/stepEntry.ts`
-- [ ] T003 Create `src/web-ui/src/components/SortableStepItem.tsx` — wraps a step row with `useSortable({ id, data: { scopeId, type: 'step' } })`; applies dnd-kit `transform`/`transition` styles; accepts `id: string`, `scopeId: string`, `disabled?: boolean`, `children: React.ReactNode`; renders a visible drag handle (e.g., `⠿` grip icon) so users can see and interact with the drag affordance (addresses SC-004)
-- [ ] T003a Create `src/web-ui/src/components/__tests__/SortableStepItem.test.tsx` — unit tests covering: (a) renders children; (b) renders drag handle icon; (c) applies `transform`/`transition` style from useSortable (mock dnd-kit hooks); (d) applies disabled state correctly; (e) passes `scopeId` and `type: 'step'` in useSortable data (constitution: ≥80% line / ≥70% branch coverage for new module)
+- [X] T002 Add `StepDragData` type `{ scopeId: string; type: 'step' }` to `src/web-ui/src/types/stepEntry.ts`
+- [X] T003 Create `src/web-ui/src/components/SortableStepItem.tsx` — wraps a step row with `useSortable({ id, data: { scopeId, type: 'step' } })`; applies dnd-kit `transform`/`transition` styles; accepts `id: string`, `scopeId: string`, `disabled?: boolean`, `children: React.ReactNode`; renders a visible drag handle (e.g., `⠿` grip icon) so users can see and interact with the drag affordance (addresses SC-004)
+- [X] T003a Create `src/web-ui/src/components/__tests__/SortableStepItem.test.tsx` — unit tests covering: (a) renders children; (b) renders drag handle icon; (c) applies `transform`/`transition` style from useSortable (mock dnd-kit hooks); (d) applies disabled state correctly; (e) passes `scopeId` and `type: 'step'` in useSortable data (constitution: ≥80% line / ≥70% branch coverage for new module)
 
 **Checkpoint**: Shared drag infrastructure ready — US1 (Phase 3) and US2 (Phase 4) can now proceed.
 
@@ -42,9 +42,9 @@
 
 ### Implementation for User Story 1
 
-- [ ] T004 [US1] Add `handleAddTopLevelStep()` function to `SequencesPage.tsx` — creates a blank `SequenceStep` with `stepType: 'Action'` and `actionType: 'command'` (same pattern as `createLoopStep` which returns `SequenceStep`); appends it to `form.steps` via `setForm`; follow existing `nextGeneratedStepId` helper for ID generation
-- [ ] T005 [US1] In `SequencesPage.tsx` create-sequence form section (after the `<ReorderableList>` at ~line 1267), add `<button type="button" data-testid="add-top-level-step" onClick={handleAddTopLevelStep} disabled={submitting || loading}>Add step</button>`
-- [ ] T006 [US1] In `SequencesPage.tsx` edit-sequence form section (after the `<ReorderableList>` at ~line 1495), add the same persistent "Add step" button wired to `handleAddTopLevelStep`
+- [X] T004 [US1] Add `handleAddTopLevelStep()` function to `SequencesPage.tsx` — creates a blank `SequenceStep` with `stepType: 'Action'` and `actionType: 'command'` (same pattern as `createLoopStep` which returns `SequenceStep`); appends it to `form.steps` via `setForm`; follow existing `nextGeneratedStepId` helper for ID generation
+- [X] T005 [US1] In `SequencesPage.tsx` create-sequence form section (after the `<ReorderableList>` at ~line 1267), add `<button type="button" data-testid="add-top-level-step" onClick={handleAddTopLevelStep} disabled={submitting || loading}>Add step</button>`
+- [X] T006 [US1] In `SequencesPage.tsx` edit-sequence form section (after the `<ReorderableList>` at ~line 1495), add the same persistent "Add step" button wired to `handleAddTopLevelStep`
 
 **Checkpoint**: US1 is fully functional. User can now add top-level steps when a loop is present. Test independently before proceeding to US2.
 
@@ -58,12 +58,12 @@
 
 ### Implementation for User Story 2
 
-- [ ] T007 [P] [US2] Create `src/web-ui/src/components/SortableSequenceStepList.tsx` — accepts `steps: SequenceStep[]`, `onDelete`, `disabled`, `isDragInvalid: boolean` (no `onChange` — reordering is handled entirely by `DndContext.onDragEnd` in `SequencesPage`, not by this component); wraps items in a `SortableContext` (ids = step ids, each with `scopeId = "root"` in data); renders each step in a `SortableStepItem`; for Loop steps renders `LoopBlock` as child content and passes `isDragInvalid` as `isDropInvalid` to `LoopBlock`; does NOT own `DndContext` (that lives in SequencesPage)
-- [ ] T008 [US2] Refactor `src/web-ui/src/components/sequences/LoopBlock.tsx` — remove the `move()` helper and `handleBodyReorder()` function; remove the ↑/↓ `<button>` elements (lines 124–125); wrap the `<ol>` body in a `SortableContext` (ids = body step ids, `scopeId = loop.id`); render each body step `<li>` inside a `SortableStepItem` with `scopeId={loop.id}`; preserve `handleAddBodyStep`, `handleAddBreakStep`, and their buttons unchanged; add `isDropInvalid?: boolean` prop; apply CSS class `loop-block--drop-invalid` to the `loop-block__body` div when `isDropInvalid` is true
-- [ ] T009 [US2] Add `activeStepId: string | null` and `isDragInvalid: boolean` state to `SequencesPage.tsx`; implement `handleDragStart`, `handleDragEnd`, `handleDragOver`, `handleDragCancel` handlers: `handleDragStart` sets `activeStepId`; `handleDragEnd` compares `active.data.current.scopeId` vs `over?.data.current?.scopeId` — if matching, performs reorder in `form.steps` via array splice; always clears both state vars; `handleDragCancel` clears both state vars; `handleDragOver` sets `isDragInvalid = true` when active and over scopes differ
-- [ ] T010 [US2] Wrap the step list section in `SequencesPage.tsx` create-sequence form in `<DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragOver={handleDragOver} onDragCancel={handleDragCancel}>`; replace `<ReorderableList ... />` (~line 1254) with `<SortableSequenceStepList steps={form.steps} onDelete={(item) => { setForm(prev => ({ ...prev, steps: prev.steps.filter(s => s.id !== item.id) })); setDirty(true); }} disabled={submitting || loading} isDragInvalid={isDragInvalid} />`
-- [ ] T011 [US2] Wrap the step list section in `SequencesPage.tsx` edit-sequence form (~line 1495) in `<DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragOver={handleDragOver} onDragCancel={handleDragCancel}>`; replace `<ReorderableList ... />` with `<SortableSequenceStepList steps={form.steps} onDelete={(item) => { setForm(prev => ({ ...prev, steps: prev.steps.filter(s => s.id !== item.id) })); setDirty(true); }} disabled={submitting || loading} isDragInvalid={isDragInvalid} />`
-- [ ] T012 [P] [US2] Add `.loop-block--drop-invalid { outline: 2px solid #d32f2f; opacity: 0.7; }` CSS rule to the project stylesheet (`src/web-ui/src/index.css` or equivalent)
+- [X] T007 [P] [US2] Create `src/web-ui/src/components/SortableSequenceStepList.tsx` — accepts `steps: SequenceStep[]`, `onDelete`, `disabled`, `isDragInvalid: boolean` (no `onChange` — reordering is handled entirely by `DndContext.onDragEnd` in `SequencesPage`, not by this component); wraps items in a `SortableContext` (ids = step ids, each with `scopeId = "root"` in data); renders each step in a `SortableStepItem`; for Loop steps renders `LoopBlock` as child content and passes `isDragInvalid` as `isDropInvalid` to `LoopBlock`; does NOT own `DndContext` (that lives in SequencesPage)
+- [X] T008 [US2] Refactor `src/web-ui/src/components/sequences/LoopBlock.tsx` — remove the `move()` helper and `handleBodyReorder()` function; remove the ↑/↓ `<button>` elements (lines 124–125); wrap the `<ol>` body in a `SortableContext` (ids = body step ids, `scopeId = loop.id`); render each body step `<li>` inside a `SortableStepItem` with `scopeId={loop.id}`; preserve `handleAddBodyStep`, `handleAddBreakStep`, and their buttons unchanged; add `isDropInvalid?: boolean` prop; apply CSS class `loop-block--drop-invalid` to the `loop-block__body` div when `isDropInvalid` is true
+- [X] T009 [US2] Add `activeStepId: string | null` and `isDragInvalid: boolean` state to `SequencesPage.tsx`; implement `handleDragStart`, `handleDragEnd`, `handleDragOver`, `handleDragCancel` handlers: `handleDragStart` sets `activeStepId`; `handleDragEnd` compares `active.data.current.scopeId` vs `over?.data.current?.scopeId` — if matching, performs reorder in `form.steps` via array splice; always clears both state vars; `handleDragCancel` clears both state vars; `handleDragOver` sets `isDragInvalid = true` when active and over scopes differ
+- [X] T010 [US2] Wrap the step list section in `SequencesPage.tsx` create-sequence form in `<DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragOver={handleDragOver} onDragCancel={handleDragCancel}>`; replace `<ReorderableList ... />` (~line 1254) with `<SortableSequenceStepList steps={form.steps} onDelete={(item) => { setForm(prev => ({ ...prev, steps: prev.steps.filter(s => s.id !== item.id) })); setDirty(true); }} disabled={submitting || loading} isDragInvalid={isDragInvalid} />`
+- [X] T011 [US2] Wrap the step list section in `SequencesPage.tsx` edit-sequence form (~line 1495) in `<DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragOver={handleDragOver} onDragCancel={handleDragCancel}>`; replace `<ReorderableList ... />` with `<SortableSequenceStepList steps={form.steps} onDelete={(item) => { setForm(prev => ({ ...prev, steps: prev.steps.filter(s => s.id !== item.id) })); setDirty(true); }} disabled={submitting || loading} isDragInvalid={isDragInvalid} />`
+- [X] T012 [P] [US2] Add `.loop-block--drop-invalid { outline: 2px solid #d32f2f; opacity: 0.7; }` CSS rule to the project stylesheet (`src/web-ui/src/index.css` or equivalent)
 
 **Checkpoint**: US2 is fully functional. Drag-and-drop reordering works at both nesting levels. Cross-scope drops are rejected visually. Test independently.
 
@@ -77,7 +77,7 @@
 
 ### Implementation for User Story 3
 
-- [ ] T013 [US3] Update `src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx` (create file if it doesn't exist) — add/update tests to verify: (a) "Add step" button adds an action step to the loop body; (b) "Add break" button adds a break step; (c) `isDropInvalid=true` prop applies `loop-block--drop-invalid` CSS class; (d) ↑/↓ buttons are absent; existing passing tests remain green
+- [X] T013 [US3] Update `src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx` (create file if it doesn't exist) — add/update tests to verify: (a) "Add step" button adds an action step to the loop body; (b) "Add break" button adds a break step; (c) `isDropInvalid=true` prop applies `loop-block--drop-invalid` CSS class; (d) ↑/↓ buttons are absent; existing passing tests remain green
 
 **Checkpoint**: US3 preserved — in-loop step addition works identically to before the refactor.
 
@@ -85,10 +85,10 @@
 
 ## Phase N: Polish & Cross-Cutting Concerns
 
-- [ ] T014 [P] Update form hint text in `SequencesPage.tsx` — change `"Steps execute in listed order; drag buttons to reorder before saving."` (appears in both create and edit forms) to `"Steps execute in listed order; drag to reorder within the same level."`
-- [ ] T015 Add unit tests for `SortableSequenceStepList.tsx` in `src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx` — cover: renders step list items; `isDragInvalid=true` passes `isDropInvalid=true` to `LoopBlock`; `onDelete` callback fires with the correct step; loop steps render `LoopBlock` as child content
-- [ ] T016 Run `npm test` in `src/web-ui/` and fix any failing tests or coverage regressions introduced by the DnD refactor
-- [ ] T017 [P] Add Playwright E2E test in `src/web-ui/tests/sequences-loop-steps.spec.ts` covering US1 (add step after loop at top level) and US2 (drag step past loop; attempt cross-scope drag and verify snap-back)
+- [X] T014 [P] Update form hint text in `SequencesPage.tsx` — change `"Steps execute in listed order; drag buttons to reorder before saving."` (appears in both create and edit forms) to `"Steps execute in listed order; drag to reorder within the same level."`
+- [X] T015 Add unit tests for `SortableSequenceStepList.tsx` in `src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx` — cover: renders step list items; `isDragInvalid=true` passes `isDropInvalid=true` to `LoopBlock`; `onDelete` callback fires with the correct step; loop steps render `LoopBlock` as child content
+- [X] T016 Run `npm test` in `src/web-ui/` and fix any failing tests or coverage regressions introduced by the DnD refactor
+- [X] T017 [P] Add Playwright E2E test in `src/web-ui/tests/sequences-loop-steps.spec.ts` covering US1 (add step after loop at top level) and US2 (drag step past loop; attempt cross-scope drag and verify snap-back)
 
 ---
 

--- a/src/web-ui/package-lock.json
+++ b/src/web-ui/package-lock.json
@@ -8,6 +8,9 @@
       "name": "gamebot-web-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -738,6 +741,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -9649,6 +9705,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -13,6 +13,9 @@
     "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/web-ui/src/components/DropIndicator.tsx
+++ b/src/web-ui/src/components/DropIndicator.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export const DropIndicator: React.FC = () => (
+  <div className="drop-indicator" aria-hidden="true" />
+);
+
+/** Returns the index BEFORE which the indicator line should be rendered.
+ *  Returns null when no drag is active or the item is hovering itself. */
+export const dropIndicatorBefore = (
+  ids: string[],
+  activeId: string | null,
+  overId: string | null,
+): number | null => {
+  if (!activeId || !overId || activeId === overId) return null;
+  const activeIndex = ids.indexOf(activeId);
+  const overIndex = ids.indexOf(overId);
+  if (activeIndex === -1 || overIndex === -1) return null;
+  // dragging down → item lands after the over item; dragging up → before
+  return activeIndex < overIndex ? overIndex + 1 : overIndex;
+};

--- a/src/web-ui/src/components/SortableSequenceStepList.tsx
+++ b/src/web-ui/src/components/SortableSequenceStepList.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { SortableStepItem } from './SortableStepItem';
+import { DropIndicator, dropIndicatorBefore } from './DropIndicator';
+import type { ReorderableListItem } from './ReorderableList';
+
+type SortableSequenceStepListProps = {
+  items: ReorderableListItem[];
+  onDelete: (item: ReorderableListItem) => void;
+  disabled?: boolean;
+  emptyMessage?: string;
+  activeId?: string | null;
+  overId?: string | null;
+};
+
+export const SortableSequenceStepList: React.FC<SortableSequenceStepListProps> = ({
+  items,
+  onDelete,
+  disabled,
+  emptyMessage = 'No steps added yet.',
+  activeId,
+  overId,
+}) => {
+  const ids = items.map((item) => item.id);
+  const indicatorBefore = dropIndicatorBefore(ids, activeId ?? null, overId ?? null);
+
+  if (items.length === 0) {
+    return <div className="reorderable-list"><div className="empty-state">{emptyMessage}</div></div>;
+  }
+
+  return (
+    <div className="reorderable-list">
+      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+        {items.map((item, index) => (
+          <React.Fragment key={item.id}>
+            {indicatorBefore === index && <DropIndicator />}
+            <div className="reorderable-list__item">
+              <SortableStepItem id={item.id} scopeId="root" disabled={disabled}>
+                <div className="reorderable-list__content">
+                  <div className="reorderable-list__label">{item.label}</div>
+                  {item.description && <div className="reorderable-list__description">{item.description}</div>}
+                  {item.details && <div className="reorderable-list__details">{item.details}</div>}
+                </div>
+                <div className="reorderable-list__controls">
+                  <button type="button" onClick={() => onDelete(item)} disabled={disabled}>Delete</button>
+                </div>
+              </SortableStepItem>
+            </div>
+          </React.Fragment>
+        ))}
+        {indicatorBefore === items.length && <DropIndicator />}
+      </SortableContext>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/SortableStepItem.tsx
+++ b/src/web-ui/src/components/SortableStepItem.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { StepDragData } from '../types/stepEntry';
+
+type SortableStepItemProps = {
+  id: string;
+  scopeId: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+};
+
+export const SortableStepItem: React.FC<SortableStepItemProps> = ({ id, scopeId, disabled, children }) => {
+  const data: StepDragData = { scopeId, type: 'step' };
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    data,
+    disabled,
+  });
+
+  const style: React.CSSProperties = {
+    transform: transform ? CSS.Translate.toString(transform) : undefined,
+    transition,
+    opacity: isDragging ? 0.4 : undefined,
+    position: 'relative',
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="sortable-step-item">
+      <span
+        className="sortable-step-item__handle"
+        aria-label="Drag to reorder"
+        title="Drag to reorder"
+        {...attributes}
+        {...listeners}
+        style={{ cursor: disabled ? 'not-allowed' : 'grab', userSelect: 'none', padding: '0 6px', color: '#888' }}
+      >
+        ⠿
+      </span>
+      {children}
+    </div>
+  );
+};

--- a/src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx
+++ b/src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SortableSequenceStepList } from '../SortableSequenceStepList';
+import type { ReorderableListItem } from '../ReorderableList';
+
+jest.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: { Translate: { toString: () => '' }, Transform: { toString: () => '' } },
+}));
+
+const items: ReorderableListItem[] = [
+  { id: '1', label: 'Step 1' },
+  { id: '2', label: 'Step 2', description: 'desc' },
+  { id: '3', label: 'Step 3', details: <span data-testid="detail-3">detail</span> },
+];
+
+describe('SortableSequenceStepList', () => {
+  it('renders all item labels', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} />);
+    expect(screen.getByText('Step 1')).toBeInTheDocument();
+    expect(screen.getByText('Step 2')).toBeInTheDocument();
+    expect(screen.getByText('Step 3')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} />);
+    expect(screen.getByText('desc')).toBeInTheDocument();
+  });
+
+  it('renders details when provided', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} />);
+    expect(screen.getByTestId('detail-3')).toBeInTheDocument();
+  });
+
+  it('calls onDelete with the correct item when Delete is clicked', () => {
+    const onDelete = jest.fn();
+    render(<SortableSequenceStepList items={items} onDelete={onDelete} />);
+    const deleteButtons = screen.getAllByText('Delete');
+    fireEvent.click(deleteButtons[1]);
+    expect(onDelete).toHaveBeenCalledWith(items[1]);
+  });
+
+  it('shows empty state message when items list is empty', () => {
+    render(<SortableSequenceStepList items={[]} onDelete={() => {}} emptyMessage="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('delete buttons are disabled when disabled prop is true', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} disabled />);
+    screen.getAllByText('Delete').forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('renders a drag handle for each item', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} />);
+    expect(screen.getAllByLabelText('Drag to reorder')).toHaveLength(items.length);
+  });
+});

--- a/src/web-ui/src/components/__tests__/SortableStepItem.test.tsx
+++ b/src/web-ui/src/components/__tests__/SortableStepItem.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SortableStepItem } from '../SortableStepItem';
+
+// dnd-kit hooks require a DndContext; mock useSortable to isolate the component.
+jest.mock('@dnd-kit/sortable', () => ({
+  useSortable: jest.fn(() => ({
+    attributes: { role: 'button' },
+    listeners: { onPointerDown: jest.fn() },
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  })),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: { Translate: { toString: () => '' }, Transform: { toString: () => '' } },
+}));
+
+import { useSortable } from '@dnd-kit/sortable';
+
+describe('SortableStepItem', () => {
+  const defaultProps = { id: 'step-1', scopeId: 'root' };
+
+  it('renders children', () => {
+    render(<SortableStepItem {...defaultProps}><span>Step content</span></SortableStepItem>);
+    expect(screen.getByText('Step content')).toBeInTheDocument();
+  });
+
+  it('renders drag handle icon', () => {
+    render(<SortableStepItem {...defaultProps}><span>x</span></SortableStepItem>);
+    expect(screen.getByLabelText('Drag to reorder')).toBeInTheDocument();
+  });
+
+  it('passes scopeId and type in useSortable data', () => {
+    render(<SortableStepItem id="abc" scopeId="loop-123"><span>x</span></SortableStepItem>);
+    expect(useSortable).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'abc',
+      data: { scopeId: 'loop-123', type: 'step' },
+    }));
+  });
+
+  it('applies not-allowed cursor when disabled', () => {
+    render(<SortableStepItem {...defaultProps} disabled><span>x</span></SortableStepItem>);
+    const handle = screen.getByLabelText('Drag to reorder');
+    expect(handle).toHaveStyle({ cursor: 'not-allowed' });
+  });
+
+  it('reduces opacity when isDragging', () => {
+    (useSortable as jest.Mock).mockReturnValueOnce({
+      attributes: {},
+      listeners: {},
+      setNodeRef: jest.fn(),
+      transform: null,
+      transition: undefined,
+      isDragging: true,
+    });
+    const { container } = render(<SortableStepItem {...defaultProps}><span>x</span></SortableStepItem>);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.opacity).toBe('0.4');
+  });
+});

--- a/src/web-ui/src/components/sequences/LoopBlock.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlock.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { LoopStepEntry, StepEntry, ActionStepEntry } from '../../types/stepEntry';
 import type { SequenceStepCondition } from '../../types/sequenceFlow';
 import { LoopBlockHeader } from './LoopBlockHeader';
 import { BreakStepRow } from './BreakStepRow';
+import { SortableStepItem } from '../SortableStepItem';
+import { DropIndicator, dropIndicatorBefore } from '../DropIndicator';
 
 export type CommandOption = { value: string; label: string };
 
@@ -12,6 +15,9 @@ export type LoopBlockProps = {
   onRemove: () => void;
   commandOptions?: CommandOption[];
   disabled?: boolean;
+  isDropInvalid?: boolean;
+  activeBodyStepId?: string | null;
+  overBodyStepId?: string | null;
 };
 
 const makeId = () =>
@@ -19,20 +25,13 @@ const makeId = () =>
     ? crypto.randomUUID()
     : Math.random().toString(36).slice(2);
 
-const move = (items: StepEntry[], from: number, to: number): StepEntry[] => {
-  const next = [...items];
-  const [item] = next.splice(from, 1);
-  next.splice(to, 0, item);
-  return next;
-};
-
-export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, commandOptions = [], disabled }) => {
+export const LoopBlock: React.FC<LoopBlockProps> = ({
+  loop, onChange, onRemove, commandOptions = [], disabled, isDropInvalid,
+  activeBodyStepId, overBodyStepId,
+}) => {
   const body = loop.body;
-
-  const handleBodyReorder = (from: number, to: number) => {
-    if (to < 0 || to >= body.length) return;
-    onChange({ ...loop, body: move(body, from, to) });
-  };
+  const bodyIds = body.map((s) => s.id);
+  const indicatorBefore = dropIndicatorBefore(bodyIds, activeBodyStepId ?? null, overBodyStepId ?? null);
 
   const handleBodyDelete = (index: number) => {
     onChange({ ...loop, body: body.filter((_, i) => i !== index) });
@@ -79,57 +78,61 @@ export const LoopBlock: React.FC<LoopBlockProps> = ({ loop, onChange, onRemove, 
         <button type="button" onClick={onRemove} disabled={disabled} data-testid="loop-remove">Remove Loop</button>
       </div>
 
-      <div className="loop-block__body" data-testid="loop-body">
+      <div className={`loop-block__body${isDropInvalid ? ' loop-block--drop-invalid' : ''}`} data-testid="loop-body">
         {body.length === 0 && (
           <div className="empty-state" data-testid="loop-body-empty">No body steps yet.</div>
         )}
-        <ol>
+        <SortableContext items={bodyIds} strategy={verticalListSortingStrategy}>
           {body.map((step, index) => (
-            <li key={step.id} className="loop-block__body-step" data-testid="loop-body-step">
-              <div className="loop-block__body-step-content">
-                {step.type === 'Break' ? (
-                  <BreakStepRow
-                    breakCondition={step.breakCondition}
-                    onChange={(bc) => {
-                      const updated = body.map((s, i) =>
-                        i === index ? { ...s, breakCondition: bc } as StepEntry : s
-                      );
-                      onChange({ ...loop, body: updated });
-                    }}
-                    onRemove={() => handleBodyDelete(index)}
-                    disabled={disabled}
-                  />
-                ) : (
-                  <div className="loop-block__action-step" data-testid="loop-action-step">
-                    <select
-                      data-testid="loop-body-command-select"
-                      value={(step as ActionStepEntry).commandId}
-                      disabled={disabled}
-                      onChange={(e) => {
-                        const updated = body.map((s, i) =>
-                          i === index ? { ...s, commandId: e.target.value, commandReference: undefined } as StepEntry : s
-                        );
-                        onChange({ ...loop, body: updated });
-                      }}
-                    >
-                      <option value="">Select command…</option>
-                      {commandOptions.map((opt) => (
-                        <option key={opt.value} value={opt.value}>{opt.label}</option>
-                      ))}
-                    </select>
+            <React.Fragment key={step.id}>
+              {indicatorBefore === index && <DropIndicator />}
+              <div className="loop-block__body-step" data-testid="loop-body-step">
+                <SortableStepItem id={step.id} scopeId={loop.id} disabled={disabled}>
+                  <div className="loop-block__body-step-content">
+                    {step.type === 'Break' ? (
+                      <BreakStepRow
+                        breakCondition={step.breakCondition}
+                        onChange={(bc) => {
+                          const updated = body.map((s, i) =>
+                            i === index ? { ...s, breakCondition: bc } as StepEntry : s
+                          );
+                          onChange({ ...loop, body: updated });
+                        }}
+                        onRemove={() => handleBodyDelete(index)}
+                        disabled={disabled}
+                      />
+                    ) : (
+                      <div className="loop-block__action-step" data-testid="loop-action-step">
+                        <select
+                          data-testid="loop-body-command-select"
+                          value={(step as ActionStepEntry).commandId}
+                          disabled={disabled}
+                          onChange={(e) => {
+                            const updated = body.map((s, i) =>
+                              i === index ? { ...s, commandId: e.target.value, commandReference: undefined } as StepEntry : s
+                            );
+                            onChange({ ...loop, body: updated });
+                          }}
+                        >
+                          <option value="">Select command…</option>
+                          {commandOptions.map((opt) => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
                   </div>
-                )}
+                  {step.type !== 'Break' && (
+                    <div className="loop-block__body-step-controls">
+                      <button type="button" onClick={() => handleBodyDelete(index)} disabled={disabled}>Delete</button>
+                    </div>
+                  )}
+                </SortableStepItem>
               </div>
-              <div className="loop-block__body-step-controls">
-                <button type="button" aria-label="Move up" onClick={() => handleBodyReorder(index, index - 1)} disabled={disabled || index === 0}>↑</button>
-                <button type="button" aria-label="Move down" onClick={() => handleBodyReorder(index, index + 1)} disabled={disabled || index === body.length - 1}>↓</button>
-                {step.type !== 'Break' && (
-                  <button type="button" onClick={() => handleBodyDelete(index)} disabled={disabled}>Delete</button>
-                )}
-              </div>
-            </li>
+            </React.Fragment>
           ))}
-        </ol>
+          {indicatorBefore === body.length && <DropIndicator />}
+        </SortableContext>
       </div>
 
       <div className="loop-block__add-buttons">

--- a/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
+++ b/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
@@ -6,6 +6,25 @@ import { LoopBlock } from '../LoopBlock';
 import type { LoopStepEntry } from '../../../types/stepEntry';
 import type { CommandOption } from '../LoopBlock';
 
+// LoopBlock now uses SortableContext and SortableStepItem (dnd-kit).
+// Mock dnd-kit to avoid needing a full DndContext in unit tests.
+jest.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: { Translate: { toString: () => '' }, Transform: { toString: () => '' } },
+}));
+
 const testCommands: CommandOption[] = [
   { value: 'cmd-a', label: 'Command A' },
   { value: 'cmd-b', label: 'Command B' },
@@ -47,7 +66,7 @@ describe('LoopBlockHeader', () => {
         condition={{ type: 'imageVisible', imageId: 'done', minSimilarity: null }}
       />
     );
-    expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('Repeat\u2011Until');
+    expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('Repeat‑Until');
     expect(screen.queryByTestId('loop-iteration-hint')).not.toBeInTheDocument();
   });
 
@@ -269,24 +288,6 @@ describe('LoopBlock', () => {
     expect(updated.body[0].type).toBe('Break');
   });
 
-  it('reordering a body step fires onChange with updated order', () => {
-    const onChange = jest.fn();
-    const loop: LoopStepEntry = {
-      ...baseLoop,
-      body: [
-        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd-a', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
-        { type: 'Action', id: 'a2', stepId: 'a2', commandId: 'cmd-b', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
-      ],
-    };
-    render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} commandOptions={testCommands} />);
-    const moveDownButtons = screen.getAllByLabelText('Move down');
-    fireEvent.click(moveDownButtons[0]);
-    expect(onChange).toHaveBeenCalledTimes(1);
-    const updated = onChange.mock.calls[0][0] as LoopStepEntry;
-    expect(updated.body[0].id).toBe('a2');
-    expect(updated.body[1].id).toBe('a1');
-  });
-
   it('calls onRemove when Remove Loop clicked', () => {
     const onRemove = jest.fn();
     render(<LoopBlock loop={baseLoop} onChange={() => {}} onRemove={onRemove} />);
@@ -351,7 +352,6 @@ describe('LoopBlock', () => {
       ],
     };
     render(<LoopBlock loop={loop} onChange={onChange} onRemove={() => {}} />);
-    // Toggle "Always break" to clear the condition
     fireEvent.click(screen.getByTestId('always-break-toggle'));
     expect(onChange).toHaveBeenCalledTimes(1);
     const updated = onChange.mock.calls[0][0] as LoopStepEntry;
@@ -359,28 +359,27 @@ describe('LoopBlock', () => {
     expect((updated.body[0] as any).breakCondition).toBeUndefined();
   });
 
-  it('move up on first step is disabled', () => {
+  it('does not render move-up or move-down buttons (reordering is drag-and-drop only)', () => {
     const loop: LoopStepEntry = {
       ...baseLoop,
       body: [
         { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
+        { type: 'Action', id: 'a2', stepId: 'a2', commandId: 'cmd', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
       ],
     };
     render(<LoopBlock loop={loop} onChange={() => {}} onRemove={() => {}} />);
-    const moveUp = screen.getByLabelText('Move up');
-    expect(moveUp).toBeDisabled();
+    expect(screen.queryByLabelText('Move up')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Move down')).not.toBeInTheDocument();
   });
 
-  it('move down on last step is disabled', () => {
-    const loop: LoopStepEntry = {
-      ...baseLoop,
-      body: [
-        { type: 'Action', id: 'a1', stepId: 'a1', commandId: 'cmd', conditionType: 'none', imageId: '', minSimilarity: '', outcomeStepRef: '', expectedState: 'success' },
-      ],
-    };
-    render(<LoopBlock loop={loop} onChange={() => {}} onRemove={() => {}} />);
-    const moveDown = screen.getByLabelText('Move down');
-    expect(moveDown).toBeDisabled();
+  it('applies loop-block--drop-invalid class when isDropInvalid is true', () => {
+    render(<LoopBlock loop={baseLoop} onChange={() => {}} onRemove={() => {}} isDropInvalid />);
+    expect(screen.getByTestId('loop-body')).toHaveClass('loop-block--drop-invalid');
+  });
+
+  it('does not apply loop-block--drop-invalid class when isDropInvalid is false', () => {
+    render(<LoopBlock loop={baseLoop} onChange={() => {}} onRemove={() => {}} isDropInvalid={false} />);
+    expect(screen.getByTestId('loop-body')).not.toHaveClass('loop-block--drop-invalid');
   });
 
   it('removing a break step from body via its Remove button calls onChange without that step', () => {

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { CollisionDetection, DndContext, DragEndEvent, DragOverEvent, DragStartEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
 import { listSequences, SequenceDto, createSequence, getSequence, updateSequence, deleteSequence, isSequenceConflictError } from '../services/sequences';
 import { ConfirmDeleteModal } from '../components/ConfirmDeleteModal';
 import { ApiError } from '../lib/api';
@@ -6,7 +8,8 @@ import { listCommands, CommandDto } from '../services/commands';
 import { FormError } from '../components/Form';
 import { FormActions, FormSection } from '../components/unified/FormLayout';
 import { SearchableDropdown, SearchableOption } from '../components/SearchableDropdown';
-import { ReorderableList, ReorderableListItem } from '../components/ReorderableList';
+import type { ReorderableListItem } from '../components/ReorderableList';
+import { SortableSequenceStepList } from '../components/SortableSequenceStepList';
 import { useUnsavedChangesPrompt } from '../hooks/useUnsavedChangesPrompt';
 import { navigateToUnified } from '../lib/navigation';
 import { validatePerStepConditions } from '../lib/validation';
@@ -40,6 +43,25 @@ type SequenceFormValue = {
   useCustomDelayRange: boolean;
   delayMin: string;
   delayMax: string;
+};
+
+// Collision detection that uses the cursor position rather than the dragged item's
+// bounding box, and only considers droppables in the same scope as the active item.
+// This prevents body steps inside nested loops from being picked as collision targets
+// when dragging a top-level step, which was causing the drop indicator to not appear.
+const closestCenterToCursor: CollisionDetection = ({ active, droppableContainers, droppableRects, pointerCoordinates }) => {
+  if (!pointerCoordinates) return [];
+  const activeScope = active.data.current?.scopeId as string | undefined;
+  let minDist = Infinity;
+  let closestId: string | number | null = null;
+  for (const container of droppableContainers) {
+    if (activeScope && container.data.current?.scopeId !== activeScope) continue;
+    const rect = droppableRects.get(container.id);
+    if (!rect) continue;
+    const dist = Math.abs(pointerCoordinates.y - (rect.top + rect.height / 2));
+    if (dist < minDist) { minDist = dist; closestId = container.id; }
+  }
+  return closestId !== null ? [{ id: closestId }] : [];
 };
 
 const makeId = () => (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : Math.random().toString(36).slice(2));
@@ -246,6 +268,9 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         actionType: 'command' as const,
         commandId: '',
         commandReference: undefined,
+        waitReferenceImageId: '',
+        waitConfidence: '',
+        waitTimeoutMs: '1000',
         conditionType: 'none' as const,
         conditionNegate: false,
         imageId: '',
@@ -330,12 +355,15 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         actionType: 'command' as const,
         commandId,
         commandReference: step.commandReference ?? undefined,
+        waitReferenceImageId: '',
+        waitConfidence: '',
+        waitTimeoutMs: '1000',
         conditionType: 'imageVisible',
         conditionNegate: step.condition.negate ?? false,
         imageId: step.condition.imageId,
         minSimilarity: step.condition.minSimilarity == null ? '' : String(step.condition.minSimilarity),
         outcomeStepRef: '',
-        expectedState: 'success'
+        expectedState: 'success' as const,
       };
     }
 
@@ -347,12 +375,15 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         actionType: 'command' as const,
         commandId,
         commandReference: step.commandReference ?? undefined,
+        waitReferenceImageId: '',
+        waitConfidence: '',
+        waitTimeoutMs: '1000',
         conditionType: 'commandOutcome',
         conditionNegate: step.condition.negate ?? false,
         imageId: '',
         minSimilarity: '',
         outcomeStepRef: step.condition.stepRef,
-        expectedState: step.condition.expectedState
+        expectedState: step.condition.expectedState,
       };
     }
 
@@ -423,7 +454,7 @@ const bodyEntryToPayloadStep = (entry: StepEntry): SequenceLinearStep => {
     };
   }
   // Action body step
-  const a = entry as { stepId: string; commandId: string; commandReference?: SequenceCommandReference; conditionType: string; conditionNegate: boolean; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
+  const a = entry as unknown as { stepId: string; commandId: string; commandReference?: SequenceCommandReference; conditionType: string; conditionNegate: boolean; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
   const cond = a.conditionType === 'imageVisible'
     ? { type: 'imageVisible' as const, imageId: a.imageId.trim(), minSimilarity: a.minSimilarity.trim() === '' ? null : Number(a.minSimilarity), negate: a.conditionNegate || undefined }
     : a.conditionType === 'commandOutcome'
@@ -518,6 +549,68 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
   const [submitting, setSubmitting] = useState(false);
   const [loading, setLoading] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [activeStepId, setActiveStepId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+  const [isDragInvalid, setIsDragInvalid] = useState(false);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveStepId(event.active.id as string);
+    setOverId(null);
+    setIsDragInvalid(false);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const activeScope = event.active.data.current?.scopeId;
+    const overScope = event.over?.data.current?.scopeId;
+    setIsDragInvalid(!!activeScope && !!overScope && activeScope !== overScope);
+    setOverId(event.over?.id as string ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveStepId(null);
+    setOverId(null);
+    setIsDragInvalid(false);
+    if (!over || active.id === over.id) return;
+    const activeScope = active.data.current?.scopeId as string | undefined;
+    const overScope = over.data.current?.scopeId as string | undefined;
+    if (!activeScope || !overScope || activeScope !== overScope) return;
+
+    if (activeScope === 'root') {
+      setForm((prev) => {
+        const oldIndex = prev.steps.findIndex((s) => s.id === active.id);
+        const newIndex = prev.steps.findIndex((s) => s.id === over.id);
+        if (oldIndex === -1 || newIndex === -1) return prev;
+        return { ...prev, steps: arrayMove(prev.steps, oldIndex, newIndex) };
+      });
+      setDirty(true);
+    } else {
+      setForm((prev) => {
+        const loopStep = prev.steps.find((s) => s.stepType === 'Loop' && s.loopEntry?.id === activeScope);
+        if (!loopStep?.loopEntry) return prev;
+        const body = loopStep.loopEntry.body;
+        const oldIndex = body.findIndex((s) => s.id === active.id);
+        const newIndex = body.findIndex((s) => s.id === over.id);
+        if (oldIndex === -1 || newIndex === -1) return prev;
+        const newBody = arrayMove(body, oldIndex, newIndex);
+        return {
+          ...prev,
+          steps: prev.steps.map((s) =>
+            s.id === loopStep.id ? { ...s, loopEntry: { ...s.loopEntry!, body: newBody } } : s
+          ),
+        };
+      });
+      setDirty(true);
+    }
+  };
+
+  const handleDragCancel = () => {
+    setActiveStepId(null);
+    setOverId(null);
+    setIsDragInvalid(false);
+  };
   const [filterName, setFilterName] = useState('');
   const [tableMessage, setTableMessage] = useState<string | undefined>(undefined);
   const [tableError, setTableError] = useState<string | undefined>(undefined);
@@ -826,6 +919,30 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
     </div>
   ), [form.steps, submitting, loading]);
 
+  const handleAddTopLevelStep = () => {
+    const id = makeId();
+    const stepId = nextGeneratedStepId(form.steps);
+    const newStep: SequenceStep = {
+      id,
+      stepId,
+      stepType: 'Action',
+      actionType: 'command',
+      commandId: '',
+      commandReference: undefined,
+      waitReferenceImageId: '',
+      waitConfidence: '',
+      waitTimeoutMs: '1000',
+      conditionType: 'none',
+      conditionNegate: false,
+      imageId: '',
+      minSimilarity: '',
+      outcomeStepRef: '',
+      expectedState: 'success',
+    };
+    setForm((prev) => ({ ...prev, steps: [...prev.steps, newStep] }));
+    setDirty(true);
+  };
+
   const createLoopStep = (loopType: 'count' | 'while' | 'repeatUntil'): SequenceStep => {
     const id = makeId();
     const stepId = nextGeneratedStepId(form.steps);
@@ -881,6 +998,9 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
               }}
               commandOptions={editorCommandOptions}
               disabled={submitting || loading}
+              isDropInvalid={isDragInvalid}
+              activeBodyStepId={s.loopEntry.body.some(b => b.id === activeStepId) ? activeStepId : null}
+              overBodyStepId={s.loopEntry.body.some(b => b.id === overId) ? overId : null}
             />
           ),
         };
@@ -893,7 +1013,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         details: renderStepConditionEditor(s, idx),
       };
     });
-  }, [form.steps, editorCommandOptions, commandLookup, submitting, loading, renderStepConditionEditor]);
+  }, [form.steps, editorCommandOptions, commandLookup, submitting, loading, renderStepConditionEditor, isDragInvalid, activeStepId, overId]);
 
   const validate = (v: SequenceFormValue): Record<string, string> | undefined => {
     const next: Record<string, string> = {};
@@ -1251,21 +1371,37 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
               <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
               <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
             </div>
-            <ReorderableList
-              items={stepItems}
-              onChange={(next) => {
-                const mapped = next.map((item, idx) => form.steps.find((s) => s.id === item.id) ?? form.steps[idx]);
-                setForm({ ...form, steps: mapped.filter((s): s is SequenceStep => s?.stepType === 'Loop' || s?.stepType === 'Break' || (s?.stepType === 'Action' && (s.actionType === 'WaitForImage' || !!s.commandId))) });
-                setDirty(true);
-              }}
-              onDelete={(item) => {
-                setForm({ ...form, steps: form.steps.filter((s) => s.id !== item.id) });
-                setDirty(true);
-              }}
-              disabled={submitting || loading}
-              emptyMessage="No steps added yet."
-            />
-            <div className="form-hint">Steps execute in listed order; drag buttons to reorder before saving.</div>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenterToCursor}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragEnd={handleDragEnd}
+              onDragCancel={handleDragCancel}
+            >
+              <SortableSequenceStepList
+                items={stepItems}
+                activeId={activeStepId}
+                overId={overId}
+                onDelete={(item) => {
+                  setForm((prev) => ({ ...prev, steps: prev.steps.filter((s) => s.id !== item.id) }));
+                  setDirty(true);
+                }}
+                disabled={submitting || loading}
+                emptyMessage="No steps added yet."
+              />
+            </DndContext>
+            <div className="field">
+              <button
+                type="button"
+                data-testid="add-top-level-step"
+                onClick={handleAddTopLevelStep}
+                disabled={submitting || loading}
+              >
+                Add step
+              </button>
+            </div>
+            <div className="form-hint">Steps execute in listed order; drag to reorder within the same level.</div>
           </FormSection>
 
 
@@ -1492,21 +1628,37 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
                 <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
               </div>
-              <ReorderableList
-                items={stepItems}
-                onChange={(next) => {
-                  const mapped = next.map((item, idx) => form.steps.find((s) => s.id === item.id) ?? form.steps[idx]);
-                  setForm({ ...form, steps: mapped.filter((s): s is SequenceStep => s?.stepType === 'Loop' || s?.stepType === 'Break' || (s?.stepType === 'Action' && (s.actionType === 'WaitForImage' || !!s.commandId))) });
-                  setDirty(true);
-                }}
-                onDelete={(item) => {
-                  setForm({ ...form, steps: form.steps.filter((s) => s.id !== item.id) });
-                  setDirty(true);
-                }}
-                disabled={submitting || loading}
-                emptyMessage="No steps added yet."
-              />
-              <div className="form-hint">Use Move up/down to set the execution order before saving.</div>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenterToCursor}
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
+              >
+                <SortableSequenceStepList
+                  items={stepItems}
+                  activeId={activeStepId}
+                  overId={overId}
+                  onDelete={(item) => {
+                    setForm((prev) => ({ ...prev, steps: prev.steps.filter((s) => s.id !== item.id) }));
+                    setDirty(true);
+                  }}
+                  disabled={submitting || loading}
+                  emptyMessage="No steps added yet."
+                />
+              </DndContext>
+              <div className="field">
+                <button
+                  type="button"
+                  data-testid="add-top-level-step"
+                  onClick={handleAddTopLevelStep}
+                  disabled={submitting || loading}
+                >
+                  Add step
+                </button>
+              </div>
+              <div className="form-hint">Steps execute in listed order; drag to reorder within the same level.</div>
             </FormSection>
 
 

--- a/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
@@ -31,7 +31,7 @@ describe('SequencesPage', () => {
     expect(screen.getByText(/No sequences yet\. Create your first sequence/i)).toBeInTheDocument();
   });
 
-  it('creates a sequence with ordered steps', async () => {
+  it('creates a sequence with multiple steps', async () => {
     render(<SequencesPage />);
 
     await waitFor(() => expect(listSequencesMock).toHaveBeenCalled());
@@ -45,9 +45,6 @@ describe('SequencesPage', () => {
     fireEvent.change(screen.getByLabelText('Add command'), { target: { value: 'c2' } });
     fireEvent.click(screen.getByText('Add to steps'));
 
-    const moveUpButtons = screen.getAllByLabelText('Move up');
-    fireEvent.click(moveUpButtons[1]);
-
     createSequenceMock.mockResolvedValue({} as any);
     fireEvent.click(screen.getByText('Save'));
 
@@ -57,15 +54,15 @@ describe('SequencesPage', () => {
       interStepDelayRangeMs: null,
       steps: [
         {
-          stepId: 'step-2',
-          stepType: 'Action',
-          primitiveAction: { type: 'command', schemaVersion: 'v1', payload: { commandId: 'c2' } },
-          condition: null
-        },
-        {
           stepId: 'step-1',
           stepType: 'Action',
           primitiveAction: { type: 'command', schemaVersion: 'v1', payload: { commandId: 'c1' } },
+          condition: null
+        },
+        {
+          stepId: 'step-2',
+          stepType: 'Action',
+          primitiveAction: { type: 'command', schemaVersion: 'v1', payload: { commandId: 'c2' } },
           condition: null
         }
       ]

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -114,3 +114,10 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 .collapsible-section-title:hover { color: var(--gb-color-primary); }
 .collapsible-section-content { padding: 0 var(--gb-space-3) var(--gb-space-3); }
 
+
+/* Drag-and-drop */
+.loop-block--drop-invalid { outline: 2px solid #d32f2f; opacity: 0.7; }
+.sortable-step-item { display: flex; align-items: flex-start; }
+.sortable-step-item__handle { flex-shrink: 0; line-height: 1; padding-top: 2px; }
+.drop-indicator { height: 2px; background: #4a90d9; border-radius: 1px; margin: 2px 4px; position: relative; pointer-events: none; }
+.drop-indicator::before { content: ''; display: block; position: absolute; left: -5px; top: -4px; width: 10px; height: 10px; background: #4a90d9; border-radius: 50%; }

--- a/src/web-ui/src/types/stepEntry.ts
+++ b/src/web-ui/src/types/stepEntry.ts
@@ -36,3 +36,9 @@ export type BreakStepEntry = {
   stepId: string;
   breakCondition?: SequenceStepCondition;
 };
+
+/** Metadata attached to each draggable step via useSortable data prop. */
+export type StepDragData = {
+  scopeId: string;
+  type: 'step';
+};

--- a/src/web-ui/tests/e2e/sequences-loop-steps.spec.ts
+++ b/src/web-ui/tests/e2e/sequences-loop-steps.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+
+const jsonHeaders = { 'content-type': 'application/json' };
+
+const stubApiRoutes = async (page: import('@playwright/test').Page) => {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname.toLowerCase();
+    const listBodies: Record<string, unknown> = {
+      '/api/commands': [{ id: 'cmd-1', name: 'Test Command' }],
+      '/api/sequences': [],
+      '/api/games': [],
+      '/api/triggers': [],
+      '/api/config': { host: '', token: '' },
+    };
+    if (path in listBodies) {
+      await route.fulfill({ status: 200, headers: jsonHeaders, body: JSON.stringify(listBodies[path]) });
+    } else if (route.request().method() === 'POST' && path.startsWith('/api/sequences')) {
+      await route.fulfill({ status: 201, headers: jsonHeaders, body: JSON.stringify({ id: 'new-seq', name: 'Test', steps: [] }) });
+    } else {
+      await route.fulfill({ status: 200, headers: jsonHeaders, body: JSON.stringify({}) });
+    }
+  });
+};
+
+test.describe('Sequence loop step management', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubApiRoutes(page);
+    await page.goto('/');
+    await page.getByRole('link', { name: /sequences/i }).click();
+    await page.getByRole('button', { name: 'Create Sequence' }).click();
+  });
+
+  test('US1: persistent Add step button is visible and adds a top-level step outside any loop', async ({ page }) => {
+    // Add a count loop so there is a loop in the sequence
+    await page.getByTestId('add-loop-buttons').getByRole('button', { name: 'Count' }).click();
+
+    // The persistent top-level "Add step" button must be present
+    const addStepBtn = page.getByTestId('add-top-level-step').first();
+    await expect(addStepBtn).toBeVisible();
+
+    // Click it — should append a step at the top-level sequence scope
+    await addStepBtn.click();
+
+    // There should now be a step item outside the loop-body (loop-block itself + new step = 2 items in the list)
+    const stepItems = page.locator('.reorderable-list__item');
+    await expect(stepItems).toHaveCount(2);
+  });
+
+  test('US1: Add step button is accessible even when sequence contains only a loop', async ({ page }) => {
+    await page.getByTestId('add-loop-buttons').getByRole('button', { name: 'Count' }).click();
+    const addStepBtn = page.getByTestId('add-top-level-step').first();
+    await expect(addStepBtn).toBeVisible();
+    await expect(addStepBtn).toBeEnabled();
+  });
+
+  test('US2: drag handles are present on top-level steps', async ({ page }) => {
+    // Add two steps then a loop
+    await page.getByTestId('add-top-level-step').first().click();
+    await page.getByTestId('add-loop-buttons').getByRole('button', { name: 'Count' }).click();
+
+    // All top-level items should have a drag handle
+    const handles = page.locator('.sortable-step-item__handle');
+    const count = await handles.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test('US2: cross-scope drag shows loop-block--drop-invalid class when dragging top-level step over loop body', async ({ page }) => {
+    // Add a top-level step, then a loop
+    await page.getByTestId('add-top-level-step').first().click();
+    await page.getByTestId('add-loop-buttons').getByRole('button', { name: 'Count' }).click();
+
+    const handle = page.locator('.reorderable-list__item').first().locator('.sortable-step-item__handle');
+    const loopBody = page.getByTestId('loop-body');
+
+    // Start dragging the top-level step over the loop body
+    await handle.hover();
+    await page.mouse.down();
+    const loopBodyBox = await loopBody.boundingBox();
+    if (loopBodyBox) {
+      await page.mouse.move(loopBodyBox.x + loopBodyBox.width / 2, loopBodyBox.y + loopBodyBox.height / 2, { steps: 5 });
+      await expect(loopBody).toHaveClass(/loop-block--drop-invalid/);
+    }
+    await page.mouse.up();
+  });
+
+  test('US3: in-loop Add step button still adds steps inside the loop after refactor', async ({ page }) => {
+    // Add a loop and use its internal Add step button
+    await page.getByTestId('add-loop-buttons').getByRole('button', { name: 'Count' }).click();
+
+    const addBodyStepBtn = page.getByTestId('add-body-step');
+    await expect(addBodyStepBtn).toBeVisible();
+    await addBodyStepBtn.click();
+
+    // The loop body should contain exactly one step
+    const loopBodySteps = page.getByTestId('loop-body-step');
+    await expect(loopBodySteps).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **Add step outside loops**: A persistent "Add step" button at the bottom of the sequence editor lets users append top-level steps even when the sequence contains a loop. Previously, only the in-loop "Add step" was accessible once a loop was added.
- **Drag-and-drop reordering**: Replaces the move-up/move-down button approach with `@dnd-kit` drag-and-drop for both top-level steps and loop body steps. Reordering is scope-constrained — steps cannot be dragged across loop boundaries.
- **Drop insertion indicator**: A blue `●───` line shows exactly where the dragged item will land, including at the very start and end of the list (the previously ambiguous edge cases).
- **Cursor-based collision detection**: Custom scope-filtered collision detection uses the cursor Y position (not the dragged item's bounding box center), so large items like loop blocks track the pointer precisely.
- **"Not allowed" visual**: Dragging over an invalid cross-scope target highlights it in red; releasing snaps the item back.

## Test plan

- [ ] Open a sequence with a loop → click "Add step" at the bottom → new step appears outside the loop
- [ ] Drag a top-level step past a loop block → indicator line shows correct insertion point at all positions including first/last
- [ ] Drag the loop block itself → indicator tracks cursor, not the loop's bounding-box center
- [ ] Drag a top-level step over a loop body → red "not allowed" highlight, item snaps back on release
- [ ] Drag steps inside a loop body → reorder works within the loop, indicator shows insertion point
- [ ] `npm test` in `src/web-ui/` → 57 suites, 216 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)