### PR TITLE
Edit queue page layout refinement (#048)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-﻿{ "feature_directory": "specs/047-queue-templates" }
+{
+  "feature_directory": "specs/048-edit-queue-layout"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 ﻿<!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/047-queue-templates/plan.md
+at specs/048-edit-queue-layout/plan.md
 <!-- SPECKIT END -->

--- a/specs/048-edit-queue-layout/checklists/requirements.md
+++ b/specs/048-edit-queue-layout/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Edit Queue Page Layout
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Reload Template is the one new behavior; layout reorder and inline template sections refine existing 046/047 UI. Validated against quality criteria — all items pass on first iteration.

--- a/specs/048-edit-queue-layout/contracts/edit-queue-ui.md
+++ b/specs/048-edit-queue-layout/contracts/edit-queue-ui.md
@@ -1,0 +1,55 @@
+# UI Contract: Edit Queue Page
+
+No REST/external contracts are added or changed. This feature reuses, unchanged:
+
+- `GET /api/queue-templates` — list templates (used to resolve a reload by name).
+- `GET /api/queue-templates/{id}` — template detail (entries) for load/reload.
+- `POST /api/queue-templates` — save (with `overwrite`) — inline Save section.
+- `DELETE /api/queue-templates/{id}` — delete (inline Load section, per-row).
+- `PUT /api/queues/{id}/entries` — replace queue entries (load and reload apply path;
+  `409 queue_running` while running).
+
+The contract below is the **UI contract** for the edit-queue page (appropriate for an
+application feature). Each item maps to functional requirements in `spec.md`.
+
+## Row order (top → bottom) — FR-001
+
+1. **Name** (editable text) + **Emulator** (read-only). No "cannot be changed" hint
+   (FR-002, FR-003).
+2. **Template controls** (single row) + inline Save/Load panels below it (FR-006, FR-009).
+3. **Cycle execution** (checkbox).
+4. **Sequences** — one row per entry, existing add/remove controls and empty state
+   (FR-005).
+5. **Save** / **Cancel** — commit/discard Name + Cycle execution only (FR-004, FR-004a).
+
+## Row 2 controls — FR-006 … FR-013
+
+| Control | Behavior |
+|---------|----------|
+| Template-name button | Label `(no template)` when none associated, else the name. Click → open inline **Load** panel (FR-007, FR-008). |
+| Save Template button | Click → open inline **Save** panel. |
+| Reload Template button | Disabled when no template associated (FR-016) or queue Running (FR-017). Click → reload flow. |
+| Inline panels | Appear between row 2 and row 3; default closed (FR-010); at most one open (FR-011); collapse on complete/dismiss (FR-012). |
+| Save panel | Existing name validation + overwrite confirmation, now inline (FR-013). |
+| Load panel | Existing template list, empty state, per-row Delete (with confirm), now inline; Load disabled while Running (FR-013). |
+
+## Reload flow — FR-014 … FR-018
+
+1. Resolve associated template by **name** (case-insensitive) from the list.
+   - No match → message "Template '<name>' is no longer available"; no change (FR-018).
+2. Fetch its entries; compute `templateSequenceIds`.
+3. Compare with the queue's current ordered `sequenceIds`:
+   - Equal → no-op, no prompt.
+   - Queue empty → apply, no prompt.
+   - Non-empty and different → confirmation modal; **Reload** applies, **Cancel** leaves
+     entries unchanged (FR-015).
+4. Apply = replace queue entries with the template's (full, order-preserving) via
+   `PUT /api/queues/{id}/entries`.
+
+## States observed
+
+- **Running queue**: Reload and Load disabled; Save allowed. Save/Cancel field edits
+  follow existing running-queue rules.
+- **No template associated**: name button shows placeholder, still opens Load; Reload
+  disabled.
+- **Empty sequences**: row 4 shows the existing empty state; row order unchanged.

--- a/specs/048-edit-queue-layout/data-model.md
+++ b/specs/048-edit-queue-layout/data-model.md
@@ -1,0 +1,70 @@
+# Phase 1 Data Model: Edit Queue Page Layout
+
+This feature introduces **no new persisted entities** and changes no existing ones. It
+reorganizes presentation and adds a Reload action over the existing model. The "model"
+here is therefore the **UI/component state** of the edit page, plus the (unchanged)
+domain entities it references.
+
+## Referenced domain entities (unchanged)
+
+- **Queue** (from 046): `id`, `name`, `emulatorSerial`, `cycleExecution`, `status`
+  (`Stopped` | `Running`), runtime-only ordered `entries`. Only `name` and
+  `cycleExecution` are editable via the page-level Save.
+- **Queue Entry** (from 046): `{ entryId, sequenceId, sequenceName, stale }` — runtime
+  only; mutated immediately by add/remove/replace, independent of page Save/Cancel.
+- **Queue Template** (from 047): `{ id, name, entryCount, createdAt, updatedAt,
+  entries[] }`, file-backed. Read for load/reload; written by save; removed by delete.
+
+## UI state model (new/changed, frontend only)
+
+### `QueuesPage` edit-session state
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `detail` | `QueueDetailDto \| undefined` | The queue being edited (existing). |
+| `form` | `{ name, emulatorSerial, cycleExecution }` | Row-1/row-3 fields; committed by Save (existing). |
+| `associatedTemplateName` | `string \| undefined` | Name of the template last loaded or saved this session (replaces `loadedTemplateName`). Drives the template-name button label, the Save pre-fill, and reload resolution. UI-state only — no live link. |
+| `pendingLoad` | `{ name, sequenceIds } \| undefined` | Existing replace-on-load confirmation (non-empty queue). |
+| `pendingReload` | `{ name, sequenceIds } \| undefined` | NEW — drives the reload confirmation modal; set only when a reload would change a non-empty queue. |
+
+### `QueueTemplateControls` (new component) state
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `openSection` | `'none' \| 'save' \| 'load'` | Default `'none'` (FR-010). At most one open (FR-011). Reset to `'none'` on completion/dismiss (FR-012). |
+
+Props (shape; finalized in code): `associatedTemplateName?`, `status`,
+`currentSequenceIds: string[]`, `onSaveTemplate(name, overwrite)`,
+`onLoadTemplate(templateId)`, `onReload()`.
+
+### `QueueForm` (modified) props
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `templateControls?` | `React.ReactNode` | Rendered between emulator and cycle (row 2). Edit only. |
+| `entries?` | `React.ReactNode` | Rendered between cycle and form-actions (row 4). Edit only. |
+
+(The emulator hint text is removed; no prop change for that.)
+
+## Derived values / rules
+
+- **Template-name button label** = `associatedTemplateName ?? '(no template)'`.
+- **Reload enabled** = `Boolean(associatedTemplateName) && status !== 'Running'`
+  (FR-016/FR-017).
+- **Reload needs confirmation** = `currentSequenceIds.length > 0 &&
+  !sameSequenceOrder(currentSequenceIds, templateSequenceIds)` (FR-015).
+- **`sameSequenceOrder(a, b)`** = pure, order-sensitive array equality (lengths equal and
+  each index equal). Backs the diff; unit-tested independently.
+- **Reload target missing** = no case-insensitive name match in `listQueueTemplates()` →
+  "Template '<name>' is no longer available" (FR-018).
+
+## State transitions
+
+- Open edit page → `openSection = 'none'`, both panels closed.
+- Click template-name → `openSection = 'load'`.
+- Click Save Template → `openSection = 'save'`.
+- Open one panel → the other closes (`openSection` is single-valued).
+- Save success → `associatedTemplateName = savedName`; panel closes.
+- Load success → `associatedTemplateName = loadedName`; panel closes; entries replaced.
+- Reload: resolve by name → diff → (confirm if needed) → entries replaced;
+  `associatedTemplateName` unchanged (same template).

--- a/specs/048-edit-queue-layout/plan.md
+++ b/specs/048-edit-queue-layout/plan.md
@@ -1,0 +1,252 @@
+# Implementation Plan: Edit Queue Page Layout
+
+**Branch**: `048-edit-queue-layout` | **Date**: 2026-06-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/048-edit-queue-layout/spec.md`
+
+## Summary
+
+Refine the **Edit Queue** page into a fixed, ordered set of rows and add a **Reload
+Template** action — a frontend-only change. The edit page becomes, top to bottom:
+(1) Name (editable) + Emulator (read-only, with the "cannot be changed" hint removed),
+(2) a single template-controls row (template-name button + **Save Template** +
+**Reload Template**) with the Save and Load panels expanding **inline** between rows 2
+and 3 (collapsed by default, only one open at a time), (3) Cycle execution,
+(4) Sequences, (5) page-level Save/Cancel.
+
+No backend, API, or persistence change is needed: Save/Load already exist
+(`POST /api/queue-templates`, `GET /api/queue-templates[/{id}]`, `PUT /api/queues/{id}/entries`)
+from feature 047. The work is: (a) interleave the existing edit controls via two
+render slots on `QueueForm`, (b) convert the two template **dialogs** into inline
+collapsible **sections** owned by a new `QueueTemplateControls` component, and (c) add
+**Reload Template** — resolve the queue's associated template by its remembered name,
+diff the current entries against it, and re-apply via the existing replace-entries
+service, prompting only when the reload would actually discard changes (per
+clarification). Save/Cancel govern only Name + Cycle execution; entry/template actions
+act on the queue immediately and independently (per clarification).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.6.3 / React 18.3.1 (web-ui). No backend change.
+**Primary Dependencies**: React, Vite; existing in-house components
+(`QueueForm`, `QueueEntryList`, `SaveTemplateDialog`, `TemplatePickerDialog`,
+`ConfirmDeleteModal`, `SearchableDropdown`); existing services (`queues.ts`,
+`queueTemplates.ts`).
+**Storage**: N/A — no persisted-data change. Queue sequence entries remain runtime-only
+(non-persistent); templates remain file-backed exactly as in 047.
+**Testing**: Jest 29 + React Testing Library 14 (frontend). No xUnit change required.
+**Target Platform**: Modern web browser (authoring SPA) against the GameBot service.
+**Project Type**: Web application (frontend slice only this iteration).
+**Performance Goals**: Interactions reflected <1s at the established scale (≤~50
+templates × ≤~100 entries); UI-only, no heavy compute (reuses SC-007 budget from 047).
+**Constraints**: CamelCase method names only (no underscores); functions ≤50 LOC;
+reuse existing confirmation/UX conventions; Reload disabled while running and when no
+template is associated; confirm-on-reload only when entries would change.
+**Scale/Scope**: ~4 frontend files touched + 1 new component; no new dependencies.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI),
+implementation progression is blocked until failures are fixed or a documented
+maintainer waiver exists.
+
+| Gate (from constitution) | Status | Notes |
+|--------------------------|--------|-------|
+| Lint/format/static analysis clean | Must pass | ESLint; enforced in CI |
+| No underscores in method names — CamelCase only | Must pass | All new TS handlers/components CamelCase |
+| Functions ≤50 LOC | Must pass | Reload handler + section components kept thin; diff helper extracted |
+| Unit ≥80% line / ≥70% branch on touched areas | Must pass | Tests for `QueueTemplateControls` (reload diff/confirm, section toggling), inline sections, `QueueForm` slots, `QueuesPage` wiring |
+| Deterministic, isolated, fast tests | Must pass | RTL with mocked services; no real I/O |
+| UX consistency with existing conventions | Must pass | Reuses `ConfirmDeleteModal`, existing form/field classes, error envelope; same Save/Load logic, now inline |
+| Actionable error messages | Must pass | "Template no longer available" on reload-missing; existing name/queue-running messages preserved |
+| Performance goals declared | ✅ Declared | <1s interactions (SC inherited) |
+| Public API/contract documented | ✅ N/A new | No backend contract change; UI contract in `contracts/edit-queue-ui.md` |
+| Observability | ✅ N/A | No new logging (consistent with 046/047) |
+| No unjustified new dependencies | ✅ None added | Reuses existing stack |
+
+No constitution violations. No waivers required. No Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/048-edit-queue-layout/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (UI state model; no new persisted entities)
+├── quickstart.md        # Phase 1 output (manual verification)
+├── contracts/
+│   └── edit-queue-ui.md # Phase 1 output — UI contract (rows + control behaviors)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/web-ui/src/components/queues/
+├── QueueForm.tsx                     # MODIFIED — remove emulator hint; add `templateControls`/`entries` render slots (edit only)
+├── QueueTemplateControls.tsx         # NEW — row 2: template-name button + Save/Reload buttons; owns which inline section is open; reload orchestration
+├── SaveTemplateDialog.tsx            # MODIFIED → inline section (drop modal-backdrop; collapsible panel; keep name validation + overwrite confirm)
+├── TemplatePickerDialog.tsx          # MODIFIED → inline section (drop modal-backdrop; collapsible panel; keep list/empty-state/delete)
+├── QueueEntryList.tsx                # UNCHANGED — rendered in row 4 via QueueForm `entries` slot
+└── __tests__/
+    ├── QueueForm.test.tsx            # MODIFIED — assert hint removed; slots render in order
+    ├── SaveTemplateDialog.test.tsx   # MODIFIED — inline rendering (no backdrop), unchanged logic
+    ├── TemplatePickerDialog.test.tsx # MODIFIED — inline rendering, unchanged logic
+    └── QueueTemplateControls.test.tsx# NEW — section mutual-exclusion, reload diff/confirm/disabled/missing
+
+src/web-ui/src/pages/
+├── QueuesPage.tsx                    # MODIFIED — compose edit rows via QueueForm slots; track associatedTemplateName; reload handler; remove standalone modal mounts for Save/Load
+└── __tests__/
+    ├── QueuesPage.layout.spec.tsx    # NEW — row order + Save/Cancel scope (US1)
+    ├── QueuesPage.templates.spec.tsx # MODIFIED — inline sections; associated-name pre-fill; Load disabled while running (US2)
+    └── QueuesPage.reload.spec.tsx    # NEW — reload diff/confirm/disabled/missing (US3)
+
+src/web-ui/src/lib/
+├── sequenceOrder.ts                  # NEW — pure, order-sensitive `sameSequenceOrder(a, b)` helper (backs the reload diff)
+└── __tests__/sequenceOrder.test.ts   # NEW — equal/empty/diff-length/diff-order/duplicates
+
+src/web-ui/src/services/
+├── queues.ts                         # UNCHANGED — replaceQueueEntries already exists
+└── queueTemplates.ts                 # UNCHANGED — list/get/save/delete already exist
+
+src/web-ui/src/styles.css             # MODIFIED — template-controls row + inline section panel styles
+```
+
+**Structure Decision**: Web application, **frontend-only** slice. The edit page is
+recomposed by giving `QueueForm` two optional render slots so the existing form keeps a
+single `<form>` (and the row-5 Save/Cancel stay its submit/cancel) while the template
+controls and the sequence list are interleaved at rows 2 and 4. The two template
+experiences are converted from modal dialogs to inline collapsible sections owned by a
+new `QueueTemplateControls` component; genuine confirmations (overwrite, delete,
+replace-on-load, reload) remain modal via the existing `ConfirmDeleteModal`. No backend
+module, endpoint, contract, or persisted entity changes.
+
+## Implementation Design
+
+### Row layout via QueueForm slots
+
+`QueueForm` gains two optional props, rendered only when provided (create mode passes
+neither, preserving today's layout):
+
+- `templateControls?: React.ReactNode` — rendered immediately **after** the emulator
+  field and **before** the cycle-execution field (row 2, plus the inline panel area
+  between rows 2 and 3).
+- `entries?: React.ReactNode` — rendered **after** cycle execution and **before** the
+  `form-actions` (row 4, before row 5).
+
+Remove the `form-hint` "The bound emulator cannot be changed after creation." (FR-003).
+Emulator stays read-only in edit mode (unchanged). The page-level Save/Cancel remain the
+form's submit/cancel and continue to commit only Name + Cycle execution (FR-004).
+
+### QueueTemplateControls (new) — row 2
+
+Props: `{ associatedTemplateName?, status, currentSequenceIds, onSaveTemplate,
+onLoadTemplate, onReload }` (exact shape finalized in `data-model.md`). Internal state:
+`openSection: 'none' | 'save' | 'load'` (FR-010 default `'none'`; FR-011 mutual
+exclusion — opening one sets the other closed).
+
+Row contents (FR-006):
+- **Template-name button**: label = `associatedTemplateName ?? '(no template)'`;
+  `onClick` → `openSection = 'load'` (FR-007/FR-008).
+- **Save Template button**: `onClick` → `openSection = 'save'`.
+- **Reload Template button**: `disabled = !associatedTemplateName || status ===
+  'Running'` (FR-016/FR-017); `onClick` → `onReload()`.
+
+Inline sections (rendered between the row and the slot boundary, FR-009):
+- When `openSection === 'save'` → the converted `SaveTemplateDialog` (now an inline
+  section; file/component name unchanged).
+- When `openSection === 'load'` → the converted `TemplatePickerDialog` (now an inline
+  section; file/component name unchanged).
+- Completing or dismissing a section calls back to set `openSection = 'none'` (FR-012).
+
+> Naming: the two template components keep their existing names/files
+> (`SaveTemplateDialog`, `TemplatePickerDialog`); only their rendering changes from a
+> modal overlay to an inline collapsible section. They are **not** renamed.
+
+### Inline section conversion
+
+`SaveTemplateDialog` and `TemplatePickerDialog` keep all of their current logic (name
+validation, `template_exists` → overwrite confirm; template list, empty state, per-row
+Delete with `ConfirmDeleteModal`) but render as **inline panels**: drop the
+`modal-backdrop`/`modal` wrappers and `aria-modal`, render a labeled `<section>` with the
+existing controls, and expose an `onClose`/Cancel that collapses the panel. Behavior
+otherwise unchanged (FR-013), so existing tests change only their container assertions.
+
+### Reload Template
+
+Handled in `QueuesPage` via `onReload`:
+1. Guard: ignore if no associated template or `status === 'Running'` (the button is
+   already disabled; defensive).
+2. Resolve by **remembered name**: `listQueueTemplates()` → find a case-insensitive name
+   match. None → surface "Template '<name>' is no longer available." and stop (FR-018;
+   covers delete and rename).
+3. `getQueueTemplate(match.id)` → `templateSeqIds = entries.map(e => e.sequenceId)`.
+4. Diff against `detail.entries.map(e => e.sequenceId)` (order-sensitive equality).
+   - Identical → no-op, no prompt (nothing to do).
+   - `detail.entries.length === 0` → apply directly, no prompt.
+   - Otherwise (non-empty and differs) → show a reload confirm modal; on confirm apply,
+     on cancel leave unchanged (FR-015, clarified).
+5. Apply = reuse the existing `applyLoad(name, sequenceIds)` path
+   (`replaceQueueEntries` → set associated name → `reloadDetail` → `refresh`).
+
+A small pure helper `sameSequenceOrder(a, b)` (≤50 LOC, CamelCase) backs the diff and is
+unit-tested directly.
+
+### QueuesPage wiring changes
+
+- Replace `loadedTemplateName?: string` with an associated-template object that also
+  carries the id when known, **or** keep the name and always resolve the id on reload
+  via the list call (chosen: keep name-only state + resolve-by-name, so rename correctly
+  reads as "unavailable"). Set on successful load (already) and on successful save
+  (the `POST` response name).
+- Render the edit section through `QueueForm` slots: pass `<QueueTemplateControls .../>`
+  as `templateControls` and `<QueueEntryList .../>` as `entries`. Remove the separate
+  `queue-templates-section` block and the standalone `<SaveTemplateDialog>` /
+  `<TemplatePickerDialog>` mounts (now owned by `QueueTemplateControls`).
+- Add a reload confirm `ConfirmDeleteModal` (title "Reload template", confirm
+  "Reload") driven by a `pendingReload` state, mirroring the existing `pendingLoad`
+  replace-confirm.
+
+## Contracts
+
+No new or changed external/REST contracts. Reuses `GET /api/queue-templates`,
+`GET /api/queue-templates/{id}`, and `PUT /api/queues/{id}/entries` from 047. The
+**UI contract** (row order, control set, and behaviors) is documented in
+`contracts/edit-queue-ui.md`.
+
+## Testing Strategy
+
+**Frontend (Jest + RTL)** — touched-area coverage ≥80% line / ≥70% branch:
+- `sameSequenceOrder`: equal/empty/different-length/different-order/duplicates.
+- `QueueTemplateControls`: default both sections closed; clicking the name opens Load;
+  clicking Save opens Save; opening one closes the other; Reload disabled when no
+  associated template and when running; Reload enabled + fires otherwise.
+- `SaveTemplateDialog` / `TemplatePickerDialog` (now inline sections): render inline (no
+  `modal-backdrop`); preserve validation/overwrite-confirm and list/empty-state/delete;
+  Cancel/Close collapses (calls `onClose`).
+- `QueueForm`: emulator hint absent; in edit, slots render in order
+  emulator → templateControls → cycle → entries → actions; create renders without slots.
+- `QueuesPage.layout` (US1): row order on the edit page (name+emulator → template
+  controls → cycle → sequences → Save/Cancel); emulator read-only, hint absent; Cancel
+  discards name/cycle edits; entry add/remove applies immediately (independent of Save).
+- `QueuesPage.templates` (US2): associated name pre-fills the inline Save section and
+  updates after save/load; Load disabled while the queue is running.
+- `QueuesPage.reload` (US3): Reload with identical entries → no prompt, no change; with
+  an empty queue → applies without prompt; with divergent non-empty entries → confirm
+  shown and cancelable; when the template is missing → "no longer available"; Reload
+  disabled with no associated template and while running.
+
+The `QueuesPage` test scenarios are split across three spec files —
+`QueuesPage.layout.spec.tsx`, `QueuesPage.templates.spec.tsx`, and
+`QueuesPage.reload.spec.tsx` — one per user story (US1/US2/US3).
+
+**No backend tests** change (no backend change). Manual verification in `quickstart.md`.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/048-edit-queue-layout/quickstart.md
+++ b/specs/048-edit-queue-layout/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Edit Queue Page Layout
+
+Manual verification of the refined edit-queue page (frontend-only). Assumes the GameBot
+service is running and the web-ui dev server is up (or the built UI is served), with at
+least one queue and a couple of saved templates available.
+
+## A. Row order and Name/Emulator (FR-001 … FR-005)
+
+1. Open the **Queues** tab and click a queue's name (or **Edit**) to open the edit page.
+2. Confirm the controls appear top to bottom in this order:
+   1. **Name** (editable) + **Emulator** (read-only)
+   2. **Template controls** (template-name button, Save Template, Reload Template)
+   3. **Cycle execution**
+   4. **Sequences** (one row per entry)
+   5. **Save** / **Cancel**
+3. Confirm there is **no** text saying the bound emulator cannot be changed/exchanged.
+4. Edit the name and toggle cycle execution, click **Save**, reopen — values persisted.
+   Click **Cancel** on a fresh edit — field edits discarded, page closes.
+
+## B. Inline template sections (FR-006 … FR-013)
+
+1. On open, both the Save and Load panels are **closed**.
+2. Click the **template-name button** → the **Load** panel opens inline between rows 2
+   and 3, listing templates (or an empty state).
+3. Click **Save Template** → the **Load** panel closes and the **Save** panel opens in
+   the same place (only one open at a time).
+4. In Save, leave the name blank → validation message; enter an existing name → overwrite
+   confirmation; cancel → nothing saved.
+5. In Load, delete a template (confirm) → it disappears from the list. Close the panel →
+   row 2 returns to default (both closed).
+
+## C. Reload Template (FR-014 … FR-018)
+
+1. Load a template into the queue → the template-name button now shows that name and
+   **Reload Template** becomes enabled.
+2. Add or remove a sequence so the queue diverges from the template.
+3. Click **Reload Template** → a **confirmation** appears; **Cancel** leaves entries
+   unchanged; **Reload** restores the template's entries in order.
+4. Click **Reload Template** again immediately (entries now match the template) → it
+   applies **without** a confirmation prompt (nothing to discard).
+5. With an **empty** queue associated with a template, click Reload → applies without a
+   prompt.
+6. Start the queue (status **Running**) → **Reload Template** (and Load) are disabled.
+7. Delete or rename the associated template elsewhere, return and click Reload → message
+   "Template '<name>' is no longer available"; entries unchanged.
+
+## D. Independence from Save/Cancel (FR-004a)
+
+1. Load/reload/add/remove entries, then click **Cancel** (row 5) → the field edits are
+   discarded but the queue's sequence entries reflect the actions already applied
+   (entry actions are immediate and independent of Save/Cancel).
+
+## E. Automated tests
+
+Run the frontend suite:
+
+```powershell
+npm --prefix src/web-ui test
+```
+
+Expect green: `QueueForm`, `SaveTemplateDialog`/section, `TemplatePickerDialog`/section,
+`QueueTemplateControls`, and `QueuesPage.templates` specs covering layout order, inline
+section toggling, and the reload diff/confirm/disabled/missing behaviors.

--- a/specs/048-edit-queue-layout/research.md
+++ b/specs/048-edit-queue-layout/research.md
@@ -1,0 +1,73 @@
+# Phase 0 Research: Edit Queue Page Layout
+
+All Technical Context items are known (frontend-only refinement of an existing,
+fully-specified page). No `NEEDS CLARIFICATION` remained after `/speckit-clarify`. The
+decisions below resolve the design choices the layout change raises.
+
+## Decision 1 — How to interleave the new row order without breaking create mode
+
+- **Decision**: Add two optional render slots to `QueueForm` (`templateControls`,
+  `entries`) rendered between the emulator field and cycle execution, and between cycle
+  execution and the form actions, respectively. Edit mode passes both; create mode
+  passes neither.
+- **Rationale**: The required edit-page order (name+emulator → templates → cycle →
+  sequences → save/cancel) interleaves template/sequence content into the middle of the
+  existing form. Slots keep a single `<form>` (so row-5 Save/Cancel stay the form's
+  native submit/cancel and Name/Cycle stay controlled) while leaving the create form's
+  layout untouched. Lowest-risk, smallest diff.
+- **Alternatives considered**:
+  - *Build a separate edit-page layout in `QueuesPage`*: duplicates field rendering and
+    diverges create/edit markup — more code, drift risk.
+  - *Reorder fields inside one monolithic form for both modes*: changes the create
+    layout unnecessarily and couples unrelated content into the form component.
+
+## Decision 2 — Inline sections vs. keeping modal dialogs
+
+- **Decision**: Convert `SaveTemplateDialog` and `TemplatePickerDialog` into inline
+  collapsible **sections** (drop the `modal-backdrop`/`aria-modal` wrappers; render a
+  labeled `<section>`), keeping all internal logic. A new `QueueTemplateControls`
+  component owns which section is open (mutual exclusion).
+- **Rationale**: The spec requires the Save/Load panels to "open between row 2 and 3"
+  inline and default closed — a modal overlay does not satisfy "between rows." Reusing
+  the existing components preserves validated behavior (name rules, overwrite confirm,
+  list/empty-state/delete) and limits changes to container markup + tests.
+- **Alternatives considered**:
+  - *Write brand-new section components*: more churn and duplicated logic for no benefit.
+  - *Keep modals, add Reload only*: violates the explicit inline-section requirement.
+
+## Decision 3 — Resolving the template to reload (by name vs. by id)
+
+- **Decision**: Track the associated template by **name** only and resolve it on reload
+  via `listQueueTemplates()` + case-insensitive name match, then `getQueueTemplate(id)`.
+- **Rationale**: The spec says a reload whose template was "deleted **or renamed**" must
+  report "no longer available." Name-based resolution makes a rename read as not-found
+  (the stored name changed), satisfying FR-018 with no backend change. An id-based
+  lookup would still resolve after a rename, contradicting the spec.
+- **Alternatives considered**:
+  - *Track id and `getQueueTemplate(id)`*: rename would not be detected as unavailable.
+  - *Add a `GET /api/queue-templates?name=` endpoint*: unnecessary backend work; the
+    list endpoint already returns names at the target scale (<1s, ≤50 templates).
+
+## Decision 4 — When the Reload confirmation appears (diff-aware)
+
+- **Decision**: Prompt for confirmation only when the queue is non-empty **and** its
+  current ordered `sequenceIds` differ from the template's. Identical entries → no-op,
+  no prompt; empty queue → apply directly, no prompt.
+- **Rationale**: Directly encodes the clarification ("confirm only when entries would
+  change"). A pure, order-sensitive `sameSequenceOrder(a, b)` helper makes the rule
+  testable and keeps the handler thin.
+- **Alternatives considered**:
+  - *Always confirm*: rejected by clarification (annoying when nothing to discard).
+  - *Confirm whenever non-empty*: still prompts on a no-op identical reload.
+
+## Decision 5 — Independence of entry actions from page Save/Cancel
+
+- **Decision**: Add/remove/load/reload act on the queue immediately via their services;
+  row-5 Save/Cancel commit or discard only Name + Cycle execution.
+- **Rationale**: Clarified directly — sequence entries are runtime-only and not
+  persisted with the queue, so they have no relationship to the page-level form
+  submission. This also matches the current architecture (entries mutate via dedicated
+  endpoints), so no buffering layer is introduced.
+- **Alternatives considered**:
+  - *Buffer all entry edits until Save*: large change (queue-entry buffering, optimistic
+    state), explicitly out of scope per the clarification ("for now at least").

--- a/specs/048-edit-queue-layout/spec.md
+++ b/specs/048-edit-queue-layout/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Edit Queue Page Layout
+
+**Feature Branch**: `048-edit-queue-layout`  
+**Created**: 2026-06-01  
+**Status**: Draft  
+**Input**: User description: "let's refine the edit queue page a bit more. I want the controls be raw by raw like this: 1. Name, editable. Emulator read-only. Remove the text that 'bound emulator cannot be exchanged...' 2. Template name; Save Template; Reload Template (new button). Reload should ask for confirmation. Template name is a button, which is clickable, when clicked it opens the current Load Template section. Both Load and Save template sections open between row 2 and 3, and closed. 3. Cycle execution 4. Sequences (as many rows as there are) 5. Save and Cancel buttons for the edit page."
+
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: When the operator clicks Reload Template, when should the confirmation prompt appear? → A: Only when entries would actually change — skip the prompt when there is nothing to discard (empty queue, or no edits since the template was loaded); confirm only when the queue's current entries differ from the template's.
+- Q: Do template Load/Reload (and add/remove) actions on the queue's sequence entries apply immediately, or are they part of the page-level Save/Cancel? → A: They apply immediately and are independent of Save/Cancel. The template defines only the sequence entries, which are not persisted with the queue, so they have no relation to the page-level Save/Cancel (which govern the queue's name and cycle-execution setting only).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Edit a queue through a clear, ordered layout (Priority: P1)
+
+While editing a queue, an operator sees the edit page organized as an ordered set of rows, top to bottom: (1) the queue name (editable) alongside its bound emulator (read-only), (2) the template controls, (3) the cycle-execution setting, (4) the queue's sequence entries, and (5) the Save and Cancel actions for the edit page. Each concern lives in its own row in this order, so the operator always knows where to find a given control.
+
+**Why this priority**: The whole request is a layout refinement of the existing edit queue page. This row-by-row ordering is the backbone everything else hangs on; without it the other refinements have no home. It delivers immediate value by making the edit page predictable and scannable.
+
+**Independent Test**: Open a queue for editing and confirm the controls appear, top to bottom, in the order: name + emulator, template controls, cycle execution, sequences, then Save/Cancel — and that name is editable while emulator is read-only.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator opens a queue for editing, **When** the edit page renders, **Then** the rows appear in order: (1) name + emulator, (2) template controls, (3) cycle execution, (4) sequences, (5) Save/Cancel.
+2. **Given** the edit page is open, **When** the operator views row 1, **Then** the queue name is an editable field and the bound emulator is shown read-only.
+3. **Given** the edit page is open, **When** the operator views the bound emulator, **Then** no explanatory text stating the bound emulator cannot be changed/exchanged after creation is shown.
+4. **Given** the operator changes the name and cycle-execution setting and clicks Save (row 5), **Then** the queue is saved with the new values; clicking Cancel discards the in-progress edits and closes the edit page.
+
+---
+
+### User Story 2 - Manage templates from a single inline row (Priority: P1)
+
+The template controls occupy row 2 as a single row containing: the current template name (rendered as a clickable button), a **Save Template** action, and a **Reload Template** action. Clicking the template name opens the Load Template section. The Save Template and Load Template sections expand inline between row 2 and row 3; they are collapsed by default and only one is shown at a time. The operator can therefore save, load, or reload a template without leaving the edit page or opening a separate modal.
+
+**Why this priority**: Templates are the primary working tool on this page (from the Queue Templates feature). Consolidating them into one row with inline, collapsible sections is the core of the refinement and is what the operator interacts with most.
+
+**Independent Test**: On the edit page, confirm row 2 shows the template name as a button plus Save Template and Reload Template buttons; click the template name and confirm the Load Template section opens inline below row 2; trigger Save Template and confirm the Save section opens in the same place; confirm both are closed by default.
+
+**Acceptance Scenarios**:
+
+1. **Given** the edit page is open, **When** the operator views row 2, **Then** it shows the current template name as a clickable button, a Save Template button, and a Reload Template button, with both the Save and Load sections collapsed.
+2. **Given** row 2 is shown, **When** the operator clicks the template-name button, **Then** the Load Template section opens inline between row 2 and row 3.
+3. **Given** row 2 is shown, **When** the operator clicks Save Template, **Then** the Save Template section opens inline between row 2 and row 3.
+4. **Given** the Load Template section is open, **When** the operator opens the Save Template section, **Then** the Load Template section closes (only one inline section is open at a time).
+5. **Given** an inline template section is open, **When** the operator completes or dismisses it, **Then** the section collapses and row 2 returns to its default (both sections closed).
+6. **Given** no template has been loaded or saved yet in this editing session, **When** the operator views the template-name button, **Then** it shows a neutral "no template" placeholder and still opens the Load Template section when clicked.
+
+---
+
+### User Story 3 - Reload the current template with confirmation (Priority: P2)
+
+The operator clicks **Reload Template** to re-apply the template the queue was most recently loaded from or saved as, restoring the queue's sequence entries to that template's persisted contents. Because reloading can discard edits made since the template was loaded, the operator is asked to confirm — but only when the reload would actually change the queue's entries; if there is nothing to discard (the queue is empty or its entries already match the template), the reload proceeds without a prompt.
+
+**Why this priority**: Reload is the one genuinely new action in this refinement. It builds on the existing save/load round trip (the queue must already be associated with a template name) and is a convenience over re-opening the Load Template picker, so it ranks below the layout and the consolidated template row.
+
+**Independent Test**: Load a template into a queue, edit its entries, click Reload Template, confirm the prompt, and verify the queue's entries are restored to the template's persisted contents.
+
+**Acceptance Scenarios**:
+
+1. **Given** the queue is associated with a template name (loaded or saved this session) and its entries have been edited away from the template, **When** the operator clicks Reload Template and confirms, **Then** the queue's entries are replaced with the named template's current persisted entries.
+2. **Given** the reload confirmation is shown, **When** the operator cancels, **Then** the queue's current entries are left unchanged and nothing is reloaded.
+3. **Given** the queue is associated with a template and its entries already match the template (or the queue is empty), **When** the operator clicks Reload Template, **Then** the reload proceeds without a confirmation prompt (there is nothing to discard).
+4. **Given** no template is associated with the queue (no template name yet), **When** the operator views row 2, **Then** Reload Template is disabled (there is nothing to reload).
+5. **Given** the queue is in the "running" state, **When** the operator views row 2, **Then** Reload Template is disabled (reloading is a bulk replacement of all entries), consistent with the existing block on loading into a running queue.
+6. **Given** the associated template no longer exists (it was deleted or renamed since), **When** the operator triggers a reload, **Then** the operator is told the template is no longer available and the queue's entries are left unchanged.
+
+---
+
+### Edge Cases
+
+- **No template associated yet**: The template-name button shows a neutral placeholder, Reload Template is disabled, and Save/Load still work (Save lets the operator name a new template; Load opens the picker).
+- **Running queue**: Loading and reloading are disabled while the queue is running (consistent with the existing block); saving a template from a running queue remains allowed. The name field and cycle-execution editing follow the existing running-queue rules from the queue feature.
+- **Switching inline sections**: Opening one inline template section closes the other; only one is open at a time, and they always open in the same place (between row 2 and row 3).
+- **Reload target missing**: If the associated template was deleted or renamed, triggering a reload reports that the template is unavailable and changes nothing.
+- **Reload with nothing to discard**: If the queue is empty or its entries already match the associated template, Reload proceeds without a confirmation prompt.
+- **Cancel on the edit page**: Cancel (row 5) discards in-progress edits to the queue's name and cycle-execution setting and closes the edit page. It does not affect the queue's sequence entries: add/remove/load/reload act on the queue immediately and independently of the page-level Save/Cancel, because a queue's sequence entries are runtime-only (not persisted with the queue) and Save/Cancel govern only the persisted name and cycle-execution fields.
+- **Empty sequences**: When the queue has no sequence entries, row 4 shows the existing empty state for sequences; the layout order is unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Layout & ordering
+
+- **FR-001**: The edit queue page MUST arrange its controls as ordered rows, top to bottom: (1) name + emulator, (2) template controls, (3) cycle execution, (4) sequence entries, (5) Save/Cancel actions.
+- **FR-002**: Row 1 MUST present the queue name as an editable field and the bound emulator as read-only.
+- **FR-003**: The edit page MUST NOT display explanatory text stating that the bound emulator cannot be changed/exchanged after creation.
+- **FR-004**: Row 5 MUST present the edit page's Save and Cancel actions. Save persists the queue's name and cycle-execution changes; Cancel discards in-progress edits to those fields and closes the edit page. Save/Cancel MUST govern only the name and cycle-execution fields — they MUST NOT gate or revert changes to the queue's sequence entries (which are runtime-only and not persisted with the queue).
+- **FR-004a**: Actions on the queue's sequence entries — add, remove, load (template), and reload (template) — MUST apply to the queue immediately and independently of the page-level Save/Cancel.
+- **FR-005**: Row 3 MUST present the cycle-execution setting, and row 4 MUST present the queue's sequence entries (one row per entry, as many rows as there are entries), preserving the existing add and remove behavior.
+
+#### Template controls row
+
+- **FR-006**: Row 2 MUST present, in a single row: the current template name (rendered as a clickable button), a Save Template action, and a Reload Template action.
+- **FR-007**: The template-name button MUST open the Load Template section when clicked.
+- **FR-008**: When no template is associated with the queue in the current editing session, the template-name button MUST show a neutral placeholder and MUST still open the Load Template section when clicked.
+- **FR-009**: The Save Template and Load Template sections MUST appear inline between row 2 and row 3 when opened.
+- **FR-010**: The Save Template and Load Template sections MUST be collapsed (closed) by default when the edit page opens.
+- **FR-011**: At most one inline template section (Save or Load) MUST be open at a time; opening one MUST close the other.
+- **FR-012**: An inline template section MUST collapse after the operator completes or dismisses it, returning row 2 to its default closed state.
+- **FR-013**: The Save Template and Load Template sections MUST preserve the existing save and load behaviors from the Queue Templates feature (name validation, overwrite confirmation, template picker with per-template delete, empty state, replace-on-load confirmation, and the block on loading into a running queue).
+
+#### Reload Template
+
+- **FR-014**: The Reload Template action MUST re-apply the template the queue is currently associated with (the one most recently loaded or saved this session), replacing the queue's current sequence entries with that template's current persisted entries.
+- **FR-015**: The system MUST ask the operator to confirm a reload before replacing the queue's entries ONLY when the reload would change the queue's entries (i.e., the current entries differ from the template's). When there is nothing to discard — the queue is empty or its entries already match the template — the reload MUST proceed without a confirmation prompt. When a confirmation is shown and the operator cancels, the queue's entries MUST be left unchanged.
+- **FR-016**: Reload Template MUST be disabled when no template is associated with the queue (nothing to reload).
+- **FR-017**: Reload Template MUST be disabled while the queue is in the "running" state, consistent with the existing block on loading into a running queue.
+- **FR-018**: When a reload targets a template that no longer exists, the system MUST inform the operator that the template is unavailable and MUST leave the queue's entries unchanged.
+
+### Key Entities *(include if feature involves data)*
+
+This feature reorganizes the presentation of the existing edit queue page; it introduces no new persisted entities. It operates on the existing **Queue**, **Queue Entry**, and **Queue Template** entities defined by the Emulator Execution Queue and Queue Templates features.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On opening the edit queue page, 100% of the time the controls render in the order: name + emulator, template controls, cycle execution, sequences, Save/Cancel.
+- **SC-002**: An operator can locate and trigger Save Template, Load Template (via the template-name button), and Reload Template from row 2 without scrolling past row 4 or opening any separate top-level area.
+- **SC-003**: The Save and Load inline sections are closed on every fresh open of the edit page, and only one is ever open at a time, in 100% of interactions.
+- **SC-004**: 100% of reloads that would change the queue's entries present a confirmation the operator can cancel (and canceling leaves the entries unchanged), while reloads with nothing to discard proceed without a prompt.
+- **SC-005**: After a confirmed reload, the queue's entries match the associated template's persisted entries 100% of the time (when the template still exists).
+- **SC-006**: The bound-emulator "cannot be changed" explanatory text is absent from the edit page in 100% of renders.
+
+## Assumptions
+
+- **Refinement, not rebuild**: This changes only the arrangement and the addition of Reload Template on the existing edit queue page. The underlying queue editing, template save/load/delete, validation, and running-queue rules from the Emulator Execution Queue (046) and Queue Templates (047) features are unchanged unless stated here.
+- **Inline sections replace modals**: The Save Template and Load Template experiences, previously surfaced as dialogs, are now inline collapsible sections opening between row 2 and row 3. Their internal behavior (fields, validation, picker, per-template delete, confirmations) is preserved.
+- **"Associated template"**: The queue is "associated" with a template name when it was loaded from a template or saved as one during the current editing session (the same UI-state association the Queue Templates feature already tracks for the save dialog's pre-filled name). It is not a persisted live link.
+- **Reload semantics**: Reload re-fetches the associated template's current persisted entries by name and fully replaces the queue's entries — effectively "load again." It is guarded by confirmation only when it would actually discard changes (current entries differ from the template); when the queue is empty or already matches the template, it proceeds silently.
+- **Entries independent of Save/Cancel**: The queue's sequence entries are runtime-only and not persisted with the queue, so all entry actions (add, remove, load, reload) apply to the queue immediately and are unrelated to the page-level Save/Cancel, which commit or discard only the name and cycle-execution fields.
+- **Mutual exclusivity of sections**: Only one inline template section is open at a time to keep row 2's footprint predictable; opening the other closes the first.
+- **Running-queue consistency**: Reload follows the same running-queue restriction as Load (blocked while running). Saving remains allowed while running.
+- **Confirmation pattern**: Reload and existing replace/overwrite/delete confirmations use the app's established confirmation-prompt convention.
+
+## Out of Scope
+
+- Any change to template persistence, the template data model, or the template API beyond what already exists.
+- Changing the queue's bound emulator after creation (still immutable; only the explanatory text is removed).
+- Reordering or redesigning the Queues list/table view; this refinement targets the edit queue page only.
+- A dedicated template editor or any new template management surface outside the edit page.
+- Changes to start/stop execution behavior or to the cycle-execution flag's (still deferred) runtime semantics.
+- Persisting the queue's sequence entries or the associated-template UI state across service restarts.

--- a/specs/048-edit-queue-layout/tasks.md
+++ b/specs/048-edit-queue-layout/tasks.md
@@ -28,7 +28,7 @@ subsection, per TDD.
 
 **Purpose**: Establish a green baseline before changing the edit-queue page.
 
-- [ ] T001 Run the frontend suite to confirm a green baseline and confirm the touched files exist (`npm --prefix src/web-ui test`); files: `src/web-ui/src/pages/QueuesPage.tsx`, `src/web-ui/src/components/queues/{QueueForm,QueueEntryList,SaveTemplateDialog,TemplatePickerDialog}.tsx`
+- [X] T001 Run the frontend suite to confirm a green baseline and confirm the touched files exist (`npm --prefix src/web-ui test`); files: `src/web-ui/src/pages/QueuesPage.tsx`, `src/web-ui/src/components/queues/{QueueForm,QueueEntryList,SaveTemplateDialog,TemplatePickerDialog}.tsx`
 
 ---
 
@@ -39,8 +39,8 @@ subsection, per TDD.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 Add optional `templateControls` and `entries` render slots to `QueueForm` — render `templateControls` after the emulator field and before cycle execution, and `entries` after cycle execution and before `form-actions`; remove the "The bound emulator cannot be changed after creation." hint (FR-003); create mode passes neither slot, preserving its layout — in `src/web-ui/src/components/queues/QueueForm.tsx`
-- [ ] T003 [P] Update `QueueForm` tests: assert the emulator hint is absent, that in edit mode the slot nodes render in order (emulator → templateControls → cycle → entries → actions), and that create mode renders without the slots — in `src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx`
+- [X] T002 Add optional `templateControls` and `entries` render slots to `QueueForm` — render `templateControls` after the emulator field and before cycle execution, and `entries` after cycle execution and before `form-actions`; remove the "The bound emulator cannot be changed after creation." hint (FR-003); create mode passes neither slot, preserving its layout — in `src/web-ui/src/components/queues/QueueForm.tsx`
+- [X] T003 [P] Update `QueueForm` tests: assert the emulator hint is absent, that in edit mode the slot nodes render in order (emulator → templateControls → cycle → entries → actions), and that create mode renders without the slots — in `src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx`
 
 **Checkpoint**: `QueueForm` exposes ordered slots and no longer shows the emulator hint.
 
@@ -59,11 +59,11 @@ name + cycle execution (entry add/remove persists regardless).
 
 ### Tests for User Story 1
 
-- [ ] T004 [P] [US1] Layout-order and Save/Cancel-scope test: edit page renders rows in order (name+emulator, a template-controls region between rows 2 and 3, cycle, sequences, Save/Cancel); emulator read-only; hint absent; Cancel discards name/cycle edits and closes; entry add/remove applies immediately and is unaffected by Cancel (FR-001–FR-005, FR-004a) — in `src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx`
+- [X] T004 [P] [US1] Layout-order and Save/Cancel-scope test: edit page renders rows in order (name+emulator, a template-controls region between rows 2 and 3, cycle, sequences, Save/Cancel); emulator read-only; hint absent; Cancel discards name/cycle edits and closes; entry add/remove applies immediately and is unaffected by Cancel (FR-001–FR-005, FR-004a) — in `src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx`
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] Compose the Edit-Queue section via `QueueForm` slots in `QueuesPage`: pass `<QueueEntryList>` as the `entries` slot (row 4) and an **empty/placeholder** template-controls region as the `templateControls` slot (row 2) — this placeholder is replaced by `<QueueTemplateControls>` in T012; remove the standalone `queue-templates-section` block so ordering follows rows 1–5; keep `submitForm` committing only name + cycle execution and `closeForms` as Cancel; leave entry add/remove calling their services immediately — in `src/web-ui/src/pages/QueuesPage.tsx`
+- [X] T005 [US1] Compose the Edit-Queue section via `QueueForm` slots in `QueuesPage`: pass `<QueueEntryList>` as the `entries` slot (row 4) and an **empty/placeholder** template-controls region as the `templateControls` slot (row 2) — this placeholder is replaced by `<QueueTemplateControls>` in T012; remove the standalone `queue-templates-section` block so ordering follows rows 1–5; keep `submitForm` committing only name + cycle execution and `closeForms` as Cancel; leave entry add/remove calling their services immediately — in `src/web-ui/src/pages/QueuesPage.tsx`
 
 **Checkpoint**: Edit page shows the correct row order; Name/Emulator/Cycle/Save/Cancel behave per FR-001–FR-005 (the template row content arrives in US2).
 
@@ -87,16 +87,16 @@ open at a time; saving/loading updates the displayed template name.
 
 ### Tests for User Story 2
 
-- [ ] T006 [P] [US2] `QueueTemplateControls` tests: both sections closed by default (FR-010); template-name button shows `(no template)` placeholder when none and opens the Load section (FR-007, FR-008); Save Template opens the Save section; opening one closes the other (FR-011); completing/dismissing collapses back to closed (FR-012) — in `src/web-ui/src/components/queues/__tests__/QueueTemplateControls.test.tsx`
-- [ ] T007 [P] [US2] Update inline-section tests: assert the Save and Load sections render inline (no `modal-backdrop`/`aria-modal`) while preserving behavior — name validation + overwrite confirm (Save); list/empty-state/per-row delete (Load) — in `src/web-ui/src/components/queues/__tests__/SaveTemplateDialog.test.tsx` and `src/web-ui/src/components/queues/__tests__/TemplatePickerDialog.test.tsx`
-- [ ] T008 [US2] Update `QueuesPage` template-wiring tests: associated template name pre-fills the inline Save section and updates after a successful save/load; Load disabled while the queue is Running (FR-013) — in `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx`
+- [X] T006 [P] [US2] `QueueTemplateControls` tests: both sections closed by default (FR-010); template-name button shows `(no template)` placeholder when none and opens the Load section (FR-007, FR-008); Save Template opens the Save section; opening one closes the other (FR-011); completing/dismissing collapses back to closed (FR-012) — in `src/web-ui/src/components/queues/__tests__/QueueTemplateControls.test.tsx`
+- [X] T007 [P] [US2] Update inline-section tests: assert the Save and Load sections render inline (no `modal-backdrop`/`aria-modal`) while preserving behavior — name validation + overwrite confirm (Save); list/empty-state/per-row delete (Load) — in `src/web-ui/src/components/queues/__tests__/SaveTemplateDialog.test.tsx` and `src/web-ui/src/components/queues/__tests__/TemplatePickerDialog.test.tsx`
+- [X] T008 [US2] Update `QueuesPage` template-wiring tests: associated template name pre-fills the inline Save section and updates after a successful save/load; Load disabled while the queue is Running (FR-013) — in `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx`
 
 ### Implementation for User Story 2
 
-- [ ] T009 [P] [US2] Convert `SaveTemplateDialog` into an inline collapsible section (keep the file/component name): drop the `modal-backdrop`/`modal`/`aria-modal` wrappers, render a labeled `<section>`, expose Cancel/Close that calls `onClose` to collapse; keep name validation and the `template_exists` → overwrite-confirm flow unchanged — in `src/web-ui/src/components/queues/SaveTemplateDialog.tsx`
-- [ ] T010 [P] [US2] Convert `TemplatePickerDialog` into an inline collapsible section (keep the file/component name): drop the modal wrappers, render a labeled `<section>`; keep the template list, empty state, and per-row Delete (with `ConfirmDeleteModal`) and the `loadDisabled` behavior unchanged — in `src/web-ui/src/components/queues/TemplatePickerDialog.tsx`
-- [ ] T011 [US2] Create `QueueTemplateControls`: row with a template-name button (label `associatedTemplateName ?? '(no template)'`, opens Load) and a Save Template button (opens Save); `openSection: 'none' | 'save' | 'load'` state defaulting to `'none'` with mutual exclusion; render the inline Save/Load sections (from T009/T010) below the row; props `{ associatedTemplateName?, status, currentSequenceIds, onSaveTemplate, onLoadTemplate }` — in `src/web-ui/src/components/queues/QueueTemplateControls.tsx` (depends on T009, T010)
-- [ ] T012 [US2] Wire `QueueTemplateControls` into the `QueuesPage` `templateControls` slot, replacing the T005 placeholder region: replace `loadedTemplateName` usage with `associatedTemplateName` set on successful save and load, pass `currentSequenceIds` from `detail.entries`, and remove the standalone `<SaveTemplateDialog>`/`<TemplatePickerDialog>` mounts (now owned by the controls) — in `src/web-ui/src/pages/QueuesPage.tsx` (depends on T011, T005)
+- [X] T009 [P] [US2] Convert `SaveTemplateDialog` into an inline collapsible section (keep the file/component name): drop the `modal-backdrop`/`modal`/`aria-modal` wrappers, render a labeled `<section>`, expose Cancel/Close that calls `onClose` to collapse; keep name validation and the `template_exists` → overwrite-confirm flow unchanged — in `src/web-ui/src/components/queues/SaveTemplateDialog.tsx`
+- [X] T010 [P] [US2] Convert `TemplatePickerDialog` into an inline collapsible section (keep the file/component name): drop the modal wrappers, render a labeled `<section>`; keep the template list, empty state, and per-row Delete (with `ConfirmDeleteModal`) and the `loadDisabled` behavior unchanged — in `src/web-ui/src/components/queues/TemplatePickerDialog.tsx`
+- [X] T011 [US2] Create `QueueTemplateControls`: row with a template-name button (label `associatedTemplateName ?? '(no template)'`, opens Load) and a Save Template button (opens Save); `openSection: 'none' | 'save' | 'load'` state defaulting to `'none'` with mutual exclusion; render the inline Save/Load sections (from T009/T010) below the row; props `{ associatedTemplateName?, status, currentSequenceIds, onSaveTemplate, onLoadTemplate }` — in `src/web-ui/src/components/queues/QueueTemplateControls.tsx` (depends on T009, T010)
+- [X] T012 [US2] Wire `QueueTemplateControls` into the `QueuesPage` `templateControls` slot, replacing the T005 placeholder region: replace `loadedTemplateName` usage with `associatedTemplateName` set on successful save and load, pass `currentSequenceIds` from `detail.entries`, and remove the standalone `<SaveTemplateDialog>`/`<TemplatePickerDialog>` mounts (now owned by the controls) — in `src/web-ui/src/pages/QueuesPage.tsx` (depends on T011, T005)
 
 **Checkpoint**: The template row + inline Save/Load sections work end-to-end; existing save/load/delete behavior preserved (Reload arrives in US3).
 
@@ -116,14 +116,14 @@ applies without a prompt; running queue → Reload disabled; deleted/renamed tem
 
 ### Tests for User Story 3
 
-- [ ] T013 [P] [US3] Unit tests for `sameSequenceOrder`: equal arrays, empty arrays, different lengths, different order, duplicates — in `src/web-ui/src/lib/__tests__/sequenceOrder.test.ts`
-- [ ] T014 [P] [US3] Reload behavior tests in `QueuesPage`: Reload disabled when no associated template and when Running (FR-016/FR-017); identical entries → no prompt, no change; empty queue → applies without prompt; non-empty + divergent → confirmation shown and cancelable (FR-015); missing template → "Template '<name>' is no longer available", entries unchanged (FR-018) — in `src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx`
+- [X] T013 [P] [US3] Unit tests for `sameSequenceOrder`: equal arrays, empty arrays, different lengths, different order, duplicates — in `src/web-ui/src/lib/__tests__/sequenceOrder.test.ts`
+- [X] T014 [P] [US3] Reload behavior tests in `QueuesPage`: Reload disabled when no associated template and when Running (FR-016/FR-017); identical entries → no prompt, no change; empty queue → applies without prompt; non-empty + divergent → confirmation shown and cancelable (FR-015); missing template → "Template '<name>' is no longer available", entries unchanged (FR-018) — in `src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx`
 
 ### Implementation for User Story 3
 
-- [ ] T015 [P] [US3] Create the pure, order-sensitive `sameSequenceOrder(a: string[], b: string[]): boolean` helper — in `src/web-ui/src/lib/sequenceOrder.ts`
-- [ ] T016 [US3] Add the Reload Template button to `QueueTemplateControls` (completing row 2 per FR-006): disabled when `!associatedTemplateName || status === 'Running'` (FR-016/FR-017); calls a new `onReload` prop — in `src/web-ui/src/components/queues/QueueTemplateControls.tsx` (depends on T011)
-- [ ] T017 [US3] Implement the reload handler in `QueuesPage`: resolve the associated template by name via `listQueueTemplates()` (case-insensitive) → missing → surface "no longer available" (FR-018); else `getQueueTemplate(id)`, diff its `sequenceIds` against `detail.entries` via `sameSequenceOrder`; if non-empty and divergent set `pendingReload` and confirm via `ConfirmDeleteModal` (title "Reload template", confirm "Reload"), otherwise apply directly; apply reuses the existing `applyLoad` path; pass `onReload` to `QueueTemplateControls` — in `src/web-ui/src/pages/QueuesPage.tsx` (depends on T015, T016, T012)
+- [X] T015 [P] [US3] Create the pure, order-sensitive `sameSequenceOrder(a: string[], b: string[]): boolean` helper — in `src/web-ui/src/lib/sequenceOrder.ts`
+- [X] T016 [US3] Add the Reload Template button to `QueueTemplateControls` (completing row 2 per FR-006): disabled when `!associatedTemplateName || status === 'Running'` (FR-016/FR-017); calls a new `onReload` prop — in `src/web-ui/src/components/queues/QueueTemplateControls.tsx` (depends on T011)
+- [X] T017 [US3] Implement the reload handler in `QueuesPage`: resolve the associated template by name via `listQueueTemplates()` (case-insensitive) → missing → surface "no longer available" (FR-018); else `getQueueTemplate(id)`, diff its `sequenceIds` against `detail.entries` via `sameSequenceOrder`; if non-empty and divergent set `pendingReload` and confirm via `ConfirmDeleteModal` (title "Reload template", confirm "Reload"), otherwise apply directly; apply reuses the existing `applyLoad` path; pass `onReload` to `QueueTemplateControls` — in `src/web-ui/src/pages/QueuesPage.tsx` (depends on T015, T016, T012)
 
 **Checkpoint**: All three stories function independently; reload honors the diff-aware confirmation rule.
 
@@ -133,8 +133,8 @@ applies without a prompt; running queue → Reload disabled; deleted/renamed tem
 
 **Purpose**: Styling and verification across the refined page.
 
-- [ ] T018 [P] Add styles for the template-controls row (template-name button, action buttons) and the inline Save/Load section panels so they read as rows between rows 2 and 3 — in `src/web-ui/src/styles.css`
-- [ ] T019 Run the full frontend suite and lint; confirm ≥80% line / ≥70% branch coverage on touched areas and zero lint errors (`npm --prefix src/web-ui test` and `npm --prefix src/web-ui run lint`)
+- [X] T018 [P] Add styles for the template-controls row (template-name button, action buttons) and the inline Save/Load section panels so they read as rows between rows 2 and 3 — in `src/web-ui/src/styles.css`
+- [X] T019 Run the full frontend suite and lint; confirm ≥80% line / ≥70% branch coverage on touched areas and zero lint errors (`npm --prefix src/web-ui test` and `npm --prefix src/web-ui run lint`)
 - [ ] T020 Execute `specs/048-edit-queue-layout/quickstart.md` manual verification (row order, inline section toggling, reload diff/confirm/disabled/missing, Save/Cancel independence)
 
 ---

--- a/specs/048-edit-queue-layout/tasks.md
+++ b/specs/048-edit-queue-layout/tasks.md
@@ -1,0 +1,218 @@
+---
+
+description: "Task list for Edit Queue Page Layout"
+---
+
+# Tasks: Edit Queue Page Layout
+
+**Input**: Design documents from `/specs/048-edit-queue-layout/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included — the GameBot constitution (Testing Standards II) requires tests for
+executable logic, and the plan declares a frontend test strategy. Within each user story
+the Tests subsection is written first (and is numbered before) its Implementation
+subsection, per TDD.
+
+**Organization**: Tasks are grouped by user story. This is a **frontend-only** change
+(no backend, API, or persisted-entity work). All paths are under `src/web-ui/`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (maps to spec.md user stories)
+- Exact file paths included in each task
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a green baseline before changing the edit-queue page.
+
+- [ ] T001 Run the frontend suite to confirm a green baseline and confirm the touched files exist (`npm --prefix src/web-ui test`); files: `src/web-ui/src/pages/QueuesPage.tsx`, `src/web-ui/src/components/queues/{QueueForm,QueueEntryList,SaveTemplateDialog,TemplatePickerDialog}.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared `QueueForm` change that the layout (US1) and the template row
+(US2) both build on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Add optional `templateControls` and `entries` render slots to `QueueForm` — render `templateControls` after the emulator field and before cycle execution, and `entries` after cycle execution and before `form-actions`; remove the "The bound emulator cannot be changed after creation." hint (FR-003); create mode passes neither slot, preserving its layout — in `src/web-ui/src/components/queues/QueueForm.tsx`
+- [ ] T003 [P] Update `QueueForm` tests: assert the emulator hint is absent, that in edit mode the slot nodes render in order (emulator → templateControls → cycle → entries → actions), and that create mode renders without the slots — in `src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx`
+
+**Checkpoint**: `QueueForm` exposes ordered slots and no longer shows the emulator hint.
+
+---
+
+## Phase 3: User Story 1 - Edit a queue through a clear, ordered layout (Priority: P1) 🎯 MVP
+
+**Goal**: The edit page renders its controls top-to-bottom as rows 1–5; Name is
+editable, Emulator read-only; the page-level Save/Cancel commit/discard only Name +
+Cycle execution, while sequence-entry actions apply immediately.
+
+**Independent Test**: Open a queue for editing and confirm the row order
+(name+emulator → template-controls region → cycle → sequences → Save/Cancel), that
+emulator is read-only with no "cannot be changed" hint, and that Save/Cancel affect only
+name + cycle execution (entry add/remove persists regardless).
+
+### Tests for User Story 1
+
+- [ ] T004 [P] [US1] Layout-order and Save/Cancel-scope test: edit page renders rows in order (name+emulator, a template-controls region between rows 2 and 3, cycle, sequences, Save/Cancel); emulator read-only; hint absent; Cancel discards name/cycle edits and closes; entry add/remove applies immediately and is unaffected by Cancel (FR-001–FR-005, FR-004a) — in `src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx`
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Compose the Edit-Queue section via `QueueForm` slots in `QueuesPage`: pass `<QueueEntryList>` as the `entries` slot (row 4) and an **empty/placeholder** template-controls region as the `templateControls` slot (row 2) — this placeholder is replaced by `<QueueTemplateControls>` in T012; remove the standalone `queue-templates-section` block so ordering follows rows 1–5; keep `submitForm` committing only name + cycle execution and `closeForms` as Cancel; leave entry add/remove calling their services immediately — in `src/web-ui/src/pages/QueuesPage.tsx`
+
+**Checkpoint**: Edit page shows the correct row order; Name/Emulator/Cycle/Save/Cancel behave per FR-001–FR-005 (the template row content arrives in US2).
+
+---
+
+## Phase 4: User Story 2 - Manage templates from a single inline row (Priority: P1)
+
+**Goal**: Row 2 is a single template-controls row (template-name button + Save Template)
+whose Save and Load panels expand inline between rows 2 and 3, default closed, only one
+open at a time.
+
+> **Scope note (FR-006)**: FR-006 lists three row-2 controls — template-name button,
+> Save Template, **and Reload Template**. US2 delivers the row plus the name button and
+> Save Template; the **Reload Template** button is added in US3 (T016). US2 therefore
+> completes row 2 except for the Reload control.
+
+**Independent Test**: On the edit page, row 2 shows the template name as a button plus a
+Save Template button; clicking the name opens the Load section inline; triggering Save
+opens the Save section in the same place; both are closed by default and only one is
+open at a time; saving/loading updates the displayed template name.
+
+### Tests for User Story 2
+
+- [ ] T006 [P] [US2] `QueueTemplateControls` tests: both sections closed by default (FR-010); template-name button shows `(no template)` placeholder when none and opens the Load section (FR-007, FR-008); Save Template opens the Save section; opening one closes the other (FR-011); completing/dismissing collapses back to closed (FR-012) — in `src/web-ui/src/components/queues/__tests__/QueueTemplateControls.test.tsx`
+- [ ] T007 [P] [US2] Update inline-section tests: assert the Save and Load sections render inline (no `modal-backdrop`/`aria-modal`) while preserving behavior — name validation + overwrite confirm (Save); list/empty-state/per-row delete (Load) — in `src/web-ui/src/components/queues/__tests__/SaveTemplateDialog.test.tsx` and `src/web-ui/src/components/queues/__tests__/TemplatePickerDialog.test.tsx`
+- [ ] T008 [US2] Update `QueuesPage` template-wiring tests: associated template name pre-fills the inline Save section and updates after a successful save/load; Load disabled while the queue is Running (FR-013) — in `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx`
+
+### Implementation for User Story 2
+
+- [ ] T009 [P] [US2] Convert `SaveTemplateDialog` into an inline collapsible section (keep the file/component name): drop the `modal-backdrop`/`modal`/`aria-modal` wrappers, render a labeled `<section>`, expose Cancel/Close that calls `onClose` to collapse; keep name validation and the `template_exists` → overwrite-confirm flow unchanged — in `src/web-ui/src/components/queues/SaveTemplateDialog.tsx`
+- [ ] T010 [P] [US2] Convert `TemplatePickerDialog` into an inline collapsible section (keep the file/component name): drop the modal wrappers, render a labeled `<section>`; keep the template list, empty state, and per-row Delete (with `ConfirmDeleteModal`) and the `loadDisabled` behavior unchanged — in `src/web-ui/src/components/queues/TemplatePickerDialog.tsx`
+- [ ] T011 [US2] Create `QueueTemplateControls`: row with a template-name button (label `associatedTemplateName ?? '(no template)'`, opens Load) and a Save Template button (opens Save); `openSection: 'none' | 'save' | 'load'` state defaulting to `'none'` with mutual exclusion; render the inline Save/Load sections (from T009/T010) below the row; props `{ associatedTemplateName?, status, currentSequenceIds, onSaveTemplate, onLoadTemplate }` — in `src/web-ui/src/components/queues/QueueTemplateControls.tsx` (depends on T009, T010)
+- [ ] T012 [US2] Wire `QueueTemplateControls` into the `QueuesPage` `templateControls` slot, replacing the T005 placeholder region: replace `loadedTemplateName` usage with `associatedTemplateName` set on successful save and load, pass `currentSequenceIds` from `detail.entries`, and remove the standalone `<SaveTemplateDialog>`/`<TemplatePickerDialog>` mounts (now owned by the controls) — in `src/web-ui/src/pages/QueuesPage.tsx` (depends on T011, T005)
+
+**Checkpoint**: The template row + inline Save/Load sections work end-to-end; existing save/load/delete behavior preserved (Reload arrives in US3).
+
+---
+
+## Phase 5: User Story 3 - Reload the current template with confirmation (Priority: P2)
+
+**Goal**: A Reload Template button re-applies the associated template's persisted
+entries, prompting for confirmation only when the reload would change a non-empty queue;
+disabled when no template is associated or the queue is running; reports when the
+template is missing.
+
+**Independent Test**: Load a template, edit entries, click Reload, confirm → entries
+restored; click Reload again (now identical) → applies without a prompt; empty queue →
+applies without a prompt; running queue → Reload disabled; deleted/renamed template →
+"no longer available".
+
+### Tests for User Story 3
+
+- [ ] T013 [P] [US3] Unit tests for `sameSequenceOrder`: equal arrays, empty arrays, different lengths, different order, duplicates — in `src/web-ui/src/lib/__tests__/sequenceOrder.test.ts`
+- [ ] T014 [P] [US3] Reload behavior tests in `QueuesPage`: Reload disabled when no associated template and when Running (FR-016/FR-017); identical entries → no prompt, no change; empty queue → applies without prompt; non-empty + divergent → confirmation shown and cancelable (FR-015); missing template → "Template '<name>' is no longer available", entries unchanged (FR-018) — in `src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx`
+
+### Implementation for User Story 3
+
+- [ ] T015 [P] [US3] Create the pure, order-sensitive `sameSequenceOrder(a: string[], b: string[]): boolean` helper — in `src/web-ui/src/lib/sequenceOrder.ts`
+- [ ] T016 [US3] Add the Reload Template button to `QueueTemplateControls` (completing row 2 per FR-006): disabled when `!associatedTemplateName || status === 'Running'` (FR-016/FR-017); calls a new `onReload` prop — in `src/web-ui/src/components/queues/QueueTemplateControls.tsx` (depends on T011)
+- [ ] T017 [US3] Implement the reload handler in `QueuesPage`: resolve the associated template by name via `listQueueTemplates()` (case-insensitive) → missing → surface "no longer available" (FR-018); else `getQueueTemplate(id)`, diff its `sequenceIds` against `detail.entries` via `sameSequenceOrder`; if non-empty and divergent set `pendingReload` and confirm via `ConfirmDeleteModal` (title "Reload template", confirm "Reload"), otherwise apply directly; apply reuses the existing `applyLoad` path; pass `onReload` to `QueueTemplateControls` — in `src/web-ui/src/pages/QueuesPage.tsx` (depends on T015, T016, T012)
+
+**Checkpoint**: All three stories function independently; reload honors the diff-aware confirmation rule.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Styling and verification across the refined page.
+
+- [ ] T018 [P] Add styles for the template-controls row (template-name button, action buttons) and the inline Save/Load section panels so they read as rows between rows 2 and 3 — in `src/web-ui/src/styles.css`
+- [ ] T019 Run the full frontend suite and lint; confirm ≥80% line / ≥70% branch coverage on touched areas and zero lint errors (`npm --prefix src/web-ui test` and `npm --prefix src/web-ui run lint`)
+- [ ] T020 Execute `specs/048-edit-queue-layout/quickstart.md` manual verification (row order, inline section toggling, reload diff/confirm/disabled/missing, Save/Cancel independence)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories (provides the `QueueForm` slots).
+- **User Stories (Phase 3–5)**: All depend on Foundational.
+  - US1 (layout composition) lands before US2 wiring: T012 depends on T005 (US2 replaces the T005 placeholder region with `QueueTemplateControls`).
+  - US3 builds on US2's `QueueTemplateControls` (T016 depends on T011) and US1's page composition (T017 depends on T012).
+- **Polish (Phase 6)**: After the desired stories are complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Foundational. Independently testable for row order + Save/Cancel scope (with a placeholder template region).
+- **US2 (P1)**: After Foundational; T012 replaces the US1 placeholder region (depends on T005 and T011).
+- **US3 (P2)**: After US2 (T016 depends on T011) and US1 page composition (T017 depends on T012); the `sameSequenceOrder` helper (T013/T015) is independent and parallelizable.
+
+### Within Each User Story
+
+- Write tests first and watch them fail, then implement (TDD per constitution); the
+  Tests subsection is numbered before the Implementation subsection in each story.
+- Section conversions (T009/T010) before the controls component (T011).
+- Controls component (T011) before page wiring (T012) and before the Reload button (T016).
+- Helper (T015) and Reload button (T016) before the reload handler (T017).
+
+### Parallel Opportunities
+
+- Foundational: T003 after T002.
+- US2: tests T006 and T007 are [P]; implementations T009 and T010 are [P] (different files); then T011 → T012 are sequential.
+- US3: tests T013 and T014 are [P]; helper T015 is [P]; then T016 → T017 are sequential.
+- Polish: T018 is [P] with the others.
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Author the section/controls tests in parallel:
+Task: "QueueTemplateControls tests in .../__tests__/QueueTemplateControls.test.tsx"   # T006
+Task: "Inline-section tests in .../__tests__/{SaveTemplateDialog,TemplatePickerDialog}.test.tsx"  # T007
+
+# Convert both dialogs to inline sections in parallel (different files):
+Task: "Convert SaveTemplateDialog to inline section in .../SaveTemplateDialog.tsx"    # T009
+Task: "Convert TemplatePickerDialog to inline section in .../TemplatePickerDialog.tsx" # T010
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 (Setup) and Phase 2 (Foundational — `QueueForm` slots).
+2. Complete **US1** (ordered layout) → validate row order + Save/Cancel scope.
+3. Complete **US2** (inline template row) → both P1 stories together form the
+   shippable layout-refinement MVP (the template row is empty without US2).
+4. **STOP and VALIDATE** the MVP, then proceed to US3.
+
+### Incremental Delivery
+
+1. Setup + Foundational → slots ready.
+2. US1 + US2 (both P1) → refined, inline template-aware edit page (MVP).
+3. US3 (P2) → Reload Template with diff-aware confirmation (completes row 2 per FR-006).
+4. Polish → styling + full verification.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks.
+- This feature is frontend-only — no backend/API/persistence tasks (Save/Load and
+  `PUT /api/queues/{id}/entries` already exist from feature 047).
+- US1 and US2 are both P1 and tightly coupled (both touch `QueuesPage.tsx`); US3 is the
+  cleanly separable increment.
+- The two template components keep their existing names (`SaveTemplateDialog`,
+  `TemplatePickerDialog`); only their rendering changes from modal to inline section.
+- Verify tests fail before implementing; commit after each task or logical group.

--- a/src/web-ui/src/components/ConfirmDeleteModal.tsx
+++ b/src/web-ui/src/components/ConfirmDeleteModal.tsx
@@ -55,10 +55,10 @@ export const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({
           </div>
         )}
         <div className="modal-actions">
-          <button className="btn btn-secondary" onClick={onCancel}>
+          <button type="button" className="btn btn-secondary" onClick={onCancel}>
             {cancelText}
           </button>
-          <button className="btn btn-danger" onClick={onConfirm}>
+          <button type="button" className="btn btn-danger" onClick={onConfirm}>
             {confirmText}
           </button>
         </div>

--- a/src/web-ui/src/components/queues/QueueForm.tsx
+++ b/src/web-ui/src/components/queues/QueueForm.tsx
@@ -17,6 +17,10 @@ type QueueFormProps = {
   submitting?: boolean;
   formError?: string;
   fieldErrors?: { name?: string; emulatorSerial?: string };
+  /** Edit-mode only: row 2 — template controls, rendered after the emulator and before cycle execution. */
+  templateControls?: React.ReactNode;
+  /** Edit-mode only: row 4 — queue sequence entries, rendered after cycle execution and before the actions. */
+  entries?: React.ReactNode;
 };
 
 export const QueueForm: React.FC<QueueFormProps> = ({
@@ -28,6 +32,8 @@ export const QueueForm: React.FC<QueueFormProps> = ({
   submitting,
   formError,
   fieldErrors,
+  templateControls,
+  entries,
 }) => {
   const isEdit = mode === 'edit';
   // The emulator binding is immutable after creation, so only fetch devices when creating.
@@ -53,6 +59,14 @@ export const QueueForm: React.FC<QueueFormProps> = ({
           id="queue-name"
           value={value.name}
           onChange={(e) => onChange({ ...value, name: e.target.value })}
+          onKeyDown={(e) => {
+            // Row 2/4 slots carry their own inputs; with no submit button the form never
+            // implicitly submits, so trigger submit explicitly from the name field.
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              onSubmit();
+            }
+          }}
           aria-invalid={Boolean(fieldErrors?.name)}
           aria-describedby={fieldErrors?.name ? 'queue-name-error' : undefined}
           disabled={submitting}
@@ -75,8 +89,9 @@ export const QueueForm: React.FC<QueueFormProps> = ({
             error={fieldErrors?.emulatorSerial}
           />
         )}
-        {isEdit && <div className="form-hint">The bound emulator cannot be changed after creation.</div>}
       </div>
+
+      {isEdit && templateControls}
 
       <div className="field">
         <label>
@@ -91,8 +106,10 @@ export const QueueForm: React.FC<QueueFormProps> = ({
         </label>
       </div>
 
+      {isEdit && entries}
+
       <div className="form-actions">
-        <button type="submit" disabled={submitting}>Save</button>
+        <button type="button" onClick={onSubmit} disabled={submitting}>Save</button>
         <button type="button" onClick={onCancel} disabled={submitting}>Cancel</button>
       </div>
       {formError && <div className="form-error" role="alert">{formError}</div>}

--- a/src/web-ui/src/components/queues/QueueForm.tsx
+++ b/src/web-ui/src/components/queues/QueueForm.tsx
@@ -53,42 +53,44 @@ export const QueueForm: React.FC<QueueFormProps> = ({
         onSubmit();
       }}
     >
-      <div className="field">
-        <label htmlFor="queue-name">Name *</label>
-        <input
-          id="queue-name"
-          value={value.name}
-          onChange={(e) => onChange({ ...value, name: e.target.value })}
-          onKeyDown={(e) => {
-            // Row 2/4 slots carry their own inputs; with no submit button the form never
-            // implicitly submits, so trigger submit explicitly from the name field.
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              onSubmit();
-            }
-          }}
-          aria-invalid={Boolean(fieldErrors?.name)}
-          aria-describedby={fieldErrors?.name ? 'queue-name-error' : undefined}
-          disabled={submitting}
-        />
-        {fieldErrors?.name && <div id="queue-name-error" className="field-error" role="alert">{fieldErrors.name}</div>}
-      </div>
-
-      <div className="field">
-        <label htmlFor="queue-emulator">Emulator *</label>
-        {isEdit ? (
-          <input id="queue-emulator" value={value.emulatorSerial} readOnly aria-readonly="true" disabled />
-        ) : (
-          <SearchableDropdown
-            id="queue-emulator"
-            value={value.emulatorSerial || undefined}
-            options={emulatorOptions}
-            placeholder={devicesLoading ? 'Loading devices…' : 'Select an emulator…'}
+      <div className="field-row">
+        <div className="field">
+          <label htmlFor="queue-name">Name *</label>
+          <input
+            id="queue-name"
+            value={value.name}
+            onChange={(e) => onChange({ ...value, name: e.target.value })}
+            onKeyDown={(e) => {
+              // Row 2/4 slots carry their own inputs; with no submit button the form never
+              // implicitly submits, so trigger submit explicitly from the name field.
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                onSubmit();
+              }
+            }}
+            aria-invalid={Boolean(fieldErrors?.name)}
+            aria-describedby={fieldErrors?.name ? 'queue-name-error' : undefined}
             disabled={submitting}
-            onChange={(serial) => onChange({ ...value, emulatorSerial: serial ?? '' })}
-            error={fieldErrors?.emulatorSerial}
           />
-        )}
+          {fieldErrors?.name && <div id="queue-name-error" className="field-error" role="alert">{fieldErrors.name}</div>}
+        </div>
+
+        <div className="field">
+          <label htmlFor="queue-emulator">Emulator *</label>
+          {isEdit ? (
+            <input id="queue-emulator" value={value.emulatorSerial} readOnly aria-readonly="true" disabled />
+          ) : (
+            <SearchableDropdown
+              id="queue-emulator"
+              value={value.emulatorSerial || undefined}
+              options={emulatorOptions}
+              placeholder={devicesLoading ? 'Loading devices…' : 'Select an emulator…'}
+              disabled={submitting}
+              onChange={(serial) => onChange({ ...value, emulatorSerial: serial ?? '' })}
+              error={fieldErrors?.emulatorSerial}
+            />
+          )}
+        </div>
       </div>
 
       {isEdit && templateControls}

--- a/src/web-ui/src/components/queues/QueueTemplateControls.tsx
+++ b/src/web-ui/src/components/queues/QueueTemplateControls.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { QueueStatus } from '../../services/queues';
+import { SaveTemplateDialog } from './SaveTemplateDialog';
+import { TemplatePickerDialog } from './TemplatePickerDialog';
+
+type OpenSection = 'none' | 'save' | 'load';
+
+type QueueTemplateControlsProps = {
+  /** Name of the template the queue is currently associated with (loaded or saved this session). */
+  associatedTemplateName?: string;
+  status: QueueStatus;
+  /** Persists the current queue entries as a template; rejects with ApiError(409) when the name exists. */
+  onSaveTemplate: (name: string, overwrite: boolean) => Promise<void>;
+  /** Loads the chosen template's entries into the queue. */
+  onLoadTemplate: (templateId: string) => void;
+  /** Re-applies the associated template's persisted entries (with diff-aware confirmation). */
+  onReload: () => void;
+};
+
+export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
+  associatedTemplateName,
+  status,
+  onSaveTemplate,
+  onLoadTemplate,
+  onReload,
+}) => {
+  const [openSection, setOpenSection] = useState<OpenSection>('none');
+  const running = status === 'Running';
+
+  const toggle = (section: Exclude<OpenSection, 'none'>) =>
+    setOpenSection((current) => (current === section ? 'none' : section));
+
+  const close = () => setOpenSection('none');
+
+  return (
+    <section className="queue-template-controls" aria-label="Queue templates">
+      <div className="queue-template-row">
+        <button
+          type="button"
+          className="link-button queue-template-name"
+          onClick={() => toggle('load')}
+          aria-expanded={openSection === 'load'}
+        >
+          {associatedTemplateName ?? '(no template)'}
+        </button>
+        <button type="button" onClick={() => toggle('save')} aria-expanded={openSection === 'save'}>
+          Save Template
+        </button>
+        <button
+          type="button"
+          onClick={onReload}
+          disabled={!associatedTemplateName || running}
+          title={
+            !associatedTemplateName
+              ? 'No template to reload.'
+              : running
+                ? 'Stop the queue before reloading a template.'
+                : undefined
+          }
+        >
+          Reload Template
+        </button>
+      </div>
+
+      <SaveTemplateDialog
+        open={openSection === 'save'}
+        originName={associatedTemplateName}
+        onSave={onSaveTemplate}
+        onClose={close}
+      />
+
+      <TemplatePickerDialog
+        open={openSection === 'load'}
+        loadDisabled={running}
+        onLoad={(templateId) => {
+          onLoadTemplate(templateId);
+          close();
+        }}
+        onClose={close}
+      />
+    </section>
+  );
+};

--- a/src/web-ui/src/components/queues/QueueTemplateControls.tsx
+++ b/src/web-ui/src/components/queues/QueueTemplateControls.tsx
@@ -5,6 +5,15 @@ import { TemplatePickerDialog } from './TemplatePickerDialog';
 
 type OpenSection = 'none' | 'save' | 'load';
 
+/** An inline confirmation prompt shown in place of the picker (between rows 2 and 3). */
+export type TemplateConfirm = {
+  title: string;
+  message: string;
+  confirmText: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
 type QueueTemplateControlsProps = {
   /** Name of the template the queue is currently associated with (loaded or saved this session). */
   associatedTemplateName?: string;
@@ -15,6 +24,8 @@ type QueueTemplateControlsProps = {
   onLoadTemplate: (templateId: string) => void;
   /** Re-applies the associated template's persisted entries (with diff-aware confirmation). */
   onReload: () => void;
+  /** When set, a replace/reload confirmation is shown inline (instead of the picker). */
+  pendingConfirm?: TemplateConfirm;
 };
 
 export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
@@ -23,9 +34,12 @@ export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
   onSaveTemplate,
   onLoadTemplate,
   onReload,
+  pendingConfirm,
 }) => {
   const [openSection, setOpenSection] = useState<OpenSection>('none');
   const running = status === 'Running';
+  // While a replace/reload confirmation is pending, it occupies the picker's spot.
+  const section = pendingConfirm ? 'none' : openSection;
 
   const toggle = (section: Exclude<OpenSection, 'none'>) =>
     setOpenSection((current) => (current === section ? 'none' : section));
@@ -63,14 +77,14 @@ export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
       </div>
 
       <SaveTemplateDialog
-        open={openSection === 'save'}
+        open={section === 'save'}
         originName={associatedTemplateName}
         onSave={onSaveTemplate}
         onClose={close}
       />
 
       <TemplatePickerDialog
-        open={openSection === 'load'}
+        open={section === 'load'}
         loadDisabled={running}
         onLoad={(templateId) => {
           onLoadTemplate(templateId);
@@ -78,6 +92,17 @@ export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
         }}
         onClose={close}
       />
+
+      {pendingConfirm && (
+        <section className="queue-template-section" aria-label={pendingConfirm.title}>
+          <h4>{pendingConfirm.title}</h4>
+          <p>{pendingConfirm.message}</p>
+          <div className="queue-template-section-actions">
+            <button type="button" className="btn btn-secondary" onClick={pendingConfirm.onCancel}>Cancel</button>
+            <button type="button" className="btn btn-primary" onClick={pendingConfirm.onConfirm}>{pendingConfirm.confirmText}</button>
+          </div>
+        </section>
+      )}
     </section>
   );
 };

--- a/src/web-ui/src/components/queues/SaveTemplateDialog.tsx
+++ b/src/web-ui/src/components/queues/SaveTemplateDialog.tsx
@@ -64,37 +64,41 @@ export const SaveTemplateDialog: React.FC<SaveTemplateDialogProps> = ({ open, or
   };
 
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Save template">
-      <div className="modal">
-        <h3>Save as template</h3>
-        {!confirmingOverwrite ? (
-          <>
-            <label htmlFor="template-name">Template name</label>
-            <input
-              id="template-name"
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-            {error && <div className="form-error" role="alert">{error}</div>}
-            <div className="modal-actions">
-              <button className="btn btn-secondary" onClick={onClose} disabled={saving}>Cancel</button>
-              <button className="btn btn-primary" onClick={handleSave} disabled={saving}>Save</button>
-            </div>
-          </>
-        ) : (
-          <>
-            <p>
-              A template named <strong>{name.trim()}</strong> already exists. Overwrite it?
-            </p>
-            {error && <div className="form-error" role="alert">{error}</div>}
-            <div className="modal-actions">
-              <button className="btn btn-secondary" onClick={onClose} disabled={saving}>Cancel</button>
-              <button className="btn btn-danger" onClick={() => void persist(true)} disabled={saving}>Overwrite</button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
+    <section className="queue-template-section" aria-label="Save template">
+      <h4>Save as template</h4>
+      {!confirmingOverwrite ? (
+        <>
+          <label htmlFor="template-name">Template name</label>
+          <input
+            id="template-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSave();
+              }
+            }}
+          />
+          {error && <div className="form-error" role="alert">{error}</div>}
+          <div className="queue-template-section-actions">
+            <button type="button" className="btn btn-secondary" onClick={onClose} disabled={saving}>Cancel</button>
+            <button type="button" className="btn btn-primary" onClick={handleSave} disabled={saving}>Save</button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p>
+            A template named <strong>{name.trim()}</strong> already exists. Overwrite it?
+          </p>
+          {error && <div className="form-error" role="alert">{error}</div>}
+          <div className="queue-template-section-actions">
+            <button type="button" className="btn btn-secondary" onClick={onClose} disabled={saving}>Cancel</button>
+            <button type="button" className="btn btn-danger" onClick={() => void persist(true)} disabled={saving}>Overwrite</button>
+          </div>
+        </>
+      )}
+    </section>
   );
 };

--- a/src/web-ui/src/components/queues/TemplatePickerDialog.tsx
+++ b/src/web-ui/src/components/queues/TemplatePickerDialog.tsx
@@ -48,28 +48,26 @@ export const TemplatePickerDialog: React.FC<TemplatePickerDialogProps> = ({ open
   };
 
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Load template">
-      <div className="modal">
-        <h3>Load template</h3>
-        {error && <div className="form-error" role="alert">{error}</div>}
-        {loading && <div className="form-hint">Loading…</div>}
-        {!loading && templates.length === 0 && (
-          <div className="form-hint" role="status">No templates saved yet.</div>
-        )}
-        <ul className="template-list">
-          {templates.map((t) => (
-            <li key={t.id} className="template-row" data-testid="template-row">
-              <span className="template-name">{t.name}</span>
-              <span className="template-actions">
-                <button type="button" disabled={loadDisabled} onClick={() => onLoad(t.id)}>Load</button>
-                <button type="button" className="btn btn-danger" onClick={() => setPendingDelete(t)}>Delete</button>
-              </span>
-            </li>
-          ))}
-        </ul>
-        <div className="modal-actions">
-          <button className="btn btn-secondary" onClick={onClose}>Close</button>
-        </div>
+    <section className="queue-template-section" aria-label="Load template">
+      <h4>Load template</h4>
+      {error && <div className="form-error" role="alert">{error}</div>}
+      {loading && <div className="form-hint">Loading…</div>}
+      {!loading && templates.length === 0 && (
+        <div className="form-hint" role="status">No templates saved yet.</div>
+      )}
+      <ul className="template-list">
+        {templates.map((t) => (
+          <li key={t.id} className="template-row" data-testid="template-row">
+            <span className="template-name">{t.name}</span>
+            <span className="template-actions">
+              <button type="button" disabled={loadDisabled} onClick={() => onLoad(t.id)}>Load</button>
+              <button type="button" className="btn btn-danger" onClick={() => setPendingDelete(t)}>Delete</button>
+            </span>
+          </li>
+        ))}
+      </ul>
+      <div className="queue-template-section-actions">
+        <button type="button" className="btn btn-secondary" onClick={onClose}>Close</button>
       </div>
       <ConfirmDeleteModal
         open={pendingDelete !== undefined}
@@ -77,6 +75,6 @@ export const TemplatePickerDialog: React.FC<TemplatePickerDialogProps> = ({ open
         onCancel={() => setPendingDelete(undefined)}
         onConfirm={() => void confirmDelete()}
       />
-    </div>
+    </section>
   );
 };

--- a/src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx
@@ -21,6 +21,8 @@ const renderForm = (overrides: Partial<React.ComponentProps<typeof QueueForm>> =
       onCancel={onCancel}
       fieldErrors={overrides.fieldErrors}
       formError={overrides.formError}
+      templateControls={overrides.templateControls}
+      entries={overrides.entries}
     />
   );
   return { onChange, onSubmit, onCancel };
@@ -34,13 +36,45 @@ describe('QueueForm', () => {
     expect(emulator).not.toBeDisabled();
   });
 
-  it('shows the emulator read-only in edit mode and explains it cannot change', () => {
+  it('shows the emulator read-only in edit mode without the "cannot be changed" hint', () => {
     renderForm({ mode: 'edit', value: { name: 'Farm', emulatorSerial: 'emu-9', cycleExecution: false } });
     const emulator = screen.getByLabelText('Emulator *') as HTMLInputElement;
     expect(emulator.tagName).toBe('INPUT');
     expect(emulator).toHaveValue('emu-9');
     expect(emulator).toBeDisabled();
-    expect(screen.getByText('The bound emulator cannot be changed after creation.')).toBeInTheDocument();
+    expect(screen.queryByText(/bound emulator cannot be changed/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the template-controls and entries slots in row order (emulator -> templates -> cycle -> entries -> actions)', () => {
+    renderForm({
+      mode: 'edit',
+      value: { name: 'Farm', emulatorSerial: 'emu-9', cycleExecution: false },
+      templateControls: <div data-testid="slot-templates" />,
+      entries: <div data-testid="slot-entries" />,
+    });
+    const emulator = screen.getByLabelText('Emulator *');
+    const templates = screen.getByTestId('slot-templates');
+    const cycle = screen.getByLabelText('Cycle execution');
+    const entries = screen.getByTestId('slot-entries');
+    const actions = screen.getByText('Save');
+
+    const follows = (a: Node, b: Node) =>
+      Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(follows(emulator, templates)).toBe(true);
+    expect(follows(templates, cycle)).toBe(true);
+    expect(follows(cycle, entries)).toBe(true);
+    expect(follows(entries, actions)).toBe(true);
+  });
+
+  it('does not render the slots in create mode', () => {
+    renderForm({
+      mode: 'create',
+      templateControls: <div data-testid="slot-templates" />,
+      entries: <div data-testid="slot-entries" />,
+    });
+    // Create mode receives no slots from the page; even if passed, the form omits them.
+    expect(screen.queryByTestId('slot-templates')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slot-entries')).not.toBeInTheDocument();
   });
 
   it('renders field and form errors', () => {

--- a/src/web-ui/src/components/queues/__tests__/QueueTemplateControls.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueTemplateControls.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueueTemplateControls } from '../QueueTemplateControls';
+import { listQueueTemplates } from '../../../services/queueTemplates';
+
+jest.mock('../../../services/queueTemplates');
+
+const listMock = listQueueTemplates as jest.MockedFunction<typeof listQueueTemplates>;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  listMock.mockResolvedValue([] as any);
+});
+
+const renderControls = (overrides: Partial<React.ComponentProps<typeof QueueTemplateControls>> = {}) => {
+  const onSaveTemplate = overrides.onSaveTemplate ?? jest.fn().mockResolvedValue(undefined);
+  const onLoadTemplate = overrides.onLoadTemplate ?? jest.fn();
+  const onReload = overrides.onReload ?? jest.fn();
+  render(
+    <QueueTemplateControls
+      associatedTemplateName={overrides.associatedTemplateName}
+      status={overrides.status ?? 'Stopped'}
+      onSaveTemplate={onSaveTemplate}
+      onLoadTemplate={onLoadTemplate}
+      onReload={onReload}
+    />
+  );
+  return { onSaveTemplate, onLoadTemplate, onReload };
+};
+
+describe('QueueTemplateControls', () => {
+  it('renders both sections closed by default', () => {
+    renderControls();
+    expect(screen.queryByRole('region', { name: 'Save template' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Load template' })).not.toBeInTheDocument();
+  });
+
+  it('shows the (no template) placeholder and opens the Load section when clicked', async () => {
+    renderControls();
+    fireEvent.click(screen.getByText('(no template)'));
+    expect(await screen.findByRole('region', { name: 'Load template' })).toBeInTheDocument();
+  });
+
+  it('shows the associated template name on the name button', () => {
+    renderControls({ associatedTemplateName: 'Daily Farm' });
+    expect(screen.getByText('Daily Farm')).toBeInTheDocument();
+  });
+
+  it('opens the Save section when Save Template is clicked', () => {
+    renderControls();
+    fireEvent.click(screen.getByText('Save Template'));
+    expect(screen.getByRole('region', { name: 'Save template' })).toBeInTheDocument();
+  });
+
+  it('keeps at most one section open (opening one closes the other)', async () => {
+    renderControls();
+    fireEvent.click(screen.getByText('Save Template'));
+    expect(screen.getByRole('region', { name: 'Save template' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('(no template)'));
+    expect(await screen.findByRole('region', { name: 'Load template' })).toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Save template' })).not.toBeInTheDocument();
+  });
+
+  it('collapses the open section when dismissed', () => {
+    renderControls();
+    fireEvent.click(screen.getByText('Save Template'));
+    const section = screen.getByRole('region', { name: 'Save template' });
+    fireEvent.click(within(section).getByText('Cancel'));
+    expect(screen.queryByRole('region', { name: 'Save template' })).not.toBeInTheDocument();
+  });
+
+  it('disables Reload Template when no template is associated', () => {
+    renderControls();
+    expect(screen.getByText('Reload Template')).toBeDisabled();
+  });
+
+  it('disables Reload Template while the queue is running', () => {
+    renderControls({ associatedTemplateName: 'Daily Farm', status: 'Running' });
+    expect(screen.getByText('Reload Template')).toBeDisabled();
+  });
+
+  it('fires onReload when enabled and clicked', () => {
+    const { onReload } = renderControls({ associatedTemplateName: 'Daily Farm' });
+    fireEvent.click(screen.getByText('Reload Template'));
+    expect(onReload).toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/components/queues/__tests__/SaveTemplateDialog.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/SaveTemplateDialog.test.tsx
@@ -18,6 +18,12 @@ const renderDialog = (overrides: Partial<React.ComponentProps<typeof SaveTemplat
 };
 
 describe('SaveTemplateDialog', () => {
+  it('renders as an inline section, not a modal overlay', () => {
+    renderDialog();
+    expect(screen.getByRole('region', { name: 'Save template' })).toBeInTheDocument();
+    expect(document.querySelector('.modal-backdrop')).toBeNull();
+  });
+
   it('pre-fills the origin template name', () => {
     renderDialog({ originName: 'Daily Farm' });
     expect(screen.getByLabelText('Template name')).toHaveValue('Daily Farm');

--- a/src/web-ui/src/components/queues/__tests__/TemplatePickerDialog.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/TemplatePickerDialog.test.tsx
@@ -23,6 +23,12 @@ const renderPicker = (overrides: Partial<React.ComponentProps<typeof TemplatePic
 };
 
 describe('TemplatePickerDialog', () => {
+  it('renders as an inline section, not a modal overlay', async () => {
+    renderPicker();
+    expect(await screen.findByRole('region', { name: 'Load template' })).toBeInTheDocument();
+    expect(document.querySelector('.modal-backdrop')).toBeNull();
+  });
+
   it('lists templates by name', async () => {
     renderPicker();
     expect(await screen.findByText('Daily Farm')).toBeInTheDocument();

--- a/src/web-ui/src/lib/__tests__/sequenceOrder.test.ts
+++ b/src/web-ui/src/lib/__tests__/sequenceOrder.test.ts
@@ -1,0 +1,25 @@
+import { sameSequenceOrder } from '../sequenceOrder';
+
+describe('sameSequenceOrder', () => {
+  it('returns true for equal arrays in the same order', () => {
+    expect(sameSequenceOrder(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(true);
+  });
+
+  it('returns true for two empty arrays', () => {
+    expect(sameSequenceOrder([], [])).toBe(true);
+  });
+
+  it('returns false when lengths differ', () => {
+    expect(sameSequenceOrder(['a', 'b'], ['a', 'b', 'c'])).toBe(false);
+    expect(sameSequenceOrder([], ['a'])).toBe(false);
+  });
+
+  it('returns false when the order differs', () => {
+    expect(sameSequenceOrder(['a', 'b'], ['b', 'a'])).toBe(false);
+  });
+
+  it('respects duplicates and their positions', () => {
+    expect(sameSequenceOrder(['a', 'a', 'b'], ['a', 'a', 'b'])).toBe(true);
+    expect(sameSequenceOrder(['a', 'a', 'b'], ['a', 'b', 'a'])).toBe(false);
+  });
+});

--- a/src/web-ui/src/lib/sequenceOrder.ts
+++ b/src/web-ui/src/lib/sequenceOrder.ts
@@ -1,0 +1,10 @@
+/**
+ * Order-sensitive equality for two lists of sequence ids.
+ *
+ * Used by the queue editor's Reload Template flow to decide whether a reload would
+ * actually change the queue's entries (and therefore needs a confirmation prompt).
+ */
+export const sameSequenceOrder = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+};

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -207,6 +207,33 @@ export const QueuesPage: React.FC = () => {
     }
   };
 
+  // Replace/reload confirmation shown inline within the template controls (where the picker was).
+  const templateConfirm = pendingLoad
+    ? {
+        title: 'Replace queue entries',
+        message: "Loading this template will replace the queue's current entries.",
+        confirmText: 'Replace',
+        onCancel: () => setPendingLoad(undefined),
+        onConfirm: () => {
+          const p = pendingLoad;
+          setPendingLoad(undefined);
+          if (p) void applyLoad(p.name, p.sequenceIds);
+        },
+      }
+    : pendingReload
+      ? {
+          title: 'Reload template',
+          message: "Reloading will replace the queue's current entries with the template's.",
+          confirmText: 'Reload',
+          onCancel: () => setPendingReload(undefined),
+          onConfirm: () => {
+            const p = pendingReload;
+            setPendingReload(undefined);
+            if (p) void applyLoad(p.name, p.sequenceIds);
+          },
+        }
+      : undefined;
+
   return (
     <section>
       <h2>Queues</h2>
@@ -301,6 +328,7 @@ export const QueuesPage: React.FC = () => {
                 onSaveTemplate={handleSaveTemplate}
                 onLoadTemplate={(id) => void handleLoadTemplate(id)}
                 onReload={() => void handleReload()}
+                pendingConfirm={templateConfirm}
               />
             }
             entries={
@@ -314,32 +342,6 @@ export const QueuesPage: React.FC = () => {
           />
         </section>
       )}
-
-      <ConfirmDeleteModal
-        open={pendingReload !== undefined}
-        title="Reload template"
-        message="Reloading will replace the queue's current entries with the template's."
-        confirmText="Reload"
-        onCancel={() => setPendingReload(undefined)}
-        onConfirm={() => {
-          const p = pendingReload;
-          setPendingReload(undefined);
-          if (p) void applyLoad(p.name, p.sequenceIds);
-        }}
-      />
-
-      <ConfirmDeleteModal
-        open={pendingLoad !== undefined}
-        title="Replace queue entries"
-        message="Loading this template will replace the queue's current entries."
-        confirmText="Replace"
-        onCancel={() => setPendingLoad(undefined)}
-        onConfirm={() => {
-          const p = pendingLoad;
-          setPendingLoad(undefined);
-          if (p) void applyLoad(p.name, p.sequenceIds);
-        }}
-      />
 
       <ConfirmDeleteModal
         open={deleteOpen}

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -16,10 +16,10 @@ import {
 import { listSequences, SequenceDto } from '../services/sequences';
 import { QueueForm, QueueFormValue } from '../components/queues/QueueForm';
 import { QueueEntryList } from '../components/queues/QueueEntryList';
-import { SaveTemplateDialog } from '../components/queues/SaveTemplateDialog';
-import { TemplatePickerDialog } from '../components/queues/TemplatePickerDialog';
+import { QueueTemplateControls } from '../components/queues/QueueTemplateControls';
 import { ConfirmDeleteModal } from '../components/ConfirmDeleteModal';
-import { saveQueueTemplate, getQueueTemplate } from '../services/queueTemplates';
+import { saveQueueTemplate, getQueueTemplate, listQueueTemplates } from '../services/queueTemplates';
+import { sameSequenceOrder } from '../lib/sequenceOrder';
 import { ApiError } from '../lib/api';
 
 const emptyForm: QueueFormValue = { name: '', emulatorSerial: '', cycleExecution: false };
@@ -39,10 +39,9 @@ export const QueuesPage: React.FC = () => {
 
   const [detail, setDetail] = useState<QueueDetailDto | undefined>(undefined);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [saveTemplateOpen, setSaveTemplateOpen] = useState(false);
-  const [loadedTemplateName, setLoadedTemplateName] = useState<string | undefined>(undefined);
-  const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
+  const [associatedTemplateName, setAssociatedTemplateName] = useState<string | undefined>(undefined);
   const [pendingLoad, setPendingLoad] = useState<{ name: string; sequenceIds: string[] } | undefined>(undefined);
+  const [pendingReload, setPendingReload] = useState<{ name: string; sequenceIds: string[] } | undefined>(undefined);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -83,7 +82,7 @@ export const QueuesPage: React.FC = () => {
     setCreating(false);
     setFieldErrors(undefined);
     setFormError(undefined);
-    setLoadedTemplateName(undefined);
+    setAssociatedTemplateName(undefined);
     const q = await getQueue(id);
     setDetail(q);
     setForm({ name: q.name, emulatorSerial: q.emulatorSerial, cycleExecution: q.cycleExecution });
@@ -95,7 +94,7 @@ export const QueuesPage: React.FC = () => {
     setForm(emptyForm);
     setFieldErrors(undefined);
     setFormError(undefined);
-    setLoadedTemplateName(undefined);
+    setAssociatedTemplateName(undefined);
   };
 
   const validate = (): boolean => {
@@ -155,7 +154,7 @@ export const QueuesPage: React.FC = () => {
     if (!detail) return;
     const sequenceIds = detail.entries.map((e) => e.sequenceId);
     await saveQueueTemplate({ name, sequenceIds, overwrite });
-    setLoadedTemplateName(name);
+    setAssociatedTemplateName(name);
     setTableMessage(`Template "${name}" saved successfully.`);
   };
 
@@ -163,13 +162,11 @@ export const QueuesPage: React.FC = () => {
     if (!detail) return;
     try {
       await replaceQueueEntries(detail.id, sequenceIds);
-      setLoadedTemplateName(name);
-      setTemplatePickerOpen(false);
+      setAssociatedTemplateName(name);
       setTableMessage(`Template "${name}" loaded.`);
       await reloadDetail(detail.id);
       await refresh();
     } catch (err: any) {
-      setTemplatePickerOpen(false);
       setTableError(err instanceof ApiError ? err.message : err?.message ?? 'Failed to load template');
     }
   };
@@ -182,6 +179,31 @@ export const QueuesPage: React.FC = () => {
       setPendingLoad({ name: tpl.name, sequenceIds });
     } else {
       await applyLoad(tpl.name, sequenceIds);
+    }
+  };
+
+  const handleReload = async () => {
+    if (!detail || !associatedTemplateName || detail.status === 'Running') return;
+    try {
+      const templates = await listQueueTemplates();
+      const match = templates.find(
+        (t) => t.name.toLowerCase() === associatedTemplateName.toLowerCase()
+      );
+      if (!match) {
+        setTableError(`Template "${associatedTemplateName}" is no longer available.`);
+        return;
+      }
+      const tpl = await getQueueTemplate(match.id);
+      const templateSeqIds = tpl.entries.map((e) => e.sequenceId);
+      const currentSeqIds = detail.entries.map((e) => e.sequenceId);
+      if (sameSequenceOrder(currentSeqIds, templateSeqIds)) return; // nothing to discard, no prompt
+      if (detail.entries.length > 0) {
+        setPendingReload({ name: tpl.name, sequenceIds: templateSeqIds });
+      } else {
+        await applyLoad(tpl.name, templateSeqIds);
+      }
+    } catch (err: any) {
+      setTableError(err instanceof ApiError ? err.message : err?.message ?? 'Failed to reload template');
     }
   };
 
@@ -272,42 +294,38 @@ export const QueuesPage: React.FC = () => {
             submitting={submitting}
             formError={formError}
             fieldErrors={fieldErrors}
-          />
-          <section className="queue-templates-section" aria-label="Queue templates">
-            <h4>Templates</h4>
-            <div className="queue-template-actions">
-              <button type="button" onClick={() => setSaveTemplateOpen(true)}>Save as template</button>
-              <button
-                type="button"
-                onClick={() => setTemplatePickerOpen(true)}
-                disabled={detail.status === 'Running'}
-                title={detail.status === 'Running' ? 'Stop the queue before loading a template.' : undefined}
-              >
-                Load template
-              </button>
-            </div>
-          </section>
-          <QueueEntryList
-            entries={detail.entries}
-            sequences={sequences}
-            onAdd={(sid) => void onAddEntry(sid)}
-            onRemove={(eid) => void onRemoveEntry(eid)}
+            templateControls={
+              <QueueTemplateControls
+                associatedTemplateName={associatedTemplateName}
+                status={detail.status}
+                onSaveTemplate={handleSaveTemplate}
+                onLoadTemplate={(id) => void handleLoadTemplate(id)}
+                onReload={() => void handleReload()}
+              />
+            }
+            entries={
+              <QueueEntryList
+                entries={detail.entries}
+                sequences={sequences}
+                onAdd={(sid) => void onAddEntry(sid)}
+                onRemove={(eid) => void onRemoveEntry(eid)}
+              />
+            }
           />
         </section>
       )}
 
-      <SaveTemplateDialog
-        open={saveTemplateOpen}
-        originName={loadedTemplateName}
-        onSave={handleSaveTemplate}
-        onClose={() => setSaveTemplateOpen(false)}
-      />
-
-      <TemplatePickerDialog
-        open={templatePickerOpen}
-        loadDisabled={detail?.status === 'Running'}
-        onLoad={(id) => void handleLoadTemplate(id)}
-        onClose={() => setTemplatePickerOpen(false)}
+      <ConfirmDeleteModal
+        open={pendingReload !== undefined}
+        title="Reload template"
+        message="Reloading will replace the queue's current entries with the template's."
+        confirmText="Reload"
+        onCancel={() => setPendingReload(undefined)}
+        onConfirm={() => {
+          const p = pendingReload;
+          setPendingReload(undefined);
+          if (p) void applyLoad(p.name, p.sequenceIds);
+        }}
       />
 
       <ConfirmDeleteModal

--- a/src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueuesPage } from '../QueuesPage';
+import { listQueues, getQueue, updateQueue } from '../../services/queues';
+import { listSequences } from '../../services/sequences';
+
+jest.mock('../../services/queues');
+jest.mock('../../services/sequences');
+jest.mock('../../services/queueTemplates');
+jest.mock('../../services/useAdbDevices', () => ({
+  useAdbDevices: () => ({ devices: [{ serial: 'emu-1' }], loading: false, error: undefined, refresh: () => {} }),
+}));
+
+const listQueuesMock = listQueues as jest.MockedFunction<typeof listQueues>;
+const getQueueMock = getQueue as jest.MockedFunction<typeof getQueue>;
+const updateQueueMock = updateQueue as jest.MockedFunction<typeof updateQueue>;
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+
+const detail = () => ({
+  id: 'q1', name: 'Daily', emulatorSerial: 'emu-9', cycleExecution: false, status: 'Stopped', entryCount: 1,
+  entries: [{ entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'A', stale: false }],
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  listQueuesMock.mockResolvedValue([{ id: 'q1', name: 'Daily', emulatorSerial: 'emu-9', cycleExecution: false, status: 'Stopped', entryCount: 1 }] as any);
+  listSequencesMock.mockResolvedValue([] as any);
+  getQueueMock.mockResolvedValue(detail() as any);
+  updateQueueMock.mockResolvedValue({} as any);
+});
+
+const openEdit = async () => {
+  render(<QueuesPage />);
+  await screen.findByText('Daily');
+  fireEvent.click(screen.getByText('Daily'));
+  await screen.findByText('Edit Queue');
+};
+
+const follows = (a: Node, b: Node) =>
+  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+describe('QueuesPage edit layout', () => {
+  it('renders the edit controls in row order: name+emulator -> templates -> cycle -> sequences -> Save/Cancel', async () => {
+    await openEdit();
+    const name = screen.getByLabelText('Name *');
+    const emulator = screen.getByLabelText('Emulator *');
+    const templates = screen.getByRole('region', { name: 'Queue templates' });
+    const cycle = screen.getByLabelText('Cycle execution');
+    const sequences = screen.getByRole('region', { name: 'Queue sequences' });
+    const save = screen.getByText('Save');
+
+    expect(follows(name, emulator)).toBe(true);
+    expect(follows(emulator, templates)).toBe(true);
+    expect(follows(templates, cycle)).toBe(true);
+    expect(follows(cycle, sequences)).toBe(true);
+    expect(follows(sequences, save)).toBe(true);
+  });
+
+  it('shows the emulator read-only with no "cannot be changed" hint', async () => {
+    await openEdit();
+    const emulator = screen.getByLabelText('Emulator *') as HTMLInputElement;
+    expect(emulator).toBeDisabled();
+    expect(emulator).toHaveValue('emu-9');
+    expect(screen.queryByText(/bound emulator cannot be changed/i)).not.toBeInTheDocument();
+  });
+
+  it('Save commits only name + cycle execution', async () => {
+    await openEdit();
+    fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Daily Renamed' } });
+    fireEvent.click(screen.getByLabelText('Cycle execution'));
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() =>
+      expect(updateQueueMock).toHaveBeenCalledWith('q1', { name: 'Daily Renamed', cycleExecution: true })
+    );
+  });
+
+  it('Cancel closes the edit page', async () => {
+    await openEdit();
+    fireEvent.click(screen.getByText('Cancel'));
+    await waitFor(() => expect(screen.queryByText('Edit Queue')).not.toBeInTheDocument());
+  });
+});

--- a/src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { QueuesPage } from '../QueuesPage';
+import { listQueues, getQueue, replaceQueueEntries } from '../../services/queues';
+import { listSequences } from '../../services/sequences';
+import { saveQueueTemplate, getQueueTemplate, listQueueTemplates } from '../../services/queueTemplates';
+
+jest.mock('../../services/queues');
+jest.mock('../../services/sequences');
+jest.mock('../../services/queueTemplates');
+jest.mock('../../services/useAdbDevices', () => ({
+  useAdbDevices: () => ({ devices: [{ serial: 'emu-1' }], loading: false, error: undefined, refresh: () => {} }),
+}));
+
+const listQueuesMock = listQueues as jest.MockedFunction<typeof listQueues>;
+const getQueueMock = getQueue as jest.MockedFunction<typeof getQueue>;
+const replaceEntriesMock = replaceQueueEntries as jest.MockedFunction<typeof replaceQueueEntries>;
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+const saveTemplateMock = saveQueueTemplate as jest.MockedFunction<typeof saveQueueTemplate>;
+const getTemplateMock = getQueueTemplate as jest.MockedFunction<typeof getQueueTemplate>;
+const listTemplatesMock = listQueueTemplates as jest.MockedFunction<typeof listQueueTemplates>;
+
+const queue = (over: Partial<any> = {}) => ({
+  id: 'q1', name: 'Daily', emulatorSerial: 'emu-1', cycleExecution: false, status: 'Stopped', entryCount: 2, ...over,
+});
+
+const detailWithEntries = (over: Partial<any> = {}) => ({
+  ...queue(over),
+  entries: [
+    { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'A', stale: false },
+    { entryId: 'e2', sequenceId: 'seq-b', sequenceName: 'B', stale: false },
+  ],
+  ...over,
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  listQueuesMock.mockResolvedValue([queue()] as any);
+  listSequencesMock.mockResolvedValue([] as any);
+  getQueueMock.mockResolvedValue(detailWithEntries() as any);
+  listTemplatesMock.mockResolvedValue([{ id: 't1', name: 'Daily Farm', entryCount: 1, createdAt: null, updatedAt: null }] as any);
+  saveTemplateMock.mockResolvedValue({} as any);
+  replaceEntriesMock.mockResolvedValue({} as any);
+});
+
+/** Saves a template so the queue becomes "associated" with the name "Daily Farm". */
+const openEditAndAssociate = async () => {
+  render(<QueuesPage />);
+  await screen.findByText('Daily');
+  fireEvent.click(screen.getByText('Daily'));
+  await screen.findByText('Edit Queue');
+  fireEvent.click(screen.getByText('Save Template'));
+  const section = await screen.findByRole('region', { name: 'Save template' });
+  fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Daily Farm' } });
+  fireEvent.click(within(section).getByText('Save'));
+  // After save, the name button reflects the associated template.
+  await screen.findByText('Daily Farm');
+};
+
+describe('QueuesPage reload template', () => {
+  it('disables Reload Template when no template is associated', async () => {
+    render(<QueuesPage />);
+    await screen.findByText('Daily');
+    fireEvent.click(screen.getByText('Daily'));
+    await screen.findByText('Edit Queue');
+    expect(screen.getByText('Reload Template')).toBeDisabled();
+  });
+
+  it('prompts before replacing divergent non-empty entries, then applies on confirm', async () => {
+    getTemplateMock.mockResolvedValue({
+      id: 't1', name: 'Daily Farm', entryCount: 1, createdAt: null, updatedAt: null,
+      entries: [{ sequenceId: 'seq-x', sequenceName: 'X', stale: false }],
+    } as any);
+    await openEditAndAssociate();
+
+    fireEvent.click(screen.getByText('Reload Template'));
+    const confirm = await screen.findByRole('dialog', { name: 'Reload template' });
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Reload' }));
+
+    await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
+  });
+
+  it('leaves entries unchanged when the reload confirmation is canceled', async () => {
+    getTemplateMock.mockResolvedValue({
+      id: 't1', name: 'Daily Farm', entryCount: 1, createdAt: null, updatedAt: null,
+      entries: [{ sequenceId: 'seq-x', sequenceName: 'X', stale: false }],
+    } as any);
+    await openEditAndAssociate();
+
+    fireEvent.click(screen.getByText('Reload Template'));
+    const confirm = await screen.findByRole('dialog', { name: 'Reload template' });
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Cancel' }));
+
+    expect(replaceEntriesMock).not.toHaveBeenCalled();
+  });
+
+  it('applies without a prompt when current entries already match the template', async () => {
+    getTemplateMock.mockResolvedValue({
+      id: 't1', name: 'Daily Farm', entryCount: 2, createdAt: null, updatedAt: null,
+      entries: [
+        { sequenceId: 'seq-a', sequenceName: 'A', stale: false },
+        { sequenceId: 'seq-b', sequenceName: 'B', stale: false },
+      ],
+    } as any);
+    await openEditAndAssociate();
+
+    fireEvent.click(screen.getByText('Reload Template'));
+    await waitFor(() => expect(getTemplateMock).toHaveBeenCalled());
+    expect(screen.queryByRole('dialog', { name: 'Reload template' })).not.toBeInTheDocument();
+    expect(replaceEntriesMock).not.toHaveBeenCalled();
+  });
+
+  it('applies without a prompt when the queue is empty', async () => {
+    getQueueMock.mockResolvedValue(detailWithEntries({ entryCount: 0, entries: [] }) as any);
+    getTemplateMock.mockResolvedValue({
+      id: 't1', name: 'Daily Farm', entryCount: 1, createdAt: null, updatedAt: null,
+      entries: [{ sequenceId: 'seq-x', sequenceName: 'X', stale: false }],
+    } as any);
+    await openEditAndAssociate();
+
+    fireEvent.click(screen.getByText('Reload Template'));
+    await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
+    expect(screen.queryByRole('dialog', { name: 'Reload template' })).not.toBeInTheDocument();
+  });
+
+  it('reports when the associated template is no longer available', async () => {
+    await openEditAndAssociate();
+    listTemplatesMock.mockResolvedValue([] as any);
+
+    fireEvent.click(screen.getByText('Reload Template'));
+    expect(await screen.findByText('Template "Daily Farm" is no longer available.')).toBeInTheDocument();
+    expect(replaceEntriesMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx
@@ -74,7 +74,7 @@ describe('QueuesPage reload template', () => {
     await openEditAndAssociate();
 
     fireEvent.click(screen.getByText('Reload Template'));
-    const confirm = await screen.findByRole('dialog', { name: 'Reload template' });
+    const confirm = await screen.findByRole('region', { name: 'Reload template' });
     fireEvent.click(within(confirm).getByRole('button', { name: 'Reload' }));
 
     await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
@@ -88,7 +88,7 @@ describe('QueuesPage reload template', () => {
     await openEditAndAssociate();
 
     fireEvent.click(screen.getByText('Reload Template'));
-    const confirm = await screen.findByRole('dialog', { name: 'Reload template' });
+    const confirm = await screen.findByRole('region', { name: 'Reload template' });
     fireEvent.click(within(confirm).getByRole('button', { name: 'Cancel' }));
 
     expect(replaceEntriesMock).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ describe('QueuesPage reload template', () => {
 
     fireEvent.click(screen.getByText('Reload Template'));
     await waitFor(() => expect(getTemplateMock).toHaveBeenCalled());
-    expect(screen.queryByRole('dialog', { name: 'Reload template' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Reload template' })).not.toBeInTheDocument();
     expect(replaceEntriesMock).not.toHaveBeenCalled();
   });
 
@@ -120,7 +120,7 @@ describe('QueuesPage reload template', () => {
 
     fireEvent.click(screen.getByText('Reload Template'));
     await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
-    expect(screen.queryByRole('dialog', { name: 'Reload template' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Reload template' })).not.toBeInTheDocument();
   });
 
   it('reports when the associated template is no longer available', async () => {

--- a/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
@@ -103,7 +103,7 @@ describe('QueuesPage template load wiring', () => {
     const picker = await openLoadSection();
     fireEvent.click(within(picker).getByText('Load'));
 
-    const confirm = await screen.findByRole('dialog', { name: 'Replace queue entries' });
+    const confirm = await screen.findByRole('region', { name: 'Replace queue entries' });
     fireEvent.click(within(confirm).getByRole('button', { name: 'Replace' }));
 
     await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
@@ -113,7 +113,7 @@ describe('QueuesPage template load wiring', () => {
     const picker = await openLoadSection();
     fireEvent.click(within(picker).getByText('Load'));
 
-    const confirm = await screen.findByRole('dialog', { name: 'Replace queue entries' });
+    const confirm = await screen.findByRole('region', { name: 'Replace queue entries' });
     fireEvent.click(within(confirm).getByRole('button', { name: 'Cancel' }));
 
     expect(replaceEntriesMock).not.toHaveBeenCalled();

--- a/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
@@ -49,22 +49,22 @@ beforeEach(() => {
   replaceEntriesMock.mockResolvedValue({} as any);
 });
 
-const openSaveDialog = async () => {
+const openSaveSection = async () => {
   render(<QueuesPage />);
   await screen.findByText('Daily');
   fireEvent.click(screen.getByText('Daily'));
   await screen.findByText('Edit Queue');
-  fireEvent.click(screen.getByText('Save as template'));
-  return screen.findByRole('dialog', { name: 'Save template' });
+  fireEvent.click(screen.getByText('Save Template'));
+  return screen.findByRole('region', { name: 'Save template' });
 };
 
 describe('QueuesPage template save wiring', () => {
   it('builds sequenceIds from the current entries and saves', async () => {
     saveTemplateMock.mockResolvedValue({} as any);
-    const dialog = await openSaveDialog();
+    const section = await openSaveSection();
 
-    fireEvent.change(within(dialog).getByLabelText('Template name'), { target: { value: 'Daily Farm' } });
-    fireEvent.click(within(dialog).getByText('Save'));
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Daily Farm' } });
+    fireEvent.click(within(section).getByText('Save'));
 
     await waitFor(() =>
       expect(saveTemplateMock).toHaveBeenCalledWith({ name: 'Daily Farm', sequenceIds: ['seq-a', 'seq-b'], overwrite: false })
@@ -76,12 +76,12 @@ describe('QueuesPage template save wiring', () => {
     saveTemplateMock
       .mockRejectedValueOnce(new ApiError(409, 'template_exists'))
       .mockResolvedValueOnce({} as any);
-    const dialog = await openSaveDialog();
+    const section = await openSaveSection();
 
-    fireEvent.change(within(dialog).getByLabelText('Template name'), { target: { value: 'Daily Farm' } });
-    fireEvent.click(within(dialog).getByText('Save'));
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Daily Farm' } });
+    fireEvent.click(within(section).getByText('Save'));
 
-    fireEvent.click(await within(dialog).findByText('Overwrite'));
+    fireEvent.click(await within(section).findByText('Overwrite'));
 
     await waitFor(() =>
       expect(saveTemplateMock).toHaveBeenLastCalledWith({ name: 'Daily Farm', sequenceIds: ['seq-a', 'seq-b'], overwrite: true })
@@ -89,18 +89,18 @@ describe('QueuesPage template save wiring', () => {
   });
 });
 
-const openEditAndPicker = async () => {
+const openLoadSection = async () => {
   render(<QueuesPage />);
   await screen.findByText('Daily');
   fireEvent.click(screen.getByText('Daily'));
   await screen.findByText('Edit Queue');
-  fireEvent.click(screen.getByText('Load template'));
-  return screen.findByRole('dialog', { name: 'Load template' });
+  fireEvent.click(screen.getByText('(no template)'));
+  return screen.findByRole('region', { name: 'Load template' });
 };
 
 describe('QueuesPage template load wiring', () => {
   it('replaces entries after confirming the replacement for a non-empty queue', async () => {
-    const picker = await openEditAndPicker();
+    const picker = await openLoadSection();
     fireEvent.click(within(picker).getByText('Load'));
 
     const confirm = await screen.findByRole('dialog', { name: 'Replace queue entries' });
@@ -110,7 +110,7 @@ describe('QueuesPage template load wiring', () => {
   });
 
   it('does not replace entries when the replacement is canceled', async () => {
-    const picker = await openEditAndPicker();
+    const picker = await openLoadSection();
     fireEvent.click(within(picker).getByText('Load'));
 
     const confirm = await screen.findByRole('dialog', { name: 'Replace queue entries' });
@@ -119,24 +119,26 @@ describe('QueuesPage template load wiring', () => {
     expect(replaceEntriesMock).not.toHaveBeenCalled();
   });
 
-  it('pre-fills the save dialog with the loaded template name', async () => {
+  it('pre-fills the save section with the loaded template name', async () => {
     getQueueMock.mockResolvedValue({ ...queue({ entryCount: 0 }), entries: [] } as any);
-    const picker = await openEditAndPicker();
+    const picker = await openLoadSection();
     fireEvent.click(within(picker).getByText('Load'));
     await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
 
-    fireEvent.click(screen.getByText('Save as template'));
-    const saveDialog = await screen.findByRole('dialog', { name: 'Save template' });
-    expect(within(saveDialog).getByLabelText('Template name')).toHaveValue('Daily Farm');
+    fireEvent.click(screen.getByText('Save Template'));
+    const saveSection = await screen.findByRole('region', { name: 'Save template' });
+    expect(within(saveSection).getByLabelText('Template name')).toHaveValue('Daily Farm');
   });
 
-  it('disables Load template while the queue is running', async () => {
+  it('disables the Load action while the queue is running', async () => {
     getQueueMock.mockResolvedValue({ ...detailWithEntries(), status: 'Running' } as any);
     render(<QueuesPage />);
     await screen.findByText('Daily');
     fireEvent.click(screen.getByText('Daily'));
     await screen.findByText('Edit Queue');
-    expect(screen.getByText('Load template')).toBeDisabled();
+    fireEvent.click(screen.getByText('(no template)'));
+    const picker = await screen.findByRole('region', { name: 'Load template' });
+    expect(within(picker).getByText('Load')).toBeDisabled();
   });
 
   it('loads the same template independently into two different queues (FR-016)', async () => {
@@ -148,14 +150,14 @@ describe('QueuesPage template load wiring', () => {
 
     fireEvent.click(screen.getByText('Daily'));
     await screen.findByText('Edit Queue');
-    fireEvent.click(screen.getByText('Load template'));
-    fireEvent.click(within(await screen.findByRole('dialog', { name: 'Load template' })).getByText('Load'));
+    fireEvent.click(screen.getByText('(no template)'));
+    fireEvent.click(within(await screen.findByRole('region', { name: 'Load template' })).getByText('Load'));
     await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
 
     fireEvent.click(screen.getByText('Arena'));
     await waitFor(() => expect(getQueueMock).toHaveBeenLastCalledWith('q2'));
-    fireEvent.click(screen.getByText('Load template'));
-    fireEvent.click(within(await screen.findByRole('dialog', { name: 'Load template' })).getByText('Load'));
+    fireEvent.click(screen.getByText('(no template)'));
+    fireEvent.click(within(await screen.findByRole('region', { name: 'Load template' })).getByText('Load'));
     await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q2', ['seq-x']));
   });
 });
@@ -163,7 +165,7 @@ describe('QueuesPage template load wiring', () => {
 describe('QueuesPage template delete wiring', () => {
   it('deletes a template from the picker without touching the queue entries', async () => {
     deleteTemplateMock.mockResolvedValue(undefined as any);
-    const picker = await openEditAndPicker();
+    const picker = await openLoadSection();
     expect(screen.getAllByTestId('queue-entry')).toHaveLength(2);
 
     fireEvent.click(within(picker).getByText('Delete'));

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -115,6 +115,14 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 .collapsible-section-content { padding: 0 var(--gb-space-3) var(--gb-space-3); }
 
 
+/* Edit-queue template controls (row 2) */
+.queue-template-controls { margin: var(--gb-space-3) 0; }
+.queue-template-row { display: flex; align-items: center; gap: var(--gb-space-2); flex-wrap: wrap; }
+.queue-template-name { font-weight: 600; }
+.queue-template-section { border: 1px solid var(--gb-color-border); border-radius: var(--gb-radius-lg); background: var(--gb-color-surface); padding: var(--gb-space-3); margin-top: var(--gb-space-2); }
+.queue-template-section h4 { margin-top: 0; }
+.queue-template-section-actions { display: flex; gap: var(--gb-space-2); margin-top: var(--gb-space-2); }
+
 /* Drag-and-drop */
 .loop-block--drop-invalid { outline: 2px solid #d32f2f; opacity: 0.7; }
 .sortable-step-item { display: flex; align-items: flex-start; }

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -123,6 +123,17 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 .queue-template-section h4 { margin-top: 0; }
 .queue-template-section-actions { display: flex; gap: var(--gb-space-2); margin-top: var(--gb-space-2); }
 
+/* Edit-queue form layout */
+.edit-form .field { margin-bottom: var(--gb-space-3); }
+.edit-form .field-row { display: flex; gap: var(--gb-space-3); flex-wrap: wrap; align-items: flex-start; }
+.edit-form .field-row .field { flex: 1 1 0; min-width: 14rem; margin-bottom: 0; }
+.edit-form .field > input { width: 100%; box-sizing: border-box; }
+.edit-form .form-actions { display: flex; gap: var(--gb-space-2); margin-top: var(--gb-space-4); padding-top: var(--gb-space-3); border-top: 1px solid var(--gb-color-border); }
+
+/* Queue sequence entries (row 4) — keep the ordered list as-is; only align the
+   "Add sequence" control to the list items (default <ol> indentation is 40px). */
+.queue-entries .queue-entry-add { margin-top: var(--gb-space-2); margin-left: 40px; }
+
 /* Drag-and-drop */
 .loop-block--drop-invalid { outline: 2px solid #d32f2f; opacity: 0.7; }
 .sortable-step-item { display: flex; align-items: flex-start; }


### PR DESCRIPTION
## Summary

Frontend-only refinement of the **Edit Queue** page (spec `048-edit-queue-layout`), building on Emulator Execution Queue (#046) and Queue Templates (#047). No backend/API/persistence changes — reuses existing endpoints.

The edit page is now a clear, ordered set of rows:
1. **Name** (editable) + **Emulator** (read-only) — on one line; the "bound emulator cannot be changed" hint removed.
2. **Template controls** — clickable template-name button (opens Load), **Save Template**, and a new **Reload Template**; the Save/Load panels expand inline between rows 2 and 3 (default closed, only one open at a time).
3. **Cycle execution**.
4. **Sequences**.
5. **Save / Cancel** (separated from the list by a divider).

### Highlights
- **Reload Template** re-applies the associated template (resolved by name, so a rename/delete reads as "no longer available"), with **diff-aware confirmation** — it only prompts when a non-empty queue would actually change. Disabled when no template is associated or the queue is running.
- Save/Cancel govern only **name + cycle execution**; entry/template actions (add, remove, load, reload) apply immediately (sequences aren't persisted with the queue).
- Save/Load template experiences converted from modal dialogs to **inline collapsible sections** owned by a new `QueueTemplateControls`.
- The replace/reload **confirmation renders inline** where the picker was, not as a bottom-of-page modal.

## Spec artifacts
`specs/048-edit-queue-layout/` — spec, plan, research, data-model, contracts, quickstart, tasks (all tasks complete except T020 manual quickstart).

## Testing
- Full web-ui suite: **311/311 pass** (new specs: `QueueTemplateControls`, `sequenceOrder`, `QueuesPage.layout`, `QueuesPage.reload`; updated form/dialog/templates specs).
- Lint and type-check clean for all changed files.
- Manual quickstart (`quickstart.md`) pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)