### PR TITLE
Execution logs reflect what was actually executed (#049)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/048-edit-queue-layout"
+  "feature_directory": "specs/049-execution-logs-hierarchy"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Execution logs now reflect what was actually executed (049-execution-logs-hierarchy)
+  - The execution-logs list shows only top-level executed entities — stand-alone commands and sequences. Commands invoked as part of a sequence run are no longer separate top-level rows; they are recorded as linked children (kept, not deleted) and nested under their sequence.
+  - Top-level rows are now expandable: expanding a sequence reveals its ordered sub-elements (steps, invoked commands, primitive taps, conditions, loops, wait-for-image outcomes) with the same detail available before, and command sub-elements drill into their own primitive outcomes.
+  - A running sequence appears as a single in-progress entry (new `running` status) created at start and finalized in place when it completes; the page polls (~2s) while any entry is running so sub-elements update live without a manual reload.
+  - API: `GET /api/execution-logs` returns roots-only and each item gains `childCount`; `finalStatus` now includes `running`. New `GET /api/execution-logs/{id}/subtree` returns the nested execution tree.
+  - Performance: roots-only listing and subtree fetch are in-memory filters over the existing log store (no extra I/O on the hot path); live updates use a bounded ~2s poll gated on the presence of an in-progress entry (no polling when idle).
+  - Historical logs recorded before this change remain viewable as completed leaf rows (no migration required).
+
 ### Fixed
 - Sequence step command names are now preserved across save/reopen cycles (`001-fix-sequence-step-names`)
   - Reopening a saved sequence restores each step's selected command and user-visible label without reverting to "Select command".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 ﻿<!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/048-edit-queue-layout/plan.md
+at specs/049-execution-logs-hierarchy/plan.md
 <!-- SPECKIT END -->

--- a/specs/049-execution-logs-hierarchy/checklists/requirements.md
+++ b/specs/049-execution-logs-hierarchy/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Execution Logs Reflect What Was Actually Executed
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The user explicitly granted latitude to refactor the UI and execution-logs API; this is recorded as an assumption rather than an open clarification.
+- Real-time per-step updates are intentionally scoped as a desirable (P2) enhancement, with the completed-grouped-entry behavior as the mandatory bar — per the user's stated preference.

--- a/specs/049-execution-logs-hierarchy/contracts/execution-logs-hierarchy.openapi.yaml
+++ b/specs/049-execution-logs-hierarchy/contracts/execution-logs-hierarchy.openapi.yaml
@@ -1,0 +1,213 @@
+openapi: 3.0.3
+info:
+  title: Execution Logs API — Hierarchy & Live Updates
+  version: 1.1.0
+  description: >
+    Contract additions for feature 049. The execution-logs list now returns only
+    top-level (root) entries; invoked commands of a sequence are recorded as linked
+    children and exposed via a subtree endpoint for expandable, live-updating tree
+    rendering. Additive and backward compatible with the 1.0.0 contract.
+servers:
+  - url: http://localhost:5081
+paths:
+  /api/execution-logs:
+    get:
+      summary: List top-level execution logs
+      description: >
+        Returns ONLY top-level (root) execution entries — stand-alone commands and
+        sequences. Commands invoked as part of a sequence run are excluded (they are
+        children of their sequence root). Sorting/filtering/paging unchanged from 1.0.0.
+      operationId: listExecutionLogs
+      parameters:
+        - { name: sortBy, in: query, schema: { type: string, enum: [timestamp, objectName, status], default: timestamp } }
+        - { name: sortDirection, in: query, schema: { type: string, enum: [asc, desc], default: desc } }
+        - { name: filterTimestamp, in: query, schema: { type: string } }
+        - { name: filterObjectName, in: query, schema: { type: string } }
+        - { name: filterStatus, in: query, schema: { type: string } }
+        - { name: pageSize, in: query, schema: { type: integer, minimum: 1, maximum: 200, default: 50 } }
+        - { name: pageToken, in: query, schema: { type: string } }
+      responses:
+        '200':
+          description: Paged list of top-level execution log entries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionLogListResponse'
+        '401': { description: Unauthorized }
+
+  /api/execution-logs/{id}:
+    get:
+      summary: Get execution log detail
+      description: Detail for a single execution (root or child). Unchanged from 1.0.0 plus optional status field.
+      operationId: getExecutionLog
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: Execution detail.
+          content:
+            application/json:
+              schema: { type: object }
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/execution-logs/{id}/subtree:
+    get:
+      summary: Get the execution subtree (nested sub-elements)
+      description: >
+        Returns the execution identified by {id} together with its nested sub-elements
+        (steps, invoked commands, condition evaluations, loop iterations, wait outcomes)
+        as a tree. While the root is still running, the tree reflects the children
+        recorded so far (live progress); once finalized it reflects the complete picture.
+      operationId: getExecutionSubtree
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: The execution subtree.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionSubtreeResponse'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+components:
+  schemas:
+    ExecutionLogListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/ExecutionLogListItem' }
+        nextPageToken: { type: string, nullable: true }
+        nextCursor: { type: string, nullable: true }
+
+    ExecutionLogListItem:
+      type: object
+      required: [id, timestampUtc, executionType, finalStatus, childCount, objectRef, summary]
+      properties:
+        id: { type: string }
+        timestampUtc: { type: string, format: date-time }
+        executionType: { type: string, description: "command | sequence" }
+        finalStatus:
+          type: string
+          enum: [running, success, failure]
+          description: >
+            Single status field. Enum extended to include the in-progress 'running' state for
+            sequences; drives the in-progress indicator and the client polling decision.
+        childCount:
+          type: integer
+          minimum: 0
+          description: Number of direct children. 0 ⇒ leaf (not expandable).
+        objectRef: { $ref: '#/components/schemas/ObjectRef' }
+        hierarchy: { $ref: '#/components/schemas/Hierarchy' }
+        summary: { type: string }
+
+    ExecutionSubtreeResponse:
+      type: object
+      required: [executionId, finalStatus, root]
+      properties:
+        executionId: { type: string }
+        finalStatus:
+          type: string
+          enum: [running, success, failure]
+          description: Root lifecycle status — same field/enum as the list item's finalStatus.
+        root: { $ref: '#/components/schemas/ExecutionTreeNode' }
+
+    ExecutionTreeNode:
+      type: object
+      required: [nodeKind, order, label, status]
+      properties:
+        nodeKind:
+          type: string
+          enum: [sequence, command, step, condition, loop, loopIteration, wait, tap]
+        executionId:
+          type: string
+          nullable: true
+          description: Present when the node maps to a real execution entry (sequence/command).
+        order: { type: integer }
+        label: { type: string }
+        status:
+          type: string
+          enum: [running, success, failure, skipped, not_executed]
+        message: { type: string, nullable: true }
+        appliedDelayMs: { type: integer, nullable: true }
+        commandName: { type: string, nullable: true }
+        detailAttributes:
+          $ref: '#/components/schemas/WaitForImageDetailAttributes'
+          nullable: true
+        conditionTrace:
+          $ref: '#/components/schemas/ConditionTrace'
+          nullable: true
+        deepLink:
+          $ref: '#/components/schemas/AuthoringDeepLink'
+          nullable: true
+        children:
+          type: array
+          items: { $ref: '#/components/schemas/ExecutionTreeNode' }
+
+    ObjectRef:
+      type: object
+      required: [objectType, objectId, displayNameSnapshot]
+      properties:
+        objectType: { type: string }
+        objectId: { type: string }
+        displayNameSnapshot: { type: string }
+        versionSnapshot: { type: string, nullable: true }
+
+    Hierarchy:
+      type: object
+      required: [rootExecutionId, depth]
+      properties:
+        rootExecutionId: { type: string }
+        parentExecutionId: { type: string, nullable: true, description: "null ⇒ top-level (root)" }
+        depth: { type: integer }
+        sequenceIndex: { type: integer, nullable: true }
+
+    WaitForImageDetailAttributes:
+      type: object
+      properties:
+        timeoutMs: { type: integer, nullable: true }
+        effectiveTimeoutMs: { type: integer, nullable: true }
+        referenceImageId: { type: string, nullable: true }
+        confidence: { type: number, nullable: true }
+        exitCondition: { type: string, nullable: true, enum: [image_detected, timeout_elapsed, image_unavailable, null] }
+        imageLoadStatus: { type: string, nullable: true }
+
+    ConditionTrace:
+      type: object
+      required: [finalResult, selectedBranch]
+      properties:
+        finalResult: { type: boolean }
+        selectedBranch: { type: string }
+        failureReason: { type: string, nullable: true }
+
+    AuthoringDeepLink:
+      type: object
+      required: [sequenceId, sequenceLabel, stepLabel, resolutionStatus, directPath]
+      properties:
+        sequenceId: { type: string }
+        stepId: { type: string, nullable: true }
+        sequenceLabel: { type: string }
+        stepLabel: { type: string }
+        resolutionStatus: { type: string, enum: [resolved, step_missing, sequence_missing] }
+        directPath: { type: string }
+        fallbackRoute: { type: string, nullable: true }
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code: { type: string }
+            message: { type: string }
+            hint: { type: string, nullable: true }

--- a/specs/049-execution-logs-hierarchy/data-model.md
+++ b/specs/049-execution-logs-hierarchy/data-model.md
@@ -1,0 +1,110 @@
+# Phase 1 Data Model: Execution Logs Reflect What Was Actually Executed
+
+**Feature**: 049-execution-logs-hierarchy  
+**Date**: 2026-06-01
+
+This feature **reuses** the existing execution-log entities and adds a lifecycle status, populates the already-present hierarchy fields for child executions, and introduces a derived **subtree/tree-node** projection for the UI. No new persisted entity is introduced.
+
+## 1. ExecutionLogEntry (persisted) — modified
+
+Existing record ([ExecutionLogModels.cs](../../src/GameBot.Domain/Logging/ExecutionLogModels.cs)). Changes:
+
+| Field | Type | Change | Notes |
+|-------|------|--------|-------|
+| `FinalStatus` | string | **Values extended** | Now one of `running` (in-progress), `success`, `failure`. Was only `success`/`failure`. |
+| `Hierarchy.RootExecutionId` | string | **Now populated for children** | Child command of a sequence = the sequence root's id. Stand-alone = own id (unchanged). |
+| `Hierarchy.ParentExecutionId` | string? | **Now populated for children** | `null` ⇒ top-level (root). Set to the sequence root id for invoked commands. |
+| `Hierarchy.Depth` | int | **Now meaningful** | `0` = root (top-level); `1` = command invoked by a sequence; `>1` = nested sequence descendants. |
+| `Hierarchy.SequenceIndex` | int? | **Now populated for children** | The owning sequence step's order; used to correlate a child command entry to its root step outcome and to order tree nodes. |
+| (all other fields) | — | unchanged | `StepOutcomes`, `Details`, `ObjectRef`, `Navigation`, `RetentionExpiresUtc`, etc. |
+
+**Identity**: `Id` (unchanged). **Root rule**: an entry is *top-level* iff `ParentExecutionId is null`.
+
+### Lifecycle / state transitions (sequence root only)
+
+```
+            create (start)                 finalize (end)
+   (none) ───────────────▶  running  ───────────────▶  success | failure
+```
+
+- **Stand-alone command**: no `running` phase — logged once at completion as `success`/`failure` (unchanged behavior).
+- **Sequence**: `running` written at start; same entry **upserted** to `success`/`failure` with full summary + `StepOutcomes` at end.
+- **Crash/restart while running**: an entry may remain `running` (acceptable; not persisted-as-final). UI treats `running` older than the current run as stale — display as-is (no migration required, FR-012).
+
+## 2. Validation / invariants
+
+- A top-level (`ParentExecutionId is null`) entry MUST be the only kind returned by the default list query (FR-001/FR-002).
+- A child entry's `RootExecutionId` MUST equal the id of an existing (or in-progress) root entry; `Depth >= 1`.
+- `SequenceIndex` on a child MUST match the `StepOrder` of the root step that invoked it (correlation key for the tree, FR-006).
+- A sequence root's aggregate `FinalStatus` MUST reflect its children/steps: `failure` if any executed step/child failed; otherwise `success` (FR-005).
+- Finalizing a root MUST replace (upsert) the in-progress entry — never create a second physical entry for the same run (no duplicate rows).
+- `running` entries MUST be excluded from retention deletion until finalized (they have the same `RetentionExpiresUtc` logic; only finalize sets the meaningful expiry).
+
+## 3. Repository contract changes — `IExecutionLogRepository`
+
+| Method | Signature (conceptual) | Purpose |
+|--------|------------------------|---------|
+| `UpsertAsync` | `Task UpsertAsync(ExecutionLogEntry entry, CancellationToken)` | Write-or-replace by `Id` (file already overwrites; this fixes the in-memory cache to replace, not append). Used to finalize the in-progress root. |
+| `QueryAsync` | *extended* | Honors a roots-only filter (`ParentExecutionId is null`) — the default for the list endpoint. Existing sort/filter/paging unchanged. |
+| `GetSubtreeAsync` | `Task<IReadOnlyList<ExecutionLogEntry>> GetSubtreeAsync(string rootId, CancellationToken)` | Return the root plus all descendants (`RootExecutionId == rootId`), for the subtree endpoint. Recursive nesting via `ParentExecutionId`. |
+
+`ExecutionLogQuery` gains an internal `RootsOnly` flag (default `true` for the list endpoint).
+
+## 4. Derived projection: Execution Tree (not persisted) — new
+
+Returned by `GET /api/execution-logs/{id}/subtree`. Built server-side from the root entry's ordered `StepOutcomes` plus correlated child entries.
+
+### ExecutionTreeNodeDto
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `nodeKind` | string | `sequence` \| `command` \| `step` \| `condition` \| `loop` \| `loopIteration` \| `wait` \| `tap` |
+| `executionId` | string? | Set when the node maps to a real `ExecutionLogEntry` (root sequence or invoked command); enables drill-in/deep refresh. `null` for inline steps. |
+| `order` | int | Display order within parent (from `StepOrder` / `SequenceIndex` / iteration index). |
+| `label` | string | Step label / command name / human-readable node title. |
+| `status` | string | `running` \| `success` \| `failure` \| `skipped` \| `not_executed`. |
+| `message` | string? | Reason text / outcome message (as today). |
+| `appliedDelayMs` | int? | As today. |
+| `commandName` | string? | For command-backed steps. |
+| `detailAttributes` | wait-for-image attrs? | As today (timeout, image, confidence, exit condition, load status). |
+| `conditionTrace` | condition trace? | As today. |
+| `deepLink` | authoring deep link? | As today (sequence/step deep link with resolution status). |
+| `children` | `ExecutionTreeNodeDto[]` | Nested sub-elements (loop iterations, an invoked command's primitive outcomes, a nested sequence's steps). |
+
+### ExecutionSubtreeResponseDto
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `executionId` | string | Root id. |
+| `finalStatus` | string | Root lifecycle status (`running`/`success`/`failure`) — same field/enum as the entry's `finalStatus`. |
+| `root` | `ExecutionTreeNodeDto` | The tree root (the sequence or stand-alone command) with nested `children`. |
+
+**Provisional state**: while the root is `running`, `root.children` is assembled from the child execution entries recorded so far (subtree query) so the UI shows live progress; once finalized, it is assembled from the authoritative root `StepOutcomes` correlated to child entries (Decision 6 in research.md).
+
+## 5. List item additions — `ExecutionLogEntryDto` (list view)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `finalStatus` | string | **Enum extended** to `running`/`success`/`failure` (was `success`/`failure`). The single status field — it drives both the in-progress indicator and the client polling decision. No separate `status` mirror field is added. |
+| `childCount` | int | Number of direct children (0 ⇒ leaf, not expandable). Stand-alone commands and historical entries ⇒ 0. |
+
+(Existing list fields — `id`, `timestampUtc`, `executionType`, `objectRef`, `summary`, `hierarchy` — unchanged.)
+
+## 6. Frontend types (`executionLogsApi.ts`) — additions
+
+- `ExecutionLogEntryDto`: widen `finalStatus` to `'running' | 'success' | 'failure'` and add `childCount: number` (no separate `status` field).
+- New `ExecutionTreeNodeDto` and `ExecutionSubtreeResponseDto` (with `finalStatus`) mirroring section 4.
+- New `getSubtree(executionId): Promise<ExecutionSubtreeResponseDto>` calling `GET /api/execution-logs/{id}/subtree`.
+
+## 7. Entity relationship summary
+
+```
+ExecutionLogEntry (root, ParentExecutionId = null)
+   │  Hierarchy.RootExecutionId = self.Id
+   ├── ExecutionLogEntry (child command, Depth=1, ParentExecutionId=root, SequenceIndex=stepOrder)
+   │        └── (its own StepOutcomes: taps, waits — shown on expand)
+   └── ExecutionLogEntry (nested sequence, Depth=1) 
+            └── ExecutionLogEntry (its child commands, Depth=2, ParentExecutionId=nested seq)
+
+Execution Tree (derived) = root StepOutcomes (ordered) ⨝ child entries (by SequenceIndex)
+```

--- a/specs/049-execution-logs-hierarchy/plan.md
+++ b/specs/049-execution-logs-hierarchy/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Execution Logs Reflect What Was Actually Executed
+
+**Branch**: `049-execution-logs-hierarchy` | **Date**: 2026-06-01 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/049-execution-logs-hierarchy/spec.md`
+
+## Summary
+
+Today, executing a sequence pollutes the execution-logs list: the sequence runner's per-command callback calls `commandExecutor.ForceExecuteAsync`, which logs **each invoked command as its own top-level entry** (`Depth = 0`, no parent), and the endpoint then logs the **sequence** as another top-level entry. The list query never filters by hierarchy, so the user sees one row per invoked command plus one sequence row.
+
+This feature makes the execution-logs list show **only top-level executed entities** — stand-alone commands and sequences — with each sequence's invoked commands recorded as **linked children** (kept, not deleted) and rendered as **expandable tree rows** beneath the sequence. A sequence run produces a single **in-progress root entry** created at start, linked child command entries written as steps execute, and a finalized root entry (complete picture) at the end. The execution-logs UI **polls while any visible entry is in progress** so nested sub-elements update **live** without a manual reload.
+
+The data model already carries the needed `RootExecutionId` / `ParentExecutionId` / `Depth` / `SequenceIndex` hierarchy fields — they are simply not yet populated for child commands nor used to filter the list. The core work is: (1) link child command executions to the sequence root during execution, (2) create + finalize an in-progress root entry, (3) filter the list to roots-only and add a subtree/children endpoint, (4) support an in-progress lifecycle status and entry upsert in the repository, and (5) refactor the UI into a polling expandable tree.
+
+## Technical Context
+
+**Language/Version**: C# / .NET (GameBot.Service minimal API, GameBot.Domain) + TypeScript 5.6.3 / React 18.3.1 (web-ui)  
+**Primary Dependencies**: ASP.NET Core Minimal APIs, System.Text.Json; React, Vite 7.3.2, existing in-house hooks (`useNavigationCollapse`) and `getJson` API client  
+**Storage**: File-backed JSON per entry under `{storageRoot}/execution-logs/` via `FileExecutionLogRepository` (in-memory `ImmutableArray` cache)  
+**Testing**: xUnit (`tests/unit`, `tests/integration`, `tests/contract`) + Jest 29 + React Testing Library 14 (web-ui)  
+**Target Platform**: Windows desktop service + modern web browser (same as existing app)  
+**Project Type**: Web application (separate backend service + frontend SPA)  
+**Performance Goals**: List (roots-only) and subtree fetch reflected <1s at target scale (SC-006/SC-007); live sub-element updates visible within ~2s of a step completing (SC-005) via a 2s poll while in-progress  
+**Constraints**: CamelCase method names only (no underscores); functions ≤50 LOC; child records kept and filtered, not deleted (FR-002a); historical logs remain viewable (FR-012); no new runtime dependencies  
+**Scale/Scope**: Single-operator tool — hundreds to low-thousands of execution entries; a sequence run produces ~1 root + N child entries (N = invoked commands). Backend: extend log service/repository/endpoints + sequence-execute wiring. Frontend: rework `ExecutionLogs.tsx` list into an expandable polling tree.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+| Gate (from constitution) | Status | Notes |
+|--------------------------|--------|-------|
+| Lint/format/static analysis clean | Must pass | ESLint + .NET analyzers; enforced in CI |
+| No underscores in method names — CamelCase only | Must pass | New methods (`QueryRootsAsync`, `GetSubtreeAsync`, `UpsertAsync`, `LogSequenceStartAsync`) all CamelCase |
+| Functions ≤50 LOC | Must pass | Endpoints/handlers kept thin; projection/tree logic factored into helpers |
+| Unit ≥80% line / ≥70% branch on touched areas | Must pass | Tests planned for hierarchy linking, roots-only query, subtree projection, upsert, in-progress lifecycle, and UI tree/polling |
+| Deterministic, isolated, fast tests | Must pass | Repo tests use temp dirs; service tests use in-memory repo; UI mocks the execution-logs service and fake timers for polling |
+| UX consistency with existing conventions | Must pass | Reuses existing list/detail layout, `{ error: { code, message, hint } }` shape, phone/desktop responsive split, deep-link navigation |
+| Actionable error messages | Must pass | Subtree/not-found returns existing `not_found` shape; expand failures show inline hint |
+| Performance goals declared | ✅ Declared above | SC-005 (~2s live), SC-006/007 (<1s) |
+| Public API/contract documented | Must pass | `contracts/execution-logs-hierarchy.openapi.yaml` + DTO docs in `data-model.md`; `specs/openapi.json` + contract tests updated |
+| Observability | Must pass | Sequence start/finalize + child linking logged via existing `ILogger` |
+| No unjustified new dependencies | ✅ None added | Polling uses native `setInterval`; reuses existing stack |
+| Backward compatibility | Must pass | List response stays shape-compatible (adds `childCount`; widens `finalStatus` enum with `running`); historical entries (no in-progress status, no children) render as leaf roots |
+
+No constitution violations. No waivers required. No Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/049-execution-logs-hierarchy/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── execution-logs-hierarchy.openapi.yaml   # Phase 1 — list(roots) + subtree/children contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   └── Logging/
+│       ├── ExecutionLogModels.cs            # ExecutionLogEntry: add lifecycle status ("running"); reuse Hierarchy
+│       ├── IExecutionLogRepository.cs       # add UpsertAsync + roots-only / subtree query support
+│       └── FileExecutionLogRepository.cs    # in-memory upsert (replace by id); roots-only filter; subtree by root id
+├── GameBot.Service/
+│   ├── Services/
+│   │   ├── CommandExecutor.cs               # accept caller-supplied ExecutionLogContext (parent/root/depth) for child commands
+│   │   └── ExecutionLog/
+│   │       ├── ExecutionLogService.cs       # LogSequenceStartAsync (in-progress root) + finalize; subtree projection
+│   │       └── ExecutionLogContext.cs       # already supports parent/root/depth/sequenceIndex
+│   ├── Endpoints/
+│   │   └── ExecutionLogsEndpoints.cs        # list defaults roots-only; GET /{id}/subtree (or /children)
+│   ├── Models/
+│   │   └── ExecutionLogs.cs                 # DTOs: finalStatus(+running), childCount, subtree/tree-node DTO
+│   └── Program.cs                           # sequences/{id}/execute: create root, pass child context, finalize root
+└── web-ui/src/
+    ├── services/executionLogsApi.ts         # roots-only list types; getSubtree; finalStatus(+running)/childCount fields
+    └── pages/ExecutionLogs.tsx              # expandable tree rows + polling while in-progress
+
+tests/
+├── unit/ExecutionLogs/                      # hierarchy linking, roots-only query, upsert, subtree projection, status mapping
+├── integration/ExecutionLogs/              # sequence run → 1 root + linked children; list excludes children; live finalize
+├── contract/ExecutionLogs/                 # OpenAPI: list(roots) + subtree endpoint + new fields
+└── web-ui (Jest)                            # ExecutionLogs tree expand/collapse + polling (fake timers)
+```
+
+**Structure Decision**: Web application. Backend changes are localized to the existing `ExecutionLog` service/repository/endpoints plus the `sequences/{id}/execute` wiring in `Program.cs` and a small `CommandExecutor` change to accept a caller-supplied execution context. Frontend changes are localized to `executionLogsApi.ts` and `ExecutionLogs.tsx`. The execution **queue** (specs 046–048) is a status-flip placeholder with no real execution and produces no logs, so it is out of scope.
+
+## Complexity Tracking
+
+> No Constitution Check violations — section intentionally empty.

--- a/specs/049-execution-logs-hierarchy/quickstart.md
+++ b/specs/049-execution-logs-hierarchy/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Execution Logs Reflect What Was Actually Executed
+
+**Feature**: 049-execution-logs-hierarchy
+
+This guide validates the feature end-to-end after implementation.
+
+## Prerequisites
+
+- Service running (`GameBot.Service`) and web-ui dev server (or built bundle).
+- At least one game + ADB device/session available.
+- A **sequence** that invokes **two or more commands** (each command with at least one primitive tap / wait), plus one **stand-alone command** for the control case.
+
+## Scenario A — Sequence shows as one top-level entry with nested sub-elements (FR-001/002/003/003a)
+
+1. Open the **Execution** page; start a session.
+2. Execute the multi-command sequence.
+3. Open **Execution Logs**.
+4. **Expect**: exactly **one new top-level row** for the sequence run. No standalone rows for the commands the sequence invoked.
+5. Expand the sequence row.
+6. **Expect**: nested tree rows for each step in order — command-backed steps show the command name; conditions show their result; loops show iterations; waits show wait details; each shows applied delay. Expanding a command-backed step reveals that command's own primitive/tap/wait outcomes.
+7. **Expect**: 100% of the detail visible today (taps, reasons, condition traces, wait timeouts, deep links) is reachable through expansion (SC-002, SC-007).
+
+## Scenario B — Stand-alone command still appears as its own entry (FR-004)
+
+1. From the Execution page, execute the stand-alone command directly.
+2. Open **Execution Logs**.
+3. **Expect**: a single top-level row for that command with full details, exactly as before. It is a leaf (no expand affordance, `childCount = 0`).
+
+## Scenario C — Live updates during a running sequence (FR-007/008, SC-005)
+
+1. Execute a longer-running sequence (multiple commands / waits).
+2. Open **Execution Logs** while it is still running (or keep the page open from before starting).
+3. **Expect**: a single **in-progress** top-level entry (status `running`) for the run — and **no** standalone child-command rows.
+4. Expand it.
+5. **Expect**: sub-elements appear/update as steps complete, without a manual page reload (polling ~2s).
+6. When the sequence finishes:
+7. **Expect**: the **same** top-level entry settles into its final state (`success`/`failure`) with all nested sub-elements and the correct aggregate status (FR-005).
+
+## Scenario D — Nested sequences (FR-009)
+
+1. Execute a sequence that invokes another sequence.
+2. **Expect**: the nested sequence appears as an expandable node **under** the parent sequence, with its own sub-elements — never as a separate top-level row for that run.
+
+## Scenario E — Filtering / sorting over roots only (FR-010, SC-006)
+
+1. In Execution Logs, sort by Object Name and by Status; apply object-name and status filters.
+2. **Expect**: results contain only top-level entries; no child-command rows leak into results; counts/order are correct.
+
+## Scenario F — Historical logs (FR-012)
+
+1. Confirm logs recorded before this change still appear in the list and open without error (rendered as completed leaf roots).
+
+## API checks (optional, via curl/REST client)
+
+```bash
+# Roots only — should NOT include commands invoked by a sequence run
+GET /api/execution-logs
+
+# Subtree of a sequence run — root + nested sub-elements
+GET /api/execution-logs/{sequenceExecutionId}/subtree
+```
+
+- `GET /api/execution-logs` items each include `status` and `childCount`.
+- `GET /api/execution-logs/{id}/subtree` returns `{ executionId, status, root: { ...children[] } }`.
+- A child command's own execution detail is still retrievable via `GET /api/execution-logs/{childId}` (kept, just filtered from the list).
+
+## Automated test verification
+
+```powershell
+dotnet test                      # backend unit/integration/contract (ExecutionLogs/*)
+npm --prefix src/web-ui test     # web-ui Jest (ExecutionLogs tree + polling)
+```
+
+**Expect**: all green, including new tests for roots-only listing, child linkage, subtree projection, in-progress→final upsert, and the UI expandable-tree + polling behavior. Coverage on touched areas ≥80% line / ≥70% branch.

--- a/specs/049-execution-logs-hierarchy/research.md
+++ b/specs/049-execution-logs-hierarchy/research.md
@@ -1,0 +1,76 @@
+# Phase 0 Research: Execution Logs Reflect What Was Actually Executed
+
+**Feature**: 049-execution-logs-hierarchy  
+**Date**: 2026-06-01
+
+All Technical Context items are known (the feature extends an existing subsystem). This document records the key investigation findings and the design decisions that resolve them. There are no open `NEEDS CLARIFICATION` items (the three clarifications were resolved in the spec on 2026-06-01).
+
+## Finding 1 — Root cause of the duplicated/flat entries
+
+**Investigation**: `sequences/{id}/execute` ([Program.cs:822-877](../../src/GameBot.Service/Program.cs)) drives `SequenceRunner.ExecuteAsync` with an `executeCommandAsync` callback that calls `commandExecutor.ForceExecuteAsync(sessionId, commandId, ct)`. `ForceExecuteAsync` → `ForceExecuteDetailedAsync` ([CommandExecutor.cs:61-84](../../src/GameBot.Service/Services/CommandExecutor.cs)) **always** logs a command entry with `new ExecutionLogContext { Depth = 0 }` — no parent/root. After the runner finishes, the endpoint logs the sequence entry, also `Depth = 0` ([Program.cs:1016](../../src/GameBot.Service/Program.cs)). `FileExecutionLogRepository.QueryAsync` ([FileExecutionLogRepository.cs:45-99](../../src/GameBot.Domain/Logging/FileExecutionLogRepository.cs)) never filters by hierarchy.
+
+**Conclusion**: The list shows every command (one row each) plus the sequence, all flat. The fix is to (a) link child command executions to the sequence root, and (b) filter the list to roots-only.
+
+## Decision 1 — Reuse the existing hierarchy fields; do not invent new ones
+
+- **Decision**: Populate the already-existing `ExecutionHierarchyContext` (`RootExecutionId`, `ParentExecutionId`, `Depth`, `SequenceIndex`) for child command executions during a sequence run, and treat a "root" entry as `ParentExecutionId == null` (equivalently `Depth == 0`).
+- **Rationale**: The model, builder ([ExecutionHierarchyBuilder.cs](../../src/GameBot.Service/Services/ExecutionLog/ExecutionHierarchyBuilder.cs)), DTOs, and persisted JSON all already carry these fields; they are just unset for children. Reusing them is the least-disruptive change (clarification: "keep recording each child execution but link it to a parent/root").
+- **Alternatives considered**: A brand-new "grouping id" field — rejected as redundant with `RootExecutionId`. Deleting/suppressing child records entirely — rejected by clarification (records must be kept, only filtered from the list).
+
+## Decision 2 — Pass a caller-supplied execution context into `CommandExecutor`
+
+- **Decision**: Add a `ForceExecuteDetailedAsync` overload (and `ForceExecuteAsync` overload) accepting an optional `ExecutionLogContext`. The sequence-execute callback supplies `{ ParentExecutionId = rootId, RootExecutionId = rootId, Depth = 1, SequenceIndex = <step order>, SequenceId, SequenceLabel }`. Direct (stand-alone) command execution keeps `Depth = 0` / no parent.
+- **Rationale**: Keeps command logging in one place; the only new information is the parent linkage, supplied by the caller that knows it. CamelCase, small surface.
+- **Alternatives considered**: An ambient/`AsyncLocal` execution scope — rejected as implicit and harder to test deterministically. Logging children from the endpoint instead of the executor — rejected because the executor owns the per-command outcome detail.
+
+## Decision 3 — In-progress root entry + finalize (lifecycle status)
+
+- **Decision**: Add a `LogSequenceStartAsync` that writes an **in-progress** root entry (new `FinalStatus` value `"running"`) before the runner starts, returning its id to use as the root/parent id for children. After the runner completes, **update** that same entry in place to `success`/`failure` with the full summary + `StepOutcomes`. `NormalizeStatus` is extended to allow `running` (in addition to `success`/`failure`).
+- **Rationale**: Satisfies FR-007 (single in-progress top-level entry while running) and FR-008/SC-005 (the entry settles into its final state). Stand-alone commands remain single-shot (logged once at completion) — they need no in-progress phase for this feature.
+- **Alternatives considered**: Only writing the root at the end — rejected because then nothing represents the running sequence and live updates are impossible. A separate "sessions/in-flight" store — rejected as duplicative of the log store.
+
+## Decision 4 — Repository upsert (replace-by-id)
+
+- **Decision**: Add `UpsertAsync` to `IExecutionLogRepository` / `FileExecutionLogRepository`. The file write already overwrites by id (`File.Create`), but the in-memory `ImmutableArray` currently appends unconditionally ([FileExecutionLogRepository.cs:28-30](../../src/GameBot.Domain/Logging/FileExecutionLogRepository.cs)); upsert replaces the matching in-memory element (or appends if absent) so finalizing the root does not create a duplicate.
+- **Rationale**: Required to finalize the in-progress root without a duplicate row. Minimal, localized.
+- **Alternatives considered**: Keep `AddAsync` append-only and dedupe at query time — rejected as fragile (two physical rows, ordering ambiguity).
+
+## Decision 5 — Roots-only list + subtree endpoint
+
+- **Decision**:
+  - List (`GET /api/execution-logs`) returns **roots only** (`ParentExecutionId == null`) by default. Add an optional `includeChildren=false` (default) / explicit override only if needed for tests; the default behavior is roots-only.
+  - Add `GET /api/execution-logs/{id}/subtree` returning the root entry plus its descendant entries (ordered by `SequenceIndex`, recursive for nested sequences) as a tree, so the UI can render and lazily expand nested rows.
+  - Each list item gains `childCount` and its `finalStatus` enum is widened to include `running`, so the UI knows a row is expandable and whether to keep polling. No separate `status` mirror field is added (avoids two fields carrying the same data).
+- **Rationale**: Roots-only directly fixes the pollution (FR-001/FR-002). A dedicated subtree endpoint keeps the list light and supports lazy expansion + nested sequences (FR-003a/FR-009). `childCount` + the widened `finalStatus` drive expansion affordance and polling.
+- **Alternatives considered**: Embedding the full subtree in every list item — rejected (heavier payload, most rows never expanded). Client-side reconstruction from a flat "include children" list — viable but pushes tree-assembly + nested-sequence recursion into the client; the server-built subtree is simpler and testable. Keeping subtree assembly server-side is preferred.
+
+## Decision 6 — Nested tree content: combine root step outcomes with linked child detail
+
+- **Decision**: The root sequence entry's `StepOutcomes` remain the authoritative **ordered** list of sub-elements (steps, command names, condition traces, loop iterations, wait details, applied delays — the complete "today" picture). Command-backed steps are correlated to their child execution entry via `SequenceIndex`; expanding such a step reveals that command's own primitive/tap/wait outcomes (from the child entry). While the sequence is still running and the root's `StepOutcomes` are not yet finalized, the UI shows the child entries recorded so far (from the subtree endpoint) as provisional nodes.
+- **Rationale**: Preserves 100% of today's detail (SC-002) while honoring "keep & link child records." Correlating by `SequenceIndex` avoids inventing a new cross-reference id.
+- **Alternatives considered**: Rebuilding the entire tree purely from child execution entries — rejected because non-command steps (inline conditions, loops, waits) are not separate executions and live only in the root's step outcomes.
+
+## Decision 7 — Real-time via polling (no streaming infra)
+
+- **Decision**: The `ExecutionLogs` page polls the list on an interval (~2s) **while any visible entry has `status == "running"`**, and re-fetches the subtree of any expanded in-progress root. Polling stops when nothing is in progress.
+- **Rationale**: The app has no SSE/WebSocket infrastructure; introducing it would add dependencies and violate the "no unjustified new dependencies" gate. Child command entries are already written in real time during the synchronous run, so polling surfaces live progress. ~2s meets SC-005. Existing UI uses manual `refresh()` patterns; a bounded interval is a small, conventional addition.
+- **Alternatives considered**: Server-Sent Events / WebSockets — rejected for scope/dependency cost; can be a future enhancement. Always-on polling — rejected (wasteful when idle); gate polling on presence of an in-progress entry.
+
+## Decision 8 — Backward compatibility for historical logs
+
+- **Decision**: Entries persisted before this change have no `running` status and no linked children; they are treated as completed leaf roots (`childCount = 0`, not expandable) and continue to render and open normally (FR-012). The list/detail DTOs add only optional fields.
+- **Rationale**: Avoids a migration; old JSON deserializes with default/empty hierarchy → treated as root. Contract stays additive/backward-compatible (validated by `OpenApiBackwardCompatTests`).
+- **Alternatives considered**: A one-time migration to re-group historical logs — rejected (clarification says historical logs need not be re-grouped, only remain viewable).
+
+## Summary of decisions
+
+| # | Decision |
+|---|----------|
+| 1 | Reuse existing `Root/Parent/Depth/SequenceIndex` hierarchy fields; root = no parent |
+| 2 | `CommandExecutor` accepts a caller-supplied `ExecutionLogContext` for child linkage |
+| 3 | In-progress root entry created at start, finalized at end; add `running` status |
+| 4 | Repository `UpsertAsync` (replace-by-id) to finalize without duplicates |
+| 5 | List returns roots-only; new `GET /{id}/subtree`; list items gain `childCount` and widened `finalStatus` (incl. `running`) — no separate `status` field |
+| 6 | Tree = root step outcomes (ordered, complete) correlated to child entries by `SequenceIndex` |
+| 7 | Real-time via ~2s polling gated on in-progress entries; no streaming infra |
+| 8 | Historical logs render as completed leaf roots; additive, backward-compatible contract |

--- a/specs/049-execution-logs-hierarchy/spec.md
+++ b/specs/049-execution-logs-hierarchy/spec.md
@@ -1,0 +1,120 @@
+# Feature Specification: Execution Logs Reflect What Was Actually Executed
+
+**Feature Branch**: `049-execution-logs-hierarchy`  
+**Created**: 2026-06-01  
+**Status**: Draft  
+**Input**: User description: "Let's change the logic of the execution logs a bit. I want to have a clear view of what's been executed. At the moment, if I execute sequence, then I see in the real time the execution logs of the individual commands from it, but nothing else and at the end of sequence execution I see the whole picture: with all the sequence of steps, primitive actions, etc. In this particular case, I want to see only the sequence with the subelements under it. Ideally it should work in the real time (with updates of the steps as they progress), but it's ok to see the proper results once the sequence ends. You may need to refactor the UI and API for that, that's OK, just make sure the execution logs contain the things what actually have been executed: stand-alone commands or sequences with all the information provided as today."
+
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: How should child commands invoked by a sequence be stored, given the goal of showing only the sequence at the top level? → A: Keep recording each child execution but link it to a parent/root execution; show only root entries in the top-level list (child records are filtered out of the list, not deleted).
+- Q: Where should the sequence's nested sub-elements be displayed? → A: As expandable/collapsible tree rows inline in the execution logs list (each top-level row can be expanded to reveal nested sub-elements).
+- Q: Should live, per-step updates during a running sequence be built now, or deferred? → A: Include live updates now — sub-elements update as steps progress without requiring a manual reload.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Executed sequence appears as a single entry with its sub-elements nested (Priority: P1)
+
+A user runs a sequence. They open the execution logs and see **one** entry representing that sequence run. Expanding it reveals the ordered sub-elements (steps, the commands those steps invoked, primitive actions, condition evaluations, loop iterations, wait-for-image outcomes) — exactly the information available today — grouped beneath the sequence. The individual commands that the sequence invoked do **not** appear as their own separate top-level entries in the list.
+
+**Why this priority**: This is the core of the request. Today a single sequence run pollutes the log list with one row per invoked command plus a separate sequence row, making it impossible to tell at a glance "what did I actually run." Fixing the top-level grouping delivers the primary value on its own.
+
+**Independent Test**: Execute a sequence that invokes multiple commands, then open the execution logs. Verify the list contains a single new top-level row (the sequence) and that all per-command/per-step detail is reachable underneath it, with no separate top-level rows for the invoked commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence that invokes three commands, **When** the user executes the sequence and opens the execution logs, **Then** exactly one new top-level entry (the sequence) appears in the list.
+2. **Given** the completed sequence entry, **When** the user views/expands its details, **Then** all sub-elements (steps, invoked command names, primitive actions, conditions, loops, wait outcomes, applied delays) are shown nested under the sequence with the same depth of information available today.
+3. **Given** a sequence run, **When** the user scans the top-level list, **Then** none of the commands invoked as part of that sequence appear as standalone top-level entries.
+
+---
+
+### User Story 2 - Stand-alone command execution still appears as its own entry (Priority: P1)
+
+A user executes a single command directly (not as part of a sequence). The execution logs show that command as its own top-level entry, with all of its details (primitive actions, taps, wait-for-image outcomes, applied delays) exactly as today.
+
+**Why this priority**: The request explicitly says the log should contain "stand-alone commands or sequences." Directly-executed commands are first-class top-level items and must not be lost or hidden by the grouping change.
+
+**Independent Test**: Execute a command directly from the Execution page, open the execution logs, and verify a single top-level entry for that command with full details.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command executed directly (not via a sequence), **When** the user opens the execution logs, **Then** the command appears as its own top-level entry.
+2. **Given** a directly-executed command entry, **When** the user views its details, **Then** all step/primitive/wait/delay information available today is present.
+
+---
+
+### User Story 3 - Progress updates live during sequence execution (Priority: P2)
+
+While a sequence is running, the user sees a single in-progress top-level entry for that run, and its nested sub-elements update live as steps progress — without requiring a manual page reload. At no point does the list show orphaned standalone command rows for that run. Once the sequence finishes, the entry settles into its final, complete grouped state.
+
+**Why this priority**: Grouping correctness (P1) is the foundation and must land first; live updates build on top of that same grouped entry. Live progress is in scope for this feature but depends on P1 being correct.
+
+**Independent Test**: Start a longer-running sequence and observe the execution logs. Confirm a single in-progress sequence entry is shown, its sub-elements update as steps complete without a manual reload, and no standalone child-command rows ever appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence is executing, **When** the user views the execution logs before it finishes, **Then** they see a single in-progress top-level entry for that run and no standalone top-level rows for the sequence's invoked commands.
+2. **Given** a step within a running sequence completes, **When** the user is viewing the execution logs, **Then** the corresponding sub-element under the sequence entry reflects its outcome live, without requiring a manual page reload.
+3. **Given** a sequence finishes executing, **When** the user views the execution logs, **Then** the same top-level entry is shown in its final state with all nested sub-elements and the correct aggregate status.
+
+---
+
+### Edge Cases
+
+- **Nested sequences**: When a sequence invokes another sequence, the nested sequence and its sub-elements appear grouped beneath the parent sequence, and the nested sequence does not appear as a separate top-level entry for that run.
+- **Failed / partial runs**: A sequence that fails partway still appears as a single top-level entry whose status reflects the failure, with sub-elements showing which steps succeeded, failed, were skipped, or never ran.
+- **Loops**: A loop step shows its per-iteration outcomes nested under the sequence as it does today, not as separate top-level entries.
+- **Command reused across runs**: The same command invoked by a sequence today and executed stand-alone tomorrow yields two distinct, correctly-attributed entries (one nested, one top-level).
+- **Empty / no-op steps**: Skipped steps or steps whose condition evaluated false are still represented as sub-elements (with skipped/not-executed status), not omitted.
+- **Existing/historical logs**: Logs recorded before this change are still viewable; they are not required to be retroactively re-grouped, but they must not cause errors in the list.
+- **Concurrent executions**: If two sequences (or a sequence and a stand-alone command) run close together, each maps to its own correctly-grouped top-level entry without sub-elements leaking between them.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The execution logs list MUST show only top-level executed entities — a stand-alone command (one executed directly) or a sequence — as its rows.
+- **FR-002**: A command that is invoked as part of a sequence run MUST NOT appear as a separate top-level row for that run; it MUST be represented as a sub-element of that sequence's entry.
+- **FR-002a**: The system MUST continue to record each child execution as its own underlying record, linked to its parent and root execution; child records MUST be filtered out of the top-level list rather than deleted, so that the parent/child/root relationship is preserved for nesting and possible future drill-down.
+- **FR-003**: A sequence entry MUST expose all of its executed sub-elements (ordered steps, the commands those steps invoked, primitive actions/taps, condition evaluations, loop iterations and their per-iteration outcomes, wait-for-image outcomes, and applied delays) with at least the same depth of information available today.
+- **FR-003a**: Top-level rows in the execution logs list MUST be expandable/collapsible, revealing their nested sub-elements inline as tree rows; sub-elements that are themselves containers (e.g., a nested sequence or a loop) MUST also be expandable to show their own children.
+- **FR-004**: A stand-alone command entry MUST continue to display all of its details (primitive actions, taps, wait-for-image outcomes, applied delays, reasons) exactly as today.
+- **FR-005**: Each top-level entry MUST display its overall final status, and that status MUST correctly reflect the aggregate outcome of its sub-elements (e.g., a sequence with a failed step is not reported as fully successful).
+- **FR-006**: The system MUST correctly attribute every sub-element to its owning top-level execution so that details from different runs never intermingle.
+- **FR-007**: During sequence execution, the execution logs MUST NOT present orphaned standalone command rows for commands invoked by that sequence; the running sequence MUST be represented as a single in-progress top-level entry.
+- **FR-008**: The execution logs MUST update live during a running sequence so that nested sub-elements reflect their outcomes as steps progress, without requiring a manual page reload; the same top-level entry MUST settle into its final, complete grouped state once execution ends.
+- **FR-009**: Nested sequences (a sequence invoking another sequence) MUST be represented hierarchically under the parent sequence rather than as separate top-level entries for that run.
+- **FR-010**: Existing filtering and sorting of the execution logs list MUST continue to operate over the top-level entries (e.g., by timestamp, object name, status).
+- **FR-011**: Deep links / navigation from a sub-element to its underlying authored object (e.g., the sequence step or command) MUST continue to work where that information is available today.
+- **FR-012**: Historical execution logs recorded before this change MUST remain viewable without errors.
+
+### Key Entities *(include if data involved)*
+
+> Terminology: a **sub-element** in this spec corresponds to an **execution tree node** (`ExecutionTreeNode`) in the plan/data-model/contracts; the two terms are interchangeable.
+
+- **Execution Entry (top-level)**: Represents one user-initiated execution that actually ran — either a stand-alone command or a sequence. Attributes: timestamp, executed object reference (name/type), overall final status (including an in-progress state while running), summary, and an ordered collection of sub-elements. This is the only level shown as top-level rows in the list.
+- **Sub-element (nested)**: Represents something that happened within a top-level execution — a sequence step, an invoked command, a primitive action/tap, a condition evaluation, a loop and its iterations, or a wait-for-image outcome. Attributes mirror what is captured today (status, reason, applied delay, command name, condition trace, wait details, deep link). Each invoked-command sub-element continues to exist as its own underlying record, linked to its parent and root execution and filtered out of the top-level list (not deleted).
+- **Execution hierarchy/relationship**: The parent/child/root association that ties sub-elements to their owning top-level execution, distinguishes root (top-level) from child records for list filtering, and supports nested sequences.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After executing any single sequence, the execution logs list shows exactly one new top-level row for that run (regardless of how many commands the sequence invoked).
+- **SC-002**: 100% of the information available today for invoked commands and steps remains reachable from the sequence entry (no detail is lost relative to the current behavior).
+- **SC-003**: After executing a stand-alone command, the execution logs list shows exactly one new top-level row for that command with full details.
+- **SC-004**: A user can determine "what did I actually run" from the top-level list alone, without needing to mentally filter out child-command noise — verified by zero standalone rows for sequence-invoked commands.
+- **SC-005**: While a sequence runs, its in-progress entry's sub-elements reflect each completed step live (within ~2 seconds of the step completing) without a manual page reload, and the entry shows its final complete state within ~2 seconds of the sequence finishing.
+- **SC-006**: Sorting and filtering the execution logs returns correct results over top-level entries only, with no child-command rows leaking into results.
+- **SC-007**: A user can expand any top-level entry to reveal its nested sub-elements, and 100% of the detail captured today is reachable through that expansion.
+
+## Assumptions
+
+- "Stand-alone command" means a command executed directly by the user (e.g., from the Execution page or queue), not one invoked as a step inside a sequence.
+- The level of per-element detail currently captured (steps, primitive actions, taps, conditions, loop iterations, wait-for-image outcomes, applied delays, deep links) is the target for what must be preserved under the nested view; this feature does not require adding new kinds of detail beyond what exists today.
+- Real-time, per-step live updates during a running sequence are in scope for this feature (see Clarifications): the running sequence is shown as a single in-progress top-level entry whose sub-elements update live, and orphaned child rows never appear.
+- Historical logs created before this change are read-only artifacts; they do not need to be migrated/re-grouped, only to remain viewable.
+- It is acceptable to refactor the UI and the execution-logs API/data shape to deliver this grouping, as the user explicitly permitted.

--- a/specs/049-execution-logs-hierarchy/tasks.md
+++ b/specs/049-execution-logs-hierarchy/tasks.md
@@ -1,0 +1,202 @@
+---
+
+description: "Task list for feature 049 — Execution Logs Reflect What Was Actually Executed"
+---
+
+# Tasks: Execution Logs Reflect What Was Actually Executed
+
+**Input**: Design documents from `specs/049-execution-logs-hierarchy/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/execution-logs-hierarchy.openapi.yaml, quickstart.md
+
+**Tests**: Included — the project constitution (Principle II, Testing Standards) makes tests mandatory for executable logic.
+
+**Organization**: Tasks are grouped by user story (US1, US2, US3) so each story is independently implementable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, Polish carry no story label)
+
+## Path Conventions
+
+Web application: backend at `src/GameBot.Service/` + `src/GameBot.Domain/`; frontend at `src/web-ui/src/`; tests under `tests/{unit,integration,contract}/` and `src/web-ui/src/**/__tests__/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the constitution green-build gate before changes.
+
+- [X] T001 Confirm baseline is green before changes: run `dotnet build`, `dotnet test`, and `npm --prefix src/web-ui test`; record any pre-existing failures so they are not attributed to this feature.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared model/repository/DTO plumbing that ALL user stories build on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Add the `running` lifecycle status: extend `NormalizeStatus` to allow `running` (alongside `success`/`failure`) in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs and document the value on `ExecutionLogEntry.FinalStatus` in src/GameBot.Domain/Logging/ExecutionLogModels.cs
+- [X] T003 [P] Add a `RootsOnly` flag to `ExecutionLogQuery` (filters `ParentExecutionId is null`) in src/GameBot.Domain/Logging/ExecutionLogModels.cs
+- [X] T004 Add `UpsertAsync` and `GetSubtreeAsync(rootId)` to the repository interface in src/GameBot.Domain/Logging/IExecutionLogRepository.cs
+- [X] T005 [P] Unit tests (write first, expect FAIL) for repository hierarchy behavior — upsert replaces by id with no duplicate, roots-only query excludes children, subtree returns descendants ordered by `SequenceIndex` — in tests/unit/ExecutionLogs/ExecutionLogRepositoryHierarchyTests.cs
+- [X] T006 Implement `UpsertAsync` (replace-by-id in memory + overwrite file), roots-only filtering in `QueryAsync`, and `GetSubtreeAsync` (descendants by `RootExecutionId`, recursive via `ParentExecutionId`) in src/GameBot.Domain/Logging/FileExecutionLogRepository.cs (depends on T004, makes T005 pass)
+- [X] T007 [P] Add backend DTOs — widen `finalStatus` to include `running` and add `childCount` on `ExecutionLogEntryDto` (no separate `status` field), plus `ExecutionTreeNodeDto` and `ExecutionSubtreeResponseDto` (root `finalStatus`) — in src/GameBot.Service/Models/ExecutionLogs.cs
+- [X] T008 [P] Add frontend types (widen `finalStatus` to `'running' | 'success' | 'failure'`, add `childCount`, `ExecutionTreeNodeDto`, `ExecutionSubtreeResponseDto`) and a `getSubtree(executionId)` client calling `GET /api/execution-logs/{id}/subtree` in src/web-ui/src/services/executionLogsApi.ts
+
+**Checkpoint**: Repository/model/DTO plumbing ready — user stories can begin.
+
+---
+
+## Phase 3: User Story 1 - Executed sequence appears as a single entry with sub-elements nested (Priority: P1) 🎯 MVP
+
+**Goal**: A sequence run shows as exactly one top-level row; invoked commands are recorded as linked children (kept, filtered from the list) and rendered as expandable nested tree rows with all of today's detail.
+
+**Independent Test**: Execute a multi-command sequence, open Execution Logs → exactly one new top-level row; expand it → all steps/commands/primitives/conditions/loops/waits reachable; no standalone child-command rows in the list.
+
+### Tests for User Story 1 (write first, expect FAIL) ⚠️
+
+- [X] T009 [P] [US1] Integration test: a sequence run produces 1 root (`Depth 0`, no parent) + N child command entries (`Depth 1`, `ParentExecutionId` = root, `SequenceIndex` = step order); roots-only list returns only the sequence in tests/integration/ExecutionLogs/SequenceGroupingIntegrationTests.cs
+- [X] T010 [P] [US1] Contract test: `GET /api/execution-logs` returns roots-only and items expose `finalStatus` (incl. `running`)/`childCount`; **sorting + per-column filtering still return correct results over roots-only with no child rows leaking** (covers FR-010/SC-006); `GET /api/execution-logs/{id}/subtree` matches contracts/execution-logs-hierarchy.openapi.yaml in tests/contract/ExecutionLogs/ExecutionLogsHierarchyContractTests.cs
+- [X] T011 [P] [US1] Unit test: subtree projection builds ordered nested nodes — command-backed steps correlated to child entries by `SequenceIndex`, conditions/loops/loop-iterations/waits preserved with their attributes — **including a nested-sequence case (sequence-invoking-sequence) that yields a ≥2-level tree with no extra top-level entry** (covers FR-009) — in tests/unit/ExecutionLogs/ExecutionSubtreeProjectionTests.cs
+- [X] T012 [P] [US1] Web-ui test: top-level rows are expandable; expanding a sequence shows nested sub-elements; expanding a command node shows that command's primitive/tap/wait outcomes; **a sub-element's deep link navigates to its authored sequence/step** (covers FR-011) in src/web-ui/src/pages/__tests__/ExecutionLogsTree.test.tsx
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Add `ForceExecuteDetailedAsync` / `ForceExecuteAsync` overloads accepting an `ExecutionLogContext` (parent/root/depth/sequenceIndex) and pass it through to `LogCommandExecutionAsync` in src/GameBot.Service/Services/CommandExecutor.cs and src/GameBot.Service/Services/ICommandExecutor.cs
+- [X] T014 [US1] Add `LogSequenceStartAsync` (writes an in-progress root entry, returns its id) and finalize-via-`UpsertAsync` (final status, summary, full `StepOutcomes`); add the subtree projection builder producing `ExecutionSubtreeResponseDto`/`ExecutionTreeNodeDto` in src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs (depends on T002, T006, T007)
+- [X] T015 [US1] Wire `sequences/{id}/execute`: create the root first, pass `{ParentExecutionId/RootExecutionId = rootId, Depth = 1, SequenceIndex = step order, SequenceId, SequenceLabel}` into the per-command callback (`commandExecutor.ForceExecuteAsync`), and finalize the root at the end in src/GameBot.Service/Program.cs (depends on T013, T014)
+- [X] T016 [US1] Default the list endpoint to roots-only, populate `childCount` (and `finalStatus` incl. `running`), and add `GET /api/execution-logs/{id}/subtree` returning the projection in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs (depends on T006, T007, T014)
+- [X] T017 [US1] Refactor the Execution Logs page into expandable tree rows: lazy-load `getSubtree` on expand and render nested nodes (steps, commands, conditions, loops/iterations, waits) preserving today's detail (applied delay, condition trace, wait attributes, deep links) in src/web-ui/src/pages/ExecutionLogs.tsx (depends on T008)
+- [X] T018 [US1] Sync the published OpenAPI document (roots-only list fields + `/{id}/subtree`) in specs/openapi.json (depends on T016)
+
+**Checkpoint**: Sequence grouping + nested tree fully functional and independently testable (MVP).
+
+---
+
+## Phase 4: User Story 2 - Stand-alone command execution still appears as its own entry (Priority: P1)
+
+**Goal**: A directly executed command remains its own top-level leaf entry with full detail, unaffected by the linking changes.
+
+**Independent Test**: Execute a command directly → one top-level row with full details, `childCount = 0`, not expandable, not nested under any sequence.
+
+### Tests for User Story 2 (write first, expect FAIL) ⚠️
+
+- [X] T019 [P] [US2] Integration test: direct command execution yields a single root entry (`Depth 0`, `ParentExecutionId` null), `childCount = 0`, and never appears as a child in any subtree in tests/integration/ExecutionLogs/StandaloneCommandIntegrationTests.cs
+- [X] T020 [P] [US2] Web-ui test: a leaf top-level command row has no expand affordance and still surfaces full detail in src/web-ui/src/pages/__tests__/ExecutionLogsStandalone.test.tsx
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Guarantee the context-less `ForceExecute*` path keeps `Depth 0` / no parent (regression guard from T013) and ensure leaf entries (`childCount = 0`) render non-expandable in src/GameBot.Service/Services/CommandExecutor.cs and src/web-ui/src/pages/ExecutionLogs.tsx
+
+**Checkpoint**: Both stand-alone commands and grouped sequences behave correctly.
+
+---
+
+## Phase 5: User Story 3 - Progress updates live during sequence execution (Priority: P2)
+
+**Goal**: While a sequence runs, a single in-progress (`running`) top-level entry is shown and its sub-elements update live (no manual reload); it settles into its final state on completion.
+
+**Independent Test**: Start a longer sequence, watch Execution Logs → one `running` entry, sub-elements update via polling, no standalone child rows; on finish the same entry shows final status + complete tree.
+
+### Tests for User Story 3 (write first, expect FAIL) ⚠️
+
+- [X] T022 [P] [US3] Integration test: during execution an in-progress root exists with status `running`; after completion the SAME entry is upserted to `success`/`failure` (no duplicate) with full `StepOutcomes` in tests/integration/ExecutionLogs/SequenceLiveStatusIntegrationTests.cs
+- [X] T023 [P] [US3] Web-ui test (fake timers): the page polls (~2s) while a `running` entry is visible, refreshes an expanded in-progress subtree without reload, and stops polling once nothing is in progress in src/web-ui/src/pages/__tests__/ExecutionLogsPolling.test.tsx
+
+### Implementation for User Story 3
+
+- [X] T024 [US3] Ensure the in-progress (`running`) root is returned by the roots-only list with correct `finalStatus`, ordered with completed entries, and not removed by retention until finalized in src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs and src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+- [X] T025 [US3] Add interval polling (~2s) gated on the presence of any `running` entry; re-fetch the list and any expanded in-progress subtree; clear the interval when none are in progress in src/web-ui/src/pages/ExecutionLogs.tsx (depends on T017)
+
+**Checkpoint**: All three user stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Consistency, backward compatibility, performance, and validation.
+
+- [X] T026 [P] Update existing execution-log tests that assume the old flat behavior to reflect hierarchy linking + roots-only listing in tests/integration/ExecutionLogs/SequenceExecutionLoggingIntegrationTests.cs, tests/integration/ExecutionLogs/ExecutionHierarchyIntegrationTests.cs, and tests/integration/ExecutionLogs/ExecutionLogConcisenessIntegrationTests.cs
+- [X] T027 [P] Backward-compatibility test: historical entries (no `running` status, no children) render as completed leaf roots and open without error; keep the published contract additive in tests/contract/OpenApiBackwardCompatTests.cs (and a fixture-based case under tests/integration/ExecutionLogs/)
+- [X] T028 [P] Add a CHANGELOG.md entry (user-visible: execution logs now group by what was actually executed, with live nested view) and update any execution-logs notes in docs/
+- [X] T029 Performance verification: roots-only list and subtree fetch <1s at target scale, live sub-element update visible within ~2s (SC-005/006/007); add a brief perf note to the PR
+- [ ] T030 Run all quickstart.md scenarios A–F and confirm expected outcomes — NOTE: the API-level checks (roots-only list, `/{id}/subtree`) are covered by automated contract/integration tests; the UI scenarios (A–F) require a live emulator/session and remain pending manual validation on a device.
+- [X] T031 Final constitution gate: `dotnet build` clean (0 warnings/errors); `npm --prefix src/web-ui test` 317/317 across 74 suites with coverage thresholds met; `dotnet test` — all execution-log unit/integration/contract suites green (contract 67, integration 235, unit execution-log 28). One pre-existing flaky test unrelated to this feature (`BackgroundCaptureScreenSourceTests.ReturnsBitmapCloneWhenFrameAvailable`) fails only when its sibling capture tests run first and passes in isolation; it touches no code in this feature.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately.
+- **Foundational (Phase 2)**: depends on Setup — BLOCKS all user stories.
+- **User Stories (Phase 3–5)**: all depend on Foundational.
+  - US1 (P1) is the MVP and should land first (it establishes the create-root-at-start linkage, the subtree endpoint, and the tree UI that US2/US3 rely on).
+  - US2 (P1) verifies/guards the stand-alone path on the same list/UI surface; start after US1's endpoint + page exist.
+  - US3 (P2) adds the live-polling surfacing on top of US1's in-progress root + tree.
+- **Polish (Phase 6)**: after the desired user stories are complete.
+
+### User Story Dependencies
+
+- **US1**: depends only on Foundational.
+- **US2**: Foundational + reuses US1's list endpoint/page (narrower guarantee on the same surface).
+- **US3**: Foundational + US1 (in-progress root + tree); UI polling depends on T017.
+
+### Within Each User Story
+
+- Write tests first and confirm they FAIL before implementing.
+- Backend models/services before endpoints; endpoints before frontend wiring.
+- Story complete and validated before moving to the next priority.
+
+### Parallel Opportunities
+
+- Foundational: T002, T003, T005, T007, T008 are [P] (distinct files). T004 → T006 are sequential.
+- US1 tests T009–T012 are [P]. Implementation T013/T014 can proceed in parallel (different files) before T015/T016 integrate them; T017 (frontend) is [P] with backend tasks until wiring.
+- US2 tests T019, T020 are [P]. US3 tests T022, T023 are [P].
+- Polish T026, T027, T028 are [P].
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch US1 tests together (write first, expect FAIL):
+Task: "Integration grouping test in tests/integration/ExecutionLogs/SequenceGroupingIntegrationTests.cs"
+Task: "Contract test in tests/contract/ExecutionLogs/ExecutionLogsHierarchyContractTests.cs"
+Task: "Subtree projection unit test in tests/unit/ExecutionLogs/ExecutionSubtreeProjectionTests.cs"
+Task: "Tree UI test in src/web-ui/src/pages/__tests__/ExecutionLogsTree.test.tsx"
+
+# Independent implementation files that can start together:
+Task: "CommandExecutor context overloads in src/GameBot.Service/Services/CommandExecutor.cs"
+Task: "Execution Logs tree page in src/web-ui/src/pages/ExecutionLogs.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup → Phase 2 Foundational (CRITICAL — blocks all stories).
+2. Phase 3 US1 → **STOP and VALIDATE**: a sequence shows as one expandable entry with all sub-elements; no standalone child rows.
+3. Demo the MVP.
+
+### Incremental Delivery
+
+1. Foundation ready → US1 (grouping + nested tree, MVP) → demo.
+2. US2 (stand-alone command guarantee) → demo.
+3. US3 (live polling updates) → demo.
+4. Polish (compat, perf, docs, quickstart) → ship.
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on an incomplete task.
+- The execution **queue** (specs 046–048) has no real execution path yet and produces no logs — out of scope.
+- Child execution records are **kept and linked**, only filtered from the top-level list (FR-002a) — never deleted.
+- Preserve the existing `{ error: { code, message, hint } }` API error shape and the phone/desktop responsive split.
+- Commit after each task or logical group; keep the build/tests green (constitution NON-NEGOTIABLE gate).

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -20,16 +20,17 @@
                 "$ref": "#/components/schemas/CommandCreateSchema"
               },
               "example": {
-                "name": "Warmup",
+                "name": "Wait for home banner",
                 "steps": [
                   {
-                    "type": "PrimitiveTap",
+                    "type": "WaitForImage",
                     "order": 0,
-                    "primitiveTap": {
+                    "waitForImage": {
                       "detectionTarget": {
-                        "referenceImageId": "start-screen",
-                        "confidence": 0.9
-                      }
+                        "referenceImageId": "home-banner",
+                        "confidence": 0.88
+                      },
+                      "timeoutMs": 1500
                     }
                   }
                 ]
@@ -49,14 +50,20 @@
                   "$ref": "#/components/schemas/CommandResponse"
                 },
                 "example": {
-                  "id": "command-123",
-                  "name": "Warmup",
-                  "triggerId": "trigger-1",
+                  "id": "command-wait-home",
+                  "name": "Wait for home banner",
+                  "triggerId": null,
                   "steps": [
                     {
-                      "type": "Command",
-                      "targetId": "cmd-next",
-                      "order": 0
+                      "type": "WaitForImage",
+                      "order": 0,
+                      "waitForImage": {
+                        "timeoutMs": 1500,
+                        "detectionTarget": {
+                          "referenceImageId": "home-banner",
+                          "confidence": 0.88
+                        }
+                      }
                     }
                   ]
                 }
@@ -84,14 +91,20 @@
                 },
                 "example": [
                   {
-                    "id": "command-123",
-                    "name": "Warmup",
-                    "triggerId": "trigger-1",
+                    "id": "command-wait-home",
+                    "name": "Wait for home banner",
+                    "triggerId": null,
                     "steps": [
                       {
-                        "type": "Command",
-                        "targetId": "cmd-next",
-                        "order": 0
+                        "type": "WaitForImage",
+                        "order": 0,
+                        "waitForImage": {
+                          "timeoutMs": 1500,
+                          "detectionTarget": {
+                            "referenceImageId": "home-banner",
+                            "confidence": 0.88
+                          }
+                        }
                       }
                     ]
                   }
@@ -128,14 +141,20 @@
                   "$ref": "#/components/schemas/CommandResponse"
                 },
                 "example": {
-                  "id": "command-123",
-                  "name": "Warmup",
-                  "triggerId": "trigger-1",
+                  "id": "command-wait-home",
+                  "name": "Wait for home banner",
+                  "triggerId": null,
                   "steps": [
                     {
-                      "type": "Command",
-                      "targetId": "cmd-next",
-                      "order": 0
+                      "type": "WaitForImage",
+                      "order": 0,
+                      "waitForImage": {
+                        "timeoutMs": 1500,
+                        "detectionTarget": {
+                          "referenceImageId": "home-banner",
+                          "confidence": 0.88
+                        }
+                      }
                     }
                   ]
                 }
@@ -190,14 +209,20 @@
                   "$ref": "#/components/schemas/CommandResponse"
                 },
                 "example": {
-                  "id": "command-123",
-                  "name": "Warmup",
-                  "triggerId": "trigger-1",
+                  "id": "command-wait-home",
+                  "name": "Wait for home banner",
+                  "triggerId": null,
                   "steps": [
                     {
-                      "type": "Command",
-                      "targetId": "cmd-next",
-                      "order": 0
+                      "type": "WaitForImage",
+                      "order": 0,
+                      "waitForImage": {
+                        "timeoutMs": 1500,
+                        "detectionTarget": {
+                          "referenceImageId": "home-banner",
+                          "confidence": 0.88
+                        }
+                      }
                     }
                   ]
                 }
@@ -261,10 +286,33 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SessionAcceptedSchema"
+                  "$ref": "#/components/schemas/CommandExecuteResponseSchema"
                 },
                 "example": {
-                  "accepted": 1
+                  "accepted": 1,
+                  "stepOutcomes": [
+                    {
+                      "stepOrder": 0,
+                      "stepType": "waitForImage",
+                      "status": "executed",
+                      "reason": "image_detected",
+                      "detectionConfidence": 0.91,
+                      "timeoutMs": 1500,
+                      "effectiveTimeoutMs": 1500,
+                      "referenceImageId": "home-banner",
+                      "imageLoadStatus": "loaded"
+                    },
+                    {
+                      "stepOrder": 1,
+                      "stepType": "primitiveTap",
+                      "status": "executed",
+                      "resolvedPoint": {
+                        "x": 0,
+                        "y": 0
+                      },
+                      "detectionConfidence": 0.99
+                    }
+                  ]
                 }
               }
             }
@@ -305,12 +353,35 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CommandEvaluateResponseSchema"
+                  "$ref": "#/components/schemas/CommandExecuteResponseSchema"
                 },
                 "example": {
-                  "accepted": true,
+                  "accepted": 1,
                   "triggerStatus": "Satisfied",
-                  "message": "Trigger satisfied; executed"
+                  "message": "Trigger satisfied; executed",
+                  "stepOutcomes": [
+                    {
+                      "stepOrder": 0,
+                      "stepType": "waitForImage",
+                      "status": "executed",
+                      "reason": "image_detected",
+                      "detectionConfidence": 0.91,
+                      "timeoutMs": 1500,
+                      "effectiveTimeoutMs": 1500,
+                      "referenceImageId": "home-banner",
+                      "imageLoadStatus": "loaded"
+                    },
+                    {
+                      "stepOrder": 1,
+                      "stepType": "primitiveTap",
+                      "status": "executed",
+                      "resolvedPoint": {
+                        "x": 0,
+                        "y": 0
+                      },
+                      "detectionConfidence": 0.99
+                    }
+                  ]
                 }
               }
             }
@@ -993,6 +1064,84 @@
         ],
         "summary": "Get an execution log entry",
         "operationId": "GetExecutionLog",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionLogEntryDto"
+                },
+                "example": {
+                  "id": "exe_0001",
+                  "timestampUtc": "2026-01-01T00:00:00Z",
+                  "executionType": "command",
+                  "finalStatus": "success",
+                  "objectRef": {
+                    "objectType": "command",
+                    "objectId": "cmd-farm",
+                    "displayNameSnapshot": "Farm Run",
+                    "versionSnapshot": "2026.01"
+                  },
+                  "navigation": {
+                    "directPath": "/api/commands/cmd-farm",
+                    "parentPath": "/api/sequences/seq-daily",
+                    "pathKind": "command"
+                  },
+                  "hierarchy": {
+                    "rootExecutionId": "exe_root_0001",
+                    "parentExecutionId": "exe_parent_0001",
+                    "depth": 1,
+                    "sequenceIndex": 2
+                  },
+                  "summary": "Command executed successfully",
+                  "details": [
+                    {
+                      "kind": "execution",
+                      "message": "Trigger matched and command dispatched.",
+                      "attributes": {
+                        "triggerMatched": true,
+                        "durationMs": 812
+                      },
+                      "sensitivity": "public"
+                    }
+                  ],
+                  "stepOutcomes": [
+                    {
+                      "stepOrder": 1,
+                      "stepType": "tap",
+                      "outcome": "executed",
+                      "reasonCode": "none",
+                      "reasonText": "Step executed normally"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/execution-logs/{id}/subtree": {
+      "get": {
+        "tags": [
+          "ExecutionLogs"
+        ],
+        "summary": "Get an execution log entry",
+        "operationId": "GetExecutionSubtree",
         "parameters": [
           {
             "name": "id",
@@ -1776,6 +1925,624 @@
         }
       }
     },
+    "/api/queues": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Create a queue",
+        "operationId": "CreateQueue",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateQueueRequest"
+              },
+              "example": {
+                "name": "Daily Farm",
+                "emulatorSerial": "emulator-5554",
+                "cycleExecution": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueResponse"
+                },
+                "example": {
+                  "id": "queue-daily-farm",
+                  "name": "Daily Farm",
+                  "emulatorSerial": "emulator-5554",
+                  "cycleExecution": true,
+                  "status": "Stopped",
+                  "entryCount": 2
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "List queues",
+        "operationId": "ListQueues",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QueueResponse"
+                  }
+                },
+                "example": [
+                  {
+                    "id": "queue-daily-farm",
+                    "name": "Daily Farm",
+                    "emulatorSerial": "emulator-5554",
+                    "cycleExecution": true,
+                    "status": "Stopped",
+                    "entryCount": 2
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/queues/{id}": {
+      "get": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Get a queue with its ordered sequence entries",
+        "operationId": "GetQueue",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueDetailResponse"
+                },
+                "example": {
+                  "id": "queue-daily-farm",
+                  "name": "Daily Farm",
+                  "emulatorSerial": "emulator-5554",
+                  "cycleExecution": true,
+                  "status": "Stopped",
+                  "entryCount": 2,
+                  "entries": [
+                    {
+                      "entryId": "entry-0001",
+                      "sequenceId": "sequence-wait-home",
+                      "sequenceName": "Wait for image sequence",
+                      "stale": false
+                    },
+                    {
+                      "entryId": "entry-0002",
+                      "sequenceId": "sequence-removed",
+                      "sequenceName": null,
+                      "stale": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Update a queue (name and cycle execution; emulator is immutable)",
+        "operationId": "UpdateQueue",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateQueueRequest"
+              },
+              "example": {
+                "name": "Daily Farm v2",
+                "cycleExecution": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueResponse"
+                },
+                "example": {
+                  "id": "queue-daily-farm",
+                  "name": "Daily Farm",
+                  "emulatorSerial": "emulator-5554",
+                  "cycleExecution": true,
+                  "status": "Stopped",
+                  "entryCount": 2
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Queues"
+        ],
+        "operationId": "DeleteQueue",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/queues/{id}/entries": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Append a sequence entry to a queue",
+        "operationId": "AddQueueEntry",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddQueueEntryRequest"
+              },
+              "example": {
+                "sequenceId": "sequence-wait-home"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueEntryResponse"
+                },
+                "example": {
+                  "entryId": "entry-0001",
+                  "sequenceId": "sequence-wait-home",
+                  "sequenceName": "Wait for image sequence",
+                  "stale": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Replace a queue's entries (used to load a template)",
+        "operationId": "ReplaceQueueEntries",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplaceQueueEntriesRequest"
+              },
+              "example": {
+                "sequenceIds": [
+                  "sequence-wait-home",
+                  "sequence-collect"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueDetailResponse"
+                },
+                "example": {
+                  "id": "queue-daily-farm",
+                  "name": "Daily Farm",
+                  "emulatorSerial": "emulator-5554",
+                  "cycleExecution": true,
+                  "status": "Stopped",
+                  "entryCount": 2,
+                  "entries": [
+                    {
+                      "entryId": "entry-0001",
+                      "sequenceId": "sequence-wait-home",
+                      "sequenceName": "Wait for image sequence",
+                      "stale": false
+                    },
+                    {
+                      "entryId": "entry-0002",
+                      "sequenceId": "sequence-removed",
+                      "sequenceName": null,
+                      "stale": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/queues/{id}/entries/{entryId}": {
+      "delete": {
+        "tags": [
+          "Queues"
+        ],
+        "operationId": "RemoveQueueEntry",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/queues/{id}/start": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Start a queue (placeholder: sets status to Running)",
+        "operationId": "StartQueue",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueResponse"
+                },
+                "example": {
+                  "id": "queue-daily-farm",
+                  "name": "Daily Farm",
+                  "emulatorSerial": "emulator-5554",
+                  "cycleExecution": true,
+                  "status": "Stopped",
+                  "entryCount": 2
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/queues/{id}/stop": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Stop a queue (placeholder: sets status to Stopped)",
+        "operationId": "StopQueue",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueResponse"
+                },
+                "example": {
+                  "id": "queue-daily-farm",
+                  "name": "Daily Farm",
+                  "emulatorSerial": "emulator-5554",
+                  "cycleExecution": true,
+                  "status": "Stopped",
+                  "entryCount": 2
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/queue-templates": {
+      "get": {
+        "tags": [
+          "QueueTemplates"
+        ],
+        "summary": "List queue templates",
+        "operationId": "ListQueueTemplates",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QueueTemplateSummaryResponse"
+                  }
+                },
+                "example": [
+                  {
+                    "id": "template-daily-farm",
+                    "name": "Daily Farm",
+                    "entryCount": 2,
+                    "createdAt": "2026-05-31T10:00:00Z",
+                    "updatedAt": "2026-05-31T10:00:00Z"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "QueueTemplates"
+        ],
+        "summary": "Save (create or overwrite by name) a queue template",
+        "operationId": "SaveQueueTemplate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveQueueTemplateRequest"
+              },
+              "example": {
+                "name": "Daily Farm",
+                "sequenceIds": [
+                  "sequence-wait-home",
+                  "sequence-collect"
+                ],
+                "overwrite": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueTemplateDetailResponse"
+                },
+                "example": {
+                  "id": "template-daily-farm",
+                  "name": "Daily Farm",
+                  "entryCount": 2,
+                  "createdAt": "2026-05-31T10:00:00Z",
+                  "updatedAt": "2026-05-31T10:00:00Z",
+                  "entries": [
+                    {
+                      "sequenceId": "sequence-wait-home",
+                      "sequenceName": "Wait for image sequence",
+                      "stale": false
+                    },
+                    {
+                      "sequenceId": "sequence-removed",
+                      "sequenceName": null,
+                      "stale": true
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueTemplateDetailResponse"
+                },
+                "example": {
+                  "id": "template-daily-farm",
+                  "name": "Daily Farm",
+                  "entryCount": 2,
+                  "createdAt": "2026-05-31T10:00:00Z",
+                  "updatedAt": "2026-05-31T10:00:00Z",
+                  "entries": [
+                    {
+                      "sequenceId": "sequence-wait-home",
+                      "sequenceName": "Wait for image sequence",
+                      "stale": false
+                    },
+                    {
+                      "sequenceId": "sequence-removed",
+                      "sequenceName": null,
+                      "stale": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/queue-templates/{id}": {
+      "get": {
+        "tags": [
+          "QueueTemplates"
+        ],
+        "summary": "Get a queue template with its ordered entries",
+        "operationId": "GetQueueTemplate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueTemplateDetailResponse"
+                },
+                "example": {
+                  "id": "template-daily-farm",
+                  "name": "Daily Farm",
+                  "entryCount": 2,
+                  "createdAt": "2026-05-31T10:00:00Z",
+                  "updatedAt": "2026-05-31T10:00:00Z",
+                  "entries": [
+                    {
+                      "sequenceId": "sequence-wait-home",
+                      "sequenceName": "Wait for image sequence",
+                      "stale": false
+                    },
+                    {
+                      "sequenceId": "sequence-removed",
+                      "sequenceName": null,
+                      "stale": true
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "QueueTemplates"
+        ],
+        "summary": "Delete a queue template",
+        "operationId": "DeleteQueueTemplate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/sequences": {
       "post": {
         "tags": [
@@ -1788,25 +2555,19 @@
             "application/json": {
               "schema": { },
               "example": {
-                "name": "Morning routine",
+                "name": "Wait for image sequence",
                 "steps": [
                   {
-                    "stepId": "command-warmup",
+                    "stepId": "wait-home-banner",
                     "primitiveAction": {
-                      "type": "command",
+                      "type": "WaitForImage",
                       "schemaVersion": "v1",
                       "payload": {
-                        "commandId": "command-warmup"
-                      }
-                    }
-                  },
-                  {
-                    "stepId": "command-start",
-                    "primitiveAction": {
-                      "type": "command",
-                      "schemaVersion": "v1",
-                      "payload": {
-                        "commandId": "command-start"
+                        "timeoutMs": 1500,
+                        "detectionTarget": {
+                          "referenceImageId": "home-banner",
+                          "confidence": 0.88
+                        }
                       }
                     }
                   }
@@ -1828,26 +2589,20 @@
                   "$ref": "#/components/schemas/SequenceResponseSchema"
                 },
                 "example": {
-                  "id": "sequence-xyz",
-                  "name": "Morning routine",
+                  "id": "sequence-wait-home",
+                  "name": "Wait for image sequence",
                   "steps": [
                     {
-                      "stepId": "command-warmup",
+                      "stepId": "wait-home-banner",
                       "primitiveAction": {
-                        "type": "command",
+                        "type": "WaitForImage",
                         "schemaVersion": "v1",
                         "payload": {
-                          "commandId": "command-warmup"
-                        }
-                      }
-                    },
-                    {
-                      "stepId": "command-start",
-                      "primitiveAction": {
-                        "type": "command",
-                        "schemaVersion": "v1",
-                        "payload": {
-                          "commandId": "command-start"
+                          "timeoutMs": 1500,
+                          "detectionTarget": {
+                            "referenceImageId": "home-banner",
+                            "confidence": 0.88
+                          }
                         }
                       }
                     }
@@ -1877,26 +2632,20 @@
                 },
                 "example": [
                   {
-                    "id": "sequence-xyz",
-                    "name": "Morning routine",
+                    "id": "sequence-wait-home",
+                    "name": "Wait for image sequence",
                     "steps": [
                       {
-                        "stepId": "command-warmup",
+                        "stepId": "wait-home-banner",
                         "primitiveAction": {
-                          "type": "command",
+                          "type": "WaitForImage",
                           "schemaVersion": "v1",
                           "payload": {
-                            "commandId": "command-warmup"
-                          }
-                        }
-                      },
-                      {
-                        "stepId": "command-start",
-                        "primitiveAction": {
-                          "type": "command",
-                          "schemaVersion": "v1",
-                          "payload": {
-                            "commandId": "command-start"
+                            "timeoutMs": 1500,
+                            "detectionTarget": {
+                              "referenceImageId": "home-banner",
+                              "confidence": 0.88
+                            }
                           }
                         }
                       }
@@ -1935,26 +2684,20 @@
                   "$ref": "#/components/schemas/SequenceResponseSchema"
                 },
                 "example": {
-                  "id": "sequence-xyz",
-                  "name": "Morning routine",
+                  "id": "sequence-wait-home",
+                  "name": "Wait for image sequence",
                   "steps": [
                     {
-                      "stepId": "command-warmup",
+                      "stepId": "wait-home-banner",
                       "primitiveAction": {
-                        "type": "command",
+                        "type": "WaitForImage",
                         "schemaVersion": "v1",
                         "payload": {
-                          "commandId": "command-warmup"
-                        }
-                      }
-                    },
-                    {
-                      "stepId": "command-start",
-                      "primitiveAction": {
-                        "type": "command",
-                        "schemaVersion": "v1",
-                        "payload": {
-                          "commandId": "command-start"
+                          "timeoutMs": 1500,
+                          "detectionTarget": {
+                            "referenceImageId": "home-banner",
+                            "confidence": 0.88
+                          }
                         }
                       }
                     }
@@ -1988,25 +2731,19 @@
                 "$ref": "#/components/schemas/SequenceRequestSchema"
               },
               "example": {
-                "name": "Morning routine",
+                "name": "Wait for image sequence",
                 "steps": [
                   {
-                    "stepId": "command-warmup",
+                    "stepId": "wait-home-banner",
                     "primitiveAction": {
-                      "type": "command",
+                      "type": "WaitForImage",
                       "schemaVersion": "v1",
                       "payload": {
-                        "commandId": "command-warmup"
-                      }
-                    }
-                  },
-                  {
-                    "stepId": "command-start",
-                    "primitiveAction": {
-                      "type": "command",
-                      "schemaVersion": "v1",
-                      "payload": {
-                        "commandId": "command-start"
+                        "timeoutMs": 1500,
+                        "detectionTarget": {
+                          "referenceImageId": "home-banner",
+                          "confidence": 0.88
+                        }
                       }
                     }
                   }
@@ -2024,26 +2761,20 @@
                   "$ref": "#/components/schemas/SequenceResponseSchema"
                 },
                 "example": {
-                  "id": "sequence-xyz",
-                  "name": "Morning routine",
+                  "id": "sequence-wait-home",
+                  "name": "Wait for image sequence",
                   "steps": [
                     {
-                      "stepId": "command-warmup",
+                      "stepId": "wait-home-banner",
                       "primitiveAction": {
-                        "type": "command",
+                        "type": "WaitForImage",
                         "schemaVersion": "v1",
                         "payload": {
-                          "commandId": "command-warmup"
-                        }
-                      }
-                    },
-                    {
-                      "stepId": "command-start",
-                      "primitiveAction": {
-                        "type": "command",
-                        "schemaVersion": "v1",
-                        "payload": {
-                          "commandId": "command-start"
+                          "timeoutMs": 1500,
+                          "detectionTarget": {
+                            "referenceImageId": "home-banner",
+                            "confidence": 0.88
+                          }
                         }
                       }
                     }
@@ -2077,25 +2808,19 @@
                 "$ref": "#/components/schemas/SequenceRequestSchema"
               },
               "example": {
-                "name": "Morning routine",
+                "name": "Wait for image sequence",
                 "steps": [
                   {
-                    "stepId": "command-warmup",
+                    "stepId": "wait-home-banner",
                     "primitiveAction": {
-                      "type": "command",
+                      "type": "WaitForImage",
                       "schemaVersion": "v1",
                       "payload": {
-                        "commandId": "command-warmup"
-                      }
-                    }
-                  },
-                  {
-                    "stepId": "command-start",
-                    "primitiveAction": {
-                      "type": "command",
-                      "schemaVersion": "v1",
-                      "payload": {
-                        "commandId": "command-start"
+                        "timeoutMs": 1500,
+                        "detectionTarget": {
+                          "referenceImageId": "home-banner",
+                          "confidence": 0.88
+                        }
                       }
                     }
                   }
@@ -2113,26 +2838,20 @@
                   "$ref": "#/components/schemas/SequenceResponseSchema"
                 },
                 "example": {
-                  "id": "sequence-xyz",
-                  "name": "Morning routine",
+                  "id": "sequence-wait-home",
+                  "name": "Wait for image sequence",
                   "steps": [
                     {
-                      "stepId": "command-warmup",
+                      "stepId": "wait-home-banner",
                       "primitiveAction": {
-                        "type": "command",
+                        "type": "WaitForImage",
                         "schemaVersion": "v1",
                         "payload": {
-                          "commandId": "command-warmup"
-                        }
-                      }
-                    },
-                    {
-                      "stepId": "command-start",
-                      "primitiveAction": {
-                        "type": "command",
-                        "schemaVersion": "v1",
-                        "payload": {
-                          "commandId": "command-start"
+                          "timeoutMs": 1500,
+                          "detectionTarget": {
+                            "referenceImageId": "home-banner",
+                            "confidence": 0.88
+                          }
                         }
                       }
                     }
@@ -3095,6 +3814,16 @@
   },
   "components": {
     "schemas": {
+      "AddQueueEntryRequest": {
+        "type": "object",
+        "properties": {
+          "sequenceId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "AuthoringDeepLinkDto": {
         "type": "object",
         "properties": {
@@ -3216,11 +3945,12 @@
         },
         "additionalProperties": false
       },
-      "CommandEvaluateResponseSchema": {
+      "CommandExecuteResponseSchema": {
         "type": "object",
         "properties": {
           "accepted": {
-            "type": "boolean"
+            "type": "integer",
+            "format": "int32"
           },
           "triggerStatus": {
             "type": "string",
@@ -3228,6 +3958,13 @@
           },
           "message": {
             "type": "string",
+            "nullable": true
+          },
+          "stepOutcomes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StepExecutionOutcomeDto"
+            },
             "nullable": true
           }
         },
@@ -3323,6 +4060,9 @@
           "primitiveTap": {
             "$ref": "#/components/schemas/PrimitiveTapConfigDto"
           },
+          "waitForImage": {
+            "$ref": "#/components/schemas/WaitForImageConfigDto"
+          },
           "order": {
             "type": "integer",
             "format": "int32"
@@ -3333,7 +4073,8 @@
       "CommandStepTypeDto": {
         "enum": [
           "Command",
-          "PrimitiveTap"
+          "PrimitiveTap",
+          "WaitForImage"
         ],
         "type": "string"
       },
@@ -3606,6 +4347,23 @@
               "$ref": "#/components/schemas/ConfigParameterSchema"
             },
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateQueueRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "emulatorSerial": {
+            "type": "string",
+            "nullable": true
+          },
+          "cycleExecution": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -3903,6 +4661,10 @@
               "$ref": "#/components/schemas/ExecutionStepOutcomeDto"
             },
             "nullable": true
+          },
+          "childCount": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -4534,6 +5296,179 @@
         },
         "additionalProperties": false
       },
+      "QueueDetailResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "emulatorSerial": {
+            "type": "string",
+            "nullable": true
+          },
+          "cycleExecution": {
+            "type": "boolean"
+          },
+          "status": {
+            "$ref": "#/components/schemas/QueueExecutionStatus"
+          },
+          "entryCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueueEntryResponse"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueEntryResponse": {
+        "type": "object",
+        "properties": {
+          "entryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "sequenceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "sequenceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "stale": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueExecutionStatus": {
+        "enum": [
+          "Stopped",
+          "Running"
+        ],
+        "type": "string"
+      },
+      "QueueResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "emulatorSerial": {
+            "type": "string",
+            "nullable": true
+          },
+          "cycleExecution": {
+            "type": "boolean"
+          },
+          "status": {
+            "$ref": "#/components/schemas/QueueExecutionStatus"
+          },
+          "entryCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueTemplateDetailResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "entryCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueueTemplateEntryResponse"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueTemplateEntryResponse": {
+        "type": "object",
+        "properties": {
+          "sequenceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "sequenceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "stale": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueTemplateSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "entryCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "RegionSchema": {
         "type": "object",
         "properties": {
@@ -4552,6 +5487,37 @@
           "height": {
             "type": "number",
             "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReplaceQueueEntriesRequest": {
+        "type": "object",
+        "properties": {
+          "sequenceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ResolvedPointDto": {
+        "required": [
+          "x",
+          "y"
+        ],
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "y": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -4635,6 +5601,26 @@
         },
         "additionalProperties": false
       },
+      "SaveQueueTemplateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "sequenceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "overwrite": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "SemanticVersionModel": {
         "required": [
           "build",
@@ -4659,6 +5645,27 @@
           "build": {
             "type": "integer",
             "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SequenceCommandReferenceContract": {
+        "required": [
+          "commandId"
+        ],
+        "type": "object",
+        "properties": {
+          "commandId": {
+            "type": "string",
+            "nullable": true
+          },
+          "commandName": {
+            "type": "string",
+            "nullable": true
+          },
+          "isResolved": {
+            "type": "boolean",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -4973,6 +5980,9 @@
           "primitiveAction": {
             "$ref": "#/components/schemas/PrimitiveActionRequest"
           },
+          "commandReference": {
+            "$ref": "#/components/schemas/SequenceCommandReferenceContract"
+          },
           "condition": {
             "$ref": "#/components/schemas/SequenceStepConditionContract"
           },
@@ -5030,6 +6040,9 @@
           },
           "primitiveAction": {
             "$ref": "#/components/schemas/PrimitiveActionRequest"
+          },
+          "commandReference": {
+            "$ref": "#/components/schemas/SequenceCommandReferenceContract"
           },
           "condition": {
             "$ref": "#/components/schemas/SequenceStepConditionContract"
@@ -5267,6 +6280,58 @@
         },
         "additionalProperties": false
       },
+      "StepExecutionOutcomeDto": {
+        "required": [
+          "status",
+          "stepOrder"
+        ],
+        "type": "object",
+        "properties": {
+          "stepOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "stepType": {
+            "type": "string",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "resolvedPoint": {
+            "$ref": "#/components/schemas/ResolvedPointDto"
+          },
+          "detectionConfidence": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "effectiveTimeoutMs": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "referenceImageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "imageLoadStatus": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "StepResult": {
         "type": "object",
         "properties": {
@@ -5318,6 +6383,9 @@
           "message": {
             "type": "string",
             "nullable": true
+          },
+          "waitForImageDetails": {
+            "$ref": "#/components/schemas/WaitForImageStepResultDetails"
           },
           "loopIterations": {
             "type": "array",
@@ -5470,6 +6538,19 @@
         },
         "additionalProperties": false
       },
+      "UpdateQueueRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "cycleExecution": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "UploadImageRequest": {
         "required": [
           "id"
@@ -5547,6 +6628,51 @@
           "lastCiBuild": {
             "type": "integer",
             "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "WaitForImageConfigDto": {
+        "type": "object",
+        "properties": {
+          "detectionTarget": {
+            "$ref": "#/components/schemas/DetectionTargetDto"
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "WaitForImageStepResultDetails": {
+        "type": "object",
+        "properties": {
+          "timeoutMs": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "effectiveTimeoutMs": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "referenceImageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "confidence": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "exitCondition": {
+            "type": "string",
+            "nullable": true
+          },
+          "imageLoadStatus": {
+            "type": "string",
             "nullable": true
           }
         },

--- a/src/GameBot.Domain/Logging/ExecutionLogModels.cs
+++ b/src/GameBot.Domain/Logging/ExecutionLogModels.cs
@@ -62,6 +62,12 @@ public sealed record ExecutionStepOutcome(
   /// Human-readable command name for command-backed sequence steps when available.
   /// </summary>
   public string? CommandName { get; init; }
+
+  /// <summary>
+  /// Identifier of the command invoked by this step (for command-backed steps). Used to
+  /// correlate the step with its linked child execution entry when building the nested tree.
+  /// </summary>
+  public string? CommandId { get; init; }
 }
 
 public sealed record ExecutionDetailItem(
@@ -74,6 +80,9 @@ public sealed class ExecutionLogEntry {
   public string Id { get; init; } = Guid.NewGuid().ToString("N");
   public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
   public string ExecutionType { get; init; } = "command";
+  /// <summary>
+  /// Lifecycle status: "running" (in-progress sequence root), "success", or "failure".
+  /// </summary>
   public string FinalStatus { get; init; } = "success";
   public required ExecutionObjectReference ObjectRef { get; init; }
   public required ExecutionNavigationContext Navigation { get; init; }
@@ -99,6 +108,13 @@ public sealed class ExecutionLogQuery {
   public string? ObjectId { get; init; }
   public int PageSize { get; init; } = 50;
   public string? Cursor { get; init; }
+
+  /// <summary>
+  /// When true, only top-level (root) entries are returned — those whose
+  /// <see cref="ExecutionHierarchyContext.ParentExecutionId"/> is null. Child executions
+  /// (e.g. commands invoked by a sequence) are excluded from the result.
+  /// </summary>
+  public bool RootsOnly { get; init; }
 }
 
 public sealed record ExecutionLogPage(IReadOnlyList<ExecutionLogEntry> Items, string? NextCursor);

--- a/src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
+++ b/src/GameBot.Domain/Logging/FileExecutionLogRepository.cs
@@ -34,6 +34,42 @@ public sealed class FileExecutionLogRepository : IExecutionLogRepository, IDispo
     }
   }
 
+  public async Task UpsertAsync(ExecutionLogEntry entry, CancellationToken ct = default) {
+    ArgumentNullException.ThrowIfNull(entry);
+    var path = Path.Combine(_dir, entry.Id + ".json");
+    await _mutex.WaitAsync(ct).ConfigureAwait(false);
+    try {
+      using var fs = File.Create(path);
+      await JsonSerializer.SerializeAsync(fs, entry, JsonOptions, ct).ConfigureAwait(false);
+      if (_entriesLoaded) {
+        var replaced = false;
+        var builder = ImmutableArray.CreateBuilder<ExecutionLogEntry>(_entries.Length);
+        foreach (var existing in _entries) {
+          if (!replaced && string.Equals(existing.Id, entry.Id, StringComparison.Ordinal)) {
+            builder.Add(entry);
+            replaced = true;
+          }
+          else {
+            builder.Add(existing);
+          }
+        }
+        if (!replaced) builder.Add(entry);
+        _entries = builder.ToImmutable();
+      }
+    }
+    finally {
+      _mutex.Release();
+    }
+  }
+
+  public async Task<IReadOnlyList<ExecutionLogEntry>> GetSubtreeAsync(string rootId, CancellationToken ct = default) {
+    if (string.IsNullOrWhiteSpace(rootId)) return Array.Empty<ExecutionLogEntry>();
+    await EnsureEntriesLoadedAsync(ct).ConfigureAwait(false);
+    return _entries
+      .Where(e => string.Equals(e.Hierarchy.RootExecutionId, rootId, StringComparison.Ordinal))
+      .ToList();
+  }
+
   public async Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default) {
     if (string.IsNullOrWhiteSpace(id)) return null;
     var path = Path.Combine(_dir, id + ".json");
@@ -52,6 +88,7 @@ public sealed class FileExecutionLogRepository : IExecutionLogRepository, IDispo
       ct.ThrowIfCancellationRequested();
       if (query.FromUtc.HasValue && item.TimestampUtc < query.FromUtc.Value) continue;
       if (query.ToUtc.HasValue && item.TimestampUtc > query.ToUtc.Value) continue;
+      if (query.RootsOnly && !string.IsNullOrWhiteSpace(item.Hierarchy.ParentExecutionId)) continue;
       if (!string.IsNullOrWhiteSpace(query.FinalStatus) && !string.Equals(item.FinalStatus, query.FinalStatus, StringComparison.OrdinalIgnoreCase)) continue;
       if (!string.IsNullOrWhiteSpace(query.ObjectType) && !string.Equals(item.ObjectRef.ObjectType, query.ObjectType, StringComparison.OrdinalIgnoreCase)) continue;
       if (!string.IsNullOrWhiteSpace(query.ObjectId) && !string.Equals(item.ObjectRef.ObjectId, query.ObjectId, StringComparison.OrdinalIgnoreCase)) continue;

--- a/src/GameBot.Domain/Logging/IExecutionLogRepository.cs
+++ b/src/GameBot.Domain/Logging/IExecutionLogRepository.cs
@@ -2,7 +2,22 @@ namespace GameBot.Domain.Logging;
 
 public interface IExecutionLogRepository {
   Task AddAsync(ExecutionLogEntry entry, CancellationToken ct = default);
+
+  /// <summary>
+  /// Writes the entry, replacing any existing entry with the same <see cref="ExecutionLogEntry.Id"/>
+  /// (used to finalize an in-progress root execution without creating a duplicate row).
+  /// </summary>
+  Task UpsertAsync(ExecutionLogEntry entry, CancellationToken ct = default);
+
   Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default);
+
+  /// <summary>
+  /// Returns the entry identified by <paramref name="rootId"/> together with all descendant
+  /// entries (those whose <see cref="ExecutionHierarchyContext.RootExecutionId"/> equals it),
+  /// for building a nested execution tree. Empty when the root is unknown.
+  /// </summary>
+  Task<IReadOnlyList<ExecutionLogEntry>> GetSubtreeAsync(string rootId, CancellationToken ct = default);
+
   Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default);
   Task<int> DeleteExpiredAsync(DateTimeOffset nowUtc, CancellationToken ct = default);
 }

--- a/src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/ExecutionLogsEndpoints.cs
@@ -42,7 +42,8 @@ internal static class ExecutionLogsEndpoints {
           ObjectType = objectType,
           ObjectId = objectId,
           PageSize = pageSize ?? 50,
-          Cursor = cursor
+          Cursor = cursor,
+          RootsOnly = true
         }, ct).ConfigureAwait(false);
 
         return Results.Ok(new ExecutionLogListResponseDto {
@@ -62,6 +63,21 @@ internal static class ExecutionLogsEndpoints {
 
       return Results.Ok(ToDetailResponse(item));
     }).WithName("GetExecutionLog");
+
+    group.MapGet("/{id}/subtree", async (string id, IExecutionLogService svc, CancellationToken ct) => {
+      var subtree = await svc.GetSubtreeAsync(id, ct).ConfigureAwait(false);
+      if (subtree is null) {
+        return Results.NotFound(new {
+          error = new { code = "not_found", message = "Execution log entry not found", hint = (string?)null }
+        });
+      }
+
+      return Results.Ok(new ExecutionSubtreeResponseDto {
+        ExecutionId = subtree.ExecutionId,
+        FinalStatus = subtree.FinalStatus,
+        Root = ToTreeNodeDto(subtree.Root)
+      });
+    }).WithName("GetExecutionSubtree");
 
     group.MapGet("/retention", async (IExecutionLogService svc, CancellationToken ct) => {
       var policy = await svc.GetRetentionAsync(ct).ConfigureAwait(false);
@@ -123,7 +139,53 @@ internal static class ExecutionLogsEndpoints {
         ReasonCode = s.ReasonCode,
         ReasonText = s.ReasonText,
         AppliedDelayMs = s.AppliedDelayMs
-      }).ToArray()
+      }).ToArray(),
+      ChildCount = string.Equals(entry.ExecutionType, "sequence", StringComparison.OrdinalIgnoreCase)
+        ? entry.StepOutcomes.Count
+        : 0
+    };
+
+  private static ExecutionTreeNodeDto ToTreeNodeDto(ExecutionTreeNodeProjection node)
+    => new() {
+      NodeKind = node.NodeKind,
+      ExecutionId = node.ExecutionId,
+      Order = node.Order,
+      Label = node.Label,
+      Status = node.Status,
+      Message = node.Message,
+      AppliedDelayMs = node.AppliedDelayMs,
+      CommandName = node.CommandName,
+      DetailAttributes = node.DetailAttributes is null
+        ? null
+        : new ExecutionLogWaitForImageDetailAttributesDto {
+          TimeoutMs = node.DetailAttributes.TimeoutMs,
+          EffectiveTimeoutMs = node.DetailAttributes.EffectiveTimeoutMs,
+          ReferenceImageId = node.DetailAttributes.ReferenceImageId,
+          Confidence = node.DetailAttributes.Confidence,
+          ExitCondition = node.DetailAttributes.ExitCondition,
+          ImageLoadStatus = node.DetailAttributes.ImageLoadStatus
+        },
+      ConditionTrace = node.ConditionTrace is null
+        ? null
+        : new ConditionEvaluationTraceDto {
+          FinalResult = node.ConditionTrace.FinalResult,
+          SelectedBranch = node.ConditionTrace.SelectedBranch,
+          FailureReason = node.ConditionTrace.FailureReason,
+          OperandResults = node.ConditionTrace.OperandResults,
+          OperatorSteps = node.ConditionTrace.OperatorSteps
+        },
+      DeepLink = node.DeepLink is null
+        ? null
+        : new AuthoringDeepLinkDto {
+          SequenceId = node.DeepLink.SequenceId,
+          StepId = node.DeepLink.StepId,
+          SequenceLabel = node.DeepLink.SequenceLabel,
+          StepLabel = node.DeepLink.StepLabel,
+          ResolutionStatus = node.DeepLink.ResolutionStatus,
+          DirectPath = node.DeepLink.DirectPath,
+          FallbackRoute = node.DeepLink.FallbackRoute
+        },
+      Children = node.Children.Select(ToTreeNodeDto).ToArray()
     };
 
   private static object ToDetailResponse(ExecutionLogEntry entry) {

--- a/src/GameBot.Service/Models/ExecutionLogs.cs
+++ b/src/GameBot.Service/Models/ExecutionLogs.cs
@@ -57,6 +57,29 @@ internal sealed class ExecutionLogEntryDto {
   public required string Summary { get; init; }
   public required IReadOnlyList<ExecutionDetailItemDto> Details { get; init; }
   public required IReadOnlyList<ExecutionStepOutcomeDto> StepOutcomes { get; init; }
+  /// <summary>Number of direct child executions (0 ⇒ leaf, not expandable).</summary>
+  public int ChildCount { get; init; }
+}
+
+internal sealed class ExecutionTreeNodeDto {
+  public required string NodeKind { get; init; }
+  public string? ExecutionId { get; init; }
+  public int Order { get; init; }
+  public required string Label { get; init; }
+  public required string Status { get; init; }
+  public string? Message { get; init; }
+  public int? AppliedDelayMs { get; init; }
+  public string? CommandName { get; init; }
+  public ExecutionLogWaitForImageDetailAttributesDto? DetailAttributes { get; init; }
+  public ConditionEvaluationTraceDto? ConditionTrace { get; init; }
+  public AuthoringDeepLinkDto? DeepLink { get; init; }
+  public IReadOnlyList<ExecutionTreeNodeDto> Children { get; init; } = Array.Empty<ExecutionTreeNodeDto>();
+}
+
+internal sealed class ExecutionSubtreeResponseDto {
+  public required string ExecutionId { get; init; }
+  public required string FinalStatus { get; init; }
+  public required ExecutionTreeNodeDto Root { get; init; }
 }
 
 internal sealed class ExecutionLogListResponseDto {

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -819,11 +819,26 @@ sequences.MapPost("{sequenceId}/execute", async (
       // empty body, malformed JSON, or missing content-type — no sessionId override
     }
 
+    // Create the in-progress root entry up front so invoked commands can be linked to it
+    // (and the sequence shows as a single top-level entry while it runs).
+    var startSequence = await sequenceRepository.GetAsync(sequenceId).ConfigureAwait(false);
+    var startSequenceName = startSequence?.Name ?? sequenceId;
+    var rootExecutionId = await executionLogService.LogSequenceStartAsync(sequenceId, startSequenceName, ct).ConfigureAwait(false);
+    var childInvocationIndex = 0;
+
     var res = await runner.ExecuteAsync(
       sequenceId,
       async commandId => {
         try {
-          await commandExecutor.ForceExecuteAsync(sessionId, commandId, ct).ConfigureAwait(false);
+          var childContext = new GameBot.Service.Services.ExecutionLog.ExecutionLogContext {
+            ParentExecutionId = rootExecutionId,
+            RootExecutionId = rootExecutionId,
+            Depth = 1,
+            SequenceIndex = ++childInvocationIndex,
+            SequenceId = sequenceId,
+            SequenceLabel = startSequenceName
+          };
+          await commandExecutor.ForceExecuteAsync(sessionId, commandId, childContext, ct).ConfigureAwait(false);
         }
         catch (KeyNotFoundException ex) when (ex.Message == "cached_session_not_found") {
           throw new InvalidOperationException($"No cached session found for command '{commandId}'. Start a session first.");
@@ -989,7 +1004,8 @@ sequences.MapPost("{sequenceId}/execute", async (
           ["sequenceLabel"] = sequenceName,
           ["stepId"] = stepId,
           ["stepLabel"] = stepLabel,
-          ["commandName"] = isWaitForImageStep ? null : commandName
+          ["commandName"] = isWaitForImageStep ? null : commandName,
+          ["commandId"] = isWaitForImageStep ? null : step.CommandId
         },
         "normal"));
     }
@@ -1013,7 +1029,8 @@ sequences.MapPost("{sequenceId}/execute", async (
         "normal"));
     }
 
-    await executionLogService.LogSequenceExecutionAsync(
+    await executionLogService.LogSequenceFinalizeAsync(
+      rootExecutionId,
       sequenceId,
       sequenceName,
       status,

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -53,12 +53,19 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _executionLogService = executionLogService;
   }
 
-  public async Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default) {
-    var result = await ForceExecuteDetailedAsync(sessionId, commandId, ct).ConfigureAwait(false);
+  public Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default)
+    => ForceExecuteAsync(sessionId, commandId, new ExecutionLogContext { Depth = 0 }, ct);
+
+  public async Task<int> ForceExecuteAsync(string? sessionId, string commandId, ExecutionLogContext context, CancellationToken ct = default) {
+    var result = await ForceExecuteDetailedAsync(sessionId, commandId, context, ct).ConfigureAwait(false);
     return result.Accepted;
   }
 
-  public async Task<CommandForceExecutionResult> ForceExecuteDetailedAsync(string? sessionId, string commandId, CancellationToken ct = default) {
+  public Task<CommandForceExecutionResult> ForceExecuteDetailedAsync(string? sessionId, string commandId, CancellationToken ct = default)
+    => ForceExecuteDetailedAsync(sessionId, commandId, new ExecutionLogContext { Depth = 0 }, ct);
+
+  public async Task<CommandForceExecutionResult> ForceExecuteDetailedAsync(string? sessionId, string commandId, ExecutionLogContext context, CancellationToken ct = default) {
+    ArgumentNullException.ThrowIfNull(context);
     var resolvedSessionId = await ResolveSessionIdAsync(sessionId, commandId, ct).ConfigureAwait(false);
     var session = _sessions.GetSession(resolvedSessionId) ?? throw new KeyNotFoundException("Session not found");
     if (session.Status != GameBot.Domain.Sessions.SessionStatus.Running)
@@ -77,7 +84,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
         cmdName,
         status,
         stepOutcomes,
-        new ExecutionLogContext { Depth = 0 },
+        context,
         ct).ConfigureAwait(false);
     }
     return new CommandForceExecutionResult(accepted, stepOutcomes);

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -42,11 +42,33 @@ internal sealed record ExecutionLogDetailProjection(
   string? SnapshotCaption,
   IReadOnlyList<ExecutionLogStepProjection> StepOutcomes);
 
+internal sealed record ExecutionTreeNodeProjection(
+  string NodeKind,
+  string? ExecutionId,
+  int Order,
+  string Label,
+  string Status,
+  string? Message,
+  int? AppliedDelayMs,
+  string? CommandName,
+  WaitForImageDetailAttributes? DetailAttributes,
+  ConditionEvaluationTrace? ConditionTrace,
+  ExecutionLogStepDeepLinkProjection? DeepLink,
+  IReadOnlyList<ExecutionTreeNodeProjection> Children);
+
+internal sealed record ExecutionSubtreeProjection(
+  string ExecutionId,
+  string FinalStatus,
+  ExecutionTreeNodeProjection Root);
+
 internal interface IExecutionLogService {
   Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, string? parentExecutionId, int depth, CancellationToken ct = default);
   Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, ExecutionLogContext context, CancellationToken ct = default);
   Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, string? parentExecutionId, int depth, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default);
   Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default);
+  Task<string> LogSequenceStartAsync(string sequenceId, string sequenceName, CancellationToken ct = default);
+  Task LogSequenceFinalizeAsync(string executionId, string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default);
+  Task<ExecutionSubtreeProjection?> GetSubtreeAsync(string executionId, CancellationToken ct = default);
   Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default);
   Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default);
   Task<ExecutionLogRetentionPolicy> GetRetentionAsync(CancellationToken ct = default);
@@ -185,6 +207,167 @@ internal sealed class ExecutionLogService : IExecutionLogService {
     await _repository.AddAsync(entry, ct).ConfigureAwait(false);
   }
 
+  public async Task<string> LogSequenceStartAsync(string sequenceId, string sequenceName, CancellationToken ct = default) {
+    var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
+    var now = DateTimeOffset.UtcNow;
+    var id = Guid.NewGuid().ToString("N");
+    var context = new ExecutionLogContext { SequenceId = sequenceId, SequenceLabel = sequenceName };
+    var entry = new ExecutionLogEntry {
+      Id = id,
+      TimestampUtc = now,
+      ExecutionType = "sequence",
+      FinalStatus = "running",
+      ObjectRef = new ExecutionObjectReference("sequence", sequenceId, sequenceName),
+      Navigation = ExecutionNavigationBuilder.Build("sequence", sequenceId, context),
+      Hierarchy = new ExecutionHierarchyContext(id, null, 0, null),
+      Summary = TrimSummary($"Sequence '{sequenceName}' running."),
+      RetentionExpiresUtc = retention.Enabled ? now.AddDays(Math.Max(1, retention.RetentionDays)) : DateTimeOffset.MaxValue
+    };
+    await _repository.AddAsync(entry, ct).ConfigureAwait(false);
+    return id;
+  }
+
+  public async Task LogSequenceFinalizeAsync(string executionId, string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default) {
+    var retention = await _retentionRepository.GetAsync(ct).ConfigureAwait(false);
+    var existing = await _repository.GetAsync(executionId, ct).ConfigureAwait(false);
+    var timestamp = existing?.TimestampUtc ?? DateTimeOffset.UtcNow;
+    var sanitizedDetails = ExecutionLogSanitizer.SanitizeDetails(details?.ToList() ?? new List<ExecutionDetailItem>());
+    var stepOutcomes = BuildSequenceStepOutcomes(sequenceId, sequenceName, context, sanitizedDetails);
+    var trimmedDetails = TrimDetails(sanitizedDetails);
+
+    var entry = new ExecutionLogEntry {
+      Id = executionId,
+      TimestampUtc = timestamp,
+      ExecutionType = "sequence",
+      FinalStatus = NormalizeStatus(finalStatus),
+      ObjectRef = new ExecutionObjectReference("sequence", sequenceId, sequenceName),
+      Navigation = ExecutionNavigationBuilder.Build("sequence", sequenceId, context),
+      Hierarchy = new ExecutionHierarchyContext(executionId, null, 0, null),
+      Summary = TrimSummary(summary),
+      Details = trimmedDetails,
+      StepOutcomes = stepOutcomes,
+      RetentionExpiresUtc = retention.Enabled ? timestamp.AddDays(Math.Max(1, retention.RetentionDays)) : DateTimeOffset.MaxValue
+    };
+
+    await _repository.UpsertAsync(entry, ct).ConfigureAwait(false);
+  }
+
+  public async Task<ExecutionSubtreeProjection?> GetSubtreeAsync(string executionId, CancellationToken ct = default) {
+    if (string.IsNullOrWhiteSpace(executionId)) return null;
+    var entries = await _repository.GetSubtreeAsync(executionId, ct).ConfigureAwait(false);
+    var root = entries.FirstOrDefault(e => string.Equals(e.Id, executionId, StringComparison.Ordinal))
+               ?? await _repository.GetAsync(executionId, ct).ConfigureAwait(false);
+    if (root is null) return null;
+
+    return BuildSubtree(root, entries);
+  }
+
+  internal static ExecutionSubtreeProjection BuildSubtree(ExecutionLogEntry root, IReadOnlyList<ExecutionLogEntry> all) {
+    var node = BuildTreeNode(root, all);
+    return new ExecutionSubtreeProjection(root.Id, NormalizeStatus(root.FinalStatus), node);
+  }
+
+  private static ExecutionTreeNodeProjection BuildTreeNode(ExecutionLogEntry entry, IReadOnlyList<ExecutionLogEntry> all) {
+    var isSequence = string.Equals(entry.ExecutionType, "sequence", StringComparison.OrdinalIgnoreCase);
+    var children = new List<ExecutionTreeNodeProjection>();
+
+    var directChildren = all
+      .Where(e => string.Equals(e.Hierarchy.ParentExecutionId, entry.Id, StringComparison.Ordinal))
+      .OrderBy(e => e.Hierarchy.SequenceIndex ?? int.MaxValue)
+      .ThenBy(e => e.TimestampUtc)
+      .ToList();
+    // Correlate command-backed steps to their linked child execution entries by command id,
+    // preserving invocation order so repeated commands map to the right child.
+    var childrenByCommandId = directChildren
+      .GroupBy(e => e.ObjectRef.ObjectId, StringComparer.Ordinal)
+      .ToDictionary(g => g.Key, g => new Queue<ExecutionLogEntry>(g), StringComparer.Ordinal);
+
+    if (entry.StepOutcomes.Count > 0) {
+      foreach (var step in entry.StepOutcomes.OrderBy(s => s.StepOrder)) {
+        ExecutionLogEntry? childEntry = null;
+        if (!string.IsNullOrWhiteSpace(step.CommandId)
+            && childrenByCommandId.TryGetValue(step.CommandId!, out var queue)
+            && queue.Count > 0) {
+          childEntry = queue.Dequeue();
+        }
+
+        if (childEntry is not null) {
+          var childNode = BuildTreeNode(childEntry, all);
+          children.Add(childNode with {
+            Order = step.StepOrder,
+            Label = string.IsNullOrWhiteSpace(step.CommandName) ? childNode.Label : step.CommandName!,
+            Status = MapStepStatus(step.Outcome),
+            Message = step.ReasonText ?? step.ReasonCode,
+            AppliedDelayMs = step.AppliedDelayMs,
+            CommandName = step.CommandName,
+            DeepLink = BuildDeepLink(entry, step)
+          });
+        }
+        else {
+          children.Add(BuildStepNode(entry, step));
+        }
+      }
+
+      // Defensive: surface any child executions that were not matched to a step.
+      foreach (var leftover in childrenByCommandId.Values.SelectMany(q => q)) {
+        children.Add(BuildTreeNode(leftover, all));
+      }
+    }
+    else {
+      foreach (var childEntry in directChildren) {
+        children.Add(BuildTreeNode(childEntry, all));
+      }
+    }
+
+    return new ExecutionTreeNodeProjection(
+      isSequence ? "sequence" : "command",
+      entry.Id,
+      entry.Hierarchy.SequenceIndex ?? 0,
+      entry.ObjectRef.DisplayNameSnapshot,
+      NormalizeStatus(entry.FinalStatus),
+      string.IsNullOrWhiteSpace(entry.Summary) ? null : entry.Summary,
+      null,
+      null,
+      null,
+      null,
+      null,
+      children);
+  }
+
+  private static ExecutionTreeNodeProjection BuildStepNode(ExecutionLogEntry entry, ExecutionStepOutcome step)
+    => new(
+      MapStepKind(step.StepType),
+      null,
+      step.StepOrder,
+      ResolveStepLabel(step),
+      MapStepStatus(step.Outcome),
+      step.ReasonText ?? step.ReasonCode,
+      step.AppliedDelayMs,
+      step.CommandName,
+      step.DetailAttributes,
+      step.ConditionTrace,
+      BuildDeepLink(entry, step),
+      Array.Empty<ExecutionTreeNodeProjection>());
+
+  private static string MapStepKind(string? stepType)
+    => (stepType ?? string.Empty).ToLowerInvariant() switch {
+      "waitforimage" => "wait",
+      "condition" => "condition",
+      "loop" => "loop",
+      "primitivetap" or "tap" => "tap",
+      "command" => "command",
+      _ => "step"
+    };
+
+  private static string MapStepStatus(string? outcome)
+    => (outcome ?? string.Empty).ToLowerInvariant() switch {
+      "executed" or "success" or "image_detected" or "true" => "success",
+      "skipped" => "skipped",
+      "not_executed" => "not_executed",
+      "running" => "running",
+      _ => "failure"
+    };
+
   public Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default) {
     var normalized = NormalizeQuery(query);
     return _repository.QueryAsync(normalized, ct);
@@ -275,8 +458,11 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       stepOutcomes);
   }
 
-  private static string NormalizeStatus(string status)
-    => string.Equals(status, "success", StringComparison.OrdinalIgnoreCase) ? "success" : "failure";
+  private static string NormalizeStatus(string status) {
+    if (string.Equals(status, "success", StringComparison.OrdinalIgnoreCase)) return "success";
+    if (string.Equals(status, "running", StringComparison.OrdinalIgnoreCase)) return "running";
+    return "failure";
+  }
 
   private static List<ExecutionStepOutcome> BuildSequenceStepOutcomes(
     string sequenceId,
@@ -299,6 +485,7 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       var resolvedStepId = TryGetString(attributes, "stepId") ?? context.StepId;
       var resolvedStepLabel = TryGetString(attributes, "stepLabel") ?? context.StepLabel;
       var resolvedCommandName = TryGetString(attributes, "commandName");
+      var resolvedCommandId = TryGetString(attributes, "commandId");
       var appliedDelayMs = TryGetInt(attributes, "appliedDelayMs");
       var conditionTrace = TryGetConditionTrace(attributes, "conditionTrace")
                            ?? BuildConditionTraceFromAttributes(attributes);
@@ -317,6 +504,7 @@ internal sealed class ExecutionLogService : IExecutionLogService {
         conditionTrace,
         appliedDelayMs) {
         CommandName = resolvedCommandName,
+        CommandId = resolvedCommandId,
         DetailAttributes = detailAttributes
       });
     }
@@ -552,7 +740,8 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       ObjectType = source.ObjectType,
       ObjectId = source.ObjectId,
       PageSize = source.PageSize <= 0 ? 50 : source.PageSize,
-      Cursor = source.Cursor
+      Cursor = source.Cursor,
+      RootsOnly = source.RootsOnly
     };
   }
 }

--- a/src/GameBot.Service/Services/ICommandExecutor.cs
+++ b/src/GameBot.Service/Services/ICommandExecutor.cs
@@ -1,12 +1,19 @@
 using System.Threading;
 using System.Threading.Tasks;
 using GameBot.Domain.Triggers;
+using GameBot.Service.Services.ExecutionLog;
 
 namespace GameBot.Service.Services;
 
 internal interface ICommandExecutor {
   Task<CommandForceExecutionResult> ForceExecuteDetailedAsync(string? sessionId, string commandId, CancellationToken ct = default);
+  /// <summary>
+  /// Force-executes a command, logging it with the supplied execution context so a command
+  /// invoked as part of a sequence is recorded as a linked child rather than a top-level entry.
+  /// </summary>
+  Task<CommandForceExecutionResult> ForceExecuteDetailedAsync(string? sessionId, string commandId, ExecutionLogContext context, CancellationToken ct = default);
   Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default);
+  Task<int> ForceExecuteAsync(string? sessionId, string commandId, ExecutionLogContext context, CancellationToken ct = default);
   Task<CommandEvaluationExecutionResult> EvaluateAndExecuteDetailedAsync(string? sessionId, string commandId, CancellationToken ct = default);
   Task<CommandEvaluationDecision> EvaluateAndExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default);
 }

--- a/src/web-ui/src/pages/ExecutionLogs.tsx
+++ b/src/web-ui/src/pages/ExecutionLogs.tsx
@@ -1,15 +1,20 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ExecutionLogDetailDto,
   ExecutionLogEntryDto,
   ExecutionLogListSortBy,
   ExecutionLogSortDirection,
+  ExecutionLogStepDeepLinkDto,
+  ExecutionSubtreeResponseDto,
+  ExecutionTreeNodeDto,
   getExecutionLogDetail,
+  getExecutionSubtree,
   listExecutionLogs
 } from '../services/executionLogsApi';
 import { useNavigationCollapse } from '../hooks/useNavigationCollapse';
 
 const PAGE_SIZE = 50;
+const POLL_INTERVAL_MS = 2000;
 
 const formatRelativeTime = (timestampUtc: string): string => {
   const timestamp = new Date(timestampUtc);
@@ -40,6 +45,67 @@ const formatExitCondition = (exitCondition?: string): string => {
   }
 };
 
+const openAuthoringDeepLink = (deepLink?: ExecutionLogStepDeepLinkDto): void => {
+  if (!deepLink) {
+    return;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  params.set('area', 'authoring');
+  params.set('tab', 'Sequences');
+  params.set('id', deepLink.sequenceId);
+  if (deepLink.resolutionStatus === 'resolved' && deepLink.stepId) {
+    params.set('stepId', deepLink.stepId);
+    params.delete('missingStep');
+  } else {
+    params.delete('stepId');
+    params.set('missingStep', '1');
+  }
+
+  window.location.assign(`${window.location.pathname}?${params.toString()}`);
+};
+
+const ExecutionTreeNode: React.FC<{ node: ExecutionTreeNodeDto; depth: number }> = ({ node, depth }) => (
+  <li className="execution-tree-node" data-node-kind={node.nodeKind} data-status={node.status}>
+    <div className="execution-tree-node-row" style={{ paddingLeft: `${depth * 1.25}rem` }}>
+      <span className="execution-tree-node-kind">{node.nodeKind}</span>
+      <strong className="execution-tree-node-label">{node.label}</strong>
+      <span className="execution-tree-node-status">{node.status}</span>
+      {node.message && <span className="execution-tree-node-message"> — {node.message}</span>}
+      {typeof node.appliedDelayMs === 'number' && (
+        <span className="form-hint"> (delay {node.appliedDelayMs} ms)</span>
+      )}
+      {node.deepLink && (
+        <button
+          type="button"
+          className="execution-tree-deeplink"
+          onClick={() => openAuthoringDeepLink(node.deepLink)}
+        >
+          Open in sequence
+        </button>
+      )}
+    </div>
+    {node.conditionTrace && (
+      <div className="form-hint" style={{ paddingLeft: `${depth * 1.25}rem` }}>
+        Condition: final result {node.conditionTrace.finalResult ? 'true' : 'false'} ({node.conditionTrace.selectedBranch} branch)
+      </div>
+    )}
+    {node.detailAttributes && (
+      <div className="form-hint" style={{ paddingLeft: `${depth * 1.25}rem` }}>
+        Wait: timeout {typeof node.detailAttributes.timeoutMs === 'number' ? `${node.detailAttributes.timeoutMs} ms` : 'n/a'};
+        exit {formatExitCondition(node.detailAttributes.exitCondition)}.
+      </div>
+    )}
+    {node.children.length > 0 && (
+      <ul className="execution-tree-children">
+        {node.children.map((child, index) => (
+          <ExecutionTreeNode key={`${child.nodeKind}-${child.order}-${index}`} node={child} depth={depth + 1} />
+        ))}
+      </ul>
+    )}
+  </li>
+);
+
 export const ExecutionLogsPage: React.FC = () => {
   const [items, setItems] = useState<ExecutionLogEntryDto[]>([]);
   const [detail, setDetail] = useState<ExecutionLogDetailDto | undefined>(undefined);
@@ -58,6 +124,11 @@ export const ExecutionLogsPage: React.FC = () => {
   const [timestampMode, setTimestampMode] = useState<'exact' | 'relative'>('exact');
   const [showPhoneDetail, setShowPhoneDetail] = useState(false);
 
+  const [expandedId, setExpandedId] = useState<string | undefined>(undefined);
+  const [subtrees, setSubtrees] = useState<Record<string, ExecutionSubtreeResponseDto>>({});
+  const [loadingSubtreeId, setLoadingSubtreeId] = useState<string | undefined>(undefined);
+  const [subtreeError, setSubtreeError] = useState<string | undefined>(undefined);
+
   const { isCollapsed: isPhone } = useNavigationCollapse(640);
   const listRequestId = useRef(0);
   const detailRequestId = useRef(0);
@@ -70,57 +141,95 @@ export const ExecutionLogsPage: React.FC = () => {
     filterStatus
   }), [sortBy, sortDirection, filterTimestamp, filterObjectName, filterStatus]);
 
-  useEffect(() => {
-    let isMounted = true;
+  const loadSubtree = async (id: string) => {
+    setLoadingSubtreeId(id);
+    setSubtreeError(undefined);
+    try {
+      const response = await getExecutionSubtree(id);
+      setSubtrees((prev) => ({ ...prev, [id]: response }));
+    } catch (err: any) {
+      setSubtreeError(err?.message ?? 'Failed to load sub-elements');
+    } finally {
+      setLoadingSubtreeId((current) => (current === id ? undefined : current));
+    }
+  };
+
+  const toggleExpand = (id: string) => {
+    setExpandedId((current) => {
+      if (current === id) {
+        return undefined;
+      }
+      if (!subtrees[id]) {
+        void loadSubtree(id);
+      }
+      return id;
+    });
+  };
+
+  const fetchList = useCallback(async (silent = false) => {
     const requestId = ++listRequestId.current;
+    if (!silent) setLoadingList(true);
+    setError(undefined);
+    try {
+      const response = await listExecutionLogs({
+        sortBy: queryState.sortBy,
+        sortDirection: queryState.sortDirection,
+        filterTimestamp: queryState.filterTimestamp.trim() || undefined,
+        filterObjectName: queryState.filterObjectName.trim() || undefined,
+        filterStatus: queryState.filterStatus.trim() || undefined,
+        pageSize: PAGE_SIZE
+      });
 
-    const load = async () => {
-      setLoadingList(true);
-      setError(undefined);
-      try {
-        const response = await listExecutionLogs({
-          sortBy: queryState.sortBy,
-          sortDirection: queryState.sortDirection,
-          filterTimestamp: queryState.filterTimestamp.trim() || undefined,
-          filterObjectName: queryState.filterObjectName.trim() || undefined,
-          filterStatus: queryState.filterStatus.trim() || undefined,
-          pageSize: PAGE_SIZE
+      if (requestId !== listRequestId.current) return;
+
+      setItems(response.items ?? []);
+      setNextPageToken(response.nextPageToken);
+
+      if (response.items.length === 0) {
+        setSelectedId(undefined);
+        setDetail(undefined);
+        setShowPhoneDetail(false);
+      } else {
+        setSelectedId((previous) => {
+          if (previous && response.items.some((item) => item.id === previous)) {
+            return previous;
+          }
+          return response.items[0].id;
         });
-
-        if (!isMounted || requestId !== listRequestId.current) return;
-
-        setItems(response.items ?? []);
-        setNextPageToken(response.nextPageToken);
-
-        if (response.items.length === 0) {
-          setSelectedId(undefined);
-          setDetail(undefined);
-          setShowPhoneDetail(false);
-        } else {
-          setSelectedId((previous) => {
-            if (previous && response.items.some((item) => item.id === previous)) {
-              return previous;
-            }
-            return response.items[0].id;
-          });
-        }
-      } catch (err: any) {
-        if (!isMounted || requestId !== listRequestId.current) return;
+      }
+    } catch (err: any) {
+      if (requestId !== listRequestId.current) return;
+      if (!silent) {
         setItems([]);
         setNextPageToken(undefined);
-        setError(err?.message ?? 'Failed to load execution logs');
-      } finally {
-        if (isMounted && requestId === listRequestId.current) {
-          setLoadingList(false);
-        }
       }
-    };
-
-    void load();
-    return () => {
-      isMounted = false;
-    };
+      setError(err?.message ?? 'Failed to load execution logs');
+    } finally {
+      if (requestId === listRequestId.current && !silent) {
+        setLoadingList(false);
+      }
+    }
   }, [queryState]);
+
+  useEffect(() => {
+    void fetchList();
+  }, [fetchList]);
+
+  // Live updates: while any visible execution is still running, poll the list (and any
+  // expanded in-progress subtree) so sub-elements update without a manual reload.
+  const hasRunning = useMemo(() => items.some((item) => item.finalStatus === 'running'), [items]);
+
+  useEffect(() => {
+    if (!hasRunning) return undefined;
+    const interval = setInterval(() => {
+      void fetchList(true);
+      if (expandedId) {
+        void loadSubtree(expandedId);
+      }
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasRunning, fetchList, expandedId]);
 
   useEffect(() => {
     if (!selectedId) return;
@@ -173,24 +282,33 @@ export const ExecutionLogsPage: React.FC = () => {
   };
 
   const openStepDeepLink = (step: ExecutionLogDetailDto['stepOutcomes'][number]) => {
-    const deepLink = step.deepLink;
-    if (!deepLink) {
-      return;
-    }
+    openAuthoringDeepLink(step.deepLink);
+  };
 
-    const params = new URLSearchParams(window.location.search);
-    params.set('area', 'authoring');
-    params.set('tab', 'Sequences');
-    params.set('id', deepLink.sequenceId);
-    if (deepLink.resolutionStatus === 'resolved' && deepLink.stepId) {
-      params.set('stepId', deepLink.stepId);
-      params.delete('missingStep');
-    } else {
-      params.delete('stepId');
-      params.set('missingStep', '1');
-    }
+  const isExpandable = (item: ExecutionLogEntryDto) =>
+    item.executionType === 'sequence' || item.childCount > 0;
 
-    window.location.assign(`${window.location.pathname}?${params.toString()}`);
+  const renderSubtree = (id: string) => {
+    if (loadingSubtreeId === id && !subtrees[id]) {
+      return <div className="form-hint">Loading sub-elements...</div>;
+    }
+    if (subtreeError && expandedId === id && !subtrees[id]) {
+      return <div className="form-error" role="alert">{subtreeError}</div>;
+    }
+    const subtree = subtrees[id];
+    if (!subtree) {
+      return null;
+    }
+    if (subtree.root.children.length === 0) {
+      return <div className="form-hint">No sub-elements were recorded.</div>;
+    }
+    return (
+      <ul className="execution-tree" aria-label="Execution sub-elements">
+        {subtree.root.children.map((child, index) => (
+          <ExecutionTreeNode key={`${child.nodeKind}-${child.order}-${index}`} node={child} depth={0} />
+        ))}
+      </ul>
+    );
   };
 
   const renderList = () => (
@@ -245,16 +363,37 @@ export const ExecutionLogsPage: React.FC = () => {
           <tbody>
             {items.map((item) => {
               const isSelected = item.id === selectedId;
+              const expandable = isExpandable(item);
+              const expanded = expandedId === item.id;
               return (
-                <tr
-                  key={item.id}
-                  className={isSelected ? 'execution-logs-row execution-logs-row--selected' : 'execution-logs-row'}
-                  onClick={() => handleSelectRow(item.id)}
-                >
-                  <td>{renderTimestamp(item.timestampUtc)}</td>
-                  <td>{item.objectRef.displayNameSnapshot}</td>
-                  <td>{item.finalStatus}</td>
-                </tr>
+                <React.Fragment key={item.id}>
+                  <tr
+                    className={isSelected ? 'execution-logs-row execution-logs-row--selected' : 'execution-logs-row'}
+                    onClick={() => handleSelectRow(item.id)}
+                  >
+                    <td>{renderTimestamp(item.timestampUtc)}</td>
+                    <td>
+                      {expandable && (
+                        <button
+                          type="button"
+                          className="execution-logs-expand"
+                          aria-expanded={expanded}
+                          aria-label={expanded ? 'Collapse sub-elements' : 'Expand sub-elements'}
+                          onClick={(e) => { e.stopPropagation(); toggleExpand(item.id); }}
+                        >
+                          {expanded ? '▾' : '▸'}
+                        </button>
+                      )}
+                      {item.objectRef.displayNameSnapshot}
+                    </td>
+                    <td>{item.finalStatus}</td>
+                  </tr>
+                  {expanded && (
+                    <tr className="execution-logs-subtree-row">
+                      <td colSpan={3}>{renderSubtree(item.id)}</td>
+                    </tr>
+                  )}
+                </React.Fragment>
               );
             })}
           </tbody>

--- a/src/web-ui/src/pages/__tests__/ExecutionLogs.test.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionLogs.test.tsx
@@ -16,8 +16,9 @@ const getExecutionLogDetailMock = getExecutionLogDetail as jest.MockedFunction<t
 const createListItem = (id: string, name: string, status: string) => ({
   id,
   timestampUtc: new Date().toISOString(),
-  executionType: 'command',
-  finalStatus: status,
+  executionType: 'command' as const,
+  finalStatus: status as 'running' | 'success' | 'failure',
+  childCount: 0,
   objectRef: {
     objectType: 'command',
     objectId: id,

--- a/src/web-ui/src/pages/__tests__/ExecutionLogsPolling.test.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionLogsPolling.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { ExecutionLogsPage } from '../ExecutionLogs';
+import { getExecutionLogDetail, getExecutionSubtree, listExecutionLogs } from '../../services/executionLogsApi';
+
+jest.mock('../../services/executionLogsApi');
+jest.mock('../../hooks/useNavigationCollapse', () => ({
+  useNavigationCollapse: () => ({ isCollapsed: false })
+}));
+
+const listExecutionLogsMock = listExecutionLogs as jest.MockedFunction<typeof listExecutionLogs>;
+const getExecutionLogDetailMock = getExecutionLogDetail as jest.MockedFunction<typeof getExecutionLogDetail>;
+const getExecutionSubtreeMock = getExecutionSubtree as jest.MockedFunction<typeof getExecutionSubtree>;
+
+const makeItem = (finalStatus: 'running' | 'success') => ({
+  id: 'seq-live-1',
+  timestampUtc: new Date('2026-06-02T10:00:00.000Z').toISOString(),
+  executionType: 'sequence' as const,
+  finalStatus,
+  childCount: 1,
+  objectRef: { objectType: 'sequence', objectId: 'seq-1', displayNameSnapshot: 'Live Run' },
+  summary: 'Live Run'
+});
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('ExecutionLogsPage polling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetAllMocks();
+    getExecutionLogDetailMock.mockResolvedValue({
+      executionId: 'seq-live-1',
+      summary: 'Detail.',
+      relatedObjects: [],
+      snapshot: { isAvailable: false },
+      stepOutcomes: []
+    });
+    getExecutionSubtreeMock.mockResolvedValue({
+      executionId: 'seq-live-1',
+      finalStatus: 'running',
+      root: { nodeKind: 'sequence', executionId: 'seq-live-1', order: 0, label: 'Live Run', status: 'running', children: [] }
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('polls while running and stops once the execution finishes', async () => {
+    let calls = 0;
+    listExecutionLogsMock.mockImplementation((() => {
+      calls += 1;
+      return Promise.resolve({ items: [makeItem(calls < 2 ? 'running' : 'success')], nextPageToken: undefined });
+    }) as any);
+
+    render(<ExecutionLogsPage />);
+    await flush();
+
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(listExecutionLogsMock).toHaveBeenCalledTimes(1);
+
+    // First poll tick: re-fetches and the execution is now success.
+    await act(async () => { jest.advanceTimersByTime(2000); });
+    await flush();
+
+    expect(listExecutionLogsMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('success')).toBeInTheDocument();
+
+    // No longer running → polling stops; further ticks do not re-fetch.
+    const callsAfterFinish = listExecutionLogsMock.mock.calls.length;
+    await act(async () => { jest.advanceTimersByTime(6000); });
+    await flush();
+    expect(listExecutionLogsMock).toHaveBeenCalledTimes(callsAfterFinish);
+  });
+
+  it('refreshes an expanded in-progress subtree on each poll tick', async () => {
+    listExecutionLogsMock.mockResolvedValue({ items: [makeItem('running')], nextPageToken: undefined });
+
+    render(<ExecutionLogsPage />);
+    await flush();
+
+    // Expand the running sequence to load its subtree once.
+    await act(async () => {
+      screen.getByRole('button', { name: 'Expand sub-elements' }).click();
+    });
+    await flush();
+    expect(getExecutionSubtreeMock).toHaveBeenCalledTimes(1);
+
+    // A poll tick re-fetches the expanded subtree for live progress.
+    await act(async () => { jest.advanceTimersByTime(2000); });
+    await flush();
+    expect(getExecutionSubtreeMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/web-ui/src/pages/__tests__/ExecutionLogsStandalone.test.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionLogsStandalone.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ExecutionLogsPage } from '../ExecutionLogs';
+import { getExecutionLogDetail, getExecutionSubtree, listExecutionLogs } from '../../services/executionLogsApi';
+
+jest.mock('../../services/executionLogsApi');
+jest.mock('../../hooks/useNavigationCollapse', () => ({
+  useNavigationCollapse: () => ({ isCollapsed: false })
+}));
+
+const listExecutionLogsMock = listExecutionLogs as jest.MockedFunction<typeof listExecutionLogs>;
+const getExecutionLogDetailMock = getExecutionLogDetail as jest.MockedFunction<typeof getExecutionLogDetail>;
+const getExecutionSubtreeMock = getExecutionSubtree as jest.MockedFunction<typeof getExecutionSubtree>;
+
+const commandItem = {
+  id: 'cmd-exec-1',
+  timestampUtc: new Date('2026-06-02T10:00:00.000Z').toISOString(),
+  executionType: 'command' as const,
+  finalStatus: 'success' as const,
+  childCount: 0,
+  objectRef: { objectType: 'command', objectId: 'cmd-1', displayNameSnapshot: 'Solo Command' },
+  summary: 'Solo Command success'
+};
+
+describe('ExecutionLogsPage stand-alone command', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    listExecutionLogsMock.mockResolvedValue({ items: [commandItem], nextPageToken: undefined });
+    getExecutionLogDetailMock.mockResolvedValue({
+      executionId: 'cmd-exec-1',
+      summary: 'Solo Command finished successfully.',
+      relatedObjects: [],
+      snapshot: { isAvailable: false },
+      stepOutcomes: [
+        { stepName: 'Tap target', status: 'success', message: 'Tapped at the expected location.' }
+      ]
+    });
+  });
+
+  it('shows a stand-alone command as a non-expandable leaf row', async () => {
+    render(<ExecutionLogsPage />);
+
+    await screen.findByText('Solo Command');
+    expect(screen.queryByRole('button', { name: 'Expand sub-elements' })).not.toBeInTheDocument();
+    expect(getExecutionSubtreeMock).not.toHaveBeenCalled();
+  });
+
+  it('still surfaces full command detail in the detail panel', async () => {
+    render(<ExecutionLogsPage />);
+
+    fireEvent.click(await screen.findByText('Solo Command'));
+
+    expect(await screen.findByText('Solo Command finished successfully.')).toBeInTheDocument();
+    expect(screen.getByText(/Tap target/)).toBeInTheDocument();
+    expect(screen.getByText(/Tapped at the expected location./)).toBeInTheDocument();
+  });
+});

--- a/src/web-ui/src/pages/__tests__/ExecutionLogsTree.test.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionLogsTree.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ExecutionLogsPage } from '../ExecutionLogs';
+import { getExecutionLogDetail, getExecutionSubtree, listExecutionLogs } from '../../services/executionLogsApi';
+
+jest.mock('../../services/executionLogsApi');
+jest.mock('../../hooks/useNavigationCollapse', () => ({
+  useNavigationCollapse: () => ({ isCollapsed: false })
+}));
+
+const listExecutionLogsMock = listExecutionLogs as jest.MockedFunction<typeof listExecutionLogs>;
+const getExecutionLogDetailMock = getExecutionLogDetail as jest.MockedFunction<typeof getExecutionLogDetail>;
+const getExecutionSubtreeMock = getExecutionSubtree as jest.MockedFunction<typeof getExecutionSubtree>;
+
+const sequenceItem = {
+  id: 'seq-exec-1',
+  timestampUtc: new Date('2026-06-02T10:00:00.000Z').toISOString(),
+  executionType: 'sequence' as const,
+  finalStatus: 'success' as const,
+  childCount: 2,
+  objectRef: { objectType: 'sequence', objectId: 'seq-1', displayNameSnapshot: 'My Sequence' },
+  summary: 'My Sequence success'
+};
+
+const subtree = {
+  executionId: 'seq-exec-1',
+  finalStatus: 'success' as const,
+  root: {
+    nodeKind: 'sequence' as const,
+    executionId: 'seq-exec-1',
+    order: 0,
+    label: 'My Sequence',
+    status: 'success' as const,
+    children: [
+      {
+        nodeKind: 'command' as const,
+        executionId: 'child-a',
+        order: 1,
+        label: 'Open Mail',
+        status: 'success' as const,
+        commandName: 'Open Mail',
+        deepLink: {
+          sequenceId: 'seq-1',
+          stepId: 'step-1',
+          sequenceLabel: 'My Sequence',
+          stepLabel: 'Step 1',
+          resolutionStatus: 'resolved' as const,
+          directPath: '/authoring/sequences/seq-1?stepId=step-1'
+        },
+        children: [
+          { nodeKind: 'tap' as const, order: 1, label: 'Tap target', status: 'success' as const, children: [] }
+        ]
+      }
+    ]
+  }
+};
+
+describe('ExecutionLogsPage tree', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    listExecutionLogsMock.mockResolvedValue({ items: [sequenceItem], nextPageToken: undefined });
+    getExecutionLogDetailMock.mockResolvedValue({
+      executionId: 'seq-exec-1',
+      summary: 'My Sequence success',
+      relatedObjects: [],
+      snapshot: { isAvailable: false },
+      stepOutcomes: []
+    });
+    getExecutionSubtreeMock.mockResolvedValue(subtree);
+  });
+
+  it('expands a sequence row to reveal nested sub-elements', async () => {
+    render(<ExecutionLogsPage />);
+
+    await screen.findByText('My Sequence');
+    fireEvent.click(screen.getByRole('button', { name: 'Expand sub-elements' }));
+
+    await waitFor(() => expect(getExecutionSubtreeMock).toHaveBeenCalledWith('seq-exec-1'));
+    expect(await screen.findByText('Open Mail')).toBeInTheDocument();
+    // Nested command primitive is reachable through expansion.
+    expect(screen.getByText('Tap target')).toBeInTheDocument();
+  });
+
+  it('exposes a deep link from a sub-element to its authored sequence/step', async () => {
+    render(<ExecutionLogsPage />);
+
+    await screen.findByText('My Sequence');
+    fireEvent.click(screen.getByRole('button', { name: 'Expand sub-elements' }));
+    await screen.findByText('Open Mail');
+
+    // The nested command sub-element offers an in-sequence deep link (FR-011) and
+    // activating it is handled without error.
+    const deepLink = screen.getByRole('button', { name: 'Open in sequence' });
+    expect(deepLink).toBeInTheDocument();
+    expect(() => fireEvent.click(deepLink)).not.toThrow();
+  });
+});

--- a/src/web-ui/src/services/executionLogsApi.ts
+++ b/src/web-ui/src/services/executionLogsApi.ts
@@ -10,13 +10,49 @@ export type ExecutionLogObjectRefDto = {
   versionSnapshot?: string;
 };
 
+export type ExecutionStatus = 'running' | 'success' | 'failure';
+
 export type ExecutionLogEntryDto = {
   id: string;
   timestampUtc: string;
   executionType: string;
-  finalStatus: string;
+  finalStatus: ExecutionStatus;
+  childCount: number;
   objectRef: ExecutionLogObjectRefDto;
   summary: string;
+};
+
+export type ExecutionTreeNodeKind =
+  | 'sequence'
+  | 'command'
+  | 'step'
+  | 'condition'
+  | 'loop'
+  | 'loopIteration'
+  | 'wait'
+  | 'tap';
+
+export type ExecutionTreeNodeStatus = ExecutionStatus | 'skipped' | 'not_executed';
+
+export type ExecutionTreeNodeDto = {
+  nodeKind: ExecutionTreeNodeKind;
+  executionId?: string;
+  order: number;
+  label: string;
+  status: ExecutionTreeNodeStatus;
+  message?: string;
+  appliedDelayMs?: number;
+  commandName?: string;
+  detailAttributes?: ExecutionLogWaitForImageDetailAttributesDto;
+  conditionTrace?: ExecutionLogConditionTraceDto;
+  deepLink?: ExecutionLogStepDeepLinkDto;
+  children: ExecutionTreeNodeDto[];
+};
+
+export type ExecutionSubtreeResponseDto = {
+  executionId: string;
+  finalStatus: ExecutionStatus;
+  root: ExecutionTreeNodeDto;
 };
 
 export type ExecutionLogListResponseDto = {
@@ -125,3 +161,6 @@ export const listExecutionLogs = async (query: ListExecutionLogsRequest = {}): P
 };
 
 export const getExecutionLogDetail = (executionId: string) => getJson<ExecutionLogDetailDto>(`/api/execution-logs/${encodeURIComponent(executionId)}`);
+
+export const getExecutionSubtree = (executionId: string) =>
+  getJson<ExecutionSubtreeResponseDto>(`/api/execution-logs/${encodeURIComponent(executionId)}/subtree`);

--- a/tests/contract/ExecutionLogs/ExecutionLogsHierarchyContractTests.cs
+++ b/tests/contract/ExecutionLogs/ExecutionLogsHierarchyContractTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.ContractTests.ExecutionLogs;
+
+public sealed class ExecutionLogsHierarchyContractTests : IDisposable {
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynPort;
+  private readonly string? _prevToken;
+
+  public ExecutionLogsHierarchyContractTests() {
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+    _prevToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynPort);
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevToken);
+    GC.SuppressFinalize(this);
+  }
+
+  [Fact]
+  public async Task ListReturnsRootsOnlyWithStatusAndChildCount() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var token = Token();
+    var commandName = $"{token}-CommandA";
+    var svc = app.Services.GetRequiredService<IExecutionLogService>();
+    await SeedSequenceRunAsync(svc, $"{token} Alpha", token, commandName).ConfigureAwait(false);
+
+    var response = await client.GetAsync(new Uri($"/api/execution-logs?filterObjectName={token}&pageSize=50", UriKind.Relative)).ConfigureAwait(false);
+    response.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+    var items = doc.RootElement.GetProperty("items");
+    items.GetArrayLength().Should().Be(1, "the invoked commands must not appear as their own list rows");
+
+    var item = items[0];
+    var hierarchy = item.GetProperty("hierarchy");
+    (hierarchy.TryGetProperty("parentExecutionId", out var parent) && parent.ValueKind == JsonValueKind.String)
+      .Should().BeFalse("the list must contain only top-level entries");
+    item.GetProperty("finalStatus").GetString().Should().Be("success");
+    item.GetProperty("childCount").ValueKind.Should().Be(JsonValueKind.Number);
+    item.GetProperty("objectRef").GetProperty("displayNameSnapshot").GetString().Should().Be($"{token} Alpha");
+    // The invoked command must not appear as its own list row (it may appear inside the
+    // sequence's own step details, which is expected).
+    items.EnumerateArray()
+      .Select(i => i.GetProperty("objectRef").GetProperty("displayNameSnapshot").GetString())
+      .Should().NotContain(commandName);
+  }
+
+  [Fact]
+  public async Task ListSortAndFilterApplyOverRootsOnly() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var token = Token();
+    var commandName = $"{token}-CommandA";
+    var svc = app.Services.GetRequiredService<IExecutionLogService>();
+    await SeedSequenceRunAsync(svc, $"{token} Alpha", token + "-a", commandName).ConfigureAwait(false);
+    await SeedSequenceRunAsync(svc, $"{token} Zulu", token + "-z", commandName).ConfigureAwait(false);
+
+    var sorted = await client.GetAsync(new Uri($"/api/execution-logs?sortBy=objectName&sortDirection=asc&filterObjectName={token}&pageSize=50", UriKind.Relative)).ConfigureAwait(false);
+    sorted.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await sorted.Content.ReadAsStringAsync().ConfigureAwait(false));
+    var names = doc.RootElement.GetProperty("items").EnumerateArray()
+      .Select(i => i.GetProperty("objectRef").GetProperty("displayNameSnapshot").GetString())
+      .ToList();
+
+    names.Should().HaveCount(2, "only the two sequence roots match — no child command rows leak in");
+    names[0].Should().Be($"{token} Alpha");
+    names[1].Should().Be($"{token} Zulu");
+    names.Should().NotContain(commandName);
+  }
+
+  [Fact]
+  public async Task SubtreeEndpointReturnsNestedTree() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var token = Token();
+    var svc = app.Services.GetRequiredService<IExecutionLogService>();
+    var rootId = await SeedSequenceRunAsync(svc, $"{token} Alpha", token, $"{token}-CommandA").ConfigureAwait(false);
+
+    var response = await client.GetAsync(new Uri($"/api/execution-logs/{rootId}/subtree", UriKind.Relative)).ConfigureAwait(false);
+    response.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+    var root = doc.RootElement;
+    root.GetProperty("executionId").GetString().Should().Be(rootId);
+    root.TryGetProperty("finalStatus", out _).Should().BeTrue();
+    root.GetProperty("root").GetProperty("children").GetArrayLength().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task SubtreeEndpointReturnsNotFoundForUnknownId() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var response = await client.GetAsync(new Uri("/api/execution-logs/does-not-exist/subtree", UriKind.Relative)).ConfigureAwait(false);
+    response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+  }
+
+  private static string Token() => "ctrhier" + Guid.NewGuid().ToString("N")[..8];
+
+  private static async Task<string> SeedSequenceRunAsync(IExecutionLogService svc, string sequenceName, string sequenceId, string commandName) {
+    var rootId = await svc.LogSequenceStartAsync(sequenceId, sequenceName).ConfigureAwait(false);
+    await svc.LogCommandExecutionAsync("cmd-a", commandName, "success", Array.Empty<PrimitiveTapStepOutcome>(),
+      new ExecutionLogContext { ParentExecutionId = rootId, RootExecutionId = rootId, Depth = 1, SequenceIndex = 1, SequenceId = sequenceId, SequenceLabel = sequenceName }).ConfigureAwait(false);
+    await svc.LogCommandExecutionAsync("cmd-b", commandName + "B", "success", Array.Empty<PrimitiveTapStepOutcome>(),
+      new ExecutionLogContext { ParentExecutionId = rootId, RootExecutionId = rootId, Depth = 1, SequenceIndex = 2, SequenceId = sequenceId, SequenceLabel = sequenceName }).ConfigureAwait(false);
+
+    var details = new List<ExecutionDetailItem> {
+      Step(1, "cmd-a", commandName, sequenceId, sequenceName),
+      Step(2, "cmd-b", commandName + "B", sequenceId, sequenceName)
+    };
+    await svc.LogSequenceFinalizeAsync(rootId, sequenceId, sequenceName, "success",
+      $"Sequence '{sequenceName}' success with 2 steps executed.",
+      new ExecutionLogContext { Depth = 0, SequenceId = sequenceId, SequenceLabel = sequenceName }, details).ConfigureAwait(false);
+    return rootId;
+  }
+
+  private static ExecutionDetailItem Step(int order, string commandId, string commandName, string seqId, string seqLabel)
+    => new("step", $"Step ran command '{commandName}'.", new Dictionary<string, object?> {
+        ["stepOrder"] = order, ["stepType"] = "command", ["status"] = "executed", ["actionOutcome"] = "executed",
+        ["commandId"] = commandId, ["commandName"] = commandName, ["sequenceId"] = seqId, ["sequenceLabel"] = seqLabel,
+        ["stepId"] = $"step-{order}", ["stepLabel"] = $"Step {order}"
+      }, "normal");
+}

--- a/tests/integration/ExecutionLogs/HistoricalLogBackwardCompatIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/HistoricalLogBackwardCompatIntegrationTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class HistoricalLogBackwardCompatIntegrationTests {
+  [Fact]
+  public async Task HistoricalEntriesRenderAsCompletedLeafRootsWithoutError() {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+    var repository = app.Services.GetRequiredService<IExecutionLogRepository>();
+    var svc = app.Services.GetRequiredService<IExecutionLogService>();
+
+    // Simulate a pre-feature entry: no "running" status, no linked children, root hierarchy.
+    var legacy = new ExecutionLogEntry {
+      Id = "legacy-1",
+      TimestampUtc = DateTimeOffset.UtcNow.AddDays(-1),
+      ExecutionType = "command",
+      FinalStatus = "success",
+      ObjectRef = new ExecutionObjectReference("command", "cmd-legacy", "Legacy Command"),
+      Navigation = new ExecutionNavigationContext("/authoring/commands/cmd-legacy", null),
+      Hierarchy = new ExecutionHierarchyContext("legacy-1", null, 0, null),
+      Summary = "Legacy command executed.",
+      RetentionExpiresUtc = DateTimeOffset.UtcNow.AddDays(30)
+    };
+    await repository.AddAsync(legacy).ConfigureAwait(false);
+
+    // Appears in the roots-only list (it is top-level).
+    var roots = await svc.QueryAsync(new ExecutionLogQuery { RootsOnly = true, PageSize = 50 }).ConfigureAwait(false);
+    roots.Items.Should().Contain(i => i.Id == "legacy-1");
+
+    // Detail and subtree both resolve without error; the subtree is a leaf root.
+    var detail = await svc.GetAsync("legacy-1").ConfigureAwait(false);
+    detail.Should().NotBeNull();
+
+    var subtree = await svc.GetSubtreeAsync("legacy-1").ConfigureAwait(false);
+    subtree.Should().NotBeNull();
+    subtree!.Root.ExecutionId.Should().Be("legacy-1");
+    subtree.Root.Children.Should().BeEmpty("a historical command has no recorded sub-elements");
+  }
+}

--- a/tests/integration/ExecutionLogs/SequenceGroupingIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/SequenceGroupingIntegrationTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class SequenceGroupingIntegrationTests {
+  private static readonly string[] CommandNames = { "Command A", "Command B" };
+
+  [Fact]
+  public async Task SequenceRunProducesSingleRootWithLinkedChildrenAndNestedSubtree() {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+    var logService = app.Services.GetRequiredService<IExecutionLogService>();
+
+    var rootId = await logService.LogSequenceStartAsync("seq-1", "My Sequence").ConfigureAwait(false);
+
+    await logService.LogCommandExecutionAsync(
+      "cmd-a", "Command A", "success",
+      new[] { new PrimitiveTapStepOutcome(1, "executed", null, new PrimitiveTapResolvedPoint(10, 20), 0.9) },
+      ChildContext(rootId, 1)).ConfigureAwait(false);
+    await logService.LogCommandExecutionAsync(
+      "cmd-b", "Command B", "success",
+      Array.Empty<PrimitiveTapStepOutcome>(),
+      ChildContext(rootId, 2)).ConfigureAwait(false);
+
+    var details = new List<ExecutionDetailItem> {
+      StepDetail(1, "cmd-a", "Command A"),
+      StepDetail(2, "cmd-b", "Command B")
+    };
+    await logService.LogSequenceFinalizeAsync(
+      rootId, "seq-1", "My Sequence", "success",
+      "Sequence 'My Sequence' success with 2 steps executed.",
+      new ExecutionLogContext { Depth = 0, SequenceId = "seq-1", SequenceLabel = "My Sequence" },
+      details).ConfigureAwait(false);
+
+    // Roots-only list returns ONLY the sequence — invoked commands are excluded.
+    var roots = await logService.QueryAsync(new ExecutionLogQuery { RootsOnly = true, PageSize = 50 }).ConfigureAwait(false);
+    roots.Items.Should().ContainSingle();
+    roots.Items[0].Id.Should().Be(rootId);
+    roots.Items[0].FinalStatus.Should().Be("success");
+
+    // But the child records are kept (linked), not deleted.
+    var all = await logService.QueryAsync(new ExecutionLogQuery { RootsOnly = false, PageSize = 50 }).ConfigureAwait(false);
+    all.Items.Should().HaveCount(3);
+
+    // The subtree nests the invoked commands under the sequence.
+    var subtree = await logService.GetSubtreeAsync(rootId).ConfigureAwait(false);
+    subtree.Should().NotBeNull();
+    subtree!.Root.ExecutionId.Should().Be(rootId);
+    subtree.Root.Children.Should().HaveCount(2);
+    subtree.Root.Children.Select(c => c.CommandName).Should().BeEquivalentTo(CommandNames);
+    subtree.Root.Children.Should().OnlyContain(c => c.ExecutionId != null);
+    // The command with a primitive tap exposes it as a nested child.
+    subtree.Root.Children.Single(c => c.CommandName == "Command A").Children.Should().NotBeEmpty();
+  }
+
+  private static ExecutionLogContext ChildContext(string rootId, int sequenceIndex)
+    => new() {
+      ParentExecutionId = rootId,
+      RootExecutionId = rootId,
+      Depth = 1,
+      SequenceIndex = sequenceIndex,
+      SequenceId = "seq-1",
+      SequenceLabel = "My Sequence"
+    };
+
+  private static ExecutionDetailItem StepDetail(int order, string commandId, string commandName)
+    => new(
+      "step",
+      $"Step ran command '{commandName}'.",
+      new Dictionary<string, object?> {
+        ["stepOrder"] = order,
+        ["stepType"] = "command",
+        ["status"] = "executed",
+        ["actionOutcome"] = "executed",
+        ["commandId"] = commandId,
+        ["commandName"] = commandName,
+        ["sequenceId"] = "seq-1",
+        ["sequenceLabel"] = "My Sequence",
+        ["stepId"] = $"step-{order}",
+        ["stepLabel"] = $"Step {order}"
+      },
+      "normal");
+}

--- a/tests/integration/ExecutionLogs/SequenceLiveStatusIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/SequenceLiveStatusIntegrationTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class SequenceLiveStatusIntegrationTests {
+  [Fact]
+  public async Task RunningRootIsSurfacedThenFinalizedInPlaceWithoutDuplicate() {
+    TestEnvironment.PrepareCleanDataDir();
+
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+    var svc = app.Services.GetRequiredService<IExecutionLogService>();
+
+    // Start: a single in-progress root entry is visible while the sequence runs.
+    var rootId = await svc.LogSequenceStartAsync("seq-live", "Live Sequence").ConfigureAwait(false);
+
+    var running = await svc.QueryAsync(new ExecutionLogQuery { RootsOnly = true, PageSize = 50 }).ConfigureAwait(false);
+    running.Items.Should().ContainSingle();
+    running.Items[0].Id.Should().Be(rootId);
+    running.Items[0].FinalStatus.Should().Be("running");
+
+    var runningSubtree = await svc.GetSubtreeAsync(rootId).ConfigureAwait(false);
+    runningSubtree!.FinalStatus.Should().Be("running");
+
+    // Children execute and link to the running root.
+    await svc.LogCommandExecutionAsync("cmd-a", "Command A", "success", Array.Empty<PrimitiveTapStepOutcome>(),
+      new ExecutionLogContext { ParentExecutionId = rootId, RootExecutionId = rootId, Depth = 1, SequenceIndex = 1, SequenceId = "seq-live", SequenceLabel = "Live Sequence" }).ConfigureAwait(false);
+
+    // Finalize: the SAME entry settles to its terminal status — no duplicate root row.
+    await svc.LogSequenceFinalizeAsync(rootId, "seq-live", "Live Sequence", "success",
+      "Sequence 'Live Sequence' success with 1 step executed.",
+      new ExecutionLogContext { Depth = 0, SequenceId = "seq-live", SequenceLabel = "Live Sequence" },
+      new List<ExecutionDetailItem> {
+        new("step", "Step ran command 'Command A'.", new Dictionary<string, object?> {
+          ["stepOrder"] = 1, ["stepType"] = "command", ["status"] = "executed", ["actionOutcome"] = "executed",
+          ["commandId"] = "cmd-a", ["commandName"] = "Command A", ["sequenceId"] = "seq-live", ["sequenceLabel"] = "Live Sequence",
+          ["stepId"] = "step-1", ["stepLabel"] = "Step 1"
+        }, "normal")
+      }).ConfigureAwait(false);
+
+    var finalized = await svc.QueryAsync(new ExecutionLogQuery { RootsOnly = true, PageSize = 50 }).ConfigureAwait(false);
+    finalized.Items.Should().ContainSingle("finalize must replace the in-progress entry, not add a second root");
+    finalized.Items[0].Id.Should().Be(rootId);
+    finalized.Items[0].FinalStatus.Should().Be("success");
+
+    var all = await svc.QueryAsync(new ExecutionLogQuery { RootsOnly = false, PageSize = 50 }).ConfigureAwait(false);
+    all.Items.Should().HaveCount(2, "one root + one linked child");
+  }
+}

--- a/tests/integration/ExecutionLogs/StandaloneCommandIntegrationTests.cs
+++ b/tests/integration/ExecutionLogs/StandaloneCommandIntegrationTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using FluentAssertions;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.ExecutionLogs;
+
+[Collection("ConfigIsolation")]
+public sealed class StandaloneCommandIntegrationTests {
+  [Fact]
+  public async Task DirectCommandExecutionIsTopLevelLeafWithoutChildren() {
+    TestEnvironment.PrepareCleanDataDir();
+
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var svc = app.Services.GetRequiredService<IExecutionLogService>();
+    // A directly executed command logs with the default (root) context — no parent.
+    await svc.LogCommandExecutionAsync(
+      "cmd-solo", "Solo Command", "success",
+      new[] { new PrimitiveTapStepOutcome(1, "executed", null, new PrimitiveTapResolvedPoint(5, 5), 0.95) },
+      new ExecutionLogContext { Depth = 0 }).ConfigureAwait(false);
+
+    var response = await client.GetAsync(new Uri("/api/execution-logs?filterObjectName=Solo%20Command&pageSize=50", UriKind.Relative)).ConfigureAwait(false);
+    response.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+    var items = doc.RootElement.GetProperty("items");
+    items.GetArrayLength().Should().Be(1);
+
+    var item = items[0];
+    item.GetProperty("executionType").GetString().Should().Be("command");
+    item.GetProperty("childCount").GetInt32().Should().Be(0, "a stand-alone command is a leaf, not expandable");
+    item.GetProperty("finalStatus").GetString().Should().Be("success");
+    var hierarchy = item.GetProperty("hierarchy");
+    (hierarchy.TryGetProperty("parentExecutionId", out var parent) && parent.ValueKind == JsonValueKind.String)
+      .Should().BeFalse("a directly executed command is top-level (no parent)");
+  }
+}

--- a/tests/unit/ExecutionLogs/ExecutionLogRepositoryHierarchyTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionLogRepositoryHierarchyTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using Xunit;
+
+namespace GameBot.UnitTests.ExecutionLogs;
+
+public sealed class ExecutionLogRepositoryHierarchyTests {
+  private static readonly string[] AllEntryIds = { "root-1", "child-1", "child-2" };
+  private static readonly string[] Root1SubtreeIds = { "root-1", "child-1", "child-2" };
+
+  [Fact]
+  public async Task UpsertAsyncReplacesExistingEntryWithoutDuplicate() {
+    var storageRoot = CreateTempStorageRoot();
+    using var repository = new FileExecutionLogRepository(storageRoot);
+
+    var now = DateTimeOffset.UtcNow;
+    await repository.AddAsync(CreateRoot("root-1", now, "Sequence A", "running")).ConfigureAwait(false);
+
+    // Prime the in-memory cache before upserting.
+    var running = await repository.QueryAsync(new ExecutionLogQuery { PageSize = 50 }).ConfigureAwait(false);
+    running.Items.Should().ContainSingle().Which.FinalStatus.Should().Be("running");
+
+    await repository.UpsertAsync(CreateRoot("root-1", now, "Sequence A", "success")).ConfigureAwait(false);
+
+    var finalized = await repository.QueryAsync(new ExecutionLogQuery { PageSize = 50 }).ConfigureAwait(false);
+    finalized.Items.Should().ContainSingle("upsert must replace, not duplicate");
+    finalized.Items[0].FinalStatus.Should().Be("success");
+  }
+
+  [Fact]
+  public async Task QueryRootsOnlyExcludesChildExecutions() {
+    var storageRoot = CreateTempStorageRoot();
+    using var repository = new FileExecutionLogRepository(storageRoot);
+
+    var now = DateTimeOffset.UtcNow;
+    await repository.AddAsync(CreateRoot("root-1", now, "Sequence A", "success")).ConfigureAwait(false);
+    await repository.AddAsync(CreateChild("child-1", now.AddSeconds(1), "Command One", "root-1", 1)).ConfigureAwait(false);
+    await repository.AddAsync(CreateChild("child-2", now.AddSeconds(2), "Command Two", "root-1", 2)).ConfigureAwait(false);
+
+    var rootsOnly = await repository.QueryAsync(new ExecutionLogQuery { RootsOnly = true, PageSize = 50 }).ConfigureAwait(false);
+    rootsOnly.Items.Should().ContainSingle().Which.Id.Should().Be("root-1");
+
+    var all = await repository.QueryAsync(new ExecutionLogQuery { RootsOnly = false, PageSize = 50 }).ConfigureAwait(false);
+    all.Items.Select(i => i.Id).Should().BeEquivalentTo(AllEntryIds);
+  }
+
+  [Fact]
+  public async Task GetSubtreeReturnsRootAndDescendantsOnly() {
+    var storageRoot = CreateTempStorageRoot();
+    using var repository = new FileExecutionLogRepository(storageRoot);
+
+    var now = DateTimeOffset.UtcNow;
+    await repository.AddAsync(CreateRoot("root-1", now, "Sequence A", "success")).ConfigureAwait(false);
+    await repository.AddAsync(CreateChild("child-1", now.AddSeconds(1), "Command One", "root-1", 1)).ConfigureAwait(false);
+    await repository.AddAsync(CreateChild("child-2", now.AddSeconds(2), "Command Two", "root-1", 2)).ConfigureAwait(false);
+    // Unrelated root + child that must not leak into the subtree.
+    await repository.AddAsync(CreateRoot("root-2", now, "Sequence B", "success")).ConfigureAwait(false);
+    await repository.AddAsync(CreateChild("child-3", now.AddSeconds(1), "Other", "root-2", 1)).ConfigureAwait(false);
+
+    var subtree = await repository.GetSubtreeAsync("root-1").ConfigureAwait(false);
+
+    subtree.Select(e => e.Id).Should().BeEquivalentTo(Root1SubtreeIds);
+  }
+
+  [Fact]
+  public async Task GetSubtreeReturnsEmptyForUnknownRoot() {
+    var storageRoot = CreateTempStorageRoot();
+    using var repository = new FileExecutionLogRepository(storageRoot);
+
+    var subtree = await repository.GetSubtreeAsync("does-not-exist").ConfigureAwait(false);
+
+    subtree.Should().BeEmpty();
+  }
+
+  private static ExecutionLogEntry CreateRoot(string id, DateTimeOffset timestampUtc, string objectName, string status)
+    => new() {
+      Id = id,
+      TimestampUtc = timestampUtc,
+      ExecutionType = "sequence",
+      FinalStatus = status,
+      ObjectRef = new ExecutionObjectReference("sequence", id, objectName),
+      Navigation = new ExecutionNavigationContext($"/authoring/sequences/{id}", null),
+      Hierarchy = new ExecutionHierarchyContext(id, null, 0, null),
+      Summary = "Summary",
+      RetentionExpiresUtc = timestampUtc.AddDays(30)
+    };
+
+  private static ExecutionLogEntry CreateChild(string id, DateTimeOffset timestampUtc, string objectName, string rootId, int sequenceIndex)
+    => new() {
+      Id = id,
+      TimestampUtc = timestampUtc,
+      ExecutionType = "command",
+      FinalStatus = "success",
+      ObjectRef = new ExecutionObjectReference("command", id, objectName),
+      Navigation = new ExecutionNavigationContext($"/authoring/commands/{id}", $"/authoring/sequences/{rootId}"),
+      Hierarchy = new ExecutionHierarchyContext(rootId, rootId, 1, sequenceIndex),
+      Summary = "Summary",
+      RetentionExpiresUtc = timestampUtc.AddDays(30)
+    };
+
+  private static string CreateTempStorageRoot() {
+    var root = Path.Combine(Path.GetTempPath(), "GameBot.UnitTests", Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(root);
+    return root;
+  }
+}

--- a/tests/unit/ExecutionLogs/ExecutionSubtreeProjectionTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionSubtreeProjectionTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using Xunit;
+
+namespace GameBot.UnitTests.ExecutionLogs;
+
+public sealed class ExecutionSubtreeProjectionTests {
+  private static readonly string[] CommandLabels = { "Open Mail", "Collect" };
+
+  [Fact]
+  public void BuildSubtreeCorrelatesCommandStepsToChildEntriesByCommandId() {
+    var root = SequenceEntry("root-1", "My Sequence", "success", new[] {
+      CommandStep(1, "cmd-a", "Open Mail"),
+      CommandStep(2, "cmd-b", "Collect")
+    });
+    var childA = CommandChild("child-a", "cmd-a", "Open Mail", "root-1", 1);
+    var childB = CommandChild("child-b", "cmd-b", "Collect", "root-1", 2);
+
+    var subtree = ExecutionLogService.BuildSubtree(root, new[] { root, childA, childB });
+
+    subtree.FinalStatus.Should().Be("success");
+    subtree.Root.Children.Should().HaveCount(2);
+    subtree.Root.Children.Select(c => c.Label).Should().BeEquivalentTo(CommandLabels);
+    subtree.Root.Children.Should().OnlyContain(c => c.ExecutionId != null);
+    // Command nodes carry their child execution's own primitive outcomes as nested children.
+    subtree.Root.Children[0].Children.Should().NotBeEmpty();
+  }
+
+  [Fact]
+  public void BuildSubtreePreservesInlineConditionAndWaitSteps() {
+    var root = SequenceEntry("root-2", "Conditional", "success", new[] {
+      ConditionStep(1),
+      WaitStep(2)
+    });
+
+    var subtree = ExecutionLogService.BuildSubtree(root, new[] { root });
+
+    subtree.Root.Children.Should().HaveCount(2);
+    subtree.Root.Children[0].NodeKind.Should().Be("condition");
+    subtree.Root.Children[0].ConditionTrace.Should().NotBeNull();
+    subtree.Root.Children[1].NodeKind.Should().Be("wait");
+    subtree.Root.Children[1].DetailAttributes.Should().NotBeNull();
+  }
+
+  [Fact]
+  public void BuildSubtreeNestsChildSequenceWithoutExtraTopLevelNode() {
+    // Sequence-invoking-sequence: a child entry that is itself a sequence with its own command child.
+    var root = SequenceEntry("root-3", "Outer", "success", new[] { CommandStep(1, "seq-inner", "Inner") });
+    var innerSeqLinked = LinkAsChild(SequenceEntry("child-inner", "Inner", "success", new[] { CommandStep(1, "cmd-x", "Tap") }), "seq-inner", "root-3", 1);
+    var grandChildLinked = ReParent(CommandChild("gc-1", "cmd-x", "Tap", "root-3", 1), "child-inner");
+
+    var subtree = ExecutionLogService.BuildSubtree(root, new[] { root, innerSeqLinked, grandChildLinked });
+
+    subtree.Root.Children.Should().ContainSingle();
+    var innerNode = subtree.Root.Children[0];
+    innerNode.NodeKind.Should().Be("sequence");
+    innerNode.ExecutionId.Should().Be("child-inner");
+    innerNode.Children.Should().ContainSingle();
+    innerNode.Children[0].NodeKind.Should().Be("command");
+  }
+
+  private static ExecutionLogEntry SequenceEntry(string id, string name, string status, ExecutionStepOutcome[] steps)
+    => new() {
+      Id = id,
+      ExecutionType = "sequence",
+      FinalStatus = status,
+      ObjectRef = new ExecutionObjectReference("sequence", id, name),
+      Navigation = new ExecutionNavigationContext($"/authoring/sequences/{id}", null),
+      Hierarchy = new ExecutionHierarchyContext(id, null, 0, null),
+      Summary = $"{name} executed.",
+      StepOutcomes = steps,
+      RetentionExpiresUtc = DateTimeOffset.UtcNow.AddDays(1)
+    };
+
+  private static ExecutionStepOutcome CommandStep(int order, string commandId, string commandName)
+    => new(order, "command", "executed", "executed", $"Step ran command '{commandName}'.", "seq", $"step-{order}", "Seq", $"Step {order}") {
+      CommandName = commandName,
+      CommandId = commandId
+    };
+
+  private static ExecutionStepOutcome ConditionStep(int order)
+    => new(order, "condition", "executed", "executed", "Condition evaluated to true.", "seq", $"step-{order}", "Seq", $"Step {order}",
+      new ConditionEvaluationTrace(true, "true", null, Array.Empty<Dictionary<string, object?>>(), Array.Empty<Dictionary<string, object?>>()));
+
+  private static ExecutionStepOutcome WaitStep(int order)
+    => new(order, "waitForImage", "image_detected", "image_detected", "Wait completed.", "seq", $"step-{order}", "Seq", $"Step {order}") {
+      DetailAttributes = new WaitForImageDetailAttributes(5000, 5000, "img-1", 0.8, "image_detected", "loaded")
+    };
+
+  private static ExecutionLogEntry CommandChild(string id, string commandId, string commandName, string rootId, int sequenceIndex)
+    => new() {
+      Id = id,
+      ExecutionType = "command",
+      FinalStatus = "success",
+      ObjectRef = new ExecutionObjectReference("command", commandId, commandName),
+      Navigation = new ExecutionNavigationContext($"/authoring/commands/{commandId}", $"/authoring/sequences/{rootId}"),
+      Hierarchy = new ExecutionHierarchyContext(rootId, rootId, 1, sequenceIndex),
+      Summary = $"{commandName} executed.",
+      StepOutcomes = new[] {
+        new ExecutionStepOutcome(1, "primitiveTap", "executed", "executed", "Tap executed.")
+      },
+      RetentionExpiresUtc = DateTimeOffset.UtcNow.AddDays(1)
+    };
+
+  private static ExecutionLogEntry LinkAsChild(ExecutionLogEntry entry, string commandId, string rootId, int sequenceIndex)
+    => new() {
+      Id = entry.Id,
+      ExecutionType = entry.ExecutionType,
+      FinalStatus = entry.FinalStatus,
+      ObjectRef = new ExecutionObjectReference(entry.ObjectRef.ObjectType, commandId, entry.ObjectRef.DisplayNameSnapshot),
+      Navigation = entry.Navigation,
+      Hierarchy = new ExecutionHierarchyContext(rootId, rootId, 1, sequenceIndex),
+      Summary = entry.Summary,
+      StepOutcomes = entry.StepOutcomes,
+      RetentionExpiresUtc = entry.RetentionExpiresUtc
+    };
+
+  private static ExecutionLogEntry ReParent(ExecutionLogEntry entry, string parentId)
+    => new() {
+      Id = entry.Id,
+      ExecutionType = entry.ExecutionType,
+      FinalStatus = entry.FinalStatus,
+      ObjectRef = entry.ObjectRef,
+      Navigation = entry.Navigation,
+      Hierarchy = new ExecutionHierarchyContext("root-3", parentId, 2, entry.Hierarchy.SequenceIndex),
+      Summary = entry.Summary,
+      StepOutcomes = entry.StepOutcomes,
+      RetentionExpiresUtc = entry.RetentionExpiresUtc
+    };
+}


### PR DESCRIPTION
## Summary

Reworks the execution logs so the list shows **only what was actually executed** — stand-alone commands and sequences — instead of one flat row per invoked command plus the sequence.

Previously, running a sequence logged each invoked command as its own top-level entry (`Depth 0`, no parent) **and** the sequence as another top-level entry, so the list was cluttered and it was hard to tell what actually ran.

Now:
- A **sequence run is a single top-level entry**; its invoked commands are recorded as **linked children** (kept, not deleted) and nested beneath it.
- **Stand-alone commands** remain top-level leaf entries with full detail.
- A **running sequence** shows as a single in-progress entry that updates live.

## What changed

- **Linking**: invoked commands log with the existing `RootExecutionId` / `ParentExecutionId` / `Depth` / `SequenceIndex` hierarchy fields; the list query defaults to **roots-only**.
- **Lifecycle**: new `running` status; the root entry is created at sequence start and **finalized in place** via a new repository `UpsertAsync` (no duplicate root row).
- **API**: new `GET /api/execution-logs/{id}/subtree` returns the nested execution tree; list items gain `childCount`; `finalStatus` now includes `running`. `specs/openapi.json` regenerated; change is additive/backward-compatible.
- **Web UI**: expandable tree rows with lazy subtree loading + **~2s polling** while any entry is running, so sub-elements update without a manual reload.
- **Backward compatibility**: historical logs render as completed leaf roots (no migration).

## Spec / design

Full Spec Kit artifacts under `specs/049-execution-logs-hierarchy/` (spec, plan, research, data-model, contract, quickstart, tasks).

## Testing

- **Backend**: new unit (repo hierarchy, subtree projection incl. nested sequence), integration (grouping, stand-alone, live status to finalize, backward-compat), and contract (roots-only + sort/filter, subtree endpoint) suites — all green (contract 67, integration 235, execution-log unit 28).
- **Web UI**: new tree, stand-alone-leaf, and polling suites — full suite 317/317 across 74 suites, coverage thresholds met.
- **Build**: clean (0 warnings / 0 errors).

### Known items

- Manual UI quickstart scenarios (A–F) need a live emulator/session to validate end-to-end; the API-level behaviors are covered by automated tests.
- One pre-existing flaky test unrelated to this change — `BackgroundCaptureScreenSourceTests.ReturnsBitmapCloneWhenFrameAvailable` — passes in isolation but fails when its sibling GDI/capture tests run first. It touches no code in this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
