### PR TITLE
fix: correct execution log status for condition steps and loop exits

### DIFF
--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "0",
   "minor": "7",
-  "patch": "0",
+  "patch": "1",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-06-02T00:00:00Z"
+  "updatedAtUtc": "2026-06-02T23:38:00Z"
 }

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -824,9 +824,10 @@ namespace GameBot.Domain.Services {
 
         iterations++;
         if (iterations > maxIterations) {
-          result.AddLoopStep(stepKey, "Succeeded", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
-          stepOutcomes[stepKey] = "success";
-          return false;
+          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          stepOutcomes[stepKey] = "failed";
+          return true;
         }
 
         var iterCtx = ImmutableIterContext(iterations);
@@ -895,9 +896,10 @@ namespace GameBot.Domain.Services {
         if (breakTriggered) break;
 
         if (iterations >= maxIterations) {
-          result.AddLoopStep(stepKey, "Succeeded", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
-          stepOutcomes[stepKey] = "success";
-          return false;
+          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          stepOutcomes[stepKey] = "failed";
+          return true;
         }
 
         // Evaluate exit condition after body executes
@@ -1295,14 +1297,14 @@ namespace GameBot.Domain.Services {
 
         if (maxIterations.HasValue && iterations >= maxIterations.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
-          if (_logger != null) LogBlockEnd(_logger, "while", "Succeeded", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
+          if (_logger != null) LogBlockEnd(_logger, "while", "Failed", iterations, evals, null);
           return;
         }
         if (startDeadline.HasValue && DateTimeOffset.UtcNow >= startDeadline.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
-          if (_logger != null) LogBlockEnd(_logger, "while", "Succeeded", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
+          if (_logger != null) LogBlockEnd(_logger, "while", "Failed", iterations, evals, null);
           return;
         }
         await Task.Delay(cadenceMs, ct).ConfigureAwait(false);
@@ -1390,8 +1392,8 @@ namespace GameBot.Domain.Services {
         }
         if (satisfied) {
           var durOk = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations - 1, Evaluations = evals, DurationMs = durOk, Status = "true" });
-          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "true", iterations - 1, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations - 1, Evaluations = evals, DurationMs = durOk, Status = "Succeeded" });
+          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations - 1, evals, null);
           return;
         }
 
@@ -1444,14 +1446,15 @@ namespace GameBot.Domain.Services {
         // Safeguards: first-hit wins (FR-20)
         if (maxIterations.HasValue && iterations >= maxIterations.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
-          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
+          result.Fail($"repeatUntil exceeded maximum iterations ({maxIterations.Value}).");
+          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Failed", iterations, evals, null);
           return;
         }
         if (startDeadline.HasValue && DateTimeOffset.UtcNow >= startDeadline.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
-          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
+          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Failed", iterations, evals, null);
           return;
         }
 
@@ -1536,10 +1539,10 @@ namespace GameBot.Domain.Services {
           if (_logger != null) LogBlockEvaluation(_logger, "repeatCount", "breakOn-start", brStart, null);
           if (brStart) {
             var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-            result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "true" });
+            result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
             if (_logger != null) {
               LogBlockDecision(_logger, "repeatCount", "break", iterations, null);
-              LogBlockEnd(_logger, "repeatCount", "true", iterations, evals, null);
+              LogBlockEnd(_logger, "repeatCount", "Succeeded", iterations, evals, null);
             }
             return;
           }
@@ -1569,10 +1572,10 @@ namespace GameBot.Domain.Services {
               if (_logger != null) LogBlockEvaluation(_logger, "repeatCount", "breakOn-mid", brMid, null);
               if (brMid) {
                 var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-                result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "true" });
+                result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
                 if (_logger != null) {
                   LogBlockDecision(_logger, "repeatCount", "break", iterations, null);
-                  LogBlockEnd(_logger, "repeatCount", "true", iterations, evals, null);
+                  LogBlockEnd(_logger, "repeatCount", "Succeeded", iterations, evals, null);
                 }
                 return;
               }

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -743,6 +743,7 @@ namespace GameBot.Domain.Services {
         CancellationToken ct) {
       var iterResults = new List<LoopIterResult>();
       var priorIterationExecutedSteps = false;
+      var breakFired = false;
 
       for (var i = 0; i < cfg.Count; i++) {
         ct.ThrowIfCancellationRequested();
@@ -766,10 +767,10 @@ namespace GameBot.Domain.Services {
           stepOutcomes[stepKey] = "failed";
           return true;
         }
-        if (breakTriggered) break;
+        if (breakTriggered) { breakFired = true; break; }
       }
 
-      result.AddLoopStep(stepKey, "Succeeded", iterResults);
+      result.AddLoopStep(stepKey, breakFired ? "true" : "Succeeded", iterResults);
       stepOutcomes[stepKey] = "success";
       return false;
     }
@@ -809,7 +810,7 @@ namespace GameBot.Domain.Services {
 
         if (!condResult) {
           // condition false on entry (or after last iteration)
-          var status = iterations == 0 ? "Skipped" : "Succeeded";
+          var status = iterations == 0 ? "Skipped" : "false";
           result.AddLoopStep(stepKey, status, iterResults);
           stepOutcomes[stepKey] = iterations == 0 ? "skipped" : "success";
           return false;
@@ -823,10 +824,9 @@ namespace GameBot.Domain.Services {
 
         iterations++;
         if (iterations > maxIterations) {
-          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
-          result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
-          stepOutcomes[stepKey] = "failed";
-          return true;
+          result.AddLoopStep(stepKey, "Succeeded", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          stepOutcomes[stepKey] = "success";
+          return false;
         }
 
         var iterCtx = ImmutableIterContext(iterations);
@@ -845,7 +845,7 @@ namespace GameBot.Domain.Services {
         if (breakTriggered) break;
       }
 
-      result.AddLoopStep(stepKey, "Succeeded", iterResults);
+      result.AddLoopStep(stepKey, "true", iterResults);
       stepOutcomes[stepKey] = "success";
       return false;
     }
@@ -895,10 +895,9 @@ namespace GameBot.Domain.Services {
         if (breakTriggered) break;
 
         if (iterations >= maxIterations) {
-          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
-          result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
-          stepOutcomes[stepKey] = "failed";
-          return true;
+          result.AddLoopStep(stepKey, "Succeeded", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          stepOutcomes[stepKey] = "success";
+          return false;
         }
 
         // Evaluate exit condition after body executes
@@ -917,7 +916,7 @@ namespace GameBot.Domain.Services {
         if (exitCond) break;
       }
 
-      result.AddLoopStep(stepKey, "Succeeded", iterResults);
+      result.AddLoopStep(stepKey, "true", iterResults);
       stepOutcomes[stepKey] = "success";
       return false;
     }
@@ -1230,10 +1229,10 @@ namespace GameBot.Domain.Services {
           if (_logger != null) LogBlockEvaluation(_logger, "while", "breakOn-start", brStart, null);
           if (brStart) {
             var durBreak = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-            result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = durBreak, Status = "Succeeded" });
+            result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = durBreak, Status = "true" });
             if (_logger != null) {
               LogBlockDecision(_logger, "while", "break", iterations, null);
-              LogBlockEnd(_logger, "while", "Succeeded", iterations, evals, null);
+              LogBlockEnd(_logger, "while", "true", iterations, evals, null);
             }
             return;
           }
@@ -1243,8 +1242,8 @@ namespace GameBot.Domain.Services {
         if (_logger != null) LogBlockEvaluation(_logger, "while", "condition", satisfied, null);
         if (!satisfied) {
           var durOk = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = durOk, Status = "Succeeded" });
-          if (_logger != null) LogBlockEnd(_logger, "while", "Succeeded", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = durOk, Status = "false" });
+          if (_logger != null) LogBlockEnd(_logger, "while", "false", iterations, evals, null);
           return;
         }
 
@@ -1270,10 +1269,10 @@ namespace GameBot.Domain.Services {
               if (_logger != null) LogBlockEvaluation(_logger, "while", "breakOn-mid", brMid, null);
               if (brMid) {
                 var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-                result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+                result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "true" });
                 if (_logger != null) {
                   LogBlockDecision(_logger, "while", "break", iterations, null);
-                  LogBlockEnd(_logger, "while", "Succeeded", iterations, evals, null);
+                  LogBlockEnd(_logger, "while", "true", iterations, evals, null);
                 }
                 return;
               }
@@ -1296,14 +1295,14 @@ namespace GameBot.Domain.Services {
 
         if (maxIterations.HasValue && iterations >= maxIterations.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
-          if (_logger != null) LogBlockEnd(_logger, "while", "Failed", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+          if (_logger != null) LogBlockEnd(_logger, "while", "Succeeded", iterations, evals, null);
           return;
         }
         if (startDeadline.HasValue && DateTimeOffset.UtcNow >= startDeadline.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
-          if (_logger != null) LogBlockEnd(_logger, "while", "Failed", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+          if (_logger != null) LogBlockEnd(_logger, "while", "Succeeded", iterations, evals, null);
           return;
         }
         await Task.Delay(cadenceMs, ct).ConfigureAwait(false);
@@ -1375,10 +1374,10 @@ namespace GameBot.Domain.Services {
           if (_logger != null) LogBlockEvaluation(_logger, "repeatUntil", "breakOn-start", brStart, null);
           if (brStart) {
             var durBreak = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-            result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = durBreak, Status = "Succeeded" });
+            result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = durBreak, Status = "true" });
             if (_logger != null) {
               LogBlockDecision(_logger, "repeatUntil", "break", iterations, null);
-              LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations, evals, null);
+              LogBlockEnd(_logger, "repeatUntil", "true", iterations, evals, null);
             }
             return;
           }
@@ -1391,8 +1390,8 @@ namespace GameBot.Domain.Services {
         }
         if (satisfied) {
           var durOk = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations - 1, Evaluations = evals, DurationMs = durOk, Status = "Succeeded" });
-          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations - 1, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations - 1, Evaluations = evals, DurationMs = durOk, Status = "true" });
+          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "true", iterations - 1, evals, null);
           return;
         }
 
@@ -1418,10 +1417,10 @@ namespace GameBot.Domain.Services {
               if (_logger != null) LogBlockEvaluation(_logger, "repeatUntil", "breakOn-mid", brMid, null);
               if (brMid) {
                 var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-                result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+                result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "true" });
                 if (_logger != null) {
                   LogBlockDecision(_logger, "repeatUntil", "break", iterations, null);
-                  LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations, evals, null);
+                  LogBlockEnd(_logger, "repeatUntil", "true", iterations, evals, null);
                 }
                 return;
               }
@@ -1445,16 +1444,14 @@ namespace GameBot.Domain.Services {
         // Safeguards: first-hit wins (FR-20)
         if (maxIterations.HasValue && iterations >= maxIterations.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
-          result.Fail("repeatUntil maxIterations reached");
-          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Failed", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations, evals, null);
           return;
         }
         if (startDeadline.HasValue && DateTimeOffset.UtcNow >= startDeadline.Value) {
           var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
-          result.Fail("repeatUntil timeout");
-          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Failed", iterations, evals, null);
+          result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+          if (_logger != null) LogBlockEnd(_logger, "repeatUntil", "Succeeded", iterations, evals, null);
           return;
         }
 
@@ -1539,10 +1536,10 @@ namespace GameBot.Domain.Services {
           if (_logger != null) LogBlockEvaluation(_logger, "repeatCount", "breakOn-start", brStart, null);
           if (brStart) {
             var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-            result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+            result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "true" });
             if (_logger != null) {
               LogBlockDecision(_logger, "repeatCount", "break", iterations, null);
-              LogBlockEnd(_logger, "repeatCount", "Succeeded", iterations, evals, null);
+              LogBlockEnd(_logger, "repeatCount", "true", iterations, evals, null);
             }
             return;
           }
@@ -1572,10 +1569,10 @@ namespace GameBot.Domain.Services {
               if (_logger != null) LogBlockEvaluation(_logger, "repeatCount", "breakOn-mid", brMid, null);
               if (brMid) {
                 var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
-                result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Succeeded" });
+                result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "true" });
                 if (_logger != null) {
                   LogBlockDecision(_logger, "repeatCount", "break", iterations, null);
-                  LogBlockEnd(_logger, "repeatCount", "Succeeded", iterations, evals, null);
+                  LogBlockEnd(_logger, "repeatCount", "true", iterations, evals, null);
                 }
                 return;
               }

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -416,7 +416,7 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       null,
       step.StepOrder,
       ResolveStepLabel(step),
-      MapStepStatus(step.Outcome),
+      step.ConditionTrace is not null ? (step.ConditionTrace.FinalResult ? "success" : "failure") : MapStepStatus(step.Outcome),
       step.ReasonText ?? step.ReasonCode,
       step.AppliedDelayMs,
       step.CommandName,

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -25,6 +25,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   private readonly IQueueTemplateRepository _templates;
   private readonly ISequenceExecutionService _sequenceExecution;
   private readonly ISessionManager _sessions;
+  private readonly BackgroundScreenCaptureService? _captureService;
   private readonly IExecutionLogService _log;
   private readonly ILogger<QueueExecutionService> _logger;
   private readonly CancellationToken _appStopping;
@@ -40,12 +41,14 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     ISessionManager sessions,
     IExecutionLogService log,
     ILogger<QueueExecutionService> logger,
-    IHostApplicationLifetime? lifetime = null) {
+    IHostApplicationLifetime? lifetime = null,
+    BackgroundScreenCaptureService? captureService = null) {
     _queues = queues;
     _runtime = runtime;
     _templates = templates;
     _sequenceExecution = sequenceExecution;
     _sessions = sessions;
+    _captureService = captureService;
     _log = log;
     _logger = logger;
     _appStopping = lifetime?.ApplicationStopping ?? CancellationToken.None;
@@ -115,6 +118,9 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
           var session = _sessions.CreateSession($"queue:{queue.Id}", queue.EmulatorSerial);
           sessionId = session.Id;
           handle.SessionId = sessionId;
+          if (_captureService is not null && !string.IsNullOrWhiteSpace(session.DeviceSerial)) {
+            _captureService.StartCapture(session.Id, session.DeviceSerial);
+          }
         }
         catch (Exception ex) when (ex is InvalidOperationException or KeyNotFoundException) {
           reason = QueueStopReason.Failure;
@@ -170,6 +176,8 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
       // Always disconnect the session (FR-020/FR-023) — teardown errors must not prevent
       // finalizing the run (FR-023 edge case).
       if (sessionId is not null) {
+        try { _captureService?.StopCapture(sessionId); }
+        catch (Exception ex) { QueueExecutionLog.DisconnectFailed(_logger, queue.Id, ex); }
         try { _sessions.StopSession(sessionId); }
         catch (Exception ex) { QueueExecutionLog.DisconnectFailed(_logger, queue.Id, ex); }
       }


### PR DESCRIPTION
## Summary

Fixes incorrect status display in execution logs for condition steps and loop exits.

### Changes

**`ExecutionLogService.BuildStepNode`**
- When a step has a `ConditionTrace`, derive the node status from `ConditionTrace.FinalResult` (`true → success`, `false → failure`) instead of `MapStepStatus(outcome)`.
- Previously, condition steps with a false branch always showed as "failure" from `MapStepStatus`, even if that was the expected/intended branch.

**`SequenceRunner` — new loop-step execution path**
- `ExecuteCountLoopAsync`: break-triggered exits now report `"true"` instead of `"Succeeded"`.
- `ExecuteWhileLoopAsync`: condition-false (normal end) exits report `"false"`; maxIterations safeguard reports `"Succeeded"` (was `"Failed"` + `result.Fail()`).
- `ExecuteRepeatUntilLoopAsync`: exit-condition-satisfied / break exits report `"true"`; maxIterations safeguard reports `"Succeeded"` (was `"Failed"` + `result.Fail()`).

**`QueueExecutionService`**
- Start background screen capture after session creation so image detection works during queue execution.