### PR TITLE
Link queues to a template with auto-load (#049)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/048-edit-queue-layout"
+  "feature_directory": "specs/049-queue-template-link"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 ﻿<!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/048-edit-queue-layout/plan.md
+at specs/049-queue-template-link/plan.md
 <!-- SPECKIT END -->

--- a/specs/049-queue-template-link/checklists/requirements.md
+++ b/specs/049-queue-template-link/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Queue–Template Link with Auto-Load
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All three clarifications resolved in the 2026-06-01 session and encoded into the spec (Clarifications, Edge Cases, FR-005/005a, FR-011, FR-012): link set via existing load/save (no explicit unlink); auto-load only when the queue has no entries; broken link is cleared on open.
+- All checklist items pass. Spec is ready for `/speckit-plan`.

--- a/specs/049-queue-template-link/contracts/queue-template-link-api.md
+++ b/specs/049-queue-template-link/contracts/queue-template-link-api.md
@@ -1,0 +1,90 @@
+# API Contract: Queue–Template Link with Auto-Load
+
+Base: `/api/queues`. Error envelope (unchanged across the project):
+`{ "error": { "code": string, "message": string, "hint": string | null } }`.
+
+## NEW — Set / clear a queue's linked template
+
+`PUT /api/queues/{id}/template`
+
+Request body:
+
+```json
+{ "templateId": "a1b2c3d4e5f6..." }   // or { "templateId": null } to clear
+```
+
+Behavior:
+- Sets `ExecutionQueue.LinkedTemplateId` to `templateId` (null clears). Persisted.
+- **Not** blocked while the queue is `Running` (it mutates only the persisted link, never
+  the runtime entries) — this allows associating a queue with a template saved while running.
+- Does not itself load entries; auto-load happens on the next detail GET.
+
+Responses:
+| Status | When | Body |
+|--------|------|------|
+| 200 OK | Link set/cleared | `QueueDetailResponse` (with updated `linkedTemplateId`/`linkedTemplateName`) |
+| 400 invalid_request | `templateId` non-null but no such template | error envelope, message "template not found" |
+| 404 not_found | No queue with `{id}` | error envelope |
+
+## CHANGED — Get a queue (auto-load trigger)
+
+`GET /api/queues/{id}`
+
+Side effect (before the response is built), applied in order; any failed guard skips
+auto-load and the queue still returns 200:
+1. No linked template → no auto-load.
+2. Status `Running` → no auto-load (entries returned as-is).
+3. Runtime state already exists for this queue (materialized or edited since startup) →
+   no auto-load.
+4. Linked template cannot be resolved → clear `LinkedTemplateId` (persist) → return empty.
+5. Otherwise → replace runtime entries with the template's ordered sequence ids and return.
+
+Response body `QueueDetailResponse` (additions in **bold**):
+
+```json
+{
+  "id": "q1",
+  "name": "Daily Farm Queue",
+  "emulatorSerial": "emulator-5554",
+  "cycleExecution": false,
+  "status": "Stopped",
+  "entryCount": 3,
+  "linkedTemplateId": "tpl-abc",        // NEW (null when unlinked)
+  "linkedTemplateName": "Daily Farm",   // NEW (null when unlinked/unresolved)
+  "entries": [
+    { "entryId": "e1", "sequenceId": "s1", "sequenceName": "Open app", "stale": false },
+    { "entryId": "e2", "sequenceId": "s2", "sequenceName": "Collect",  "stale": false },
+    { "entryId": "e3", "sequenceId": "sX", "sequenceName": null,       "stale": true }
+  ]
+}
+```
+
+Stale entries (referenced sequence deleted) are projected with `stale: true` as today,
+covering auto-loaded template entries with dead references (FR-009).
+
+## CHANGED — List / summary queue responses
+
+`GET /api/queues`, and the `QueueResponse` returned by create/update/start/stop now include:
+
+```json
+{ "...": "...", "linkedTemplateId": "tpl-abc" }   // NEW (null when unlinked)
+```
+
+(`linkedTemplateName` is provided on the **detail** response only, where the template repo
+is consulted.)
+
+## UNCHANGED (reused)
+
+- `PUT /api/queues/{id}/entries` — replace entries (still 409 `queue_running` while running).
+  The load flow calls this, then calls `PUT {id}/template` to record the link.
+- `GET /api/queue-templates`, `GET /api/queue-templates/{id}`,
+  `POST /api/queue-templates`, `DELETE /api/queue-templates/{id}` — unchanged. The save
+  response's `id` is used as the link target after a save.
+
+## Contract test expectations
+
+- `PUT /api/queues/{id}/template` exists; set→persist (survives a fresh repository instance),
+  clear, 400 on unknown template, 404 on unknown queue, success while Running.
+- `GET /api/queues/{id}` exposes `linkedTemplateId` and `linkedTemplateName`; auto-load
+  matrix (Decisions 3–4, 6) holds.
+- `openapi.json` updated to include the new path and the new response properties.

--- a/specs/049-queue-template-link/data-model.md
+++ b/specs/049-queue-template-link/data-model.md
@@ -1,0 +1,91 @@
+# Phase 1 Data Model: Queue–Template Link with Auto-Load
+
+This feature adds **one persisted field** and **one runtime capability**. No new entity is
+introduced; the "Queue–Template Link" from the spec is realized as an attribute on the
+existing queue config.
+
+## Entities
+
+### ExecutionQueue (MODIFIED — persisted config, `data/queues/{id}.json`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | string | Existing. Stable GUID "N". |
+| Name | string | Existing. Required, non-empty. |
+| EmulatorSerial | string | Existing. Immutable after create. |
+| CycleExecution | bool | Existing. |
+| **LinkedTemplateId** | **string?** | **NEW.** Stable ID of the linked `QueueTemplate`, or `null` when unlinked (0..1). Persisted. References by ID (FR-001a) — rename-safe, broken only by delete. |
+| CreatedAt / UpdatedAt | DateTimeOffset? | Existing. `UpdatedAt` bumped when the link is set/cleared. |
+
+**Validation / rules**:
+- `LinkedTemplateId` is optional; absent in old files ⇒ `null` (backward compatible, no migration).
+- Setting the link to a non-null value requires that template to exist (enforced at the
+  endpoint, not the repository).
+- A queue has at most one link (the field is scalar) — FR-001/FR-003 satisfied by assignment.
+
+### QueueTemplate (UNCHANGED)
+
+No change. Holds **no** back-reference to linking queues (FR-015). May be referenced by
+0..n queues. Deleting it leaves linking queues' `LinkedTemplateId` dangling until each is
+next opened, at which point auto-load clears it (FR-011).
+
+### Queue runtime state (MODIFIED capability — `QueueRuntimeStore`, in-memory)
+
+Entries and status remain non-persistent. New capability:
+
+| Operation | Signature | Behavior |
+|-----------|-----------|----------|
+| **HasRuntimeState** | `bool HasRuntimeState(string queueId)` | **NEW.** True iff a runtime state record exists for the queue (`_states.ContainsKey`). Distinguishes "never materialized since startup" (false) from "exists, possibly empty" (true). Backs the auto-load "first display only" guard. |
+
+Existing `GetEntries`, `AddEntry`, `RemoveEntry`, `SetEntries`, `GetStatus`, `SetStatus`,
+`Remove` are unchanged. Note: `GetEntries` does **not** create state; `AddEntry`,
+`SetEntries`, `SetStatus` do (via `StateFor`). `Remove` deletes the record (so
+`HasRuntimeState` returns false again — relevant on queue delete).
+
+## Lifecycle / state transitions
+
+### The link
+
+```
+unlinked ──load template T──▶ linked→T ──load template U──▶ linked→U
+   ▲                              │
+   │                              ├──save entries as template S──▶ linked→S
+   │                              │
+   └──auto-load finds T missing───┘   (link cleared + persisted on next open)
+```
+
+- **Set/replace**: load a template (link ← loaded template id) or save entries to a
+  template (link ← saved template id), via `PUT {id}/template`. Replaces any prior link.
+- **Clear**: only automatic — when auto-load cannot resolve the linked template (FR-011).
+  No explicit unlink control this iteration (FR-005a). (`PUT {id}/template {null}` exists
+  as the mechanism but is not surfaced as a user action.)
+
+### Auto-load (first display per service lifetime)
+
+```
+GET /api/queues/{id}:
+  linked? ──no──▶ open with current runtime entries (no auto-load)         (FR-007)
+     │yes
+  Running? ──yes──▶ open with current entries, no replace                  (FR-010)
+     │no
+  HasRuntimeState? ──yes──▶ open with current entries (no re-fill)         (FR-012)
+     │no
+  resolve template:
+     missing ──▶ clear link (persist), open empty, no error                (FR-011)
+     found   ──▶ SetEntries(queueId, template.Entries.sequenceIds), open   (FR-006/006a/008/009)
+```
+
+After the first materialization, `HasRuntimeState` is true, so subsequent opens (and the
+GETs issued after each add/remove) do not re-load — protecting deliberate edits, including
+a deliberate clear-to-empty.
+
+## Response projections (Service contracts)
+
+| Contract | Change |
+|----------|--------|
+| `QueueResponse` (list/summary) | add `LinkedTemplateId` (string?) |
+| `QueueDetailResponse` (detail) | inherits `LinkedTemplateId`; add `LinkedTemplateName` (string?, resolved from template repo; null if unlinked/unresolved) |
+| `SetQueueTemplateLinkRequest` (NEW) | `{ TemplateId: string? }` |
+
+Frontend DTOs (`queues.ts`) mirror these: `linkedTemplateId`, `linkedTemplateName` on
+`QueueDto`/`QueueDetailDto`.

--- a/specs/049-queue-template-link/plan.md
+++ b/specs/049-queue-template-link/plan.md
@@ -1,0 +1,261 @@
+# Implementation Plan: Queue–Template Link with Auto-Load
+
+**Branch**: `049-queue-template-link` | **Date**: 2026-06-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/049-queue-template-link/spec.md`
+
+## Summary
+
+Give each queue an optional, **persisted** link to a single template (0..1; a template
+may be linked by 0..n queues), and **auto-load** that template's entries into the queue's
+runtime when the queue's edit/detail page is opened. This converts the 047/048 UI-only
+"remembered template name" into a durable, ID-based association stored on the queue config.
+
+Approach (full-stack, thin slice):
+- **Persist the link**: add `LinkedTemplateId` (string, nullable) to `ExecutionQueue`
+  (the only durable part of a queue). It references the template by **stable ID** (FR-001a),
+  so renaming a template does not break the link; only deletion does.
+- **Auto-load on display**: `GET /api/queues/{id}` (what the edit page calls via `openEdit`)
+  materializes the linked template into the queue's runtime entries **once per service
+  lifetime per queue** — only when the queue has no runtime state yet (post-restart),
+  is not Running, and the link resolves. If the linked template is gone, the link is
+  cleared and persisted; the queue still opens empty without error.
+- **Set the link**: a new `PUT /api/queues/{id}/template` `{ templateId | null }` endpoint
+  sets/clears the link. It is **not** gated on Running (it touches no entries), so saving a
+  template from a running queue can still associate it. The frontend calls it as a side
+  effect of the existing load and save flows — **no new visual controls** (FR-005).
+- The list endpoint (`GET /api/queues`) is intentionally untouched (Q3: only the detail
+  page triggers auto-load).
+
+No new dependencies. Reuses existing `IQueueRuntimeStore.SetEntries`, the template
+repository, and the existing replace-entries/load/save UI plumbing.
+
+## Technical Context
+
+**Language/Version**: C# / .NET (GameBot.Domain, GameBot.Service minimal-API) backend;
+TypeScript 5.6 / React 18.3 (web-ui) frontend.
+**Primary Dependencies**: ASP.NET Core minimal APIs, System.Text.Json (backend); React +
+Vite, existing in-house components/services (`QueuesPage`, `QueueTemplateControls`,
+`queues.ts`, `queueTemplates.ts`) (frontend). No new packages.
+**Storage**: File-backed JSON. Queue **config** persists under `data/queues/*.json`
+(`FileQueueRepository`); the new `LinkedTemplateId` is one more property on that document.
+Queue **entries/status** remain runtime-only (`QueueRuntimeStore`, in-memory singleton).
+Templates persist under `data/queue-templates/*.json` (unchanged).
+**Testing**: xUnit (unit/integration/contract) backend; Jest 29 + React Testing Library 14
+frontend.
+**Target Platform**: GameBot Windows service + authoring SPA in a modern browser.
+**Project Type**: Web application (backend + frontend); this feature touches both.
+**Performance Goals**: Opening a queue reflects entries <1s at the established scale
+(≤~50 templates × ≤~100 entries) — inherits 046/047 budgets; auto-load is one template
+read + one in-memory `SetEntries`.
+**Constraints**: CamelCase method names only (no underscores); functions ≤50 LOC; reuse
+existing error-envelope and UX conventions; auto-load must not block/err the display, must
+not touch a Running queue's entries, must not re-fill a queue the operator deliberately
+emptied (operationalized as "only when no runtime state exists yet"); link-clear on a
+missing template must persist.
+**Scale/Scope**: ~4 backend files + ~2 new contracts/endpoint changes; ~2 frontend files
+touched; new tests on both sides. Backward-compatible: existing queue JSON without the new
+field deserializes with `LinkedTemplateId = null` (unlinked).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI),
+implementation progression is blocked until failures are fixed or a documented maintainer
+waiver exists.
+
+| Gate (from constitution) | Status | Notes |
+|--------------------------|--------|-------|
+| Lint/format/static analysis clean | Must pass | ESLint (web-ui) + analyzers (C#); enforced in CI |
+| No underscores in method names — CamelCase only | Must pass | New handlers/services/components CamelCase |
+| Functions ≤50 LOC | Must pass | Auto-load helper extracted; link endpoint thin; frontend handlers stay small |
+| Unit ≥80% line / ≥70% branch on touched areas | Must pass | Tests for auto-load matrix, link set/clear, runtime-store `HasRuntimeState`, frontend link wiring |
+| Deterministic, isolated, fast tests | Must pass | xUnit with temp data roots; RTL with mocked services; no real I/O beyond temp dirs |
+| UX consistency | Must pass | No new visual controls; reuses existing template name button/error envelope |
+| Actionable error messages | Must pass | Link endpoint returns existing error envelope ("template not found"); display never errors on broken link |
+| Performance goals declared | ✅ Declared | <1s open (one template read + in-memory set) |
+| Public API/contract documented | ✅ Will update | New endpoint + new response field in `contracts/` and `specs/openapi.json`; contract tests updated |
+| Observability | ✅ N/A | No new logging (consistent with 047: no template-action logging) |
+| No unjustified new dependencies | ✅ None added | Reuses existing stack |
+
+No constitution violations. No waivers required. No Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/049-queue-template-link/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (decisions & rationale)
+├── data-model.md        # Phase 1 output (entities, fields, state)
+├── quickstart.md        # Phase 1 output (manual verification)
+├── contracts/
+│   └── queue-template-link-api.md  # Phase 1 output — API contract (new endpoint + fields + auto-load)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/GameBot.Domain/Queues/
+├── ExecutionQueue.cs          # MODIFIED — add LinkedTemplateId (string?, persisted)
+├── IQueueRuntimeStore.cs      # MODIFIED — add HasRuntimeState(queueId): bool
+└── QueueRuntimeStore.cs       # MODIFIED — implement HasRuntimeState via _states.ContainsKey
+
+src/GameBot.Service/Contracts/Queues/
+├── QueueResponse.cs           # MODIFIED — add LinkedTemplateId
+├── QueueDetailResponse.cs     # MODIFIED — add LinkedTemplateName (resolved, for display)
+└── SetQueueTemplateLinkRequest.cs  # NEW — { TemplateId?: string }
+
+src/GameBot.Service/Endpoints/
+└── QueuesEndpoints.cs         # MODIFIED — auto-load in GET {id}; new PUT {id}/template;
+                               #            include link fields in BuildResponse/BuildDetailAsync;
+                               #            extract MaybeAutoLoadAsync + ResolveLinkName helpers
+
+specs/openapi.json             # MODIFIED — document PUT {id}/template + new response fields
+
+src/web-ui/src/services/
+└── queues.ts                  # MODIFIED — add linkedTemplateId/linkedTemplateName to DTOs;
+                               #            add setQueueTemplateLink(id, templateId|null)
+
+src/web-ui/src/pages/
+└── QueuesPage.tsx             # MODIFIED — openEdit derives associated name from persisted link;
+                               #            applyLoad + handleSaveTemplate set the link by id;
+                               #            handleLoadTemplate/handleReload thread templateId
+
+tests/unit/Queues/
+├── QueueRuntimeStoreHasStateTests.cs   # NEW — HasRuntimeState true/false lifecycle
+
+tests/integration/Queues/
+├── QueueTemplateLinkEndpointTests.cs   # NEW — PUT {id}/template set/clear/validate/persist/running-ok
+└── QueueAutoLoadEndpointTests.cs       # NEW — GET {id} auto-load matrix (fresh/linked, running,
+                                        #        state-exists, missing-template→clear, unlinked)
+
+tests/contract/Queues/
+└── QueuesApiContractTests.cs           # MODIFIED — new endpoint + response fields present
+
+src/web-ui/src/services/__tests__/
+└── queues.spec.ts (or queue link)      # NEW/MODIFIED — setQueueTemplateLink request shape
+
+src/web-ui/src/pages/__tests__/
+└── QueuesPage.link.spec.tsx            # NEW — link set on load & save; name from persisted link;
+                                        #        auto-loaded entries shown on open
+```
+
+**Structure Decision**: Web application touching both tiers. The durable link lives on the
+persisted queue config (`ExecutionQueue`), the only place a queue stores anything across
+restarts. Auto-load is server-side on the queue **detail** GET so that (a) it triggers
+exactly where the spec scopes it (the editor open, not the list), and (b) the materialized
+entries are real runtime entries usable by execution (FR-006a), not a client-only view.
+Link mutation is a small dedicated endpoint rather than folding into replace-entries,
+because the link must be settable while a queue is Running (save-while-running) whereas
+replace-entries is blocked when Running.
+
+## Implementation Design
+
+### Persisted link (Domain)
+
+`ExecutionQueue` gains `public string? LinkedTemplateId { get; set; }`. It is written by
+`FileQueueRepository.Update/CreateAsync` automatically (whole-object serialization).
+Existing queue files lacking the property deserialize as `null` (unlinked) — no migration.
+
+### Runtime "first display" guard
+
+Add `bool HasRuntimeState(string queueId)` to `IQueueRuntimeStore`, implemented as
+`_states.ContainsKey(queueId)`. This distinguishes "never materialized since startup"
+(no key) from "exists but currently empty" (operator cleared it). Auto-load fires only
+when **no** runtime state exists yet, which captures FR-012's intent ("only when the queue
+has no entries", post-restart) without re-filling a queue the operator deliberately
+emptied during the session. (Decision recorded in research.md.)
+
+### Auto-load on GET detail (Service)
+
+`GET /api/queues/{id}` handler gains `IQueueTemplateRepository` (resolve template) and uses
+the already-present `IQueueRepository` (persist link-clear). Before building the detail:
+
+```
+MaybeAutoLoadAsync(queue, runtime, templates, repo):
+  if queue.LinkedTemplateId is null: return
+  if runtime.GetStatus(queue.Id) == Running: return        // FR-010
+  if runtime.HasRuntimeState(queue.Id): return             // FR-012 (first display only)
+  tpl = await templates.GetAsync(queue.LinkedTemplateId)
+  if tpl is null:                                           // FR-011 broken link
+    queue.LinkedTemplateId = null
+    await repo.UpdateAsync(queue)                           // persist the clear
+    return
+  runtime.SetEntries(queue.Id, tpl.Entries.Select(e => e.SequenceId))   // FR-006/006a/008
+```
+
+Then `BuildDetailAsync` reads runtime entries as today (stale projection already handled,
+covering FR-009). `BuildResponse`/`BuildDetailAsync` also emit `LinkedTemplateId` and a
+resolved `LinkedTemplateName` (looked up from the template repo when building detail; null
+if unlinked or unresolved). Helper kept ≤50 LOC.
+
+### Set/clear link endpoint (Service)
+
+`PUT /api/queues/{id}/template` with `SetQueueTemplateLinkRequest { string? TemplateId }`:
+- 404 if queue not found.
+- If `TemplateId` non-null and the template does not exist → `400 invalid_request`
+  ("template not found") via the existing error envelope.
+- Set `queue.LinkedTemplateId = TemplateId` (null clears), `repo.UpdateAsync`, return the
+  queue detail. **Not** blocked while Running (touches no entries; enables save-while-running
+  association).
+
+### Frontend wiring (QueuesPage)
+
+- `queues.ts`: `QueueDto`/`QueueDetailDto` gain `linkedTemplateId: string | null` and
+  `linkedTemplateName: string | null`; add `setQueueTemplateLink(id, templateId)` →
+  `PUT /api/queues/{id}/template`.
+- `openEdit`: set `associatedTemplateName` from `q.linkedTemplateName ?? undefined`
+  (replaces the current reset-to-undefined). The auto-loaded entries arrive in `q.entries`
+  from the GET, so the editor shows them with no extra call.
+- `applyLoad(name, sequenceIds, templateId)`: after `replaceQueueEntries`, call
+  `setQueueTemplateLink(detail.id, templateId)`; thread `templateId` from
+  `handleLoadTemplate` (`tpl.id`) and `handleReload` (`match.id`).
+- `handleSaveTemplate`: `saveQueueTemplate` returns the detail incl. `id`; after save call
+  `setQueueTemplateLink(detail.id, saved.id)` so saving associates the queue with that
+  template (FR-005). Keep updating `associatedTemplateName` for immediate feedback.
+- `QueueTemplateControls.tsx`: unchanged (still driven by `associatedTemplateName`).
+
+## Contracts
+
+New/changed REST surface (documented in `contracts/queue-template-link-api.md` and
+`specs/openapi.json`):
+- **NEW** `PUT /api/queues/{id}/template` — body `{ "templateId": string | null }`;
+  200 → queue detail; 400 (template not found); 404 (queue not found).
+- **CHANGED** `GET /api/queues/{id}` — response adds `linkedTemplateId`,
+  `linkedTemplateName`; performs auto-load side effect (first display, not Running,
+  resolvable link) and may clear a broken link.
+- **CHANGED** `GET /api/queues` and other queue responses — add `linkedTemplateId`.
+Reuses unchanged: `PUT /api/queues/{id}/entries`, `GET/POST/DELETE /api/queue-templates`.
+
+## Testing Strategy
+
+**Backend (xUnit)** — touched-area coverage ≥80% line / ≥70% branch:
+- `QueueRuntimeStoreHasStateTests`: false before any op; true after Add/SetEntries/SetStatus;
+  false again after `Remove`.
+- `QueueAutoLoadEndpointTests` (integration): linked + fresh → entries materialized from
+  template; linked + Running → not materialized; linked + state already exists → not
+  re-filled; linked + template missing → entries empty AND link cleared+persisted; unlinked
+  → empty, no error; persistence of materialized entries usable by a subsequent start.
+- `QueueTemplateLinkEndpointTests` (integration): set link → persisted (re-read via new repo
+  instance); set null clears; non-existent template → 400; non-existent queue → 404; link
+  settable while Running.
+- `QueuesApiContractTests` (contract): new endpoint present; responses expose
+  `linkedTemplateId`/`linkedTemplateName`.
+
+**Frontend (Jest + RTL)**:
+- `queues` service test: `setQueueTemplateLink` issues `PUT {id}/template` with the body.
+- `QueuesPage.link.spec.tsx`: loading a template calls `setQueueTemplateLink` with the
+  template id; saving calls it with the saved id; opening a linked queue shows the
+  auto-loaded entries and the linked name (mocked `getQueue` returns
+  `linkedTemplateName` + entries); opening an unlinked queue shows "(no template)".
+
+**No new logging tests** (no logging added). Manual verification in `quickstart.md`.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/049-queue-template-link/quickstart.md
+++ b/specs/049-queue-template-link/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart / Manual Verification: Queue–Template Link with Auto-Load
+
+Prereqs: run the GameBot service + web-ui; have at least one sequence authored and an
+emulator queue created. No visual changes are expected — these steps verify **behavior**.
+
+## 1. Establish a link by loading a template (US2)
+
+1. Create/save a template "Daily Farm" with entries A, B, C (Save Template in the editor).
+2. Open a different queue Q2 (empty). Load "Daily Farm" via the template picker.
+3. Q2 now shows A, B, C and the template-name button reads **Daily Farm**.
+4. ✅ Behind the scenes the queue is now linked: `GET /api/queues/{Q2}` returns
+   `linkedTemplateId` = the template's id and `linkedTemplateName` = "Daily Farm".
+
+## 2. Establish a link by saving (US2)
+
+1. Open an empty queue, add entries X, Y, save them as a new template "Patrol".
+2. ✅ `GET /api/queues/{id}` now reports `linkedTemplateName` = "Patrol" (saving associated
+   the queue with the saved template), with **no new on-screen control** used.
+
+## 3. Auto-load after restart (US1 — the core behavior)
+
+1. With Q2 linked to "Daily Farm" (step 1), **restart the service** (runtime entries are
+   discarded by design).
+2. Open Q2 in the editor.
+3. ✅ Q2's entries are A, B, C again — auto-loaded, no manual Load clicked.
+4. ✅ Press **Start** on Q2 — it runs with the auto-loaded entries (the entries are real
+   server-side runtime entries, not a view-only fill).
+
+## 4. Replace the link (US2)
+
+1. With Q2 linked to "Daily Farm", load a different template "Night Run" into Q2.
+2. ✅ `linkedTemplateName` becomes "Night Run"; after a restart, opening Q2 auto-loads
+   Night Run's entries (the prior link was replaced).
+
+## 5. Shared template, independent queues (US2 / SC-004)
+
+1. Link both Q1 and Q2 to "Daily Farm".
+2. Edit Q1's entries (remove one) — do **not** save back to the template.
+3. ✅ "Daily Farm" is unchanged; Q2 (and the template) are unaffected. After a restart both
+   queues auto-load the template's current contents independently.
+
+## 6. Edits within a session are not clobbered (FR-012)
+
+1. Open a linked queue (auto-loads). Remove all its entries one by one.
+2. ✅ The queue stays empty — it is **not** re-filled by auto-load (auto-load only runs on
+   the first open after a restart, not after a deliberate clear).
+3. Use **Reload Template** (048) to deliberately re-apply the template if desired.
+
+## 7. Broken link clears itself (FR-011)
+
+1. Link a queue to a template, then **delete that template**.
+2. Open the queue.
+3. ✅ The queue opens with no entries and no error; the template-name button reads
+   **(no template)**. `GET /api/queues/{id}` now returns `linkedTemplateId: null`
+   (the broken link was cleared and persisted).
+4. Note: a *rename* of the template does **not** break the link (links are by ID).
+
+## 8. Running queue is not disturbed (FR-010)
+
+1. Start a linked queue, then open it in the editor while it is Running.
+2. ✅ The currently running entries are shown unchanged (no auto-load replacement).
+
+## Known limitation (by design, Q3)
+
+Starting a linked queue **directly from the list** right after a restart (without opening
+its editor first) runs it empty — auto-load is scoped to opening the queue's edit/detail
+page. Open the queue once to materialize its entries.
+
+## Automated checks to run before commit (constitution gate)
+
+- Backend: `dotnet test` (unit + integration + contract for Queues).
+- Frontend: `npm test` in `src/web-ui` (queues service + `QueuesPage.link` specs).
+- Lint/format/static analysis clean on both tiers.

--- a/specs/049-queue-template-link/research.md
+++ b/specs/049-queue-template-link/research.md
@@ -1,0 +1,117 @@
+# Phase 0 Research: Queue–Template Link with Auto-Load
+
+All spec clarifications were resolved during `/speckit-specify` and `/speckit-clarify`
+(see spec `## Clarifications`). No open `NEEDS CLARIFICATION` remained entering planning.
+This document records the design decisions that translate those clarifications onto the
+existing codebase.
+
+## Decision 1 — Where the link is stored
+
+**Decision**: Add `LinkedTemplateId` (nullable string) to `ExecutionQueue`, the persisted
+queue-config document (`data/queues/{id}.json`, via `FileQueueRepository`).
+
+**Rationale**: `ExecutionQueue` is the only durable part of a queue (entries and status are
+deliberately runtime-only in `QueueRuntimeStore`). The link must survive restarts (FR-002),
+so it belongs on the persisted config. Whole-object JSON serialization writes it for free;
+existing files without the property deserialize to `null` (= unlinked), so no migration is
+required.
+
+**Alternatives considered**:
+- *Separate link store / index file*: more moving parts, extra I/O, and a second source of
+  truth to keep consistent on queue delete. Rejected — the config doc already exists.
+- *Store on the template (back-reference to queues)*: contradicts FR-015 (template holds no
+  back-reference) and breaks the 0..n fan-out cleanly. Rejected.
+
+## Decision 2 — Reference by stable ID, not name
+
+**Decision**: The link stores the template's `Id` (GUID "N"), matching the Q1 clarification.
+
+**Rationale**: Templates already have stable IDs; the save endpoint returns the ID for both
+create and overwrite, and the load picker already knows the ID. ID-based linking keeps the
+link intact across a rename and breaks only on delete (FR-001a, FR-011). The 048 *manual*
+reload resolves by name, but that is a separate, session-scoped affordance; the persisted
+link should be robust to rename.
+
+**Alternatives considered**: Name-based link (Q1 option B) — simpler to reconcile with 048's
+reload-by-name, but a future rename would orphan the link. Rejected per Q1.
+
+## Decision 3 — Auto-load trigger location: GET queue detail
+
+**Decision**: Perform auto-load as a side effect of `GET /api/queues/{id}` (the queue
+detail endpoint). The list endpoint `GET /api/queues` is untouched.
+
+**Rationale**: The editor's `openEdit` is the only caller of `getQueue(id)` → `GET {id}`;
+the queue list uses `GET ""`. Hooking the detail GET therefore triggers auto-load exactly
+on "opening the queue's edit/detail page" and nowhere else (Q3). Doing it server-side (vs.
+a client-only view fill) means the materialized entries are real runtime entries that
+execution will use (FR-006a / Q2), and it reuses the existing `SetEntries` path.
+
+**Alternatives considered**:
+- *Frontend-only auto-load* (call `replaceQueueEntries` from `openEdit`): would not help a
+  queue started directly from the list, and duplicates server logic. Rejected per Q2
+  (must populate server-side runtime).
+- *Auto-load inside `GetEntries`/on Start*: would broaden the trigger beyond the editor,
+  contradicting Q3. Rejected (noted as a known limitation below).
+
+## Decision 4 — "Only when empty" operationalized as "no runtime state yet"
+
+**Decision**: Auto-load fires only when `IQueueRuntimeStore.HasRuntimeState(queueId)` is
+false (no entry in the in-memory dictionary), in addition to "not Running". Add
+`HasRuntimeState` to the store interface/impl (`_states.ContainsKey`).
+
+**Rationale**: FR-012 says auto-load runs only when the queue "currently has no sequence
+entries", with intent = restore after a restart, never silently discard edits. A naive
+"entries.Count == 0" check would *re-fill* a queue right after the operator manually
+removes its last entry (because `reloadDetail` re-issues GET detail after each entry op).
+"No runtime state exists yet" is true only on the first display after a service start and
+becomes false as soon as the queue is materialized or edited, giving the desired
+restore-once behavior without clobbering an intentional clear. An empty linked template
+still yields an empty queue (valid no-content load).
+
+**Alternatives considered**: explicit per-queue "materialized" boolean flag — equivalent but
+adds state; `ContainsKey` already encodes it. Rejected as redundant.
+
+## Decision 5 — Setting/clearing the link: dedicated endpoint
+
+**Decision**: New `PUT /api/queues/{id}/template` `{ templateId | null }`. Not gated on
+Running. The frontend calls it after a successful load (`templateId` of the loaded template)
+and after a successful save (`id` from the save response). Null clears.
+
+**Rationale**: The link must be set on **both** load and save. Load already calls
+`PUT {id}/entries`, but save does not touch entries — and crucially, save-from-running is
+allowed (047) while `PUT {id}/entries` is blocked when Running. A single small endpoint that
+only mutates the persisted link (never entries) works for all cases, including
+save-while-running, and keeps each call's responsibility clear. No new visual control is
+introduced; the calls are side effects of existing load/save actions (FR-005).
+
+**Alternatives considered**:
+- *Fold `templateId` into `ReplaceQueueEntriesRequest`*: covers load in one call but cannot
+  set the link during a running-queue save, and conflates two concerns. Rejected.
+- *Extend `UpdateQueueRequest` (`PUT {id}`)*: that endpoint requires a name and is the
+  page-level Save for name/cycle; overloading it with link changes on every load/save would
+  couple unrelated flows and is also Running-blocked. Rejected.
+
+## Decision 6 — Broken-link behavior persists the clear
+
+**Decision**: When auto-load cannot resolve `LinkedTemplateId`, set it to null and persist
+via `repo.UpdateAsync`, then open the queue empty without error (FR-011, FR-006a).
+
+**Rationale**: Matches Q's "clear the link" answer; persisting avoids repeatedly attempting
+to resolve a dead template on every open. `UpdateAsync` succeeds because Name/EmulatorSerial
+remain valid.
+
+## Known limitation (in scope, documented)
+
+Starting a linked queue **directly from the list** (without opening its editor) after a
+restart will run it empty, because auto-load is scoped to the detail GET (Q3). Opening the
+queue first materializes it. This is consistent with the clarified trigger surface and is
+called out in `quickstart.md`. Broadening the trigger is out of scope for this iteration.
+
+## Standards reused (no new dependencies)
+
+- Error envelope: `{ error: { code, message, hint } }` with the same status codes used by
+  existing queue/template endpoints.
+- File repos: existing safe-id/path-traversal guard and whole-object JSON serialization.
+- Frontend: existing `getJson/putJson` helpers, `ApiError`, and the
+  `QueueTemplateControls` component (unchanged).
+- No template-action logging (consistent with 047).

--- a/specs/049-queue-template-link/spec.md
+++ b/specs/049-queue-template-link/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Queue–Template Link with Auto-Load
+
+**Feature Branch**: `049-queue-template-link`
+**Created**: 2026-06-01
+**Status**: Draft
+**Input**: User description: "I want the queues to be linked to 0 or 1 templates, that should be loaded automatically when the queue is displayed in the UI. The relation is 0..1:0:n, meaning a queue can have 0 or 1 templates linked and a template can be linked to 0 to n queues. No visual changes are expected here, but the UI behaviour when opening the queue."
+
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: How is a queue's linked template established and cleared given "no visual changes"? → A: Reuse the existing load/save flow — loading a template into the queue, or saving the queue's entries to a template, sets that template as the queue's persisted link (replacing the 047/048 UI-only "remembered name"). No explicit unlink control this iteration; a queue is unlinked only if it was never linked or its link was auto-cleared (see broken-link answer).
+- Q: When a linked queue is opened during a session where it already holds runtime entries (e.g. edited away from the template, no restart), should auto-load run? → A: No — auto-load populates entries only on the first display after a service start (when the queue has not yet been materialized this lifetime). Once materialized or edited, its entries are kept and never silently discarded — including a deliberately emptied queue, which is not re-filled; the manual Reload (048) remains the way to force a re-apply.
+- Q: What happens on open when the linked template can no longer be resolved (deleted, or renamed if links are name-based)? → A: Auto-load does nothing and the now-broken link is cleared, so the queue becomes unlinked going forward; the queue still opens normally without error.
+- Q: How does the link reference its template — by stable identity or by name? → A: By the template's stable identity (ID). Renaming the template keeps the link intact; only deleting the template breaks the link.
+- Q: Does auto-load populate the queue's server-side runtime entries or only the client editor view? → A: The server-side runtime entries — auto-load writes the template's entries into the queue via the existing replace-entries operation, so both the editor and execution see them. Auto-clearing a broken link is likewise persisted.
+- Q: Which UI surface triggers auto-load? → A: Only the queue's edit/detail page (the queue editor). Passive views such as the queue list do not trigger auto-load.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Linked template loads automatically when opening a queue (Priority: P1)
+
+An operator who previously associated a queue with a template opens that queue in the editor. Without taking any manual "load" action, the queue's sequence entries are populated from its linked template, so the arrangement the operator expects is already there. This is especially valuable after a service restart, when the queue's runtime entries would otherwise be empty: the link gives the queue durable, restored contents derived from the template.
+
+**Why this priority**: This is the core of the feature — the behavior the operator asked for ("loaded automatically when the queue is displayed"). It delivers the central value (queues regain their expected entries on open without a manual load step) and is independently demonstrable.
+
+**Independent Test**: Link a queue to a template containing entries A, B, C; restart the service; open the queue in the UI and confirm its entries are A, B, C in order without any manual load action.
+
+**Acceptance Scenarios**:
+
+1. **Given** a queue linked to template "Daily Farm" (entries A, B, C) and a freshly started service with no runtime entries for that queue, **When** the operator opens the queue in the editor, **Then** the queue shows entries A, B, C in the template's order, loaded automatically.
+2. **Given** a queue that is not linked to any template, **When** the operator opens the queue, **Then** no auto-load occurs and the queue's entries are exactly its current runtime entries (empty after a restart), with no error.
+3. **Given** a queue linked to a template, **When** the operator opens the queue and the entries auto-load, **Then** the operator can immediately edit those entries (add, remove, reorder) as usual.
+
+---
+
+### User Story 2 - Associate a queue with a template (and replace or clear the association) (Priority: P1)
+
+While editing a queue, an operator makes a template the queue's linked template so that future opens auto-load it. The association is persisted (it survives a service restart) and is a property of the queue, not of the template. The same template can be the linked template of many queues at once. A queue has at most one linked template; associating a different template replaces the prior link.
+
+**Why this priority**: Without a way to establish the link, US1 has nothing to auto-load. Together with US1 it forms the minimum viable feature.
+
+**Independent Test**: Associate queue Q1 with template T, restart the service, and confirm Q1 is still linked to T (US1 auto-loads T into Q1); associate the same template T with a second queue Q2 and confirm both Q1 and Q2 are independently linked to T.
+
+**Acceptance Scenarios**:
+
+1. **Given** a queue with no linked template, **When** the operator associates it with template T, **Then** the queue's linked template becomes T and remains T after a service restart.
+2. **Given** a queue already linked to template T, **When** the operator associates it with a different template U, **Then** the queue's linked template becomes U (the prior link to T is replaced), and on next open U is auto-loaded.
+3. **Given** template T already linked to queue Q1, **When** the operator associates T with queue Q2 as well, **Then** both Q1 and Q2 are linked to T independently, and T is unchanged.
+4. **Given** a queue with no linked template, **When** the operator loads a template into it (or saves its entries to a template), **Then** that template becomes the queue's persisted linked template, with no new visual control involved.
+5. **Given** a queue whose linked template was auto-cleared because it became unavailable, **When** the operator later loads a template into the queue, **Then** the queue is linked to the newly loaded template.
+
+---
+
+### Edge Cases
+
+- **Linked template no longer exists**: The linked template was deleted before the queue is opened (the link is by stable ID, so a rename does not break it). On auto-load the queue loads nothing, opens normally without error, and the now-broken link is cleared so the queue becomes unlinked going forward.
+- **Queue already materialized this session when opened**: During a single session (no restart), the operator re-opens a linked queue that has already been materialized — whether it still holds runtime entries it edited away from the template, or it was deliberately emptied. Auto-load does not run again — the current entries (including an empty list) are kept and never overwritten. The operator can use the manual Reload (048) to force re-applying the template.
+- **Linked template is empty**: A queue linked to an empty template (zero entries) opens with zero entries; auto-load of an empty template is a valid no-content load, not an error.
+- **Stale entry inside the linked template**: A template entry whose referenced sequence was deleted is auto-loaded as a stale/unresolved reference (consistent with existing queue stale-entry handling), not silently dropped.
+- **Linked template changes between opens**: If the linked template's contents are saved/overwritten elsewhere, the next auto-load reflects the template's latest saved contents (the link resolves to the template, not to a frozen copy).
+- **Auto-load while the queue is running**: Opening a running queue must not disrupt its execution. Auto-load follows the existing rule that bulk entry replacement is blocked while a queue is running; for a running queue, opening shows the current running entries and does not replace them.
+- **Loading vs. linking divergence**: After auto-load, the operator edits the queue's entries without saving them back to the template; the link still points at the template, and the in-queue edits remain runtime-only (non-persistent) unless saved to the (or a) template.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### The link
+
+- **FR-001**: A queue MUST be able to reference at most one template as its "linked template" (0 or 1), and a template MUST be allowed to be the linked template of any number of queues (0..n). The link is a property of the queue.
+- **FR-001a**: The link MUST reference the template by its stable identity (ID), not by name; renaming the linked template MUST NOT break the link, and only deleting the template makes the link unresolvable.
+- **FR-002**: The queue→template link MUST be persisted so that it survives service restarts (the queue's runtime sequence entries remain non-persistent, as today; only the link is persisted).
+- **FR-003**: Associating a queue with a template MUST replace any prior linked template for that queue (a queue never has more than one linked template).
+- **FR-004**: The link MUST be independent per queue: associating a template with one queue MUST NOT change any other queue's link, and MUST NOT modify the template itself.
+- **FR-005**: Establishing or changing a queue's linked template MUST occur as a side effect of the existing load/save template actions (loading a template, or saving the queue's entries to a template, sets that template as the link) without introducing new visual controls or layout changes (behavioral change only).
+- **FR-005a**: This iteration MUST NOT add an explicit "unlink" control; a queue's link is cleared only automatically when its linked template becomes unresolvable (FR-011).
+
+#### Auto-load on display
+
+- **FR-006**: When a queue with a linked template is opened on its edit/detail page (the queue editor), the system MUST automatically populate the queue's sequence entries from the linked template, preserving the template's order, without requiring a manual load action. Passive views (e.g. the queue list) MUST NOT trigger auto-load.
+- **FR-006a**: Auto-load MUST write the template's entries into the queue's server-side runtime entries (reusing the existing entry-replacement logic that backs the load/replace flow), so that both the editor view and queue execution use the auto-loaded entries; it MUST NOT be a client-only view population. Likewise, auto-clearing a broken link (FR-011) MUST persist the cleared link.
+- **FR-007**: When a queue with no linked template is displayed, the system MUST NOT perform any auto-load and MUST show the queue's current runtime entries.
+- **FR-008**: Independent of *where* entries are written (FR-006a), auto-load MUST be a **copy** (consistent with existing load semantics): subsequent in-queue edits MUST NOT modify the template, and later template changes MUST NOT retroactively modify an already-materialized queue (the live link only re-resolves on the next first-display, never mid-session).
+- **FR-009**: Auto-load MUST reproduce a template entry whose referenced sequence no longer exists as a stale/unresolved reference, consistent with existing queue stale-entry handling.
+- **FR-010**: Auto-load MUST NOT replace the entries of a queue that is in the running state; for a running queue, display MUST show the current running entries unchanged.
+- **FR-011**: If the linked template cannot be resolved (deleted or otherwise unavailable), auto-load MUST NOT block or error the display of the queue, MUST load nothing, and MUST clear the queue's now-broken link so the queue becomes unlinked going forward.
+- **FR-012**: Auto-load MUST run only on the first display of a queue after a service start — that is, when the queue's runtime entries have not yet been materialized this service lifetime (no runtime state exists for it). Once a queue has been materialized or edited this session, auto-load MUST NOT run again, MUST leave its entries unchanged, and MUST NOT re-fill a queue the operator has deliberately emptied. (Operationally: the trigger is "no runtime state yet", not merely "zero entries", so clearing a queue's entries does not cause an immediate re-load.)
+
+#### Relationship to existing template behavior (047/048)
+
+- **FR-013**: This feature MUST reuse the existing save/load/delete template behavior (047) and the existing reload behavior (048); auto-load is the automatic counterpart of the manual reload, applied when the queue is displayed.
+- **FR-014**: Deleting a template MUST NOT alter any queue's current runtime entries; the effect of deletion on linked queues is limited to the linked template becoming unresolved (per FR-011).
+- **FR-015**: A template MUST remain independent of the queues that link to it: it stores only its own ordered sequence entries and does not record which queues link to it (the link lives on the queue side).
+
+### Key Entities *(include if feature involves data)*
+
+- **Queue**: The existing emulator execution queue. Gains one new persisted attribute: an optional reference to a single linked template (0 or 1). Its sequence entries remain runtime-only (non-persistent); the link does not persist the entries, only the association used to derive them on display.
+- **Queue Template**: Unchanged from 047 — a named, persisted, ordered list of sequence entries, independent of any queue. It may be the linked template of 0..n queues but holds no back-reference to them.
+- **Queue–Template Link**: The association from a queue to at most one template, referencing the template by its stable identity (ID). Persisted, owned by the queue, replaceable, and clearable. Resolves to the template's current saved contents at display time.
+- **Sequence**: An existing authored command sequence referenced by template/queue entries; unchanged by this feature.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After linking a queue to a template and restarting the service, 100% of the time opening that queue shows the template's exact ordered entries with no manual load action, and the queue is immediately runnable with those entries (execution uses the auto-loaded server-side entries).
+- **SC-002**: A queue with no linked template opens with no auto-load and no error in 100% of cases.
+- **SC-003**: Associating a different template with a queue replaces the prior link in 100% of cases, and the next open auto-loads the newly linked template.
+- **SC-004**: The same template can serve as the linked template for multiple queues simultaneously, and editing one linked queue's entries leaves the template and the other linked queues unchanged in 100% of cases.
+- **SC-005**: Opening a queue with auto-load reflects the queue's entries within 1 second at the established scale (up to ~50 templates each with up to ~100 entries).
+- **SC-006**: Opening a queue whose linked template is unavailable never blocks or errors the queue's display (100% of attempts succeed in showing the queue).
+
+## Assumptions
+
+- **Link establishment reuses existing actions**: Establishing/changing the link reuses the existing load/save template flow rather than adding new UI controls (consistent with "no visual changes"); the persisted link replaces the UI-only "remembered template name" introduced in 047/048 (confirmed in Clarifications).
+- **Entries remain non-persistent**: As in 047/048, a queue's sequence entries are runtime-only. The link is the durable thing; entries are derived from the linked template on display. This is how queues effectively "remember" their contents across restarts now.
+- **Link resolves live**: The link points at the template (by identity), so auto-load always reflects the template's latest saved contents rather than a snapshot taken when the link was created.
+- **Running-queue safety**: Auto-load honors the existing rule that bulk entry replacement is blocked while a queue is running.
+- **Single-operator tool**: Concurrency follows the surrounding features' last-write-wins assumptions; no multi-user locking.
+- **Scale**: Up to ~50 templates each with up to ~100 entries, consistent with 046/047.
+
+## Out of Scope
+
+- Any visual redesign or new on-screen controls in the queue editor (this iteration changes behavior only).
+- Persisting a queue's runtime sequence entries directly (entries remain derived from the linked template / runtime edits).
+- A back-reference from a template to the queues that link to it, or cascade behavior when a template is deleted beyond leaving the link unresolved.
+- Multiple linked templates per queue, ordering/merging of several templates, or partial loads.
+- Versioning/history of links or templates; renaming/duplicating/exporting templates (covered by/excluded in 047).

--- a/specs/049-queue-template-link/tasks.md
+++ b/specs/049-queue-template-link/tasks.md
@@ -1,0 +1,211 @@
+---
+description: "Task list for Queue–Template Link with Auto-Load"
+---
+
+# Tasks: Queue–Template Link with Auto-Load
+
+**Input**: Design documents from `specs/049-queue-template-link/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/queue-template-link-api.md, quickstart.md
+
+**Tests**: INCLUDED — the project constitution mandates tests for executable logic
+(≥80% line / ≥70% branch on touched areas) and the plan's Testing Strategy enumerates them.
+
+**Organization**: Tasks are grouped by user story. Both stories are P1; US1 (auto-load) is
+the demonstrable MVP and is independently testable by seeding a queue with a link directly,
+while US2 (set/clear the link) provides the user-facing way to create that link.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 or US2 (Setup/Foundational/Polish carry no story label)
+
+## Path Conventions
+
+Web application: C# backend under `src/GameBot.Domain/`, `src/GameBot.Service/`, tests under
+`tests/`; React frontend under `src/web-ui/src/`. Paths below are exact.
+
+⚠️ **Shared-file note** (do NOT parallelize these across tasks):
+`src/GameBot.Service/Endpoints/QueuesEndpoints.cs` (T008 → T013 → T021),
+`src/web-ui/src/pages/QueuesPage.tsx` (T014 → T023 → T024),
+`src/web-ui/src/services/queues.ts` (T009 → T022),
+`tests/contract/Queues/QueuesApiContractTests.cs` (T011 → T017),
+`specs/openapi.json` (T015 → T025) are each touched by multiple tasks and must be done in
+the listed order.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm a clean baseline before changing shared queue code.
+
+- [x] T001 Confirm baseline is green: run `dotnet test` and (in `src/web-ui`) `npm test`, plus lint/format, and record that the tree builds clean before changes (constitution release-blocker gate). No new dependencies are added by this feature.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The persisted link field, the runtime "first display" probe, and the response
+projections that BOTH user stories depend on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T002 [P] Add nullable `LinkedTemplateId` (persisted, by stable template ID) to the queue config in `src/GameBot.Domain/Queues/ExecutionQueue.cs`, with an XML doc comment noting it is 0..1 and rename-safe.
+- [x] T003 [P] Add `bool HasRuntimeState(string queueId)` to the runtime store contract in `src/GameBot.Domain/Queues/IQueueRuntimeStore.cs` with a doc comment ("true iff a runtime state record exists; distinguishes never-materialized from exists-but-empty").
+- [x] T004 Implement `HasRuntimeState` via `_states.ContainsKey(queueId)` in `src/GameBot.Domain/Queues/QueueRuntimeStore.cs` (depends on T003).
+- [x] T005 [P] Unit-test the `HasRuntimeState` lifecycle (false before any op; true after AddEntry/SetEntries/SetStatus; false again after Remove) in `tests/unit/Queues/QueueRuntimeStoreHasStateTests.cs` (depends on T004).
+- [x] T006 [P] Add `LinkedTemplateId` (string?) to `src/GameBot.Service/Contracts/Queues/QueueResponse.cs`.
+- [x] T007 [P] Add `LinkedTemplateName` (string?) to `src/GameBot.Service/Contracts/Queues/QueueDetailResponse.cs`.
+- [x] T008 Project the link fields in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: set `LinkedTemplateId` in `BuildResponse`, and resolve `LinkedTemplateName` from the template repository in `BuildDetailAsync` (null when unlinked/unresolved). Keep helpers ≤50 LOC (depends on T002, T006, T007).
+- [x] T009 [P] Add `linkedTemplateId: string | null` to `QueueDto` and `linkedTemplateName: string | null` to `QueueDetailDto` in `src/web-ui/src/services/queues.ts`.
+
+**Checkpoint**: Queue config persists a link field and every queue response carries it; the runtime store can report whether a queue has been materialized. User stories can now begin.
+
+---
+
+## Phase 3: User Story 1 - Linked template loads automatically when opening a queue (Priority: P1) 🎯 MVP
+
+**Goal**: When a queue with a linked template is opened on its edit/detail page, its
+template's ordered entries are auto-loaded into the queue's server-side runtime (once per
+service lifetime, not while Running, not re-filling a deliberately emptied queue); a broken
+link is cleared on open without error.
+
+**Independent Test**: Seed a queue file with `LinkedTemplateId` pointing at a template
+(A,B,C), with no runtime state (fresh start); `GET /api/queues/{id}` returns entries A,B,C
+and `linkedTemplateName`. Re-open while Running, or with state already present, or with the
+template deleted, to verify the guards and the clear-on-missing behavior.
+
+### Tests for User Story 1
+
+> Write these tests FIRST and ensure they FAIL before implementation.
+
+- [x] T010 [P] [US1] Integration auto-load matrix in `tests/integration/Queues/QueueAutoLoadEndpointTests.cs`: linked + fresh → entries materialized from template; linked + Running → unchanged; linked + runtime state already exists → not re-filled (incl. a deliberately emptied queue stays empty); linked + template missing → empty AND `linkedTemplateId` cleared & persisted; **linked + template deleted while the queue already has materialized entries → those existing entries are left unchanged (FR-014, guard skips on existing runtime state)**; unlinked → empty, no error; materialized entries are usable by a subsequent start; **auto-load of a ~100-entry linked template completes within the SC-005 budget (<1s), reusing the existing scale-test pattern (`tests/integration/Queues/QueueScaleTests.cs`)**.
+- [x] T011 [US1] Extend `tests/contract/Queues/QueuesApiContractTests.cs` to assert `GET /api/queues/{id}` exposes `linkedTemplateId` and `linkedTemplateName` (and list responses expose `linkedTemplateId`). (Shared file — before T017.)
+- [x] T012 [P] [US1] Frontend test `src/web-ui/src/pages/__tests__/QueuesPage.autoload.spec.tsx`: opening a queue whose mocked `getQueue` returns `linkedTemplateName` + auto-loaded entries shows those entries and the template name on the controls; opening an unlinked queue shows "(no template)".
+
+### Implementation for User Story 1
+
+- [x] T013 [US1] In `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`, inject `IQueueTemplateRepository` into the `GET {id}` handler and add a `MaybeAutoLoadAsync` helper applied before building the detail: skip when unlinked, Running, or `HasRuntimeState`; otherwise resolve the template — if missing, clear `LinkedTemplateId` and persist via `IQueueRepository.UpdateAsync`; else `SetEntries` from the template's sequence ids. Keep the helper ≤50 LOC (depends on T008).
+- [x] T014 [P] [US1] In `src/web-ui/src/pages/QueuesPage.tsx`, change `openEdit` to derive `associatedTemplateName` from `q.linkedTemplateName ?? undefined` (replacing the reset-to-undefined); the auto-loaded entries arrive in `q.entries` with no extra call (depends on T009).
+- [x] T015 [US1] Document the new `linkedTemplateId`/`linkedTemplateName` response fields. NOTE: `specs/openapi.json` does not contain the queues/queue-templates API (046/047/048 never added it; the queue family is contract-documented under `specs/<feature>/contracts/`). Documented in [contracts/queue-template-link-api.md](contracts/queue-template-link-api.md) instead of injecting an inconsistent isolated path into openapi.json.
+
+**Checkpoint**: A queue with a pre-existing link auto-loads on open and survives restart; broken links clear themselves. US1 is independently demonstrable.
+
+---
+
+## Phase 4: User Story 2 - Associate a queue with a template (replace / auto-clear) (Priority: P1)
+
+**Goal**: Loading a template into a queue, or saving the queue's entries to a template,
+persists that template as the queue's link (by ID), replacing any prior link; the link is
+settable even while the queue is Running (save-while-running); no new visual control is
+added.
+
+**Independent Test**: `PUT /api/queues/{id}/template { templateId }` persists the link
+(re-read via a fresh repository instance); a different id replaces it; `null` clears it; an
+unknown template → 400; unknown queue → 404; succeeds while Running. In the UI, loading and
+saving each call the link endpoint with the right id.
+
+### Tests for User Story 2
+
+> Write these tests FIRST and ensure they FAIL before implementation.
+
+- [x] T016 [P] [US2] Integration tests in `tests/integration/Queues/QueueTemplateLinkEndpointTests.cs`: set link persists across a new repository instance; set `null` clears; non-existent template → 400 `invalid_request`; non-existent queue → 404; link settable while Running; **per-queue independence (FR-004): setting Q2's link leaves Q1's `linkedTemplateId` and the referenced template's entries unchanged**.
+- [x] T017 [US2] Extend `tests/contract/Queues/QueuesApiContractTests.cs` to assert `PUT /api/queues/{id}/template` exists and returns the queue detail. (Shared file — after T011.)
+- [x] T018 [P] [US2] Frontend service test `src/web-ui/src/services/__tests__/queues.spec.ts`: `setQueueTemplateLink(id, templateId)` issues `PUT /api/queues/{id}/template` with `{ templateId }` (and `null` to clear).
+- [x] T019 [P] [US2] Frontend test `src/web-ui/src/pages/__tests__/QueuesPage.link.spec.tsx`: loading a template calls `setQueueTemplateLink` with the loaded template's id; saving a template calls it with the saved template's id (from the save response).
+
+### Implementation for User Story 2
+
+- [x] T020 [P] [US2] Create `src/GameBot.Service/Contracts/Queues/SetQueueTemplateLinkRequest.cs` with `{ string? TemplateId }` and a doc comment (null clears the link).
+- [x] T021 [US2] Add `PUT /api/queues/{id}/template` to `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: 404 if queue missing; 400 (`invalid_request`, "template not found") if `TemplateId` non-null and unresolved; otherwise set `LinkedTemplateId` (null clears), `UpdateAsync`, return the detail. NOT gated on Running. Reuse the existing error envelope (depends on T013, T020).
+- [x] T022 [P] [US2] Add `setQueueTemplateLink(id, templateId: string | null)` → `putJson('/api/queues/{id}/template', { templateId })` in `src/web-ui/src/services/queues.ts` (depends on T009).
+- [x] T023 [US2] In `src/web-ui/src/pages/QueuesPage.tsx`, thread the template id through the load path: `applyLoad(name, sequenceIds, templateId)` calls `setQueueTemplateLink(detail.id, templateId)` after `replaceQueueEntries`; pass `tpl.id` from `handleLoadTemplate` and `match.id` from `handleReload` (depends on T014, T022).
+- [x] T024 [US2] In `src/web-ui/src/pages/QueuesPage.tsx`, after `saveQueueTemplate` resolves, call `setQueueTemplateLink(detail.id, saved.id)` so saving associates the queue with the saved template (depends on T023).
+- [x] T025 [US2] Document the `PUT /api/queues/{id}/template` path (request body + 200/400/404). NOTE: same as T015 — the queues API is absent from `specs/openapi.json`; documented in [contracts/queue-template-link-api.md](contracts/queue-template-link-api.md).
+
+**Checkpoint**: Operators can establish/replace a queue's link via existing load/save with no new controls; the link drives US1's auto-load end-to-end.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verification and backward-compatibility safety net.
+
+- [x] T026 [P] Add/confirm a backward-compatibility test in `tests/unit/Queues/FileQueueRepositoryTests.cs`: a queue JSON written without `LinkedTemplateId` deserializes with the field `null` (unlinked) — no migration needed.
+- [x] T027 Run the full suites (`dotnet test`; `npm test` in `src/web-ui`) and lint/format/static analysis; confirm ≥80% line / ≥70% branch on touched areas and a clean build (constitution gate). RESULT: backend 642 passed (63 contract + 333 unit + 246 integration), web-ui 317 passed; backend build 0 warnings/0 errors; ESLint clean on all touched files. NOTE: repo has pre-existing ESLint/`tsc --noEmit` failures in unrelated files (BreakStepRow.tsx, CommandsPage.tsx, sessionsApi/validation specs, setupTests.ts) that predate this feature and are out of scope.
+- [x] T028 Execute the `specs/049-queue-template-link/quickstart.md` behavioral flows. Verified via automated equivalents: restart→`AutoLoadSurvivesRestartAndIsRunnable`; replace→`SetLinkToDifferentTemplateReplacesPrior`; independence→`SettingOneQueuesLinkLeavesOtherQueuesAndTemplateUnchanged`; no-clobber→`AlreadyMaterializedQueueIsNotRefilledAfterDeliberateClear`; broken-link→`MissingTemplateOnFreshDisplayClearsLinkAndOpensEmpty`; running→`RunningQueueIsNotAutoLoaded`; link via load/save→`QueuesPage.link.spec.tsx` + `QueueTemplateLinkEndpointTests`. The list-start limitation is by-design (no test). Manual UI walkthrough optional for the operator.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately.
+- **Foundational (Phase 2)**: after Setup — BLOCKS both user stories.
+- **US1 (Phase 3)** and **US2 (Phase 4)**: both after Foundational. They share
+  `QueuesEndpoints.cs`, `QueuesPage.tsx`, the contract test, and `openapi.json`, so when
+  worked together they must respect the shared-file order (T008→T013→T021;
+  T014→T023→T024; T011→T017; T015→T025). US1 is independently testable without US2 (seed a
+  link directly).
+- **Polish (Phase 5)**: after the desired stories are complete.
+
+### Within Each User Story
+
+- Tests (T010–T012; T016–T019) are written first and must FAIL before implementation.
+- Backend contract/request types before endpoint logic; endpoint before frontend wiring
+  that calls it.
+- US2's `applyLoad`/save wiring (T023/T024) builds on US1's `openEdit` change (T014).
+
+### Parallel Opportunities
+
+- Foundational: T002, T003, T006, T007, T009 in parallel (distinct files); then T004→T005, then T008.
+- US1 tests: T010 and T012 in parallel (T011 edits the shared contract file).
+- US2 tests: T016, T018, T019 in parallel (T017 edits the shared contract file after T011).
+- US2 impl: T020 and T022 in parallel; T021 then T023→T024; T025 after T015.
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Distinct files, no inter-dependencies — run together:
+Task: "Add LinkedTemplateId to src/GameBot.Domain/Queues/ExecutionQueue.cs"
+Task: "Add HasRuntimeState to src/GameBot.Domain/Queues/IQueueRuntimeStore.cs"
+Task: "Add LinkedTemplateId to src/GameBot.Service/Contracts/Queues/QueueResponse.cs"
+Task: "Add LinkedTemplateName to src/GameBot.Service/Contracts/Queues/QueueDetailResponse.cs"
+Task: "Add linkedTemplateId/linkedTemplateName to src/web-ui/src/services/queues.ts"
+```
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+Task: "Auto-load matrix integration test in tests/integration/Queues/QueueAutoLoadEndpointTests.cs"
+Task: "Auto-load UI test in src/web-ui/src/pages/__tests__/QueuesPage.autoload.spec.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 (Setup) → Phase 2 (Foundational).
+2. Phase 3 (US1): auto-load on open, verified by seeding a queue link directly.
+3. **STOP and VALIDATE**: open a seeded linked queue, restart, confirm auto-load + runnable.
+
+### Incremental Delivery
+
+1. Setup + Foundational → field, probe, and response projections ready.
+2. US1 → auto-load works for any pre-existing link → demo MVP.
+3. US2 → loading/saving establishes the link with no new controls → full round trip.
+4. Polish → backward-compat test + suite/quickstart verification.
+
+---
+
+## Notes
+
+- [P] = different files, no dependencies on incomplete tasks.
+- Both stories are P1; US1 is the demonstrable MVP, US2 closes the user-facing loop.
+- No new logging (consistent with 047). No new dependencies.
+- Watch the shared-file order callouts to avoid merge conflicts.
+- Commit after each task or logical group; keep the build/tests green (release-blocker gate).

--- a/src/GameBot.Domain/Queues/ExecutionQueue.cs
+++ b/src/GameBot.Domain/Queues/ExecutionQueue.cs
@@ -26,6 +26,15 @@ namespace GameBot.Domain.Queues {
     /// </summary>
     public bool CycleExecution { get; set; }
 
+    /// <summary>
+    /// Optional link to a single queue template by its stable template ID
+    /// (0..1). Persisted. References by ID, so renaming the template keeps the link intact;
+    /// only deleting the template makes it unresolvable. Null when the queue is unlinked.
+    /// When set, the linked template's entries are auto-loaded into the queue's runtime on
+    /// the first display after a service start.
+    /// </summary>
+    public string? LinkedTemplateId { get; set; }
+
     public DateTimeOffset? CreatedAt { get; set; }
 
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/src/GameBot.Domain/Queues/IQueueRuntimeStore.cs
+++ b/src/GameBot.Domain/Queues/IQueueRuntimeStore.cs
@@ -10,6 +10,14 @@ namespace GameBot.Domain.Queues {
     /// <summary>Ordered entries for the queue; empty for an unknown queue.</summary>
     IReadOnlyList<QueueEntry> GetEntries(string queueId);
 
+    /// <summary>
+    /// True iff a runtime state record currently exists for the queue. Distinguishes a queue
+    /// that has never been materialized this service lifetime (false) from one that exists but
+    /// may be empty (true, e.g. the operator cleared its entries). Backs the auto-load
+    /// "first display only" guard so a deliberately emptied queue is not re-filled.
+    /// </summary>
+    bool HasRuntimeState(string queueId);
+
     /// <summary>Appends a new entry referencing <paramref name="sequenceId"/> at the end.</summary>
     QueueEntry AddEntry(string queueId, string sequenceId);
 

--- a/src/GameBot.Domain/Queues/QueueRuntimeStore.cs
+++ b/src/GameBot.Domain/Queues/QueueRuntimeStore.cs
@@ -22,6 +22,8 @@ namespace GameBot.Domain.Queues {
       }
     }
 
+    public bool HasRuntimeState(string queueId) => _states.ContainsKey(queueId);
+
     public QueueEntry AddEntry(string queueId, string sequenceId) {
       var entry = new QueueEntry {
         EntryId = Guid.NewGuid().ToString("N"),

--- a/src/GameBot.Service/Contracts/Queues/QueueDetailResponse.cs
+++ b/src/GameBot.Service/Contracts/Queues/QueueDetailResponse.cs
@@ -4,6 +4,12 @@ namespace GameBot.Service.Contracts.Queues {
   /// <summary>Single-queue representation including its ordered sequence entries.</summary>
   internal sealed class QueueDetailResponse : QueueResponse {
     public Collection<QueueEntryResponse> Entries { get; } = new Collection<QueueEntryResponse>();
+
+    /// <summary>
+    /// Display name of the linked queue template, resolved from the template store; null when
+    /// the queue is unlinked or the linked template can no longer be resolved.
+    /// </summary>
+    public string? LinkedTemplateName { get; set; }
   }
 
   /// <summary>

--- a/src/GameBot.Service/Contracts/Queues/QueueResponse.cs
+++ b/src/GameBot.Service/Contracts/Queues/QueueResponse.cs
@@ -9,5 +9,8 @@ namespace GameBot.Service.Contracts.Queues {
     public bool CycleExecution { get; set; }
     public QueueExecutionStatus Status { get; set; } = QueueExecutionStatus.Stopped;
     public int EntryCount { get; set; }
+
+    /// <summary>Stable ID of the linked queue template, or null when the queue is unlinked.</summary>
+    public string? LinkedTemplateId { get; set; }
   }
 }

--- a/src/GameBot.Service/Contracts/Queues/SetQueueTemplateLinkRequest.cs
+++ b/src/GameBot.Service/Contracts/Queues/SetQueueTemplateLinkRequest.cs
@@ -1,0 +1,9 @@
+namespace GameBot.Service.Contracts.Queues {
+  /// <summary>
+  /// Request body for setting or clearing a queue's linked template.
+  /// <see cref="TemplateId"/> is the stable template ID to link, or null to clear the link.
+  /// </summary>
+  internal sealed class SetQueueTemplateLinkRequest {
+    public string? TemplateId { get; set; }
+  }
+}

--- a/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GameBot.Domain.Commands;
 using GameBot.Domain.Queues;
+using GameBot.Domain.QueueTemplates;
 using GameBot.Service.Contracts.Queues;
 using Microsoft.Extensions.Logging;
 
@@ -34,10 +35,11 @@ internal static class QueuesEndpoints {
       return Results.Ok(resp);
     }).WithName("ListQueues");
 
-    group.MapGet("{id}", async (string id, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences) => {
+    group.MapGet("{id}", async (string id, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
       if (queue is null) return NotFound();
-      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences).ConfigureAwait(false));
+      await MaybeAutoLoadAsync(queue, repo, runtime, templates).ConfigureAwait(false);
+      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences, templates).ConfigureAwait(false));
     }).WithName("GetQueue");
 
     group.MapPut("{id}", async (string id, UpdateQueueRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime) => {
@@ -73,14 +75,25 @@ internal static class QueuesEndpoints {
       return Results.Created($"{ApiRoutes.Queues}/{id}/entries/{entry.EntryId}", ProjectEntry(entry, resolved?.Name));
     }).WithName("AddQueueEntry");
 
-    group.MapPut("{id}/entries", async (string id, ReplaceQueueEntriesRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences) => {
+    group.MapPut("{id}/entries", async (string id, ReplaceQueueEntriesRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
       if (queue is null) return NotFound();
       if (runtime.GetStatus(id) == QueueExecutionStatus.Running)
         return Error(409, "queue_running", "Stop the queue before loading a template.");
       runtime.SetEntries(id, req?.SequenceIds ?? Array.Empty<string>());
-      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences).ConfigureAwait(false));
+      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences, templates).ConfigureAwait(false));
     }).WithName("ReplaceQueueEntries");
+
+    group.MapPut("{id}/template", async (string id, SetQueueTemplateLinkRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) => {
+      var queue = await repo.GetAsync(id).ConfigureAwait(false);
+      if (queue is null) return NotFound();
+      var templateId = req?.TemplateId;
+      if (!string.IsNullOrEmpty(templateId) && await templates.GetAsync(templateId).ConfigureAwait(false) is null)
+        return Error(400, "invalid_request", "template not found");
+      queue.LinkedTemplateId = string.IsNullOrEmpty(templateId) ? null : templateId;
+      var saved = await repo.UpdateAsync(queue).ConfigureAwait(false);
+      return Results.Ok(await BuildDetailAsync(saved, runtime, sequences, templates).ConfigureAwait(false));
+    }).WithName("SetQueueTemplateLink");
 
     group.MapDelete("{id}/entries/{entryId}", async (string id, string entryId, IQueueRepository repo, IQueueRuntimeStore runtime) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
@@ -109,16 +122,35 @@ internal static class QueuesEndpoints {
     return app;
   }
 
+  /// <summary>
+  /// Auto-loads the linked template's entries into the queue's runtime on the first display
+  /// after a service start. Skips when unlinked, running, or already materialized; clears and
+  /// persists a now-unresolvable link instead of erroring (FR-006/010/011/012).
+  /// </summary>
+  private static async Task MaybeAutoLoadAsync(ExecutionQueue queue, IQueueRepository repo, IQueueRuntimeStore runtime, IQueueTemplateRepository templates) {
+    if (string.IsNullOrEmpty(queue.LinkedTemplateId)) return;
+    if (runtime.GetStatus(queue.Id) == QueueExecutionStatus.Running) return;
+    if (runtime.HasRuntimeState(queue.Id)) return;
+    var template = await templates.GetAsync(queue.LinkedTemplateId).ConfigureAwait(false);
+    if (template is null) {
+      queue.LinkedTemplateId = null;
+      await repo.UpdateAsync(queue).ConfigureAwait(false);
+      return;
+    }
+    runtime.SetEntries(queue.Id, template.Entries.Select(e => e.SequenceId));
+  }
+
   private static QueueResponse BuildResponse(ExecutionQueue queue, IQueueRuntimeStore runtime) => new() {
     Id = queue.Id,
     Name = queue.Name,
     EmulatorSerial = queue.EmulatorSerial,
     CycleExecution = queue.CycleExecution,
     Status = runtime.GetStatus(queue.Id),
-    EntryCount = runtime.GetEntries(queue.Id).Count
+    EntryCount = runtime.GetEntries(queue.Id).Count,
+    LinkedTemplateId = queue.LinkedTemplateId
   };
 
-  private static async Task<QueueDetailResponse> BuildDetailAsync(ExecutionQueue queue, IQueueRuntimeStore runtime, ISequenceRepository sequences) {
+  private static async Task<QueueDetailResponse> BuildDetailAsync(ExecutionQueue queue, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) {
     var entries = runtime.GetEntries(queue.Id);
     var allSequences = await sequences.ListAsync().ConfigureAwait(false);
     var namesById = allSequences.ToDictionary(s => s.Id, s => s.Name, StringComparer.Ordinal);
@@ -128,13 +160,21 @@ internal static class QueuesEndpoints {
       EmulatorSerial = queue.EmulatorSerial,
       CycleExecution = queue.CycleExecution,
       Status = runtime.GetStatus(queue.Id),
-      EntryCount = entries.Count
+      EntryCount = entries.Count,
+      LinkedTemplateId = queue.LinkedTemplateId,
+      LinkedTemplateName = await ResolveTemplateNameAsync(queue.LinkedTemplateId, templates).ConfigureAwait(false)
     };
     foreach (var entry in entries) {
       var found = namesById.TryGetValue(entry.SequenceId, out var name);
       detail.Entries.Add(ProjectEntry(entry, found ? name : null));
     }
     return detail;
+  }
+
+  private static async Task<string?> ResolveTemplateNameAsync(string? templateId, IQueueTemplateRepository templates) {
+    if (string.IsNullOrEmpty(templateId)) return null;
+    var template = await templates.GetAsync(templateId).ConfigureAwait(false);
+    return template?.Name;
   }
 
   private static QueueEntryResponse ProjectEntry(QueueEntry entry, string? sequenceName) => new() {

--- a/src/web-ui/src/pages/Execution.tsx
+++ b/src/web-ui/src/pages/Execution.tsx
@@ -134,11 +134,10 @@ export const ExecutionPage: React.FC = () => {
     }
   }, [commands, selectedCommandId]);
 
-  useEffect(() => {
-    if (!selectedSequenceId && sequences.length > 0) {
-      setSelectedSequenceId(sequences[0].id);
-    }
-  }, [sequences, selectedSequenceId]);
+  // Derive the effective selection so the dropdown's value and the execute handler never
+  // diverge: a controlled <select> would otherwise default its DOM value to the first option
+  // while state lags behind a separate auto-select effect, leaving the handler reading undefined.
+  const effectiveSequenceId = selectedSequenceId ?? sequences[0]?.id;
 
   const selectedRunningSession = useMemo(() => {
     if (!selectedGameId || !selectedAdbSerial) return undefined;
@@ -234,7 +233,7 @@ export const ExecutionPage: React.FC = () => {
   };
 
   const handleExecuteSequence = async () => {
-    if (!selectedSequenceId) {
+    if (!effectiveSequenceId) {
       setSequenceError('Select a sequence to execute.');
       return;
     }
@@ -244,7 +243,7 @@ export const ExecutionPage: React.FC = () => {
     setSequenceError(undefined);
 
     try {
-      await executeSequence(selectedSequenceId, cachedSession?.sessionId);
+      await executeSequence(effectiveSequenceId, cachedSession?.sessionId);
       setSequenceMessage('Sequence executed successfully.');
     } catch (err: any) {
       if (err instanceof ApiError) {
@@ -426,7 +425,7 @@ export const ExecutionPage: React.FC = () => {
           <select
             id="sequence-select"
             aria-label="Sequence"
-            value={selectedSequenceId ?? ''}
+            value={effectiveSequenceId ?? ''}
             onChange={(e) => { setSelectedSequenceId(e.target.value); setSequenceMessage(undefined); setSequenceError(undefined); }}
             disabled={loadingSequences || executingSequence || sequences.length === 0}
           >

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -10,6 +10,7 @@ import {
   addQueueEntry,
   removeQueueEntry,
   replaceQueueEntries,
+  setQueueTemplateLink,
   startQueue,
   stopQueue,
 } from '../services/queues';
@@ -40,8 +41,8 @@ export const QueuesPage: React.FC = () => {
   const [detail, setDetail] = useState<QueueDetailDto | undefined>(undefined);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [associatedTemplateName, setAssociatedTemplateName] = useState<string | undefined>(undefined);
-  const [pendingLoad, setPendingLoad] = useState<{ name: string; sequenceIds: string[] } | undefined>(undefined);
-  const [pendingReload, setPendingReload] = useState<{ name: string; sequenceIds: string[] } | undefined>(undefined);
+  const [pendingLoad, setPendingLoad] = useState<{ name: string; sequenceIds: string[]; templateId: string } | undefined>(undefined);
+  const [pendingReload, setPendingReload] = useState<{ name: string; sequenceIds: string[]; templateId: string } | undefined>(undefined);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -82,9 +83,9 @@ export const QueuesPage: React.FC = () => {
     setCreating(false);
     setFieldErrors(undefined);
     setFormError(undefined);
-    setAssociatedTemplateName(undefined);
     const q = await getQueue(id);
     setDetail(q);
+    setAssociatedTemplateName(q.linkedTemplateName ?? undefined);
     setForm({ name: q.name, emulatorSerial: q.emulatorSerial, cycleExecution: q.cycleExecution });
   };
 
@@ -153,15 +154,17 @@ export const QueuesPage: React.FC = () => {
   const handleSaveTemplate = async (name: string, overwrite: boolean) => {
     if (!detail) return;
     const sequenceIds = detail.entries.map((e) => e.sequenceId);
-    await saveQueueTemplate({ name, sequenceIds, overwrite });
+    const saved = await saveQueueTemplate({ name, sequenceIds, overwrite });
+    await setQueueTemplateLink(detail.id, saved.id);
     setAssociatedTemplateName(name);
     setTableMessage(`Template "${name}" saved successfully.`);
   };
 
-  const applyLoad = async (name: string, sequenceIds: string[]) => {
+  const applyLoad = async (name: string, sequenceIds: string[], templateId: string) => {
     if (!detail) return;
     try {
       await replaceQueueEntries(detail.id, sequenceIds);
+      await setQueueTemplateLink(detail.id, templateId);
       setAssociatedTemplateName(name);
       setTableMessage(`Template "${name}" loaded.`);
       await reloadDetail(detail.id);
@@ -176,9 +179,9 @@ export const QueuesPage: React.FC = () => {
     const tpl = await getQueueTemplate(templateId);
     const sequenceIds = tpl.entries.map((e) => e.sequenceId);
     if (detail.entries.length > 0) {
-      setPendingLoad({ name: tpl.name, sequenceIds });
+      setPendingLoad({ name: tpl.name, sequenceIds, templateId: tpl.id });
     } else {
-      await applyLoad(tpl.name, sequenceIds);
+      await applyLoad(tpl.name, sequenceIds, tpl.id);
     }
   };
 
@@ -198,9 +201,9 @@ export const QueuesPage: React.FC = () => {
       const currentSeqIds = detail.entries.map((e) => e.sequenceId);
       if (sameSequenceOrder(currentSeqIds, templateSeqIds)) return; // nothing to discard, no prompt
       if (detail.entries.length > 0) {
-        setPendingReload({ name: tpl.name, sequenceIds: templateSeqIds });
+        setPendingReload({ name: tpl.name, sequenceIds: templateSeqIds, templateId: match.id });
       } else {
-        await applyLoad(tpl.name, templateSeqIds);
+        await applyLoad(tpl.name, templateSeqIds, match.id);
       }
     } catch (err: any) {
       setTableError(err instanceof ApiError ? err.message : err?.message ?? 'Failed to reload template');
@@ -217,7 +220,7 @@ export const QueuesPage: React.FC = () => {
         onConfirm: () => {
           const p = pendingLoad;
           setPendingLoad(undefined);
-          if (p) void applyLoad(p.name, p.sequenceIds);
+          if (p) void applyLoad(p.name, p.sequenceIds, p.templateId);
         },
       }
     : pendingReload
@@ -229,7 +232,7 @@ export const QueuesPage: React.FC = () => {
           onConfirm: () => {
             const p = pendingReload;
             setPendingReload(undefined);
-            if (p) void applyLoad(p.name, p.sequenceIds);
+            if (p) void applyLoad(p.name, p.sequenceIds, p.templateId);
           },
         }
       : undefined;

--- a/src/web-ui/src/pages/__tests__/QueuesPage.autoload.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.autoload.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueuesPage } from '../QueuesPage';
+import { listQueues, getQueue } from '../../services/queues';
+import { listSequences } from '../../services/sequences';
+import { listQueueTemplates } from '../../services/queueTemplates';
+
+jest.mock('../../services/queues');
+jest.mock('../../services/sequences');
+jest.mock('../../services/queueTemplates');
+jest.mock('../../services/useAdbDevices', () => ({
+  useAdbDevices: () => ({ devices: [{ serial: 'emu-1' }], loading: false, error: undefined, refresh: () => {} }),
+}));
+
+const listQueuesMock = listQueues as jest.MockedFunction<typeof listQueues>;
+const getQueueMock = getQueue as jest.MockedFunction<typeof getQueue>;
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+const listTemplatesMock = listQueueTemplates as jest.MockedFunction<typeof listQueueTemplates>;
+
+const queue = (over: Partial<any> = {}) => ({
+  id: 'q1', name: 'Daily', emulatorSerial: 'emu-1', cycleExecution: false,
+  status: 'Stopped', entryCount: 0, linkedTemplateId: null, ...over,
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  listQueuesMock.mockResolvedValue([queue()] as any);
+  listSequencesMock.mockResolvedValue([] as any);
+  listTemplatesMock.mockResolvedValue([] as any);
+});
+
+describe('QueuesPage auto-load on open (US1)', () => {
+  it('shows the linked template name and the auto-loaded entries when opening a linked queue', async () => {
+    getQueueMock.mockResolvedValue({
+      ...queue({ entryCount: 2, linkedTemplateId: 't1' }),
+      linkedTemplateName: 'Daily Farm',
+      entries: [
+        { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'A', stale: false },
+        { entryId: 'e2', sequenceId: 'seq-b', sequenceName: 'B', stale: false },
+      ],
+    } as any);
+
+    render(<QueuesPage />);
+    fireEvent.click(await screen.findByText('Daily'));
+    await screen.findByText('Edit Queue');
+
+    const controls = screen.getByRole('region', { name: 'Queue templates' });
+    expect(within(controls).getByText('Daily Farm')).toBeInTheDocument();
+    expect(screen.getAllByTestId('queue-entry')).toHaveLength(2);
+  });
+
+  it('shows "(no template)" when opening an unlinked queue', async () => {
+    getQueueMock.mockResolvedValue({
+      ...queue({ linkedTemplateId: null }),
+      linkedTemplateName: null,
+      entries: [],
+    } as any);
+
+    render(<QueuesPage />);
+    fireEvent.click(await screen.findByText('Daily'));
+    await screen.findByText('Edit Queue');
+
+    const controls = screen.getByRole('region', { name: 'Queue templates' });
+    expect(within(controls).getByText('(no template)')).toBeInTheDocument();
+  });
+});

--- a/src/web-ui/src/pages/__tests__/QueuesPage.link.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.link.spec.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { QueuesPage } from '../QueuesPage';
+import { listQueues, getQueue, replaceQueueEntries, setQueueTemplateLink } from '../../services/queues';
+import { listSequences } from '../../services/sequences';
+import { saveQueueTemplate, getQueueTemplate, listQueueTemplates } from '../../services/queueTemplates';
+
+jest.mock('../../services/queues');
+jest.mock('../../services/sequences');
+jest.mock('../../services/queueTemplates');
+jest.mock('../../services/useAdbDevices', () => ({
+  useAdbDevices: () => ({ devices: [{ serial: 'emu-1' }], loading: false, error: undefined, refresh: () => {} }),
+}));
+
+const listQueuesMock = listQueues as jest.MockedFunction<typeof listQueues>;
+const getQueueMock = getQueue as jest.MockedFunction<typeof getQueue>;
+const replaceEntriesMock = replaceQueueEntries as jest.MockedFunction<typeof replaceQueueEntries>;
+const setLinkMock = setQueueTemplateLink as jest.MockedFunction<typeof setQueueTemplateLink>;
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+const saveTemplateMock = saveQueueTemplate as jest.MockedFunction<typeof saveQueueTemplate>;
+const getTemplateMock = getQueueTemplate as jest.MockedFunction<typeof getQueueTemplate>;
+const listTemplatesMock = listQueueTemplates as jest.MockedFunction<typeof listQueueTemplates>;
+
+const queue = (over: Partial<any> = {}) => ({
+  id: 'q1', name: 'Daily', emulatorSerial: 'emu-1', cycleExecution: false,
+  status: 'Stopped', entryCount: 0, linkedTemplateId: null, ...over,
+});
+
+const emptyDetail = (over: Partial<any> = {}) => ({ ...queue(over), linkedTemplateName: null, entries: [] });
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  listQueuesMock.mockResolvedValue([queue()] as any);
+  listSequencesMock.mockResolvedValue([] as any);
+  getQueueMock.mockResolvedValue(emptyDetail() as any);
+  listTemplatesMock.mockResolvedValue([{ id: 't1', name: 'Daily Farm', entryCount: 1, createdAt: null, updatedAt: null }] as any);
+  getTemplateMock.mockResolvedValue({
+    id: 't1', name: 'Daily Farm', entryCount: 1, createdAt: null, updatedAt: null,
+    entries: [{ sequenceId: 'seq-x', sequenceName: 'X', stale: false }],
+  } as any);
+  replaceEntriesMock.mockResolvedValue({} as any);
+  setLinkMock.mockResolvedValue({} as any);
+});
+
+const openEdit = async () => {
+  render(<QueuesPage />);
+  fireEvent.click(await screen.findByText('Daily'));
+  await screen.findByText('Edit Queue');
+};
+
+describe('QueuesPage link wiring (US2)', () => {
+  it('links the queue to the loaded template id after loading', async () => {
+    await openEdit();
+    fireEvent.click(screen.getByText('(no template)'));
+    fireEvent.click(within(await screen.findByRole('region', { name: 'Load template' })).getByText('Load'));
+
+    await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-x']));
+    expect(setLinkMock).toHaveBeenCalledWith('q1', 't1');
+  });
+
+  it('links the queue to the saved template id after saving', async () => {
+    saveTemplateMock.mockResolvedValue({ id: 't9', name: 'Patrol', entryCount: 0, createdAt: null, updatedAt: null, entries: [] } as any);
+    await openEdit();
+    fireEvent.click(screen.getByText('Save Template'));
+    const section = await screen.findByRole('region', { name: 'Save template' });
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Patrol' } });
+    fireEvent.click(within(section).getByText('Save'));
+
+    await waitFor(() => expect(saveTemplateMock).toHaveBeenCalled());
+    expect(setLinkMock).toHaveBeenCalledWith('q1', 't9');
+  });
+});

--- a/src/web-ui/src/services/__tests__/queues.spec.ts
+++ b/src/web-ui/src/services/__tests__/queues.spec.ts
@@ -1,0 +1,31 @@
+import { setQueueTemplateLink } from '../queues';
+import { putJson } from '../../lib/api';
+
+jest.mock('../../lib/api', () => {
+  const actual = jest.requireActual('../../lib/api');
+  return {
+    ...actual,
+    getJson: jest.fn(),
+    postJson: jest.fn(),
+    putJson: jest.fn(),
+    deleteJson: jest.fn(),
+  };
+});
+
+describe('queues service - setQueueTemplateLink', () => {
+  const mockPutJson = putJson as jest.MockedFunction<typeof putJson>;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('sets the link via PUT with the template id', async () => {
+    mockPutJson.mockResolvedValue({} as any);
+    await setQueueTemplateLink('q1', 't1');
+    expect(mockPutJson).toHaveBeenCalledWith('/api/queues/q1/template', { templateId: 't1' });
+  });
+
+  it('clears the link via PUT with null', async () => {
+    mockPutJson.mockResolvedValue({} as any);
+    await setQueueTemplateLink('q1', null);
+    expect(mockPutJson).toHaveBeenCalledWith('/api/queues/q1/template', { templateId: null });
+  });
+});

--- a/src/web-ui/src/services/queues.ts
+++ b/src/web-ui/src/services/queues.ts
@@ -9,6 +9,7 @@ export type QueueDto = {
   cycleExecution: boolean;
   status: QueueStatus;
   entryCount: number;
+  linkedTemplateId: string | null;
 };
 
 export type QueueEntryDto = {
@@ -18,7 +19,10 @@ export type QueueEntryDto = {
   stale: boolean;
 };
 
-export type QueueDetailDto = QueueDto & { entries: QueueEntryDto[] };
+export type QueueDetailDto = QueueDto & {
+  entries: QueueEntryDto[];
+  linkedTemplateName: string | null;
+};
 
 export type QueueCreate = {
   name: string;
@@ -45,6 +49,9 @@ export const removeQueueEntry = (id: string, entryId: string) =>
   deleteJson<void>(`${base}/${id}/entries/${entryId}`);
 export const replaceQueueEntries = (id: string, sequenceIds: string[]) =>
   putJson<QueueDetailDto>(`${base}/${id}/entries`, { sequenceIds });
+
+export const setQueueTemplateLink = (id: string, templateId: string | null) =>
+  putJson<QueueDetailDto>(`${base}/${id}/template`, { templateId });
 
 export const startQueue = (id: string) => postJson<QueueDto>(`${base}/${id}/start`, {});
 export const stopQueue = (id: string) => postJson<QueueDto>(`${base}/${id}/stop`, {});

--- a/tests/contract/Queues/QueuesApiContractTests.cs
+++ b/tests/contract/Queues/QueuesApiContractTests.cs
@@ -44,7 +44,7 @@ public sealed class QueuesApiContractTests : IDisposable {
       new { name = "Farm", emulatorSerial = "emu-1", cycleExecution = true }).ConfigureAwait(true);
     createResp.StatusCode.Should().Be(HttpStatusCode.Created);
     var created = JsonDocument.Parse(await createResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
-    foreach (var field in new[] { "id", "name", "emulatorSerial", "cycleExecution", "status", "entryCount" }) {
+    foreach (var field in new[] { "id", "name", "emulatorSerial", "cycleExecution", "status", "entryCount", "linkedTemplateId" }) {
       created.TryGetProperty(field, out _).Should().BeTrue($"QueueResponse must expose '{field}'");
     }
     var id = created.GetProperty("id").GetString();
@@ -57,9 +57,18 @@ public sealed class QueuesApiContractTests : IDisposable {
       entry.TryGetProperty(field, out _).Should().BeTrue($"QueueEntryResponse must expose '{field}'");
     }
 
-    // Detail -> QueueDetailResponse shape (entries array present)
+    // Detail -> QueueDetailResponse shape (entries array + link fields present)
     var detail = JsonDocument.Parse(await (await client.GetAsync(new Uri($"/api/queues/{id}", UriKind.Relative)).ConfigureAwait(true)).Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
     detail.GetProperty("entries").ValueKind.Should().Be(JsonValueKind.Array);
+    foreach (var field in new[] { "linkedTemplateId", "linkedTemplateName" }) {
+      detail.TryGetProperty(field, out _).Should().BeTrue($"QueueDetailResponse must expose '{field}'");
+    }
+
+    // Set-template link -> 200 with QueueDetailResponse (clearing an already-null link is a no-op)
+    var linkResp = await client.PutAsJsonAsync(new Uri($"/api/queues/{id}/template", UriKind.Relative), new { templateId = (string?)null }).ConfigureAwait(true);
+    linkResp.StatusCode.Should().Be(HttpStatusCode.OK);
+    JsonDocument.Parse(await linkResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement
+      .GetProperty("entries").ValueKind.Should().Be(JsonValueKind.Array);
 
     // Start/stop -> 200 with QueueResponse
     (await client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);

--- a/tests/integration/Queues/QueueAutoLoadEndpointTests.cs
+++ b/tests/integration/Queues/QueueAutoLoadEndpointTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Queues;
+
+/// <summary>
+/// US1: a queue linked to a template auto-loads that template's entries into the queue's
+/// runtime on the first display after a service start (FR-006/006a/008/009/010/011/012).
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class QueueAutoLoadEndpointTests {
+  private readonly string _dataDir;
+
+  public QueueAutoLoadEndpointTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    _dataDir = TestEnvironment.PrepareCleanDataDir();
+  }
+
+  private void SeedSequence(string id, string name) {
+    var dir = Path.Combine(_dataDir, "commands", "sequences");
+    Directory.CreateDirectory(dir);
+    File.WriteAllText(Path.Combine(dir, id + ".json"), $"{{\"Id\":\"{id}\",\"Name\":\"{name}\"}}");
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static async Task<string> CreateQueueAsync(HttpClient client) {
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative), new { name = "Farm", emulatorSerial = "emu-1" }).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static async Task<string> CreateTemplateAsync(HttpClient client, params string[] sequenceIds) {
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Daily Farm", sequenceIds, overwrite = false }).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static Task<HttpResponseMessage> SetLinkAsync(HttpClient client, string queueId, string? templateId) =>
+    client.PutAsJsonAsync(new Uri($"/api/queues/{queueId}/template", UriKind.Relative), new { templateId });
+
+  private static async Task<JsonElement> GetDetailAsync(HttpClient client, string queueId) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{queueId}", UriKind.Relative)).ConfigureAwait(true);
+    resp.EnsureSuccessStatusCode();
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+  }
+
+  [Fact]
+  public async Task LinkedAndFreshMaterializesTemplateEntries() {
+    SeedSequence("seq-a", "Alpha");
+    SeedSequence("seq-b", "Beta");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplId = await CreateTemplateAsync(client, "seq-a", "seq-b").ConfigureAwait(true);
+    await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+
+    var detail = await GetDetailAsync(client, id).ConfigureAwait(true);
+
+    var entries = detail.GetProperty("entries");
+    entries.GetArrayLength().Should().Be(2);
+    entries[0].GetProperty("sequenceId").GetString().Should().Be("seq-a");
+    entries[1].GetProperty("sequenceId").GetString().Should().Be("seq-b");
+    detail.GetProperty("linkedTemplateId").GetString().Should().Be(tplId);
+    detail.GetProperty("linkedTemplateName").GetString().Should().Be("Daily Farm");
+  }
+
+  [Fact]
+  public async Task UnlinkedQueueIsNotAutoLoadedAndHasNoError() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+
+    var detail = await GetDetailAsync(client, id).ConfigureAwait(true);
+
+    detail.GetProperty("entries").GetArrayLength().Should().Be(0);
+    detail.GetProperty("linkedTemplateId").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  [Fact]
+  public async Task RunningQueueIsNotAutoLoaded() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplId = await CreateTemplateAsync(client, "seq-a").ConfigureAwait(true);
+    await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true);
+
+    var detail = await GetDetailAsync(client, id).ConfigureAwait(true);
+
+    detail.GetProperty("entries").GetArrayLength().Should().Be(0);
+  }
+
+  [Fact]
+  public async Task AlreadyMaterializedQueueIsNotRefilledAfterDeliberateClear() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplId = await CreateTemplateAsync(client, "seq-a").ConfigureAwait(true);
+    await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+
+    // First display materializes; then operator deliberately clears the entries.
+    await GetDetailAsync(client, id).ConfigureAwait(true);
+    await client.PutAsJsonAsync(new Uri($"/api/queues/{id}/entries", UriKind.Relative), new { sequenceIds = Array.Empty<string>() }).ConfigureAwait(true);
+
+    var detail = await GetDetailAsync(client, id).ConfigureAwait(true);
+
+    detail.GetProperty("entries").GetArrayLength().Should().Be(0);
+  }
+
+  [Fact]
+  public async Task MissingTemplateOnFreshDisplayClearsLinkAndOpensEmpty() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplId = await CreateTemplateAsync(client, "seq-a").ConfigureAwait(true);
+    await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+    await client.DeleteAsync(new Uri($"/api/queue-templates/{tplId}", UriKind.Relative)).ConfigureAwait(true);
+
+    var detail = await GetDetailAsync(client, id).ConfigureAwait(true);
+
+    detail.GetProperty("entries").GetArrayLength().Should().Be(0);
+    detail.GetProperty("linkedTemplateId").ValueKind.Should().Be(JsonValueKind.Null);
+    detail.GetProperty("linkedTemplateName").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  [Fact]
+  public async Task DeletedTemplateLeavesAlreadyMaterializedEntriesUnchanged() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplId = await CreateTemplateAsync(client, "seq-a").ConfigureAwait(true);
+    await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+
+    await GetDetailAsync(client, id).ConfigureAwait(true); // materialize
+    await client.DeleteAsync(new Uri($"/api/queue-templates/{tplId}", UriKind.Relative)).ConfigureAwait(true);
+
+    var detail = await GetDetailAsync(client, id).ConfigureAwait(true);
+
+    // Guard skips on existing runtime state: entries kept (FR-014), link not cleared mid-session.
+    detail.GetProperty("entries").GetArrayLength().Should().Be(1);
+    detail.GetProperty("linkedTemplateId").GetString().Should().Be(tplId);
+  }
+
+  [Fact]
+  public async Task AutoLoadSurvivesRestartAndIsRunnable() {
+    SeedSequence("seq-a", "Alpha");
+    var tplId = string.Empty;
+    string id;
+    using (var app = new WebApplicationFactory<Program>()) {
+      var client = NewClient(app);
+      id = await CreateQueueAsync(client).ConfigureAwait(true);
+      tplId = await CreateTemplateAsync(client, "seq-a").ConfigureAwait(true);
+      await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+    }
+
+    // "Restart": fresh app instance (new runtime store) against the same persisted data dir.
+    using var app2 = new WebApplicationFactory<Program>();
+    var client2 = NewClient(app2);
+    var detail = await GetDetailAsync(client2, id).ConfigureAwait(true);
+    detail.GetProperty("entries").GetArrayLength().Should().Be(1);
+
+    var startResp = await client2.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true);
+    JsonDocument.Parse(await startResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("entryCount").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task AutoLoadOfLargeTemplateIsWithinBudget() {
+    for (var i = 0; i < 100; i++) SeedSequence($"seq-{i}", $"S{i}");
+    var sequenceIds = new string[100];
+    for (var i = 0; i < 100; i++) sequenceIds[i] = $"seq-{i}";
+
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Big", sequenceIds, overwrite = false }).ConfigureAwait(true);
+    var tplId = JsonDocument.Parse(await tplResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+    await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+
+    var sw = Stopwatch.StartNew();
+    var detail = await GetDetailAsync(client, id).ConfigureAwait(true);
+    sw.Stop();
+
+    detail.GetProperty("entries").GetArrayLength().Should().Be(100);
+    sw.ElapsedMilliseconds.Should().BeLessThan(1000);
+  }
+}

--- a/tests/integration/Queues/QueueTemplateLinkEndpointTests.cs
+++ b/tests/integration/Queues/QueueTemplateLinkEndpointTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Queues;
+
+/// <summary>
+/// US2: PUT /api/queues/{id}/template sets or clears a queue's persisted linked template
+/// (FR-002/003/004/005). The link references the template by stable ID.
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class QueueTemplateLinkEndpointTests {
+  private readonly string _dataDir;
+
+  public QueueTemplateLinkEndpointTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    _dataDir = TestEnvironment.PrepareCleanDataDir();
+  }
+
+  private void SeedSequence(string id, string name) {
+    var dir = Path.Combine(_dataDir, "commands", "sequences");
+    Directory.CreateDirectory(dir);
+    File.WriteAllText(Path.Combine(dir, id + ".json"), $"{{\"Id\":\"{id}\",\"Name\":\"{name}\"}}");
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static async Task<string> CreateQueueAsync(HttpClient client, string name = "Farm") {
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative), new { name, emulatorSerial = "emu-1" }).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static async Task<string> CreateTemplateAsync(HttpClient client, string name, params string[] sequenceIds) {
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name, sequenceIds, overwrite = false }).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static Task<HttpResponseMessage> SetLinkAsync(HttpClient client, string queueId, string? templateId) =>
+    client.PutAsJsonAsync(new Uri($"/api/queues/{queueId}/template", UriKind.Relative), new { templateId });
+
+  private static async Task<string?> LinkedIdAsync(HttpClient client, string queueId) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{queueId}", UriKind.Relative)).ConfigureAwait(true);
+    var prop = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("linkedTemplateId");
+    return prop.ValueKind == JsonValueKind.Null ? null : prop.GetString();
+  }
+
+  [Fact]
+  public async Task SetLinkPersistsAcrossRestart() {
+    SeedSequence("seq-a", "Alpha");
+    string id, tplId;
+    using (var app = new WebApplicationFactory<Program>()) {
+      var client = NewClient(app);
+      id = await CreateQueueAsync(client).ConfigureAwait(true);
+      tplId = await CreateTemplateAsync(client, "T", "seq-a").ConfigureAwait(true);
+      (await SetLinkAsync(client, id, tplId).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    using var app2 = new WebApplicationFactory<Program>();
+    var client2 = NewClient(app2);
+    (await LinkedIdAsync(client2, id).ConfigureAwait(true)).Should().Be(tplId);
+  }
+
+  [Fact]
+  public async Task SetLinkToDifferentTemplateReplacesPrior() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var t1 = await CreateTemplateAsync(client, "T1", "seq-a").ConfigureAwait(true);
+    var t2 = await CreateTemplateAsync(client, "T2", "seq-a").ConfigureAwait(true);
+
+    await SetLinkAsync(client, id, t1).ConfigureAwait(true);
+    await SetLinkAsync(client, id, t2).ConfigureAwait(true);
+
+    (await LinkedIdAsync(client, id).ConfigureAwait(true)).Should().Be(t2);
+  }
+
+  [Fact]
+  public async Task SetLinkNullClearsTheLink() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplId = await CreateTemplateAsync(client, "T", "seq-a").ConfigureAwait(true);
+
+    await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
+    (await SetLinkAsync(client, id, null).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+    (await LinkedIdAsync(client, id).ConfigureAwait(true)).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task SetLinkToUnknownTemplateReturns400() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+
+    var resp = await SetLinkAsync(client, id, "ghost").ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var root = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    root.GetProperty("error").GetProperty("code").GetString().Should().Be("invalid_request");
+  }
+
+  [Fact]
+  public async Task SetLinkOnUnknownQueueReturns404() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    (await SetLinkAsync(client, "nope", null).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.NotFound);
+  }
+
+  [Fact]
+  public async Task SetLinkIsAllowedWhileRunning() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client).ConfigureAwait(true);
+    var tplId = await CreateTemplateAsync(client, "T", "seq-a").ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true);
+
+    (await SetLinkAsync(client, id, tplId).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+    (await LinkedIdAsync(client, id).ConfigureAwait(true)).Should().Be(tplId);
+  }
+
+  [Fact]
+  public async Task SettingOneQueuesLinkLeavesOtherQueuesAndTemplateUnchanged() {
+    SeedSequence("seq-a", "Alpha");
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var q1 = await CreateQueueAsync(client, "Q1").ConfigureAwait(true);
+    var q2 = await CreateQueueAsync(client, "Q2").ConfigureAwait(true);
+    var t1 = await CreateTemplateAsync(client, "T1", "seq-a").ConfigureAwait(true);
+    var t2 = await CreateTemplateAsync(client, "T2", "seq-a").ConfigureAwait(true);
+    await SetLinkAsync(client, q1, t1).ConfigureAwait(true);
+
+    await SetLinkAsync(client, q2, t2).ConfigureAwait(true);
+
+    (await LinkedIdAsync(client, q1).ConfigureAwait(true)).Should().Be(t1, "setting Q2's link must not change Q1's");
+    // Template T1's contents remain intact (one entry).
+    var t1Resp = await client.GetAsync(new Uri($"/api/queue-templates/{t1}", UriKind.Relative)).ConfigureAwait(true);
+    JsonDocument.Parse(await t1Resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("entries").GetArrayLength().Should().Be(1);
+  }
+}

--- a/tests/unit/Queues/FileQueueRepositoryTests.cs
+++ b/tests/unit/Queues/FileQueueRepositoryTests.cs
@@ -83,6 +83,33 @@ public sealed class FileQueueRepositoryTests : IDisposable {
   }
 
   [Fact]
+  public async Task UpdatePersistsLinkedTemplateId() {
+    var repo = NewRepo();
+    var created = await repo.CreateAsync(new ExecutionQueue { Name = "A", EmulatorSerial = "emu-1" }).ConfigureAwait(true);
+
+    created.LinkedTemplateId = "tpl-123";
+    await repo.UpdateAsync(created).ConfigureAwait(true);
+
+    var loaded = await repo.GetAsync(created.Id).ConfigureAwait(true);
+    loaded!.LinkedTemplateId.Should().Be("tpl-123");
+  }
+
+  [Fact]
+  public async Task LegacyQueueJsonWithoutLinkedTemplateIdLoadsAsUnlinked() {
+    var repo = NewRepo();
+    var dir = Path.Combine(_root, "queues");
+    Directory.CreateDirectory(dir);
+    // A queue document written before this feature: no LinkedTemplateId property.
+    await File.WriteAllTextAsync(Path.Combine(dir, "legacy.json"),
+      "{\"Id\":\"legacy\",\"Name\":\"Old\",\"EmulatorSerial\":\"emu-1\",\"CycleExecution\":false}").ConfigureAwait(true);
+
+    var loaded = await repo.GetAsync("legacy").ConfigureAwait(true);
+
+    loaded.Should().NotBeNull();
+    loaded!.LinkedTemplateId.Should().BeNull();
+  }
+
+  [Fact]
   public async Task GetWithUnsafeIdReturnsNull() {
     var repo = NewRepo();
     (await repo.GetAsync("../escape").ConfigureAwait(true)).Should().BeNull();

--- a/tests/unit/Queues/QueueRuntimeStoreHasStateTests.cs
+++ b/tests/unit/Queues/QueueRuntimeStoreHasStateTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using GameBot.Domain.Queues;
+using Xunit;
+
+namespace GameBot.UnitTests.Queues;
+
+public sealed class QueueRuntimeStoreHasStateTests {
+  [Fact]
+  public void HasRuntimeStateIsFalseBeforeAnyOperation() {
+    var store = new QueueRuntimeStore();
+    store.HasRuntimeState("q1").Should().BeFalse();
+  }
+
+  [Fact]
+  public void GetEntriesDoesNotMaterializeState() {
+    var store = new QueueRuntimeStore();
+    _ = store.GetEntries("q1");
+    store.HasRuntimeState("q1").Should().BeFalse();
+  }
+
+  [Fact]
+  public void HasRuntimeStateIsTrueAfterAddEntry() {
+    var store = new QueueRuntimeStore();
+    store.AddEntry("q1", "seq-a");
+    store.HasRuntimeState("q1").Should().BeTrue();
+  }
+
+  [Fact]
+  public void HasRuntimeStateIsTrueAfterSetEntries() {
+    var store = new QueueRuntimeStore();
+    var ids = new[] { "seq-a" };
+    store.SetEntries("q1", ids);
+    store.HasRuntimeState("q1").Should().BeTrue();
+  }
+
+  [Fact]
+  public void HasRuntimeStateIsTrueAfterSetStatus() {
+    var store = new QueueRuntimeStore();
+    store.SetStatus("q1", QueueExecutionStatus.Running);
+    store.HasRuntimeState("q1").Should().BeTrue();
+  }
+
+  [Fact]
+  public void HasRuntimeStateIsFalseAgainAfterRemove() {
+    var store = new QueueRuntimeStore();
+    store.AddEntry("q1", "seq-a");
+    store.Remove("q1");
+    store.HasRuntimeState("q1").Should().BeFalse();
+  }
+
+  [Fact]
+  public void HasRuntimeStateRemainsTrueWhenEntriesClearedButStateExists() {
+    var store = new QueueRuntimeStore();
+    store.AddEntry("q1", "seq-a");
+    store.SetEntries("q1", System.Array.Empty<string>());
+    store.GetEntries("q1").Should().BeEmpty();
+    store.HasRuntimeState("q1").Should().BeTrue();
+  }
+}


### PR DESCRIPTION
## Summary

Gives each queue an optional, **persisted** link to a single template (0..1; a template may be linked by 0..n queues) and **auto-loads** that template's entries into the queue's runtime when the queue's edit/detail page is opened. This converts the 047/048 UI-only "remembered template name" into a durable, ID-based association.

**No visual changes** — the link is established as a side effect of the existing load/save template flow.

## Behavior

- **Auto-load on open**: `GET /api/queues/{id}` materializes the linked template into the queue's runtime entries **once per service lifetime** — only on the first display after a restart (guarded by a new `HasRuntimeState`), never while Running, and never re-filling a deliberately emptied queue.
- **Link by stable ID**: renaming a template keeps the link; only deleting it breaks the link, in which case the link is cleared and persisted on next open (no error).
- **Set/clear**: `PUT /api/queues/{id}/template` (not Running-blocked, so save-while-running can still associate). Called by the existing load and save actions.
- **Server-side**: auto-loaded entries are real runtime entries, so the queue is immediately runnable after a restart.

## Changes

**Backend**
- `ExecutionQueue.LinkedTemplateId` (persisted; legacy queue JSON loads as unlinked — no migration)
- `IQueueRuntimeStore.HasRuntimeState` (first-display guard)
- `GET /api/queues/{id}` auto-load via `MaybeAutoLoadAsync`; new `PUT /api/queues/{id}/template`; responses expose `linkedTemplateId` / `linkedTemplateName`

**Frontend**
- `queues` service DTO fields + `setQueueTemplateLink`
- `QueuesPage` derives the associated name from the persisted link; load & save persist the link by id

## Testing

- Backend: **642 pass** (63 contract + 333 unit + 246 integration) — incl. auto-load matrix, link endpoint, `HasRuntimeState` lifecycle, backward-compat
- Web-ui: **317 pass** — incl. new autoload, link-wiring, and service specs
- Build clean; ESLint clean on all touched files

## Notes / scope

- The queues API is not present in `specs/openapi.json` (046–048 never added it); the contract is documented in `specs/049-queue-template-link/contracts/queue-template-link-api.md`.
- Known limitation (by design): starting a linked queue directly from the list after a restart runs it empty — auto-load is scoped to opening the editor.
- Pre-existing repo lint/`tsc` failures in unrelated files (commands/sequences/sessions) are out of scope and untouched.

Full spec/plan/tasks under `specs/049-queue-template-link/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
