### PR TITLE
Ensure game running primitive action (#052)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/051-queue-execution-runtime"
+  "feature_directory": "specs/052-ensure-game-running"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 ﻿<!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/051-queue-execution-runtime/plan.md
+at specs/052-ensure-game-running/plan.md
 <!-- SPECKIT END -->

--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "0",
   "minor": "7",
-  "patch": "1",
+  "patch": "2",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-06-02T23:38:00Z"
+  "updatedAtUtc": "2026-06-03T16:00:00Z"
 }

--- a/specs/052-ensure-game-running/checklists/requirements.md
+++ b/specs/052-ensure-game-running/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Ensure Game Running Primitive Action
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All checklist items pass. Spec is ready for `/speckit-plan`.

--- a/specs/052-ensure-game-running/data-model.md
+++ b/specs/052-ensure-game-running/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Ensure Game Running
+
+## Modified Entities
+
+### GameArtifact (GameBot.Domain/Games/GameArtifact.cs)
+Adds `PackageName` — the Android package identifier used to detect and launch the game.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| Id | string | yes | stable GUID |
+| Name | string | yes | display name |
+| Description | string? | no | existing |
+| PackageName | string? | no | NEW — e.g. `com.example.game` |
+
+Storage: `data/games/{id}.json` — `FileGameRepository` serializes all public properties. Existing files without `packageName` deserialize with `null`.
+
+### ExecutionQueue (GameBot.Domain/Queues/ExecutionQueue.cs)
+Adds `LinkedGameId` — optional 0..1 reference to a `GameArtifact`.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| Id | string | yes | |
+| Name | string | yes | |
+| EmulatorSerial | string | yes | |
+| CycleExecution | bool | yes | |
+| LinkedTemplateId | string? | no | existing |
+| LinkedGameId | string? | no | NEW |
+
+Storage: `data/queues/{id}.json` — same round-trip behavior.
+
+## New Entities
+
+### EnsureGameRunningActionResult (GameBot.Service/Services/EnsureGameRunning/)
+In-memory result record; not persisted.
+
+| Field | Type | Notes |
+|---|---|---|
+| Outcome | EnsureGameRunningOutcome | enum |
+| IsSuccess | bool | computed: Outcome == GameRunning |
+| ReasonCode | string | computed: see plan.md |
+
+### EnsureGameRunningOutcome (enum)
+- `GameRunning` — success, game was already the active foreground app
+- `GameNotRunning` — failure, game was not running (launch attempted)
+- `NoQueueContext` — failure, not running in a queue
+- `NoLinkedGame` — failure, queue has no linked game
+- `NoPackageName` — failure, linked game has no package name
+- `PlatformUnsupported` — failure, ADB not available (non-Windows)
+
+## Relationships
+
+```
+ExecutionQueue ──LinkedGameId──> GameArtifact (0..1)
+ExecutionQueue ──LinkedTemplateId──> QueueTemplate (0..1, existing)
+```
+
+## Validation Rules
+
+- `GameArtifact.PackageName` is optional; no format validation at persistence layer (per spec assumption).
+- `ExecutionQueue.LinkedGameId` set/cleared only via `PUT /api/queues/{id}/game`; the endpoint validates that the referenced game exists.
+- `GameArtifact` delete is blocked (409) if any `ExecutionQueue.LinkedGameId` references the game.

--- a/specs/052-ensure-game-running/plan.md
+++ b/specs/052-ensure-game-running/plan.md
@@ -1,0 +1,283 @@
+# Implementation Plan: Ensure Game Running Primitive Action
+
+**Branch**: `052-ensure-game-running` | **Date**: 2026-06-03 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add a zero-config `ensure-game-running` primitive action that checks whether the linked game is the active foreground app on the emulator. Reports success if it is; starts the game and reports failure if it is not. Requires adding `PackageName` to `GameArtifact` and `LinkedGameId` to `ExecutionQueue`.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9 (backend); TypeScript / React 18 (frontend)
+**Primary Dependencies**: Minimal API (ASP.NET Core), React, Vite, Jest
+**Storage**: File-based JSON (`data/games/`, `data/queues/`)
+**Testing**: Jest (frontend), xUnit (backend)
+**Target Platform**: Windows (ADB operations are Windows-only; non-Windows returns platform-unavailable outcome)
+**Project Type**: Desktop app — web UI + local service
+**Performance Goals**: ADB foreground check completes in < 1 second; app launch is fire-and-forget with no added wait time
+**Constraints**: Non-Windows execution must degrade gracefully (return platform-unavailable step outcome, not throw); optional injection of handler keeps `CommandExecutor` tests unaffected
+
+## Constitution Check
+
+- [x] Lint/format must pass — no new warnings; CamelCase method names throughout
+- [x] Tests required — unit tests for `EnsureGameRunningActionHandler` covering all FR outcomes; ADB method parsing tests; frontend component tests for `QueueGameControls`
+- [x] UX consistency — error messages actionable; game picker follows template picker pattern
+- [x] Performance declared — see Technical Context above
+- [x] Public-surface changes documented (API contracts, see Phase 1)
+- [x] No pre-existing build/test failures blocking this work (clean baseline)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/052-ensure-game-running/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code
+
+```text
+src/
+├── GameBot.Domain/
+│   ├── Actions/
+│   │   ├── ActionTypes.cs               ← add EnsureGameRunning constant
+│   │   ├── PrimitiveActionBase.cs       ← add to PrimitiveActionTypes.All
+│   │   └── PrimitiveActionVariants.cs   ← add PrimitiveEnsureGameRunningAction
+│   ├── Commands/
+│   │   └── CommandStep.cs               ← add CommandStepType.EnsureGameRunning
+│   ├── Games/
+│   │   └── GameArtifact.cs              ← add PackageName property
+│   └── Queues/
+│       └── ExecutionQueue.cs            ← add LinkedGameId property
+│
+├── GameBot.Emulator/
+│   └── Adb/
+│       └── AdbClient.cs                 ← add GetForegroundPackageAsync, LaunchAppAsync
+│
+└── GameBot.Service/
+    ├── Endpoints/
+    │   ├── GamesEndpoints.cs            ← read/write packageName; guard delete with queue refs
+    │   └── QueuesEndpoints.cs           ← add PUT /{id}/game endpoint
+    ├── Contracts/
+    │   └── Queues/
+    │       ├── QueueResponse.cs         ← add LinkedGameId
+    │       └── SetQueueGameLinkRequest.cs  ← new
+    ├── Models/
+    │   └── Games.cs                     ← add PackageName to GameResponse
+    └── Services/
+        ├── CommandExecutor.cs           ← add EnsureGameRunning step branch
+        └── EnsureGameRunning/           ← new folder
+            ├── IEnsureGameRunningActionHandler.cs
+            ├── EnsureGameRunningActionHandler.cs
+            └── EnsureGameRunningActionResult.cs
+
+web-ui/src/
+├── services/
+│   ├── games.ts          ← add packageName to GameDto / GameCreate / GameUpdate
+│   └── queues.ts         ← add linkedGameId, setQueueGameLink
+├── components/
+│   └── queues/
+│       ├── QueueForm.tsx            ← add gameControls?: ReactNode slot
+│       ├── QueueGameControls.tsx    ← new (mirrors QueueTemplateControls)
+│       └── GamePickerDialog.tsx     ← new (mirrors TemplatePickerDialog)
+└── pages/
+    ├── GamesPage.tsx     ← add packageName field to create/edit forms
+    └── QueuesPage.tsx    ← wire game controls
+```
+
+## Phase 0: Research
+
+Research is complete. See [research.md](research.md) for decisions and rationale.
+
+**All NEEDS CLARIFICATION items resolved:**
+- "Game running" = active foreground app, checked via `adb shell dumpsys activity activities | grep mResumedActivity`
+- Single failure reason (`game_not_running`) regardless of launch outcome
+- Zero-config action; direct execution without queue context → `no_queue_context` failure
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+Full details in [data-model.md](data-model.md).
+
+**`GameArtifact` (GameBot.Domain)**
+```csharp
+public sealed class GameArtifact {
+  public required string Id { get; set; }
+  public required string Name { get; set; }
+  public string? Description { get; set; }
+  public string? PackageName { get; set; }          // NEW — Android package identifier
+}
+```
+
+**`ExecutionQueue` (GameBot.Domain)**
+```csharp
+public class ExecutionQueue {
+  // ...existing fields...
+  public string? LinkedGameId { get; set; }         // NEW — optional game reference (0..1)
+}
+```
+
+**`ActionTypes` / `PrimitiveActionTypes` (GameBot.Domain)**
+```csharp
+public const string EnsureGameRunning = "ensure-game-running";
+// Added to PrimitiveActionTypes.All collection
+```
+
+**`PrimitiveEnsureGameRunningAction` (GameBot.Domain)**
+```csharp
+public sealed class PrimitiveEnsureGameRunningAction : PrimitiveActionBase {
+  public PrimitiveEnsureGameRunningAction() : base(PrimitiveActionTypes.EnsureGameRunning) { }
+}
+```
+
+**`CommandStepType` (GameBot.Domain)**
+```csharp
+public enum CommandStepType {
+  Command,
+  PrimitiveTap,
+  WaitForImage,
+  EnsureGameRunning    // NEW
+}
+```
+
+**`EnsureGameRunningActionResult` (GameBot.Service)**
+```csharp
+public enum EnsureGameRunningOutcome {
+  GameRunning,         // Success: game was already in foreground
+  GameNotRunning,      // Failure: game was not running (launch attempted)
+  NoQueueContext,      // Failure: action not running in a queue
+  NoLinkedGame,        // Failure: queue has no linked game
+  NoPackageName,       // Failure: linked game has no package name
+  PlatformUnsupported  // Failure: ADB not available (non-Windows)
+}
+
+public sealed record EnsureGameRunningActionResult(EnsureGameRunningOutcome Outcome) {
+  public bool IsSuccess => Outcome == EnsureGameRunningOutcome.GameRunning;
+  public string ReasonCode => Outcome switch {
+    EnsureGameRunningOutcome.GameRunning        => "game_running",
+    EnsureGameRunningOutcome.GameNotRunning     => "game_not_running",
+    EnsureGameRunningOutcome.NoQueueContext     => "no_queue_context",
+    EnsureGameRunningOutcome.NoLinkedGame       => "no_linked_game",
+    EnsureGameRunningOutcome.NoPackageName      => "no_package_name",
+    _                                           => "platform_unsupported"
+  };
+}
+```
+
+**`IEnsureGameRunningActionHandler` (GameBot.Service)**
+```csharp
+internal interface IEnsureGameRunningActionHandler {
+  Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default);
+}
+```
+
+**`EnsureGameRunningActionHandler` logic (GameBot.Service)**
+1. Get session from `ISessionManager.GetSession(sessionId)` → if null: `NoQueueContext`
+2. Parse `queue:{queueId}` from `session.GameId` → if no prefix: `NoQueueContext`
+3. `await _queues.GetAsync(queueId)` → if null or `LinkedGameId` empty: `NoLinkedGame`
+4. `await _games.GetAsync(queue.LinkedGameId)` → if null or `PackageName` empty: `NoPackageName`
+5. If `!OperatingSystem.IsWindows()` → `PlatformUnsupported`
+6. `adb.GetForegroundPackageAsync(session.DeviceSerial)` → compare to `game.PackageName`
+7. Match → `GameRunning`; no match → `adb.LaunchAppAsync(packageName)` then `GameNotRunning`
+
+**`CommandExecutor` changes**
+```csharp
+// New case in ExecuteCommandRecursiveAsync foreach loop:
+if (step.Type == CommandStepType.EnsureGameRunning) {
+  var result = _ensureGameRunning is not null
+    ? await _ensureGameRunning.ExecuteAsync(sessionId, ct).ConfigureAwait(false)
+    : new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported);
+
+  if (result.IsSuccess) {
+    totalAccepted++;
+    stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", result.ReasonCode, null, null, StepType: "ensure-game-running"));
+  } else {
+    stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running"));
+  }
+  continue;
+}
+```
+
+**`AdbClient` new methods (GameBot.Emulator)**
+```
+GetForegroundPackageAsync(CancellationToken ct):
+  runs: shell dumpsys activity activities
+  parses: line containing "mResumedActivity" → extract package before "/"
+  returns: package name string or null
+
+LaunchAppAsync(string packageName, CancellationToken ct):
+  runs: shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1
+  fire-and-forget (result not inspected by caller)
+```
+
+### API Contracts
+
+**Games API**
+
+`GET /api/games` and `GET /api/games/{id}` — add `packageName` to response shape.
+
+`POST /api/games` and `PUT /api/games/{id}` — accept optional `packageName` field; persist to `GameArtifact.PackageName`.
+
+`DELETE /api/games/{id}` — check if any `ExecutionQueue.LinkedGameId` references this game; return 409 with references if so.
+
+Frontend: `GameDto.packageName?: string`, `GameCreate.packageName?: string`, `GameUpdate.packageName?: string`.
+
+**Queues API (new endpoint)**
+
+`PUT /api/queues/{id}/game`
+- Body: `{ "gameId": "string | null" }`
+- Validates: if `gameId` non-null, game must exist
+- Sets `queue.LinkedGameId`; persists; returns `QueueDetailResponse`
+- Pattern: identical to `PUT /api/queues/{id}/template`
+
+`QueueResponse` / `QueueDetailResponse` — add `LinkedGameId: string?` (surfaced as `linkedGameId` in frontend).
+
+Frontend: `QueueDto.linkedGameId: string | null`, `QueueDetailDto.linkedGameId: string | null`, new `setQueueGameLink(queueId, gameId | null)` function.
+
+### Frontend Components
+
+**`QueueGameControls` props**
+```typescript
+type QueueGameControlsProps = {
+  linkedGameId: string | null;
+  linkedGameName: string | null;   // resolved name, null if unlinked
+  status: QueueStatus;
+  onLink: (gameId: string) => void;
+  onUnlink: () => void;
+};
+```
+Renders: linked game name (or "(no game)"), "Link Game" toggle button, "Unlink" button (only when linked and queue stopped).
+
+**`GamePickerDialog` props**
+```typescript
+type GamePickerDialogProps = {
+  open: boolean;
+  onSelect: (gameId: string) => void;
+  onClose: () => void;
+};
+```
+Renders: list of games fetched from API; "Select" button per row.
+
+**`QueueForm` changes**
+Add `gameControls?: React.ReactNode` slot — rendered in edit mode between `templateControls` and the cycle-execution checkbox.
+
+**`QueuesPage` wiring**
+- Fetch `linkedGameId` and resolve game name from `listGames()` (or `getGame()`)
+- Render `QueueGameControls` as the `gameControls` slot
+- Call `setQueueGameLink(queueId, gameId)` on link/unlink actions
+
+**`GamesPage` changes**
+Add `packageName` text field to both create and edit forms (optional, placeholder: "e.g. com.example.game").
+
+## Complexity Tracking
+
+No constitution violations. This is a straightforward additive feature: new domain fields, new endpoint, new service, new frontend components.
+
+## Agent Context
+
+Plan complete. Update `CLAUDE.md` to reference this plan.

--- a/specs/052-ensure-game-running/research.md
+++ b/specs/052-ensure-game-running/research.md
@@ -1,0 +1,75 @@
+# Research: Ensure Game Running Primitive Action
+
+## Execution Architecture
+
+**Decision**: Implement as a new `CommandStepType.EnsureGameRunning` handled in `CommandExecutor`.
+
+**Rationale**: The user will create a Command containing this step, then reference that command from a Sequence. The `CommandExecutor.ExecuteCommandRecursiveAsync` dispatches based on `step.Type`, with existing cases for `PrimitiveTap` and `WaitForImage`. Adding a third case is the established pattern. Inline sequence actions (`SequenceActionPayload`) are an alternative path but would bypass the command logging that the user expects.
+
+**Alternatives considered**: (a) Inline `SequenceActionPayload` step — skipped because the user explicitly said they will create a command from this action; (b) dedicated service class per action — skipped as over-engineering for a single action type.
+
+---
+
+## Queue Context Resolution
+
+**Decision**: Extract queue ID from the session label `queue:{queueId}` stored in `EmulatorSession.GameId`.
+
+**Rationale**: `QueueExecutionService.RunAsync` creates sessions with label `$"queue:{queue.Id}"` (line 118 of `QueueExecutionService.cs`). `EmulatorSession.GameId` holds this label. Since `CommandExecutor` already has `ISessionManager`, it can get the session and parse the label without any new interface changes. For direct (non-queue) execution, the label won't have the `queue:` prefix → action fails with `no_queue_context` (FR-008a).
+
+**Alternatives considered**: Thread a `QueueId` through `ExecutionLogContext` — valid but requires touching multiple call sites and the context model; deferred since session-label parsing achieves the same result with zero interface changes.
+
+---
+
+## ADB Foreground Detection
+
+**Decision**: Use `adb shell dumpsys activity activities | grep mResumedActivity`.
+
+**Rationale**: Outputs a line like `mResumedActivity: ActivityRecord{... u0 com.example.game/...}`. Parse the package name from the segment after `u0 ` and before `/`. Works on Android 5+ without root. More reliable than `mFocusedApp` from window dumps which can return the launcher overlay.
+
+**Launch command**: `adb shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1`. Fire-and-forget (we don't wait for the app to appear — the action has already reported failure by this point).
+
+**Alternatives considered**: `dumpsys window | grep mFocusedApp` — can return system overlays; `am start` — requires knowing the activity name. `monkey` is the most compatible launcher across API levels.
+
+---
+
+## Service Design for the Handler
+
+**Decision**: Create `IEnsureGameRunningActionHandler` interface + `EnsureGameRunningActionHandler` implementation in `GameBot.Service/Services/EnsureGameRunning/`. Inject optionally into `CommandExecutor` (like `IExecutionLogService`).
+
+**Rationale**: Keeps `CommandExecutor` focused on orchestration, not on ADB details or game context resolution. The handler is the only place that needs `IQueueRepository`, `IGameRepository`, and ADB calls. Optional injection means `CommandExecutor` constructor signature change is backward-compatible with existing tests.
+
+---
+
+## Data Model Changes
+
+**`GameArtifact`**: Add `public string? PackageName { get; set; }`. `FileGameRepository` serializes directly to JSON — new field round-trips transparently; existing files without the field deserialize with `null`.
+
+**`ExecutionQueue`**: Add `public string? LinkedGameId { get; set; }` — mirrors existing `LinkedTemplateId`. Same optional 0..1 relationship. Same file-based storage round-trip behavior.
+
+**Queue delete guard**: When a queue references a game via `LinkedGameId`, the game delete endpoint must reject with 409 (the `GamesPage` frontend already handles `ApiError(409)` for delete, checking `err.references`).
+
+---
+
+## Frontend Pattern
+
+**Decision**: Follow the `QueueTemplateControls` + `TemplatePickerDialog` pattern exactly.
+
+**Rationale**: `QueueForm.tsx` uses a `templateControls?: React.ReactNode` slot prop. Adding a parallel `gameControls?: React.ReactNode` slot keeps the form extensible and the change minimal. The game picker is simpler than the template picker (no save/reload operations — only link and unlink).
+
+**New components**: `QueueGameControls.tsx` (link/unlink button + picker toggle) and `GamePickerDialog.tsx` (list of games with a select action).
+
+---
+
+## API Contracts
+
+**Games endpoints**: `PackageName` is added to `GameArtifact` and flows through `GamesEndpoints.cs`. The endpoint uses manual `JsonDocument` parsing — add `packageName` property read/write to both `POST` and `PUT` handlers. `GameResponse` in `Models/Games.cs` gets a `PackageName` property; frontend `GameDto` gets `packageName?: string`.
+
+**Queue game link**: New `PUT /api/queues/{id}/game` endpoint (mirrors `PUT /api/queues/{id}/template`). `SetQueueGameLinkRequest` with `GameId: string?`. `QueueResponse` and `QueueDetailResponse` get `LinkedGameId: string?`. Frontend `queues.ts` gets `linkedGameId: string | null` on `QueueDto` / `QueueDetailDto` and a `setQueueGameLink(id, gameId)` function.
+
+---
+
+## Performance Goals (Constitution IV)
+
+- ADB foreground check: target < 1 second under normal emulator conditions (single `dumpsys` call).
+- ADB launch: fire-and-forget, no wait time added to the action's execution.
+- No regression on existing sequence/command execution paths — the `EnsureGameRunning` case is an additive branch in `ExecuteCommandRecursiveAsync`.

--- a/specs/052-ensure-game-running/spec.md
+++ b/specs/052-ensure-game-running/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: Ensure Game Running Primitive Action
+
+**Feature Branch**: `052-ensure-game-running`
+**Created**: 2026-06-03
+**Status**: Draft
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Check Game Running Status (Priority: P1)
+
+As a queue operator, I want a primitive action that checks whether the target game is already running on the emulator, so I can verify the execution environment is in the expected state before proceeding with game automation.
+
+**Why this priority**: This is the core capability of the feature. Without the ability to detect and report game running status, no other story is possible.
+
+**Independent Test**: Can be fully tested by configuring a queue with a linked game, adding the "ensure game running" action to a sequence, running the sequence on an emulator where the game is already open, and confirming the execution log shows success.
+
+**Acceptance Scenarios**:
+
+1. **Given** a queue linked to a game, **When** the "ensure game running" action executes and the game is already in the foreground on the emulator, **Then** the action completes with success status and the execution log records that the game was already running.
+2. **Given** a queue linked to a game, **When** the "ensure game running" action executes and the game is not visible on the emulator, **Then** the action starts the game, completes with failure status, and the execution log records that the game was not running and was started.
+3. **Given** a sequence containing an "ensure game running" action, **When** the action fails (game was not running), **Then** subsequent steps in the sequence still execute (the action does not abort the sequence).
+
+---
+
+### User Story 2 - Link Queue to Game (Priority: P1)
+
+As a queue operator, I want to associate a queue with a specific game, so that game-aware actions like "ensure game running" know which game to target without hardcoding it into each action step.
+
+**Why this priority**: The game link is a prerequisite for the "ensure game running" action to know which game to check. Both stories must be implemented together for the feature to be usable.
+
+**Independent Test**: Can be tested by editing a queue in the UI and selecting a game from a list, then verifying the queue details show the linked game name.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing queue, **When** the operator edits the queue, **Then** they can select a game from the list of configured games to link it.
+2. **Given** an existing queue with a linked game, **When** the operator edits the queue, **Then** they can change or remove the linked game.
+3. **Given** a queue with no linked game, **When** the "ensure game running" action is added to a sequence for that queue, **Then** the system warns or errors indicating the queue has no game linked.
+
+---
+
+### User Story 3 - Configure Game Package Name (Priority: P2)
+
+As a queue operator, I want each game definition to store its unique package identifier, so the system can launch the correct game on the emulator.
+
+**Why this priority**: Without the package identifier stored on the game, the system cannot launch the game on the emulator. This is a prerequisite for the start-game recovery behavior.
+
+**Independent Test**: Can be tested by creating or editing a game in the UI, entering a package name, and verifying it is saved and displayed correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the game configuration UI, **When** creating a new game, **Then** the operator can enter a package name for that game.
+2. **Given** an existing game, **When** editing it, **Then** the operator can view and update the package name.
+3. **Given** a game with a package name configured, **When** the "ensure game running" action executes on an emulator and the game is not running, **Then** the system uses that package name to launch the game.
+
+---
+
+### Edge Cases
+
+- What happens when the action executes but no game is linked to the queue? The action should fail immediately with a clear reason indicating the queue has no associated game.
+- What happens when the action is executed directly (outside a queue context, e.g., a standalone command run)? The action fails immediately with a clear reason indicating no game context is available — it requires a queue with a linked game to operate.
+- What happens if the game's package name is missing or empty? The action should fail immediately with a clear reason before attempting any emulator interaction.
+- What happens when the emulator is not reachable during the check? The action should fail with an appropriate reason code distinct from "game not running."
+- What happens if the game starts but does not become visible within a reasonable time? The action already reports failure (game was not running), so partial start behavior is consistent — the failure status is already set.
+- What happens if the linked game is deleted while a queue still references it via `LinkedGameId`? The game delete operation must be blocked (rejected with a conflict error) if any queue holds a reference to that game, preventing dangling references.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a new primitive action type named "ensure game running" that can be added to any sequence.
+- **FR-002**: When executed, the "ensure game running" action MUST check whether the target game is the **active foreground app** (frontmost and interactable) on the bound emulator. A game running in the background does not satisfy this condition.
+- **FR-003**: If the game is the active foreground app, the action MUST complete with **success** status.
+- **FR-004**: If the game is NOT running, the action MUST attempt to start the game on the emulator AND complete with **failure** status.
+- **FR-005**: The "ensure game running" action MUST NOT attempt to restart a game that is already running; it must leave a running game undisturbed.
+- **FR-006**: Each queue MUST support an optional link to a game (0..1 relationship), similar to how queues link to templates.
+- **FR-007**: Each game definition MUST store a package name field used to identify and launch the game on the emulator.
+- **FR-008**: The "ensure game running" action MUST resolve the target game and package name from the queue it is executed within. The action itself has no configurable parameters — all context comes from the queue.
+- **FR-008a**: If the action is executed outside a queue context (e.g., a command run directly without a queue), the action MUST fail immediately with a clear reason indicating that no game context is available.
+- **FR-009**: If the action runs within a queue but that queue has no linked game, the action MUST fail immediately with a reason indicating the missing game link.
+- **FR-010**: If the linked game has no package name, the action MUST fail immediately with a reason indicating the missing package name.
+- **FR-011**: The execution log for the action MUST record the outcome — specifically whether the game was already running (success) or was not running (failure). The failure reason is "game was not running" regardless of whether the subsequent start attempt succeeded or failed; the start attempt is a best-effort recovery step, not part of the action's reported status.
+- **FR-012**: The failure status when the game was not running MUST NOT cause the containing sequence to abort; execution of subsequent steps continues normally.
+
+### Key Entities
+
+- **Game**: Represents a game that can be run on an emulator. Extended with a **package name** — the unique identifier used to launch the game on Android-based emulators.
+- **Queue**: Extended with an optional **linked game** reference (0..1). When a game is linked, game-aware actions in that queue's sequences can resolve game details automatically.
+- **Ensure Game Running Action**: A primitive action that checks if the linked game is running on the emulator, starts it if not, and reports success only when the game was already running.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The "ensure game running" action can be added to a sequence and executes end-to-end without errors when a queue has a correctly configured linked game.
+- **SC-002**: The execution log correctly reflects the outcome: success when the game was already running, failure when it was not, with no ambiguity between the two cases.
+- **SC-003**: Operators can configure a game's package name and link a queue to a game in under 2 minutes using the existing UI patterns. Validated by manual UX review at demo — no automated timing test required.
+- **SC-004**: The queue-to-game link is persistent across service restarts, consistent with how queue-to-template links behave.
+- **SC-005**: An "ensure game running" action failure does not interrupt or abort the remaining steps in a sequence.
+
+## Clarifications
+
+### Session 2026-06-03
+
+- Q: What constitutes "game running" for success purposes — active foreground app only, or any running process? → A: Only the active foreground app (frontmost and interactable) counts; a backgrounded game process does not satisfy the condition.
+- Q: Should the execution log distinguish between "not running, started successfully" vs "not running, start failed"? → A: Single failure reason — "game was not running" regardless of start outcome; start attempt is best-effort recovery only.
+- Q: Does the action need configurable parameters, and how does it behave when run outside a queue? → A: Zero-config — no action parameters. When executed outside a queue context (e.g., direct command run), the action fails immediately with a clear reason indicating no game context is available.
+
+## Assumptions
+
+- The emulator connection (ADB serial) is managed by the queue, not by this action. The action reuses the queue's existing emulator binding.
+- "Game running" means the game is the **active foreground app** — backgrounded game processes do not count. This is determined by checking the active foreground application on the emulator against the game's package name — the specific detection mechanism is an implementation detail.
+- Starting the game uses the package name via the standard Android launch mechanism — implementation detail.
+- The package name format follows standard Android conventions (e.g., `com.example.game`) but format validation is not a spec requirement.
+- The queue-to-game link is optional; queues without a linked game can still function normally for non-game-aware actions.
+- The action reports failure when the game was not running regardless of whether the start attempt succeeds — the semantic is "was the game already running as expected?"

--- a/specs/052-ensure-game-running/tasks.md
+++ b/specs/052-ensure-game-running/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: Ensure Game Running Primitive Action
+
+**Input**: Design documents from `specs/052-ensure-game-running/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓
+
+**Organization**: Tasks grouped by phase in implementation-dependency order. US3 (game package name) and US2 (queue-game link) are infrastructure prerequisites that must exist before US1 (the action) can be end-to-end tested. They are scheduled before US1 despite US2 being marked P1 in the spec — this is a dependency-driven ordering, not a priority override.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other [P] tasks in the same phase (different files, no conflicts)
+- **[Story]**: User story from spec.md (US1/US2/US3)
+- All paths relative to repo root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Baseline verification before any changes.
+
+- [ ] T001 Confirm build is green: run `vite build` in `src/web-ui` and verify no pre-existing errors
+
+---
+
+## Phase 2: Foundational (Domain Model — Blocks All Phases)
+
+**Purpose**: Domain-layer additions shared by all three user stories. No story phase can proceed until this is complete.
+
+**⚠️ CRITICAL**: Complete before moving to any user story phase.
+
+- [ ] T002 Add `PackageName` property (`public string? PackageName { get; set; }`) to `GameArtifact` in `src/GameBot.Domain/Games/GameArtifact.cs`
+- [ ] T003 Add `LinkedGameId` property (`public string? LinkedGameId { get; set; }`) to `ExecutionQueue` in `src/GameBot.Domain/Queues/ExecutionQueue.cs`
+- [ ] T004 [P] Add `public const string EnsureGameRunning = "ensure-game-running";` to `ActionTypes` in `src/GameBot.Domain/Actions/ActionTypes.cs`
+- [ ] T005 [P] Add `EnsureGameRunning = "ensure-game-running"` constant to `PrimitiveActionTypes` and include it in the `All` collection in `src/GameBot.Domain/Actions/PrimitiveActionBase.cs`; add `PrimitiveEnsureGameRunningAction` class (no parameters, calls `base(PrimitiveActionTypes.EnsureGameRunning)`) to `src/GameBot.Domain/Actions/PrimitiveActionVariants.cs`
+- [ ] T006 Add `EnsureGameRunning` to the `CommandStepType` enum in `src/GameBot.Domain/Commands/CommandStep.cs`
+
+**Checkpoint**: Domain model changes complete — all user story phases can begin.
+
+---
+
+## Phase 3: User Story 3 — Configure Game Package Name (Priority: P2)
+
+**Note**: Scheduled before US2 (P1) because the game picker in US2 is more useful once games have package names, and because US1 requires both to be in place. This is a dependency-driven ordering — US2 and US3 are independently testable after Phase 2.
+
+**Goal**: Games have a configurable `packageName` field that operators can set through the UI, providing the Android package identifier used to detect and launch the game.
+
+**Independent Test**: Create a new game, enter `com.example.game` in the Package Name field, save — reload the edit form and confirm the package name is displayed. Edit an existing game and clear the package name — save succeeds without error.
+
+### Implementation
+
+- [ ] T007 [P] [US3] Add `public string? PackageName { get; init; }` to `GameResponse` in `src/GameBot.Service/Models/Games.cs`
+- [ ] T008 [P] [US3] Update `GetGame` and `ListGames` handlers in `src/GameBot.Service/Endpoints/GamesEndpoints.cs` to include `packageName` in all response shapes (both the `GameResponse` path and the anonymous `{ id, name, metadata }` path)
+- [ ] T009 [US3] Update `CreateGame` and `UpdateGame` handlers in `src/GameBot.Service/Endpoints/GamesEndpoints.cs` to read `packageName` from the request body and persist it to `GameArtifact.PackageName` (depends on T002, T007)
+- [ ] T010 [P] [US3] Add `packageName?: string` to `GameDto`, `GameCreate`, and `GameUpdate` types in `src/web-ui/src/services/games.ts`
+- [ ] T011 [US3] Add an optional `packageName` text input (label "Package Name", placeholder `e.g. com.example.game`) to both the create form and the edit form in `src/web-ui/src/pages/GamesPage.tsx`; update the `GameFormValue` type to include `packageName: string`; pass the field value to `createGame` / `updateGame` (depends on T010)
+
+**Checkpoint**: Games can store and display a package name. US3 independently verifiable.
+
+---
+
+## Phase 4: User Story 2 — Link Queue to Game (Priority: P1)
+
+**Goal**: A queue can be associated with a specific game. The operator can link and unlink the game through the queue edit UI, and the association persists across service restarts.
+
+**Independent Test**: Open the queue edit form — a "Game" row is visible below the template controls. Click "Link Game", select a game from the picker, confirm the game name now shows. Click "Unlink" and confirm the row reverts to "(no game)". Restart the service and reload — the link is preserved.
+
+### Implementation
+
+- [ ] T012 [P] [US2] Add `public string? LinkedGameId { get; set; }` and `public string? LinkedGameName { get; set; }` to `QueueResponse` in `src/GameBot.Service/Contracts/Queues/QueueResponse.cs`, and add `LinkedGameName` property to `QueueDetailResponse` in `src/GameBot.Service/Contracts/Queues/QueueDetailResponse.cs` (`LinkedGameId` is inherited from `QueueResponse`)
+- [ ] T013 [P] [US2] Create `SetQueueGameLinkRequest` class with `public string? GameId { get; set; }` in `src/GameBot.Service/Contracts/Queues/SetQueueGameLinkRequest.cs`
+- [ ] T014 [US2] Add `PUT /api/queues/{id}/game` endpoint to `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: validate game exists when `gameId` non-null (inject `IGameRepository`), set `queue.LinkedGameId`, persist, return `QueueDetailResponse` with resolved `LinkedGameName`. Also update `BuildResponse` and `BuildDetailAsync` helpers to populate `LinkedGameId` and `LinkedGameName` from the game store. (depends on T003, T012, T013)
+- [ ] T015 [P] [US2] Add `linkedGameId: string | null` and `linkedGameName: string | null` to `QueueDto` and `QueueDetailDto` types, and add `export const setQueueGameLink = (id: string, gameId: string | null) => putJson<QueueDetailDto>(...)` to `src/web-ui/src/services/queues.ts`
+- [ ] T016 [P] [US2] Create `GamePickerDialog` component in `src/web-ui/src/components/queues/GamePickerDialog.tsx`: props `open: boolean`, `onSelect: (gameId: string) => void`, `onClose: () => void`; fetches games via `listGames()`, renders each as a row with a "Select" button; mirrors the `TemplatePickerDialog` structure
+- [ ] T017 [P] [US2] Create `QueueGameControls` component in `src/web-ui/src/components/queues/QueueGameControls.tsx`: props `linkedGameId: string | null`, `linkedGameName: string | null`, `status: QueueStatus`, `onLink: (gameId: string) => void`, `onUnlink: () => void`; renders game name (or "(no game)"), "Link Game" toggle button that opens `GamePickerDialog`, "Unlink" button disabled when running or unlinked; mirrors `QueueTemplateControls` (depends on T016)
+- [ ] T018 [US2] Add `gameControls?: React.ReactNode` prop to `QueueFormProps` and `QueueForm` in `src/web-ui/src/components/queues/QueueForm.tsx`; render it in edit mode between `templateControls` and the cycle-execution checkbox (depends on T017)
+- [ ] T019 [US2] Wire `QueueGameControls` into `QueuesPage` in `src/web-ui/src/pages/QueuesPage.tsx`: read `linkedGameId` and `linkedGameName` from queue detail, pass as the `gameControls` prop on `QueueForm`, call `setQueueGameLink` on link/unlink, refresh local state after success (depends on T014, T015, T017, T018)
+
+**Checkpoint**: Queue-game link is functional end-to-end. US2 independently verifiable.
+
+---
+
+## Phase 5: User Story 1 — Check Game Running Status (Priority: P1) 🎯 Core Value
+
+**Goal**: The `ensure-game-running` primitive action is available in the command step editor, executes within a queue-run sequence, checks whether the queue's linked game is the active foreground app on the emulator, reports success if it is, and starts the game then reports failure if it is not.
+
+**Independent Test**: Create a Command with an `EnsureGameRunning` step; add that Command to a Sequence; run the Sequence from a Queue linked to a game with a configured package name. Observe execution log: when the game is in the foreground the log shows success; when it is not, the log shows failure with reason `game_not_running` and the game is launched.
+
+### Implementation
+
+- [ ] T020 [P] [US1] Add `GetForegroundPackageAsync(CancellationToken ct)` and `LaunchAppAsync(string packageName, CancellationToken ct)` methods to `AdbClient` in `src/GameBot.Emulator/Adb/AdbClient.cs`. `GetForegroundPackageAsync` runs `shell dumpsys activity activities` then delegates to an `internal static string? ParseForegroundPackage(string adbOutput)` helper that parses the line containing `mResumedActivity` to extract the package name (the token immediately after `u0 ` and before `/`), returning `null` if the line is absent — keeping the parsing logic in a pure static method enables unit testing without a real ADB process (see T026). `LaunchAppAsync` runs `shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1` (fire-and-forget, result not propagated). Add `LoggerMessage` entries to the existing `Log` static class. Add an XML doc comment to each method documenting inputs, return value, and expected execution time (< 1 second for `GetForegroundPackageAsync` under normal conditions). *(Constitution §IV: hot-path perf note required)*
+- [ ] T021 [P] [US1] Create `EnsureGameRunningOutcome` enum (values: `GameRunning`, `GameNotRunning`, `NoQueueContext`, `NoLinkedGame`, `NoPackageName`, `PlatformUnsupported`) and `EnsureGameRunningActionResult` sealed record with `Outcome` property, computed `bool IsSuccess` (`Outcome == GameRunning`), and computed `string ReasonCode` (switch expression mapping each outcome to its kebab-case string) in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionResult.cs`
+- [ ] T022 [P] [US1] Create `IAdbGameOperations` interface in `src/GameBot.Service/Services/EnsureGameRunning/IAdbGameOperations.cs` with two methods: `Task<string?> GetForegroundPackageAsync(string deviceSerial, CancellationToken ct)` and `Task LaunchAppAsync(string deviceSerial, string packageName, CancellationToken ct)`. Create `AdbGameOperations` implementation in the same folder: guards `OperatingSystem.IsWindows()` on each call, delegates to `new AdbClient().WithSerial(deviceSerial)`. Create `IEnsureGameRunningActionHandler` interface with `Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default)` in `src/GameBot.Service/Services/EnsureGameRunning/IEnsureGameRunningActionHandler.cs`
+- [ ] T023 [US1] Implement `EnsureGameRunningActionHandler` in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs`: inject `ISessionManager`, `IQueueRepository`, `IGameRepository`, and `IAdbGameOperations`; execution order: (1) get session by `sessionId` — if null return `NoQueueContext`; (2) parse `queue:{queueId}` from `session.GameId` — if no `queue:` prefix return `NoQueueContext`; (3) **`if (!OperatingSystem.IsWindows()) return PlatformUnsupported`** — handler owns this outcome explicitly; `AdbGameOperations` also guards it internally for defense in depth, but `null` from `GetForegroundPackageAsync` must not be misread as `GameNotRunning`; (4) load queue — if null or `LinkedGameId` empty return `NoLinkedGame`; (5) load game — if null or `PackageName` empty return `NoPackageName`; (6) call `_adb.GetForegroundPackageAsync(session.DeviceSerial, ct)` — if result matches `game.PackageName` (OrdinalIgnoreCase) return `GameRunning` — **no launch call in this path** (FR-005: running game must not be disturbed); (7) call `_adb.LaunchAppAsync(session.DeviceSerial, game.PackageName, ct)` then return `GameNotRunning`. Injecting `IAdbGameOperations` allows T027 to mock all ADB paths including `GameRunning` and `GameNotRunning` without platform constraints. (depends on T002, T003, T020, T021, T022)
+- [ ] T024 [US1] Add `EnsureGameRunning` case to the `foreach` loop in `ExecuteCommandRecursiveAsync` in `src/GameBot.Service/Services/CommandExecutor.cs`: if `step.Type == CommandStepType.EnsureGameRunning`, call `_ensureGameRunning is not null ? await _ensureGameRunning.ExecuteAsync(sessionId, ct) : new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported)`; if `result.IsSuccess` increment `totalAccepted` by 1 and add `PrimitiveTapStepOutcome(step.Order, "executed", result.ReasonCode, null, null, StepType: "ensure-game-running")`; otherwise add `PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running")`; **end with `continue`** (not `return`) so the loop proceeds to the next step regardless of outcome (FR-012: failure must not abort sequence). Add `private readonly IEnsureGameRunningActionHandler? _ensureGameRunning;` field and update both constructors to accept it as an optional last parameter. (depends on T005, T006, T021, T022, T023)
+- [ ] T025 [US1] Register `IAdbGameOperations` → `AdbGameOperations` and `IEnsureGameRunningActionHandler` → `EnsureGameRunningActionHandler` in the DI container in `src/GameBot.Service/Program.cs`; update the `CommandExecutor` registration to supply the handler (depends on T022, T023, T024)
+
+### Tests for User Story 1 *(Constitution §II: required for executable logic)*
+
+- [ ] T026 [P] [US1] Write unit tests for `AdbClient.GetForegroundPackageAsync` output parsing in `tests/unit/Emulator/AdbClientForegroundPackageTests.cs`: test cases — line containing `mResumedActivity` with `u0 com.example.game/` returns `"com.example.game"`; output with no `mResumedActivity` line returns `null`; multiple lines with exactly one `mResumedActivity` line returns correct package. No ADB process required — test the parsing logic in isolation.
+- [ ] T027 [P] [US1] Write unit tests for `EnsureGameRunningActionHandler` in `tests/unit/Services/EnsureGameRunning/EnsureGameRunningActionHandlerTests.cs` covering all six outcome paths: (a) `NoQueueContext` when `GetSession` returns null; (b) `NoQueueContext` when `session.GameId` has no `queue:` prefix; (c) `NoLinkedGame` when queue has no `LinkedGameId`; (d) `NoPackageName` when game has no `PackageName`; (e) `GameRunning` when foreground package matches; (f) `GameNotRunning` when foreground package does not match (also verify `LaunchAppAsync` is called). Use mocked `ISessionManager`, `IQueueRepository`, `IGameRepository`, and a mock/stub `AdbClient`-like abstraction as needed.
+- [ ] T028 [US1] Write an integration test for `CommandExecutor` `EnsureGameRunning` step in `tests/integration/CommandExecutor/EnsureGameRunningStepTests.cs`: (a) step with mock handler returning `GameRunning` → `accepted == 1`, step outcome `Status="executed"`, overall command status `"success"`; (b) step with mock handler returning `GameNotRunning` → `accepted == 0`, step outcome `Status="game_not_running"`, overall command status `"failure"`; (c) step executed after a failure → sequence continues (next step executes), confirming FR-012. (depends on T024)
+
+**Checkpoint**: `ensure-game-running` executes end-to-end in a queue run and is covered by unit + integration tests. US1 fully verifiable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Delete-guard, execution log correctness, and regression check.
+
+- [ ] T029 [P] Add queue-reference guard to `DeleteGame` in `src/GameBot.Service/Endpoints/GamesEndpoints.cs`: before deleting, call `IQueueRepository.ListAsync()`, check if any queue has `LinkedGameId == id`; if so return 409 with a references list (FR edge case: linked game must not be deletable while queues reference it; `GamesPage` frontend already handles `ApiError(409)` with `references` property)
+- [ ] T030 [P] Verify `SequenceExecutionService` in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs` does not misclassify `ensure-game-running` step type: confirm the `isWaitForImageStep` check does not accidentally match the new type; the step should appear in the execution log detail as `stepType: "command"` (wrapping command) with the `actionOutcome` propagated from the `PrimitiveTapStepOutcome` outcome field
+- [ ] T031 Run full build and test suite: `vite build` in `src/web-ui`; `jest` for frontend; `dotnet test` from repo root (covers `tests/unit/`, `tests/integration/`, `tests/contract/`) — all must pass before marking the feature complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (T001)**: No dependencies
+- **Phase 2 (T002–T006)**: Must complete before any story phase; T004/T005/T006 parallelisable after T002–T003
+- **Phase 3 / US3 (T007–T011)**: Depends on Phase 2; independently testable
+- **Phase 4 / US2 (T012–T019)**: Depends on Phase 2; independently testable
+- **Phase 5 / US1 (T020–T028)**: Depends on Phase 2; requires US2 + US3 for full integration testing
+- **Phase 6 (T029–T031)**: Depends on all story phases
+
+### User Story Dependencies
+
+- **US3**: Foundational only
+- **US2**: Foundational only
+- **US1**: Foundational required; US2 + US3 required for end-to-end testing
+
+### Parallel Opportunities
+
+**Phase 2** (after T002–T003):
+```
+T004  ActionTypes.cs
+T005  PrimitiveActionBase.cs + Variants
+T006  CommandStep.cs
+```
+
+**Phase 3** (start in parallel):
+```
+T007  GameResponse model
+T008  GET endpoint responses
+T010  games.ts types
+```
+
+**Phase 4** (start in parallel):
+```
+T012  QueueResponse/QueueDetailResponse
+T013  SetQueueGameLinkRequest
+T015  queues.ts types + setQueueGameLink
+T016  GamePickerDialog component
+T017  QueueGameControls component (needs T016)
+```
+
+**Phase 5** (start in parallel):
+```
+T020  AdbClient new methods
+T021  EnsureGameRunningActionResult types
+T022  IEnsureGameRunningActionHandler interface
+```
+
+**Phase 5 tests** (start in parallel after T020–T023):
+```
+T026  AdbClient parsing unit tests
+T027  EnsureGameRunningActionHandler unit tests
+```
+
+---
+
+## Implementation Strategy
+
+### MVP Path (all phases required for testable end-to-end)
+
+1. Phase 2: Foundation
+2. Phase 3: US3 — game has a package name
+3. Phase 4: US2 — queue can be linked to a game
+4. Phase 5: US1 — action checks and optionally starts the game + tests
+5. **VALIDATE**: run a sequence with `ensure-game-running` in a queue with a linked game; run `dotnet test`
+6. Phase 6: Polish
+
+### Incremental Delivery
+
+1. Foundation → US3 → *verify: package name saves and loads*
+2. → US2 → *verify: queue-game link persists across reload*
+3. → US1 implementation → *verify: execution log shows correct outcome*
+4. → US1 tests → *verify: `dotnet test` green*
+5. → Polish → *verify: delete guard, no regressions*
+
+---
+
+## Notes
+
+- `[P]` tasks operate on different files — no edit conflicts when run concurrently
+- `[Story]` labels map tasks to spec.md user stories for traceability
+- The Windows platform guard is encapsulated in `AdbGameOperations` (T022) — `EnsureGameRunningActionHandler` no longer constructs `AdbClient` directly, so platform concerns do not leak into the handler
+- `CommandExecutor` has two constructors — both must accept the new optional `IEnsureGameRunningActionHandler?` as the last parameter (T024)
+- The session label convention `queue:{queueId}` (set in `QueueExecutionService.cs:118`) is the only coupling between the action and queue context — no interface changes needed in the execution chain
+- `QueueDetailResponse.LinkedGameName` requires injecting `IGameRepository` into `BuildDetailAsync` in `QueuesEndpoints.cs` (T014)
+- Constitution §II requires tests for all executable logic — T026, T027, T028 are mandatory, not optional

--- a/specs/052-ensure-game-running/tasks.md
+++ b/specs/052-ensure-game-running/tasks.md
@@ -1,9 +1,9 @@
-# Tasks: Ensure Game Running Primitive Action
+﻿# Tasks: Ensure Game Running Primitive Action
 
 **Input**: Design documents from `specs/052-ensure-game-running/`
-**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓
+**Prerequisites**: plan.md âœ“, spec.md âœ“, research.md âœ“, data-model.md âœ“
 
-**Organization**: Tasks grouped by phase in implementation-dependency order. US3 (game package name) and US2 (queue-game link) are infrastructure prerequisites that must exist before US1 (the action) can be end-to-end tested. They are scheduled before US1 despite US2 being marked P1 in the spec — this is a dependency-driven ordering, not a priority override.
+**Organization**: Tasks grouped by phase in implementation-dependency order. US3 (game package name) and US2 (queue-game link) are infrastructure prerequisites that must exist before US1 (the action) can be end-to-end tested. They are scheduled before US1 despite US2 being marked P1 in the spec â€” this is a dependency-driven ordering, not a priority override.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -17,68 +17,68 @@
 
 **Purpose**: Baseline verification before any changes.
 
-- [ ] T001 Confirm build is green: run `vite build` in `src/web-ui` and verify no pre-existing errors
+- [x] T001 Confirm build is green: run `vite build` in `src/web-ui` and verify no pre-existing errors
 
 ---
 
-## Phase 2: Foundational (Domain Model — Blocks All Phases)
+## Phase 2: Foundational (Domain Model â€” Blocks All Phases)
 
 **Purpose**: Domain-layer additions shared by all three user stories. No story phase can proceed until this is complete.
 
-**⚠️ CRITICAL**: Complete before moving to any user story phase.
+**âš ï¸ CRITICAL**: Complete before moving to any user story phase.
 
-- [ ] T002 Add `PackageName` property (`public string? PackageName { get; set; }`) to `GameArtifact` in `src/GameBot.Domain/Games/GameArtifact.cs`
-- [ ] T003 Add `LinkedGameId` property (`public string? LinkedGameId { get; set; }`) to `ExecutionQueue` in `src/GameBot.Domain/Queues/ExecutionQueue.cs`
-- [ ] T004 [P] Add `public const string EnsureGameRunning = "ensure-game-running";` to `ActionTypes` in `src/GameBot.Domain/Actions/ActionTypes.cs`
-- [ ] T005 [P] Add `EnsureGameRunning = "ensure-game-running"` constant to `PrimitiveActionTypes` and include it in the `All` collection in `src/GameBot.Domain/Actions/PrimitiveActionBase.cs`; add `PrimitiveEnsureGameRunningAction` class (no parameters, calls `base(PrimitiveActionTypes.EnsureGameRunning)`) to `src/GameBot.Domain/Actions/PrimitiveActionVariants.cs`
-- [ ] T006 Add `EnsureGameRunning` to the `CommandStepType` enum in `src/GameBot.Domain/Commands/CommandStep.cs`
+- [x] T002 Add `PackageName` property (`public string? PackageName { get; set; }`) to `GameArtifact` in `src/GameBot.Domain/Games/GameArtifact.cs`
+- [x] T003 Add `LinkedGameId` property (`public string? LinkedGameId { get; set; }`) to `ExecutionQueue` in `src/GameBot.Domain/Queues/ExecutionQueue.cs`
+- [x] T004 [P] Add `public const string EnsureGameRunning = "ensure-game-running";` to `ActionTypes` in `src/GameBot.Domain/Actions/ActionTypes.cs`
+- [x] T005 [P] Add `EnsureGameRunning = "ensure-game-running"` constant to `PrimitiveActionTypes` and include it in the `All` collection in `src/GameBot.Domain/Actions/PrimitiveActionBase.cs`; add `PrimitiveEnsureGameRunningAction` class (no parameters, calls `base(PrimitiveActionTypes.EnsureGameRunning)`) to `src/GameBot.Domain/Actions/PrimitiveActionVariants.cs`
+- [x] T006 Add `EnsureGameRunning` to the `CommandStepType` enum in `src/GameBot.Domain/Commands/CommandStep.cs`
 
-**Checkpoint**: Domain model changes complete — all user story phases can begin.
+**Checkpoint**: Domain model changes complete â€” all user story phases can begin.
 
 ---
 
-## Phase 3: User Story 3 — Configure Game Package Name (Priority: P2)
+## Phase 3: User Story 3 â€” Configure Game Package Name (Priority: P2)
 
-**Note**: Scheduled before US2 (P1) because the game picker in US2 is more useful once games have package names, and because US1 requires both to be in place. This is a dependency-driven ordering — US2 and US3 are independently testable after Phase 2.
+**Note**: Scheduled before US2 (P1) because the game picker in US2 is more useful once games have package names, and because US1 requires both to be in place. This is a dependency-driven ordering â€” US2 and US3 are independently testable after Phase 2.
 
 **Goal**: Games have a configurable `packageName` field that operators can set through the UI, providing the Android package identifier used to detect and launch the game.
 
-**Independent Test**: Create a new game, enter `com.example.game` in the Package Name field, save — reload the edit form and confirm the package name is displayed. Edit an existing game and clear the package name — save succeeds without error.
+**Independent Test**: Create a new game, enter `com.example.game` in the Package Name field, save â€” reload the edit form and confirm the package name is displayed. Edit an existing game and clear the package name â€” save succeeds without error.
 
 ### Implementation
 
-- [ ] T007 [P] [US3] Add `public string? PackageName { get; init; }` to `GameResponse` in `src/GameBot.Service/Models/Games.cs`
-- [ ] T008 [P] [US3] Update `GetGame` and `ListGames` handlers in `src/GameBot.Service/Endpoints/GamesEndpoints.cs` to include `packageName` in all response shapes (both the `GameResponse` path and the anonymous `{ id, name, metadata }` path)
-- [ ] T009 [US3] Update `CreateGame` and `UpdateGame` handlers in `src/GameBot.Service/Endpoints/GamesEndpoints.cs` to read `packageName` from the request body and persist it to `GameArtifact.PackageName` (depends on T002, T007)
-- [ ] T010 [P] [US3] Add `packageName?: string` to `GameDto`, `GameCreate`, and `GameUpdate` types in `src/web-ui/src/services/games.ts`
-- [ ] T011 [US3] Add an optional `packageName` text input (label "Package Name", placeholder `e.g. com.example.game`) to both the create form and the edit form in `src/web-ui/src/pages/GamesPage.tsx`; update the `GameFormValue` type to include `packageName: string`; pass the field value to `createGame` / `updateGame` (depends on T010)
+- [x] T007 [P] [US3] Add `public string? PackageName { get; init; }` to `GameResponse` in `src/GameBot.Service/Models/Games.cs`
+- [x] T008 [P] [US3] Update `GetGame` and `ListGames` handlers in `src/GameBot.Service/Endpoints/GamesEndpoints.cs` to include `packageName` in all response shapes (both the `GameResponse` path and the anonymous `{ id, name, metadata }` path)
+- [x] T009 [US3] Update `CreateGame` and `UpdateGame` handlers in `src/GameBot.Service/Endpoints/GamesEndpoints.cs` to read `packageName` from the request body and persist it to `GameArtifact.PackageName` (depends on T002, T007)
+- [x] T010 [P] [US3] Add `packageName?: string` to `GameDto`, `GameCreate`, and `GameUpdate` types in `src/web-ui/src/services/games.ts`
+- [x] T011 [US3] Add an optional `packageName` text input (label "Package Name", placeholder `e.g. com.example.game`) to both the create form and the edit form in `src/web-ui/src/pages/GamesPage.tsx`; update the `GameFormValue` type to include `packageName: string`; pass the field value to `createGame` / `updateGame` (depends on T010)
 
 **Checkpoint**: Games can store and display a package name. US3 independently verifiable.
 
 ---
 
-## Phase 4: User Story 2 — Link Queue to Game (Priority: P1)
+## Phase 4: User Story 2 â€” Link Queue to Game (Priority: P1)
 
 **Goal**: A queue can be associated with a specific game. The operator can link and unlink the game through the queue edit UI, and the association persists across service restarts.
 
-**Independent Test**: Open the queue edit form — a "Game" row is visible below the template controls. Click "Link Game", select a game from the picker, confirm the game name now shows. Click "Unlink" and confirm the row reverts to "(no game)". Restart the service and reload — the link is preserved.
+**Independent Test**: Open the queue edit form â€” a "Game" row is visible below the template controls. Click "Link Game", select a game from the picker, confirm the game name now shows. Click "Unlink" and confirm the row reverts to "(no game)". Restart the service and reload â€” the link is preserved.
 
 ### Implementation
 
-- [ ] T012 [P] [US2] Add `public string? LinkedGameId { get; set; }` and `public string? LinkedGameName { get; set; }` to `QueueResponse` in `src/GameBot.Service/Contracts/Queues/QueueResponse.cs`, and add `LinkedGameName` property to `QueueDetailResponse` in `src/GameBot.Service/Contracts/Queues/QueueDetailResponse.cs` (`LinkedGameId` is inherited from `QueueResponse`)
-- [ ] T013 [P] [US2] Create `SetQueueGameLinkRequest` class with `public string? GameId { get; set; }` in `src/GameBot.Service/Contracts/Queues/SetQueueGameLinkRequest.cs`
-- [ ] T014 [US2] Add `PUT /api/queues/{id}/game` endpoint to `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: validate game exists when `gameId` non-null (inject `IGameRepository`), set `queue.LinkedGameId`, persist, return `QueueDetailResponse` with resolved `LinkedGameName`. Also update `BuildResponse` and `BuildDetailAsync` helpers to populate `LinkedGameId` and `LinkedGameName` from the game store. (depends on T003, T012, T013)
-- [ ] T015 [P] [US2] Add `linkedGameId: string | null` and `linkedGameName: string | null` to `QueueDto` and `QueueDetailDto` types, and add `export const setQueueGameLink = (id: string, gameId: string | null) => putJson<QueueDetailDto>(...)` to `src/web-ui/src/services/queues.ts`
-- [ ] T016 [P] [US2] Create `GamePickerDialog` component in `src/web-ui/src/components/queues/GamePickerDialog.tsx`: props `open: boolean`, `onSelect: (gameId: string) => void`, `onClose: () => void`; fetches games via `listGames()`, renders each as a row with a "Select" button; mirrors the `TemplatePickerDialog` structure
-- [ ] T017 [P] [US2] Create `QueueGameControls` component in `src/web-ui/src/components/queues/QueueGameControls.tsx`: props `linkedGameId: string | null`, `linkedGameName: string | null`, `status: QueueStatus`, `onLink: (gameId: string) => void`, `onUnlink: () => void`; renders game name (or "(no game)"), "Link Game" toggle button that opens `GamePickerDialog`, "Unlink" button disabled when running or unlinked; mirrors `QueueTemplateControls` (depends on T016)
-- [ ] T018 [US2] Add `gameControls?: React.ReactNode` prop to `QueueFormProps` and `QueueForm` in `src/web-ui/src/components/queues/QueueForm.tsx`; render it in edit mode between `templateControls` and the cycle-execution checkbox (depends on T017)
-- [ ] T019 [US2] Wire `QueueGameControls` into `QueuesPage` in `src/web-ui/src/pages/QueuesPage.tsx`: read `linkedGameId` and `linkedGameName` from queue detail, pass as the `gameControls` prop on `QueueForm`, call `setQueueGameLink` on link/unlink, refresh local state after success (depends on T014, T015, T017, T018)
+- [x] T012 [P] [US2] Add `public string? LinkedGameId { get; set; }` and `public string? LinkedGameName { get; set; }` to `QueueResponse` in `src/GameBot.Service/Contracts/Queues/QueueResponse.cs`, and add `LinkedGameName` property to `QueueDetailResponse` in `src/GameBot.Service/Contracts/Queues/QueueDetailResponse.cs` (`LinkedGameId` is inherited from `QueueResponse`)
+- [x] T013 [P] [US2] Create `SetQueueGameLinkRequest` class with `public string? GameId { get; set; }` in `src/GameBot.Service/Contracts/Queues/SetQueueGameLinkRequest.cs`
+- [x] T014 [US2] Add `PUT /api/queues/{id}/game` endpoint to `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: validate game exists when `gameId` non-null (inject `IGameRepository`), set `queue.LinkedGameId`, persist, return `QueueDetailResponse` with resolved `LinkedGameName`. Also update `BuildResponse` and `BuildDetailAsync` helpers to populate `LinkedGameId` and `LinkedGameName` from the game store. (depends on T003, T012, T013)
+- [x] T015 [P] [US2] Add `linkedGameId: string | null` and `linkedGameName: string | null` to `QueueDto` and `QueueDetailDto` types, and add `export const setQueueGameLink = (id: string, gameId: string | null) => putJson<QueueDetailDto>(...)` to `src/web-ui/src/services/queues.ts`
+- [x] T016 [P] [US2] Create `GamePickerDialog` component in `src/web-ui/src/components/queues/GamePickerDialog.tsx`: props `open: boolean`, `onSelect: (gameId: string) => void`, `onClose: () => void`; fetches games via `listGames()`, renders each as a row with a "Select" button; mirrors the `TemplatePickerDialog` structure
+- [x] T017 [P] [US2] Create `QueueGameControls` component in `src/web-ui/src/components/queues/QueueGameControls.tsx`: props `linkedGameId: string | null`, `linkedGameName: string | null`, `status: QueueStatus`, `onLink: (gameId: string) => void`, `onUnlink: () => void`; renders game name (or "(no game)"), "Link Game" toggle button that opens `GamePickerDialog`, "Unlink" button disabled when running or unlinked; mirrors `QueueTemplateControls` (depends on T016)
+- [x] T018 [US2] Add `gameControls?: React.ReactNode` prop to `QueueFormProps` and `QueueForm` in `src/web-ui/src/components/queues/QueueForm.tsx`; render it in edit mode between `templateControls` and the cycle-execution checkbox (depends on T017)
+- [x] T019 [US2] Wire `QueueGameControls` into `QueuesPage` in `src/web-ui/src/pages/QueuesPage.tsx`: read `linkedGameId` and `linkedGameName` from queue detail, pass as the `gameControls` prop on `QueueForm`, call `setQueueGameLink` on link/unlink, refresh local state after success (depends on T014, T015, T017, T018)
 
 **Checkpoint**: Queue-game link is functional end-to-end. US2 independently verifiable.
 
 ---
 
-## Phase 5: User Story 1 — Check Game Running Status (Priority: P1) 🎯 Core Value
+## Phase 5: User Story 1 â€” Check Game Running Status (Priority: P1) ðŸŽ¯ Core Value
 
 **Goal**: The `ensure-game-running` primitive action is available in the command step editor, executes within a queue-run sequence, checks whether the queue's linked game is the active foreground app on the emulator, reports success if it is, and starts the game then reports failure if it is not.
 
@@ -86,18 +86,18 @@
 
 ### Implementation
 
-- [ ] T020 [P] [US1] Add `GetForegroundPackageAsync(CancellationToken ct)` and `LaunchAppAsync(string packageName, CancellationToken ct)` methods to `AdbClient` in `src/GameBot.Emulator/Adb/AdbClient.cs`. `GetForegroundPackageAsync` runs `shell dumpsys activity activities` then delegates to an `internal static string? ParseForegroundPackage(string adbOutput)` helper that parses the line containing `mResumedActivity` to extract the package name (the token immediately after `u0 ` and before `/`), returning `null` if the line is absent — keeping the parsing logic in a pure static method enables unit testing without a real ADB process (see T026). `LaunchAppAsync` runs `shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1` (fire-and-forget, result not propagated). Add `LoggerMessage` entries to the existing `Log` static class. Add an XML doc comment to each method documenting inputs, return value, and expected execution time (< 1 second for `GetForegroundPackageAsync` under normal conditions). *(Constitution §IV: hot-path perf note required)*
-- [ ] T021 [P] [US1] Create `EnsureGameRunningOutcome` enum (values: `GameRunning`, `GameNotRunning`, `NoQueueContext`, `NoLinkedGame`, `NoPackageName`, `PlatformUnsupported`) and `EnsureGameRunningActionResult` sealed record with `Outcome` property, computed `bool IsSuccess` (`Outcome == GameRunning`), and computed `string ReasonCode` (switch expression mapping each outcome to its kebab-case string) in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionResult.cs`
-- [ ] T022 [P] [US1] Create `IAdbGameOperations` interface in `src/GameBot.Service/Services/EnsureGameRunning/IAdbGameOperations.cs` with two methods: `Task<string?> GetForegroundPackageAsync(string deviceSerial, CancellationToken ct)` and `Task LaunchAppAsync(string deviceSerial, string packageName, CancellationToken ct)`. Create `AdbGameOperations` implementation in the same folder: guards `OperatingSystem.IsWindows()` on each call, delegates to `new AdbClient().WithSerial(deviceSerial)`. Create `IEnsureGameRunningActionHandler` interface with `Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default)` in `src/GameBot.Service/Services/EnsureGameRunning/IEnsureGameRunningActionHandler.cs`
-- [ ] T023 [US1] Implement `EnsureGameRunningActionHandler` in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs`: inject `ISessionManager`, `IQueueRepository`, `IGameRepository`, and `IAdbGameOperations`; execution order: (1) get session by `sessionId` — if null return `NoQueueContext`; (2) parse `queue:{queueId}` from `session.GameId` — if no `queue:` prefix return `NoQueueContext`; (3) **`if (!OperatingSystem.IsWindows()) return PlatformUnsupported`** — handler owns this outcome explicitly; `AdbGameOperations` also guards it internally for defense in depth, but `null` from `GetForegroundPackageAsync` must not be misread as `GameNotRunning`; (4) load queue — if null or `LinkedGameId` empty return `NoLinkedGame`; (5) load game — if null or `PackageName` empty return `NoPackageName`; (6) call `_adb.GetForegroundPackageAsync(session.DeviceSerial, ct)` — if result matches `game.PackageName` (OrdinalIgnoreCase) return `GameRunning` — **no launch call in this path** (FR-005: running game must not be disturbed); (7) call `_adb.LaunchAppAsync(session.DeviceSerial, game.PackageName, ct)` then return `GameNotRunning`. Injecting `IAdbGameOperations` allows T027 to mock all ADB paths including `GameRunning` and `GameNotRunning` without platform constraints. (depends on T002, T003, T020, T021, T022)
-- [ ] T024 [US1] Add `EnsureGameRunning` case to the `foreach` loop in `ExecuteCommandRecursiveAsync` in `src/GameBot.Service/Services/CommandExecutor.cs`: if `step.Type == CommandStepType.EnsureGameRunning`, call `_ensureGameRunning is not null ? await _ensureGameRunning.ExecuteAsync(sessionId, ct) : new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported)`; if `result.IsSuccess` increment `totalAccepted` by 1 and add `PrimitiveTapStepOutcome(step.Order, "executed", result.ReasonCode, null, null, StepType: "ensure-game-running")`; otherwise add `PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running")`; **end with `continue`** (not `return`) so the loop proceeds to the next step regardless of outcome (FR-012: failure must not abort sequence). Add `private readonly IEnsureGameRunningActionHandler? _ensureGameRunning;` field and update both constructors to accept it as an optional last parameter. (depends on T005, T006, T021, T022, T023)
-- [ ] T025 [US1] Register `IAdbGameOperations` → `AdbGameOperations` and `IEnsureGameRunningActionHandler` → `EnsureGameRunningActionHandler` in the DI container in `src/GameBot.Service/Program.cs`; update the `CommandExecutor` registration to supply the handler (depends on T022, T023, T024)
+- [x] T020 [P] [US1] Add `GetForegroundPackageAsync(CancellationToken ct)` and `LaunchAppAsync(string packageName, CancellationToken ct)` methods to `AdbClient` in `src/GameBot.Emulator/Adb/AdbClient.cs`. `GetForegroundPackageAsync` runs `shell dumpsys activity activities` then delegates to an `internal static string? ParseForegroundPackage(string adbOutput)` helper that parses the line containing `mResumedActivity` to extract the package name (the token immediately after `u0 ` and before `/`), returning `null` if the line is absent â€” keeping the parsing logic in a pure static method enables unit testing without a real ADB process (see T026). `LaunchAppAsync` runs `shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1` (fire-and-forget, result not propagated). Add `LoggerMessage` entries to the existing `Log` static class. Add an XML doc comment to each method documenting inputs, return value, and expected execution time (< 1 second for `GetForegroundPackageAsync` under normal conditions). *(Constitution Â§IV: hot-path perf note required)*
+- [x] T021 [P] [US1] Create `EnsureGameRunningOutcome` enum (values: `GameRunning`, `GameNotRunning`, `NoQueueContext`, `NoLinkedGame`, `NoPackageName`, `PlatformUnsupported`) and `EnsureGameRunningActionResult` sealed record with `Outcome` property, computed `bool IsSuccess` (`Outcome == GameRunning`), and computed `string ReasonCode` (switch expression mapping each outcome to its kebab-case string) in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionResult.cs`
+- [x] T022 [P] [US1] Create `IAdbGameOperations` interface in `src/GameBot.Service/Services/EnsureGameRunning/IAdbGameOperations.cs` with two methods: `Task<string?> GetForegroundPackageAsync(string deviceSerial, CancellationToken ct)` and `Task LaunchAppAsync(string deviceSerial, string packageName, CancellationToken ct)`. Create `AdbGameOperations` implementation in the same folder: guards `OperatingSystem.IsWindows()` on each call, delegates to `new AdbClient().WithSerial(deviceSerial)`. Create `IEnsureGameRunningActionHandler` interface with `Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default)` in `src/GameBot.Service/Services/EnsureGameRunning/IEnsureGameRunningActionHandler.cs`
+- [x] T023 [US1] Implement `EnsureGameRunningActionHandler` in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs`: inject `ISessionManager`, `IQueueRepository`, `IGameRepository`, and `IAdbGameOperations`; execution order: (1) get session by `sessionId` â€” if null return `NoQueueContext`; (2) parse `queue:{queueId}` from `session.GameId` â€” if no `queue:` prefix return `NoQueueContext`; (3) **`if (!OperatingSystem.IsWindows()) return PlatformUnsupported`** â€” handler owns this outcome explicitly; `AdbGameOperations` also guards it internally for defense in depth, but `null` from `GetForegroundPackageAsync` must not be misread as `GameNotRunning`; (4) load queue â€” if null or `LinkedGameId` empty return `NoLinkedGame`; (5) load game â€” if null or `PackageName` empty return `NoPackageName`; (6) call `_adb.GetForegroundPackageAsync(session.DeviceSerial, ct)` â€” if result matches `game.PackageName` (OrdinalIgnoreCase) return `GameRunning` â€” **no launch call in this path** (FR-005: running game must not be disturbed); (7) call `_adb.LaunchAppAsync(session.DeviceSerial, game.PackageName, ct)` then return `GameNotRunning`. Injecting `IAdbGameOperations` allows T027 to mock all ADB paths including `GameRunning` and `GameNotRunning` without platform constraints. (depends on T002, T003, T020, T021, T022)
+- [x] T024 [US1] Add `EnsureGameRunning` case to the `foreach` loop in `ExecuteCommandRecursiveAsync` in `src/GameBot.Service/Services/CommandExecutor.cs`: if `step.Type == CommandStepType.EnsureGameRunning`, call `_ensureGameRunning is not null ? await _ensureGameRunning.ExecuteAsync(sessionId, ct) : new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported)`; if `result.IsSuccess` increment `totalAccepted` by 1 and add `PrimitiveTapStepOutcome(step.Order, "executed", result.ReasonCode, null, null, StepType: "ensure-game-running")`; otherwise add `PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running")`; **end with `continue`** (not `return`) so the loop proceeds to the next step regardless of outcome (FR-012: failure must not abort sequence). Add `private readonly IEnsureGameRunningActionHandler? _ensureGameRunning;` field and update both constructors to accept it as an optional last parameter. (depends on T005, T006, T021, T022, T023)
+- [x] T025 [US1] Register `IAdbGameOperations` â†’ `AdbGameOperations` and `IEnsureGameRunningActionHandler` â†’ `EnsureGameRunningActionHandler` in the DI container in `src/GameBot.Service/Program.cs`; update the `CommandExecutor` registration to supply the handler (depends on T022, T023, T024)
 
-### Tests for User Story 1 *(Constitution §II: required for executable logic)*
+### Tests for User Story 1 *(Constitution Â§II: required for executable logic)*
 
-- [ ] T026 [P] [US1] Write unit tests for `AdbClient.GetForegroundPackageAsync` output parsing in `tests/unit/Emulator/AdbClientForegroundPackageTests.cs`: test cases — line containing `mResumedActivity` with `u0 com.example.game/` returns `"com.example.game"`; output with no `mResumedActivity` line returns `null`; multiple lines with exactly one `mResumedActivity` line returns correct package. No ADB process required — test the parsing logic in isolation.
-- [ ] T027 [P] [US1] Write unit tests for `EnsureGameRunningActionHandler` in `tests/unit/Services/EnsureGameRunning/EnsureGameRunningActionHandlerTests.cs` covering all six outcome paths: (a) `NoQueueContext` when `GetSession` returns null; (b) `NoQueueContext` when `session.GameId` has no `queue:` prefix; (c) `NoLinkedGame` when queue has no `LinkedGameId`; (d) `NoPackageName` when game has no `PackageName`; (e) `GameRunning` when foreground package matches; (f) `GameNotRunning` when foreground package does not match (also verify `LaunchAppAsync` is called). Use mocked `ISessionManager`, `IQueueRepository`, `IGameRepository`, and a mock/stub `AdbClient`-like abstraction as needed.
-- [ ] T028 [US1] Write an integration test for `CommandExecutor` `EnsureGameRunning` step in `tests/integration/CommandExecutor/EnsureGameRunningStepTests.cs`: (a) step with mock handler returning `GameRunning` → `accepted == 1`, step outcome `Status="executed"`, overall command status `"success"`; (b) step with mock handler returning `GameNotRunning` → `accepted == 0`, step outcome `Status="game_not_running"`, overall command status `"failure"`; (c) step executed after a failure → sequence continues (next step executes), confirming FR-012. (depends on T024)
+- [x] T026 [P] [US1] Write unit tests for `AdbClient.GetForegroundPackageAsync` output parsing in `tests/unit/Emulator/AdbClientForegroundPackageTests.cs`: test cases â€” line containing `mResumedActivity` with `u0 com.example.game/` returns `"com.example.game"`; output with no `mResumedActivity` line returns `null`; multiple lines with exactly one `mResumedActivity` line returns correct package. No ADB process required â€” test the parsing logic in isolation.
+- [x] T027 [P] [US1] Write unit tests for `EnsureGameRunningActionHandler` in `tests/unit/Services/EnsureGameRunning/EnsureGameRunningActionHandlerTests.cs` covering all six outcome paths: (a) `NoQueueContext` when `GetSession` returns null; (b) `NoQueueContext` when `session.GameId` has no `queue:` prefix; (c) `NoLinkedGame` when queue has no `LinkedGameId`; (d) `NoPackageName` when game has no `PackageName`; (e) `GameRunning` when foreground package matches; (f) `GameNotRunning` when foreground package does not match (also verify `LaunchAppAsync` is called). Use mocked `ISessionManager`, `IQueueRepository`, `IGameRepository`, and a mock/stub `AdbClient`-like abstraction as needed.
+- [x] T028 [US1] Write an integration test for `CommandExecutor` `EnsureGameRunning` step in `tests/integration/CommandExecutor/EnsureGameRunningStepTests.cs`: (a) step with mock handler returning `GameRunning` â†’ `accepted == 1`, step outcome `Status="executed"`, overall command status `"success"`; (b) step with mock handler returning `GameNotRunning` â†’ `accepted == 0`, step outcome `Status="game_not_running"`, overall command status `"failure"`; (c) step executed after a failure â†’ sequence continues (next step executes), confirming FR-012. (depends on T024)
 
 **Checkpoint**: `ensure-game-running` executes end-to-end in a queue run and is covered by unit + integration tests. US1 fully verifiable.
 
@@ -107,9 +107,9 @@
 
 **Purpose**: Delete-guard, execution log correctness, and regression check.
 
-- [ ] T029 [P] Add queue-reference guard to `DeleteGame` in `src/GameBot.Service/Endpoints/GamesEndpoints.cs`: before deleting, call `IQueueRepository.ListAsync()`, check if any queue has `LinkedGameId == id`; if so return 409 with a references list (FR edge case: linked game must not be deletable while queues reference it; `GamesPage` frontend already handles `ApiError(409)` with `references` property)
-- [ ] T030 [P] Verify `SequenceExecutionService` in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs` does not misclassify `ensure-game-running` step type: confirm the `isWaitForImageStep` check does not accidentally match the new type; the step should appear in the execution log detail as `stepType: "command"` (wrapping command) with the `actionOutcome` propagated from the `PrimitiveTapStepOutcome` outcome field
-- [ ] T031 Run full build and test suite: `vite build` in `src/web-ui`; `jest` for frontend; `dotnet test` from repo root (covers `tests/unit/`, `tests/integration/`, `tests/contract/`) — all must pass before marking the feature complete
+- [x] T029 [P] Add queue-reference guard to `DeleteGame` in `src/GameBot.Service/Endpoints/GamesEndpoints.cs`: before deleting, call `IQueueRepository.ListAsync()`, check if any queue has `LinkedGameId == id`; if so return 409 with a references list (FR edge case: linked game must not be deletable while queues reference it; `GamesPage` frontend already handles `ApiError(409)` with `references` property)
+- [x] T030 [P] Verify `SequenceExecutionService` in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs` does not misclassify `ensure-game-running` step type: confirm the `isWaitForImageStep` check does not accidentally match the new type; the step should appear in the execution log detail as `stepType: "command"` (wrapping command) with the `actionOutcome` propagated from the `PrimitiveTapStepOutcome` outcome field
+- [x] T031 Run full build and test suite: `vite build` in `src/web-ui`; `jest` for frontend; `dotnet test` from repo root (covers `tests/unit/`, `tests/integration/`, `tests/contract/`) â€” all must pass before marking the feature complete
 
 ---
 
@@ -118,11 +118,11 @@
 ### Phase Dependencies
 
 - **Phase 1 (T001)**: No dependencies
-- **Phase 2 (T002–T006)**: Must complete before any story phase; T004/T005/T006 parallelisable after T002–T003
-- **Phase 3 / US3 (T007–T011)**: Depends on Phase 2; independently testable
-- **Phase 4 / US2 (T012–T019)**: Depends on Phase 2; independently testable
-- **Phase 5 / US1 (T020–T028)**: Depends on Phase 2; requires US2 + US3 for full integration testing
-- **Phase 6 (T029–T031)**: Depends on all story phases
+- **Phase 2 (T002â€“T006)**: Must complete before any story phase; T004/T005/T006 parallelisable after T002â€“T003
+- **Phase 3 / US3 (T007â€“T011)**: Depends on Phase 2; independently testable
+- **Phase 4 / US2 (T012â€“T019)**: Depends on Phase 2; independently testable
+- **Phase 5 / US1 (T020â€“T028)**: Depends on Phase 2; requires US2 + US3 for full integration testing
+- **Phase 6 (T029â€“T031)**: Depends on all story phases
 
 ### User Story Dependencies
 
@@ -132,7 +132,7 @@
 
 ### Parallel Opportunities
 
-**Phase 2** (after T002–T003):
+**Phase 2** (after T002â€“T003):
 ```
 T004  ActionTypes.cs
 T005  PrimitiveActionBase.cs + Variants
@@ -162,7 +162,7 @@ T021  EnsureGameRunningActionResult types
 T022  IEnsureGameRunningActionHandler interface
 ```
 
-**Phase 5 tests** (start in parallel after T020–T023):
+**Phase 5 tests** (start in parallel after T020â€“T023):
 ```
 T026  AdbClient parsing unit tests
 T027  EnsureGameRunningActionHandler unit tests
@@ -175,28 +175,29 @@ T027  EnsureGameRunningActionHandler unit tests
 ### MVP Path (all phases required for testable end-to-end)
 
 1. Phase 2: Foundation
-2. Phase 3: US3 — game has a package name
-3. Phase 4: US2 — queue can be linked to a game
-4. Phase 5: US1 — action checks and optionally starts the game + tests
+2. Phase 3: US3 â€” game has a package name
+3. Phase 4: US2 â€” queue can be linked to a game
+4. Phase 5: US1 â€” action checks and optionally starts the game + tests
 5. **VALIDATE**: run a sequence with `ensure-game-running` in a queue with a linked game; run `dotnet test`
 6. Phase 6: Polish
 
 ### Incremental Delivery
 
-1. Foundation → US3 → *verify: package name saves and loads*
-2. → US2 → *verify: queue-game link persists across reload*
-3. → US1 implementation → *verify: execution log shows correct outcome*
-4. → US1 tests → *verify: `dotnet test` green*
-5. → Polish → *verify: delete guard, no regressions*
+1. Foundation â†’ US3 â†’ *verify: package name saves and loads*
+2. â†’ US2 â†’ *verify: queue-game link persists across reload*
+3. â†’ US1 implementation â†’ *verify: execution log shows correct outcome*
+4. â†’ US1 tests â†’ *verify: `dotnet test` green*
+5. â†’ Polish â†’ *verify: delete guard, no regressions*
 
 ---
 
 ## Notes
 
-- `[P]` tasks operate on different files — no edit conflicts when run concurrently
+- `[P]` tasks operate on different files â€” no edit conflicts when run concurrently
 - `[Story]` labels map tasks to spec.md user stories for traceability
-- The Windows platform guard is encapsulated in `AdbGameOperations` (T022) — `EnsureGameRunningActionHandler` no longer constructs `AdbClient` directly, so platform concerns do not leak into the handler
-- `CommandExecutor` has two constructors — both must accept the new optional `IEnsureGameRunningActionHandler?` as the last parameter (T024)
-- The session label convention `queue:{queueId}` (set in `QueueExecutionService.cs:118`) is the only coupling between the action and queue context — no interface changes needed in the execution chain
+- The Windows platform guard is encapsulated in `AdbGameOperations` (T022) â€” `EnsureGameRunningActionHandler` no longer constructs `AdbClient` directly, so platform concerns do not leak into the handler
+- `CommandExecutor` has two constructors â€” both must accept the new optional `IEnsureGameRunningActionHandler?` as the last parameter (T024)
+- The session label convention `queue:{queueId}` (set in `QueueExecutionService.cs:118`) is the only coupling between the action and queue context â€” no interface changes needed in the execution chain
 - `QueueDetailResponse.LinkedGameName` requires injecting `IGameRepository` into `BuildDetailAsync` in `QueuesEndpoints.cs` (T014)
-- Constitution §II requires tests for all executable logic — T026, T027, T028 are mandatory, not optional
+- Constitution Â§II requires tests for all executable logic â€” T026, T027, T028 are mandatory, not optional
+

--- a/src/GameBot.Domain/Actions/ActionTypes.cs
+++ b/src/GameBot.Domain/Actions/ActionTypes.cs
@@ -10,4 +10,5 @@ public static class ActionTypes {
   public const string Key = "key";
   public const string ConnectToGame = "connect-to-game";
   public const string WaitForImage = "WaitForImage";
+  public const string EnsureGameRunning = "ensure-game-running";
 }

--- a/src/GameBot.Domain/Actions/PrimitiveActionBase.cs
+++ b/src/GameBot.Domain/Actions/PrimitiveActionBase.cs
@@ -9,6 +9,7 @@ public static class PrimitiveActionTypes {
   public const string Command = "command";
   public const string ConnectToGame = "connect-to-game";
   public const string WaitForImage = "WaitForImage";
+  public const string EnsureGameRunning = "ensure-game-running";
 
   public static IReadOnlyCollection<string> All { get; } = new ReadOnlyCollection<string>(new[] {
     Tap,
@@ -16,7 +17,8 @@ public static class PrimitiveActionTypes {
     Key,
     Command,
     ConnectToGame,
-    WaitForImage
+    WaitForImage,
+    EnsureGameRunning
   });
 }
 

--- a/src/GameBot.Domain/Actions/PrimitiveActionVariants.cs
+++ b/src/GameBot.Domain/Actions/PrimitiveActionVariants.cs
@@ -32,6 +32,10 @@ public sealed class PrimitiveCommandAction : PrimitiveActionBase {
   public PrimitiveCommandAction() : base(PrimitiveActionTypes.Command) { }
 }
 
+public sealed class PrimitiveEnsureGameRunningAction : PrimitiveActionBase {
+  public PrimitiveEnsureGameRunningAction() : base(PrimitiveActionTypes.EnsureGameRunning) { }
+}
+
 public sealed class PrimitiveConnectToGameAction : PrimitiveActionBase {
   public string? GameId { get; set; }
   public string? AdbSerial { get; set; }

--- a/src/GameBot.Domain/Commands/CommandStep.cs
+++ b/src/GameBot.Domain/Commands/CommandStep.cs
@@ -3,7 +3,8 @@ namespace GameBot.Domain.Commands;
 public enum CommandStepType {
   Command,
   PrimitiveTap,
-  WaitForImage
+  WaitForImage,
+  EnsureGameRunning
 }
 
 public sealed class PrimitiveTapConfig {

--- a/src/GameBot.Domain/Games/GameArtifact.cs
+++ b/src/GameBot.Domain/Games/GameArtifact.cs
@@ -1,8 +1,9 @@
 namespace GameBot.Domain.Games;
 
-// Simplified game model: only id, name, description
 public sealed class GameArtifact {
   public required string Id { get; set; }
   public required string Name { get; set; }
   public string? Description { get; set; }
+  /// <summary>Android package identifier used to detect and launch the game on an emulator.</summary>
+  public string? PackageName { get; set; }
 }

--- a/src/GameBot.Domain/Queues/ExecutionQueue.cs
+++ b/src/GameBot.Domain/Queues/ExecutionQueue.cs
@@ -35,6 +35,13 @@ namespace GameBot.Domain.Queues {
     /// </summary>
     public string? LinkedTemplateId { get; set; }
 
+    /// <summary>
+    /// Optional link to a single game by its stable ID (0..1). Persisted.
+    /// When set, game-aware actions in this queue's sequences resolve the target game automatically.
+    /// Null when the queue is unlinked.
+    /// </summary>
+    public string? LinkedGameId { get; set; }
+
     public DateTimeOffset? CreatedAt { get; set; }
 
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/src/GameBot.Emulator/Adb/AdbClient.cs
+++ b/src/GameBot.Emulator/Adb/AdbClient.cs
@@ -69,6 +69,46 @@ public sealed class AdbClient {
     return ExecAsync($"shell input swipe {x1} {y1} {x2} {y2} {(durationMs is null ? string.Empty : durationMs.Value.ToString(CultureInfo.InvariantCulture))}", ct);
   }
 
+  /// <summary>
+  /// Returns the package name of the activity currently in the foreground on this device,
+  /// or <c>null</c> if it cannot be determined. Parses the <c>mResumedActivity</c> line from
+  /// <c>dumpsys activity activities</c>.
+  /// Expected execution time: &lt;1 second under normal connected-emulator conditions.
+  /// </summary>
+  public async Task<string?> GetForegroundPackageAsync(CancellationToken ct = default) {
+    var (_, stdout, _) = await ExecAsync("shell dumpsys activity activities", ct).ConfigureAwait(false);
+    return ParseForegroundPackage(stdout);
+  }
+
+  /// <summary>
+  /// Parses the foreground package name from <c>dumpsys activity activities</c> output.
+  /// Looks for the line containing <c>mResumedActivity</c> and extracts the package before <c>/</c>
+  /// in the segment after <c>u0 </c>.
+  /// </summary>
+  public static string? ParseForegroundPackage(string adbOutput) {
+    ArgumentNullException.ThrowIfNull(adbOutput);
+    foreach (var line in adbOutput.Split('\n')) {
+      var trimmed = line.Trim();
+      if (!trimmed.Contains("mResumedActivity", StringComparison.OrdinalIgnoreCase)) continue;
+      var u0Index = trimmed.IndexOf("u0 ", StringComparison.Ordinal);
+      if (u0Index < 0) continue;
+      var afterU0 = trimmed[(u0Index + 3)..];
+      var slashIndex = afterU0.IndexOf('/', StringComparison.Ordinal);
+      if (slashIndex <= 0) continue;
+      return afterU0[..slashIndex];
+    }
+    return null;
+  }
+
+  /// <summary>
+  /// Launches the app with the given package name on this device using the monkey launcher.
+  /// Fire-and-forget: the result is not inspected by the caller.
+  /// </summary>
+  public Task<(int ExitCode, string StdOut, string StdErr)> LaunchAppAsync(string packageName, CancellationToken ct = default) {
+    Log.LaunchApp(_logger, packageName);
+    return ExecAsync($"shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1", ct);
+  }
+
   public async Task<byte[]> GetScreenshotPngAsync(CancellationToken ct = default) {
     // Use exec-out for raw PNG
     var cmdArgs = string.IsNullOrWhiteSpace(_serial) ? "exec-out screencap -p" : $"-s {_serial} exec-out screencap -p";
@@ -130,6 +170,10 @@ internal static class Log {
       LoggerMessage.Define<int>(LogLevel.Debug, new EventId(1007, nameof(ScreencapEnd)),
           "ADB screencap end size={Bytes}");
 
+  private static readonly Action<ILogger, string, Exception?> _launchApp =
+      LoggerMessage.Define<string>(LogLevel.Debug, new EventId(1008, nameof(LaunchApp)),
+          "ADB launch app {Package}");
+
   public static void ExecStart(ILogger? l, string adb, string args) { if (l != null) _execStart(l, adb, args, null); }
   public static void ExecEnd(ILogger? l, int exit, string args, string stdout, string stderr) { if (l != null) _execEnd(l, exit, args, stdout, null); }
   public static void KeyEvent(ILogger? l, int key) { if (l != null) _keyEvent(l, key, null); }
@@ -137,4 +181,5 @@ internal static class Log {
   public static void Swipe(ILogger? l, int x1, int y1, int x2, int y2, int? dur) { if (l != null) _swipe(l, x1, y1, x2, y2, dur, null); }
   public static void ScreencapStart(ILogger? l, string args) { if (l != null) _screencapStart(l, args, null); }
   public static void ScreencapEnd(ILogger? l, int bytes) { if (l != null) _screencapEnd(l, bytes, null); }
+  public static void LaunchApp(ILogger? l, string pkg) { if (l != null) _launchApp(l, pkg, null); }
 }

--- a/src/GameBot.Service/Contracts/Queues/QueueResponse.cs
+++ b/src/GameBot.Service/Contracts/Queues/QueueResponse.cs
@@ -12,5 +12,11 @@ namespace GameBot.Service.Contracts.Queues {
 
     /// <summary>Stable ID of the linked queue template, or null when the queue is unlinked.</summary>
     public string? LinkedTemplateId { get; set; }
+
+    /// <summary>Stable ID of the linked game, or null when the queue is unlinked from a game.</summary>
+    public string? LinkedGameId { get; set; }
+
+    /// <summary>Display name of the linked game, resolved at response time; null when unlinked or unresolvable.</summary>
+    public string? LinkedGameName { get; set; }
   }
 }

--- a/src/GameBot.Service/Contracts/Queues/SetQueueGameLinkRequest.cs
+++ b/src/GameBot.Service/Contracts/Queues/SetQueueGameLinkRequest.cs
@@ -1,0 +1,9 @@
+namespace GameBot.Service.Contracts.Queues {
+  /// <summary>
+  /// Request body for setting or clearing a queue's linked game.
+  /// <see cref="GameId"/> is the stable game ID to link, or null to clear the link.
+  /// </summary>
+  internal sealed class SetQueueGameLinkRequest {
+    public string? GameId { get; set; }
+  }
+}

--- a/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
@@ -25,12 +25,14 @@ internal static class CommandsEndpoints {
   private static CommandStepType MapStepTypeFromDto(CommandStepTypeDto dto) => dto switch {
     CommandStepTypeDto.Command => CommandStepType.Command,
     CommandStepTypeDto.WaitForImage => CommandStepType.WaitForImage,
+    CommandStepTypeDto.EnsureGameRunning => CommandStepType.EnsureGameRunning,
     _ => CommandStepType.PrimitiveTap
   };
 
   private static CommandStepTypeDto MapStepTypeToDto(CommandStepType type) => type switch {
     CommandStepType.Command => CommandStepTypeDto.Command,
     CommandStepType.WaitForImage => CommandStepTypeDto.WaitForImage,
+    CommandStepType.EnsureGameRunning => CommandStepTypeDto.EnsureGameRunning,
     _ => CommandStepTypeDto.PrimitiveTap
   };
 

--- a/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
@@ -94,6 +94,10 @@ internal static class CommandsEndpoints {
       return null;
     }
 
+    if (step.Type == CommandStepTypeDto.EnsureGameRunning) {
+      return null;
+    }
+
     if (string.IsNullOrWhiteSpace(step.TargetId)) {
       return "targetId is required for Command steps";
     }

--- a/src/GameBot.Service/Endpoints/GamesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/GamesEndpoints.cs
@@ -1,6 +1,8 @@
-using System.Text.Json;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using GameBot.Domain.Games;
+using GameBot.Domain.Queues;
 using GameBot.Service;
 using GameBot.Service.Models;
 
@@ -19,38 +21,40 @@ internal static class GamesEndpoints {
           return Results.BadRequest(new { error = new { code = "invalid_request", message = "name is required", hint = (string?)null } });
         string? description = null;
         if (root.TryGetProperty("metadata", out var metaProp)) {
-          // Store metadata as JSON string in Description to avoid changing domain storage
           description = metaProp.GetRawText();
         }
         else if (root.TryGetProperty("description", out var descProp) && descProp.ValueKind == JsonValueKind.String) {
           description = descProp.GetString();
         }
+        string? packageName = root.TryGetProperty("packageName", out var pkgProp) && pkgProp.ValueKind == JsonValueKind.String
+          ? pkgProp.GetString()
+          : null;
         var created = await repo.AddAsync(new GameArtifact {
           Id = string.Empty,
           Name = name,
-          Description = description
+          Description = description,
+          PackageName = packageName
         }, ct).ConfigureAwait(false);
-        // Return authoring shape when metadata provided
         if (description is not null && IsJsonObject(description)) {
-          return Results.Created($"{ApiRoutes.Games}/{created.Id}", new { id = created.Id, name = created.Name, metadata = JsonSerializer.Deserialize<object>(description)! });
+          return Results.Created($"{ApiRoutes.Games}/{created.Id}", new { id = created.Id, name = created.Name, packageName = created.PackageName, metadata = JsonSerializer.Deserialize<object>(description)! });
         }
-        return Results.Created($"{ApiRoutes.Games}/{created.Id}", new GameResponse { Id = created.Id, Name = created.Name, Description = created.Description });
+        return Results.Created($"{ApiRoutes.Games}/{created.Id}", new GameResponse { Id = created.Id, Name = created.Name, Description = created.Description, PackageName = created.PackageName });
       }
       // Fallback to domain DTO
       var req = root.Deserialize<CreateGameRequest>();
       if (req is null || string.IsNullOrWhiteSpace(req.Name))
         return Results.BadRequest(new { error = new { code = "invalid_request", message = "name is required", hint = (string?)null } });
       var createdDomain = await repo.AddAsync(new GameArtifact { Id = string.Empty, Name = req.Name, Description = req.Description }, ct).ConfigureAwait(false);
-      return Results.Created($"{ApiRoutes.Games}/{createdDomain.Id}", new GameResponse { Id = createdDomain.Id, Name = createdDomain.Name, Description = createdDomain.Description });
+      return Results.Created($"{ApiRoutes.Games}/{createdDomain.Id}", new GameResponse { Id = createdDomain.Id, Name = createdDomain.Name, Description = createdDomain.Description, PackageName = createdDomain.PackageName });
     }).WithName("CreateGame");
 
     group.MapGet("{id}", async (string id, IGameRepository repo, CancellationToken ct) => {
       var g = await repo.GetAsync(id, ct).ConfigureAwait(false);
       if (g is null) return Results.NotFound(new { error = new { code = "not_found", message = "Game not found", hint = (string?)null } });
       if (IsJsonObject(g.Description)) {
-        return Results.Ok(new { id = g.Id, name = g.Name, metadata = JsonSerializer.Deserialize<object>(g.Description!)! });
+        return Results.Ok(new { id = g.Id, name = g.Name, packageName = g.PackageName, metadata = JsonSerializer.Deserialize<object>(g.Description!)! });
       }
-      return Results.Ok(new GameResponse { Id = g.Id, Name = g.Name, Description = g.Description });
+      return Results.Ok(new GameResponse { Id = g.Id, Name = g.Name, Description = g.Description, PackageName = g.PackageName });
     }).WithName("GetGame");
 
     group.MapGet("", async (IGameRepository repo, CancellationToken ct) => {
@@ -58,10 +62,10 @@ internal static class GamesEndpoints {
       var resp = new System.Collections.Generic.List<object>(list.Count);
       foreach (var g in list) {
         if (IsJsonObject(g.Description)) {
-          resp.Add(new { id = g.Id, name = g.Name, metadata = JsonSerializer.Deserialize<object>(g.Description!)! });
+          resp.Add(new { id = g.Id, name = g.Name, packageName = g.PackageName, metadata = JsonSerializer.Deserialize<object>(g.Description!)! });
         }
         else {
-          resp.Add(new { id = g.Id, name = g.Name });
+          resp.Add(new { id = g.Id, name = g.Name, packageName = g.PackageName });
         }
       }
       return Results.Ok(resp);
@@ -91,19 +95,34 @@ internal static class GamesEndpoints {
         existing.Description = descProp.GetString();
       }
 
+      // Update packageName when provided (null clears it)
+      if (root.TryGetProperty("packageName", out var pkgProp)) {
+        existing.PackageName = pkgProp.ValueKind == JsonValueKind.String ? pkgProp.GetString() : null;
+      }
+
       var saved = await repo.UpdateAsync(existing, ct).ConfigureAwait(false);
       if (saved is null) return Results.NotFound(new { error = new { code = "not_found", message = "Game not found", hint = (string?)null } });
 
       if (IsJsonObject(saved.Description)) {
-        return Results.Ok(new { id = saved.Id, name = saved.Name, metadata = JsonSerializer.Deserialize<object>(saved.Description!)! });
+        return Results.Ok(new { id = saved.Id, name = saved.Name, packageName = saved.PackageName, metadata = JsonSerializer.Deserialize<object>(saved.Description!)! });
       }
-      return Results.Ok(new GameResponse { Id = saved.Id, Name = saved.Name, Description = saved.Description });
+      return Results.Ok(new GameResponse { Id = saved.Id, Name = saved.Name, Description = saved.Description, PackageName = saved.PackageName });
     }).WithName("UpdateGame");
 
-    // Authoring delete: no action references remain after the primitive cutover.
-    group.MapDelete("{id}", async (string id, IGameRepository games, CancellationToken ct) => {
+    group.MapDelete("{id}", async (string id, IGameRepository games, IQueueRepository queues, CancellationToken ct) => {
       var existing = await games.GetAsync(id, ct).ConfigureAwait(false);
       if (existing is null) return Results.NotFound(new { error = new { code = "not_found", message = "Game not found", hint = (string?)null } });
+      var allQueues = await queues.ListAsync().ConfigureAwait(false);
+      var referencingQueues = allQueues
+        .Where(q => string.Equals(q.LinkedGameId, id, StringComparison.Ordinal))
+        .Select(q => new { id = q.Id, name = q.Name })
+        .ToList();
+      if (referencingQueues.Count > 0) {
+        return Results.Json(new {
+          error = new { code = "conflict", message = "Game is linked to one or more queues. Unlink before deleting.", hint = (string?)null },
+          references = new Dictionary<string, object> { ["queues"] = referencingQueues }
+        }, statusCode: 409);
+      }
       var deleted = await games.DeleteAsync(id, ct).ConfigureAwait(false);
       return deleted ? Results.NoContent() : Results.NotFound(new { error = new { code = "not_found", message = "Game not found", hint = (string?)null } });
     })

--- a/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GameBot.Domain.Commands;
+using GameBot.Domain.Games;
 using GameBot.Domain.Queues;
 using GameBot.Domain.QueueTemplates;
 using GameBot.Service.Contracts.Queues;
@@ -36,11 +37,11 @@ internal static class QueuesEndpoints {
       return Results.Ok(resp);
     }).WithName("ListQueues");
 
-    group.MapGet("{id}", async (string id, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) => {
+    group.MapGet("{id}", async (string id, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates, IGameRepository games) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
       if (queue is null) return NotFound();
       await MaybeAutoLoadAsync(queue, repo, runtime, templates).ConfigureAwait(false);
-      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences, templates).ConfigureAwait(false));
+      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences, templates, games).ConfigureAwait(false));
     }).WithName("GetQueue");
 
     group.MapPut("{id}", async (string id, UpdateQueueRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime) => {
@@ -76,16 +77,16 @@ internal static class QueuesEndpoints {
       return Results.Created($"{ApiRoutes.Queues}/{id}/entries/{entry.EntryId}", ProjectEntry(entry, resolved?.Name));
     }).WithName("AddQueueEntry");
 
-    group.MapPut("{id}/entries", async (string id, ReplaceQueueEntriesRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) => {
+    group.MapPut("{id}/entries", async (string id, ReplaceQueueEntriesRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates, IGameRepository games) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
       if (queue is null) return NotFound();
       if (runtime.GetStatus(id) == QueueExecutionStatus.Running)
         return Error(409, "queue_running", "Stop the queue before loading a template.");
       runtime.SetEntries(id, req?.SequenceIds ?? Array.Empty<string>());
-      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences, templates).ConfigureAwait(false));
+      return Results.Ok(await BuildDetailAsync(queue, runtime, sequences, templates, games).ConfigureAwait(false));
     }).WithName("ReplaceQueueEntries");
 
-    group.MapPut("{id}/template", async (string id, SetQueueTemplateLinkRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) => {
+    group.MapPut("{id}/template", async (string id, SetQueueTemplateLinkRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates, IGameRepository games) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
       if (queue is null) return NotFound();
       var templateId = req?.TemplateId;
@@ -93,8 +94,19 @@ internal static class QueuesEndpoints {
         return Error(400, "invalid_request", "template not found");
       queue.LinkedTemplateId = string.IsNullOrEmpty(templateId) ? null : templateId;
       var saved = await repo.UpdateAsync(queue).ConfigureAwait(false);
-      return Results.Ok(await BuildDetailAsync(saved, runtime, sequences, templates).ConfigureAwait(false));
+      return Results.Ok(await BuildDetailAsync(saved, runtime, sequences, templates, games).ConfigureAwait(false));
     }).WithName("SetQueueTemplateLink");
+
+    group.MapPut("{id}/game", async (string id, SetQueueGameLinkRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates, IGameRepository games) => {
+      var queue = await repo.GetAsync(id).ConfigureAwait(false);
+      if (queue is null) return NotFound();
+      var gameId = req?.GameId;
+      if (!string.IsNullOrEmpty(gameId) && await games.GetAsync(gameId).ConfigureAwait(false) is null)
+        return Error(400, "invalid_request", "game not found");
+      queue.LinkedGameId = string.IsNullOrEmpty(gameId) ? null : gameId;
+      var saved = await repo.UpdateAsync(queue).ConfigureAwait(false);
+      return Results.Ok(await BuildDetailAsync(saved, runtime, sequences, templates, games).ConfigureAwait(false));
+    }).WithName("SetQueueGameLink");
 
     group.MapDelete("{id}/entries/{entryId}", async (string id, string entryId, IQueueRepository repo, IQueueRuntimeStore runtime) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
@@ -150,10 +162,11 @@ internal static class QueuesEndpoints {
     CycleExecution = queue.CycleExecution,
     Status = runtime.GetStatus(queue.Id),
     EntryCount = runtime.GetEntries(queue.Id).Count,
-    LinkedTemplateId = queue.LinkedTemplateId
+    LinkedTemplateId = queue.LinkedTemplateId,
+    LinkedGameId = queue.LinkedGameId
   };
 
-  private static async Task<QueueDetailResponse> BuildDetailAsync(ExecutionQueue queue, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates) {
+  private static async Task<QueueDetailResponse> BuildDetailAsync(ExecutionQueue queue, IQueueRuntimeStore runtime, ISequenceRepository sequences, IQueueTemplateRepository templates, IGameRepository games) {
     var entries = runtime.GetEntries(queue.Id);
     var allSequences = await sequences.ListAsync().ConfigureAwait(false);
     var namesById = allSequences.ToDictionary(s => s.Id, s => s.Name, StringComparer.Ordinal);
@@ -165,7 +178,9 @@ internal static class QueuesEndpoints {
       Status = runtime.GetStatus(queue.Id),
       EntryCount = entries.Count,
       LinkedTemplateId = queue.LinkedTemplateId,
-      LinkedTemplateName = await ResolveTemplateNameAsync(queue.LinkedTemplateId, templates).ConfigureAwait(false)
+      LinkedTemplateName = await ResolveTemplateNameAsync(queue.LinkedTemplateId, templates).ConfigureAwait(false),
+      LinkedGameId = queue.LinkedGameId,
+      LinkedGameName = await ResolveGameNameAsync(queue.LinkedGameId, games).ConfigureAwait(false)
     };
     foreach (var entry in entries) {
       var found = namesById.TryGetValue(entry.SequenceId, out var name);
@@ -178,6 +193,12 @@ internal static class QueuesEndpoints {
     if (string.IsNullOrEmpty(templateId)) return null;
     var template = await templates.GetAsync(templateId).ConfigureAwait(false);
     return template?.Name;
+  }
+
+  private static async Task<string?> ResolveGameNameAsync(string? gameId, IGameRepository games) {
+    if (string.IsNullOrEmpty(gameId)) return null;
+    var game = await games.GetAsync(gameId).ConfigureAwait(false);
+    return game?.Name;
   }
 
   private static QueueEntryResponse ProjectEntry(QueueEntry entry, string? sequenceName) => new() {

--- a/src/GameBot.Service/Models/Commands.cs
+++ b/src/GameBot.Service/Models/Commands.cs
@@ -40,7 +40,8 @@ internal sealed class CommandResponse {
 internal enum CommandStepTypeDto {
   Command,
   PrimitiveTap,
-  WaitForImage
+  WaitForImage,
+  EnsureGameRunning
 }
 
 internal sealed class PrimitiveTapConfigDto {

--- a/src/GameBot.Service/Models/Games.cs
+++ b/src/GameBot.Service/Models/Games.cs
@@ -9,4 +9,5 @@ internal sealed class GameResponse {
   public required string Id { get; init; }
   public required string Name { get; init; }
   public string? Description { get; init; }
+  public string? PackageName { get; init; }
 }

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -108,6 +108,8 @@ builder.Services.AddSingleton<ISessionService>(sp => {
 });
 builder.Services.AddTransient<ErrorHandlingMiddleware>();
 builder.Services.AddTransient<CorrelationIdMiddleware>();
+builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IAdbGameOperations, GameBot.Service.Services.EnsureGameRunning.AdbGameOperations>();
+builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IEnsureGameRunningActionHandler, GameBot.Service.Services.EnsureGameRunning.EnsureGameRunningActionHandler>();
 builder.Services.AddSingleton<GameBot.Service.Services.ICommandExecutor, GameBot.Service.Services.CommandExecutor>();
 
 // Data storage configuration (env: GAMEBOT_DATA_DIR or config Service:Storage:Root)

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -6,6 +6,7 @@ using GameBot.Domain.Triggers;
 using GameBot.Emulator.Session;
 using Microsoft.Extensions.Logging;
 using GameBot.Service.Services;
+using GameBot.Service.Services.EnsureGameRunning;
 using GameBot.Service.Services.ExecutionLog;
 using System.Globalization;
 
@@ -23,11 +24,12 @@ internal sealed class CommandExecutor : ICommandExecutor {
   private readonly ISessionContextCache _sessionCache;
   private readonly IExecutionLogService? _executionLogService;
   private readonly AppConfig _appConfig;
+  private readonly IEnsureGameRunningActionHandler? _ensureGameRunning;
 
-  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, AppConfig appConfig, IExecutionLogService? executionLogService = null) {
+  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, AppConfig appConfig, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null) {
     _commands = commands;
     _sessions = sessions;
-    _triggers = triggers; // No change here, just context
+    _triggers = triggers;
     _triggerEval = triggerEval;
     _logger = logger;
     _images = images;
@@ -36,10 +38,11 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _sessionCache = sessionCache;
     _appConfig = appConfig;
     _executionLogService = executionLogService;
+    _ensureGameRunning = ensureGameRunning;
   }
 
   // Fallback constructor for environments without detection services registered (non-Windows or tests)
-  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, ISessionContextCache sessionCache, IExecutionLogService? executionLogService = null) {
+  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, ISessionContextCache sessionCache, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null) {
     _commands = commands;
     _sessions = sessions;
     _triggers = triggers;
@@ -51,6 +54,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _sessionCache = sessionCache;
     _appConfig = new AppConfig();
     _executionLogService = executionLogService;
+    _ensureGameRunning = ensureGameRunning;
   }
 
   public Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default)
@@ -160,6 +164,21 @@ internal sealed class CommandExecutor : ICommandExecutor {
     foreach (var step in cmd.Steps.OrderBy(s => s.Order)) {
       if (step.Type == CommandStepType.WaitForImage) {
         stepOutcomes.Add(await ExecuteWaitForImageStepAsync(step, ct).ConfigureAwait(false));
+        continue;
+      }
+
+      if (step.Type == CommandStepType.EnsureGameRunning) {
+        var result = _ensureGameRunning is not null
+          ? await _ensureGameRunning.ExecuteAsync(sessionId, ct).ConfigureAwait(false)
+          : new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported);
+
+        if (result.IsSuccess) {
+          totalAccepted++;
+          stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", result.ReasonCode, null, null, StepType: "ensure-game-running"));
+        }
+        else {
+          stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running"));
+        }
         continue;
       }
 

--- a/src/GameBot.Service/Services/EnsureGameRunning/AdbGameOperations.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/AdbGameOperations.cs
@@ -1,0 +1,17 @@
+using GameBot.Emulator.Adb;
+
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+internal sealed class AdbGameOperations : IAdbGameOperations {
+  public async Task<string?> GetForegroundPackageAsync(string deviceSerial, CancellationToken ct = default) {
+    if (!OperatingSystem.IsWindows()) return null;
+    var adb = new AdbClient().WithSerial(deviceSerial);
+    return await adb.GetForegroundPackageAsync(ct).ConfigureAwait(false);
+  }
+
+  public async Task LaunchAppAsync(string deviceSerial, string packageName, CancellationToken ct = default) {
+    if (!OperatingSystem.IsWindows()) return;
+    var adb = new AdbClient().WithSerial(deviceSerial);
+    await adb.LaunchAppAsync(packageName, ct).ConfigureAwait(false);
+  }
+}

--- a/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs
@@ -1,0 +1,67 @@
+using GameBot.Domain.Games;
+using GameBot.Domain.Queues;
+using GameBot.Emulator.Session;
+
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+internal sealed class EnsureGameRunningActionHandler : IEnsureGameRunningActionHandler {
+  private const string QueueSessionPrefix = "queue:";
+
+  private readonly ISessionManager _sessions;
+  private readonly IQueueRepository _queues;
+  private readonly IGameRepository _games;
+  private readonly IAdbGameOperations _adb;
+
+  public EnsureGameRunningActionHandler(
+    ISessionManager sessions,
+    IQueueRepository queues,
+    IGameRepository games,
+    IAdbGameOperations adb) {
+    _sessions = sessions;
+    _queues = queues;
+    _games = games;
+    _adb = adb;
+  }
+
+  public async Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default) {
+    // 1. Resolve session
+    var session = _sessions.GetSession(sessionId);
+    if (session is null)
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoQueueContext);
+
+    // 2. Extract queue ID from session label
+    var queueId = ExtractQueueId(session.GameId);
+    if (queueId is null)
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoQueueContext);
+
+    // 3. Platform guard — must come before any ADB call
+    if (!OperatingSystem.IsWindows())
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported);
+
+    // 4. Resolve queue and linked game ID
+    var queue = await _queues.GetAsync(queueId).ConfigureAwait(false);
+    if (queue is null || string.IsNullOrEmpty(queue.LinkedGameId))
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoLinkedGame);
+
+    // 5. Resolve game and package name
+    var game = await _games.GetAsync(queue.LinkedGameId, ct).ConfigureAwait(false);
+    if (game is null || string.IsNullOrEmpty(game.PackageName))
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoPackageName);
+
+    // 6. Check foreground app
+    var foreground = await _adb.GetForegroundPackageAsync(session.DeviceSerial ?? string.Empty, ct).ConfigureAwait(false);
+    if (string.Equals(foreground, game.PackageName, StringComparison.OrdinalIgnoreCase))
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameRunning);
+
+    // 7. Game not running — launch (best effort) and report failure
+    await _adb.LaunchAppAsync(session.DeviceSerial ?? string.Empty, game.PackageName, ct).ConfigureAwait(false);
+    return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameNotRunning);
+  }
+
+  private static string? ExtractQueueId(string? sessionLabel) {
+    if (sessionLabel is null) return null;
+    return sessionLabel.StartsWith(QueueSessionPrefix, StringComparison.OrdinalIgnoreCase)
+      ? sessionLabel[QueueSessionPrefix.Length..]
+      : null;
+  }
+}

--- a/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs
@@ -27,24 +27,29 @@ internal sealed class EnsureGameRunningActionHandler : IEnsureGameRunningActionH
     // 1. Resolve session
     var session = _sessions.GetSession(sessionId);
     if (session is null)
-      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoQueueContext);
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoPackageName);
 
-    // 2. Extract queue ID from session label
-    var queueId = ExtractQueueId(session.GameId);
-    if (queueId is null)
-      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoQueueContext);
-
-    // 3. Platform guard — must come before any ADB call
+    // 2. Platform guard — must come before any ADB call
     if (!OperatingSystem.IsWindows())
       return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported);
 
-    // 4. Resolve queue and linked game ID
-    var queue = await _queues.GetAsync(queueId).ConfigureAwait(false);
-    if (queue is null || string.IsNullOrEmpty(queue.LinkedGameId))
-      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoLinkedGame);
+    // 3. Resolve the game:
+    //    - Queue context (label = "queue:{id}"): resolve game via queue's LinkedGameId
+    //    - Direct session (label = game ID): use the session label as the game ID directly
+    GameArtifact? game;
+    var queueId = ExtractQueueId(session.GameId);
+    if (queueId is not null) {
+      var queue = await _queues.GetAsync(queueId).ConfigureAwait(false);
+      if (queue is null || string.IsNullOrEmpty(queue.LinkedGameId))
+        return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoLinkedGame);
+      game = await _games.GetAsync(queue.LinkedGameId, ct).ConfigureAwait(false);
+    }
+    else {
+      // Direct session: session.GameId is the game ID
+      game = await _games.GetAsync(session.GameId, ct).ConfigureAwait(false);
+    }
 
-    // 5. Resolve game and package name
-    var game = await _games.GetAsync(queue.LinkedGameId, ct).ConfigureAwait(false);
+    // 4. Validate package name
     if (game is null || string.IsNullOrEmpty(game.PackageName))
       return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoPackageName);
 

--- a/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs
@@ -27,7 +27,7 @@ internal sealed class EnsureGameRunningActionHandler : IEnsureGameRunningActionH
     // 1. Resolve session
     var session = _sessions.GetSession(sessionId);
     if (session is null)
-      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoPackageName);
+      return new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoQueueContext);
 
     // 2. Platform guard — must come before any ADB call
     if (!OperatingSystem.IsWindows())

--- a/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionResult.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionResult.cs
@@ -1,0 +1,29 @@
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+internal enum EnsureGameRunningOutcome {
+  /// <summary>Game was already the active foreground app — action succeeded.</summary>
+  GameRunning,
+  /// <summary>Game was not running; launch was attempted — action reports failure.</summary>
+  GameNotRunning,
+  /// <summary>Action was not executed within a queue context (no queue: session label).</summary>
+  NoQueueContext,
+  /// <summary>The queue has no linked game.</summary>
+  NoLinkedGame,
+  /// <summary>The linked game has no package name configured.</summary>
+  NoPackageName,
+  /// <summary>ADB operations are not available on this platform (non-Windows).</summary>
+  PlatformUnsupported
+}
+
+internal sealed record EnsureGameRunningActionResult(EnsureGameRunningOutcome Outcome) {
+  public bool IsSuccess => Outcome == EnsureGameRunningOutcome.GameRunning;
+
+  public string ReasonCode => Outcome switch {
+    EnsureGameRunningOutcome.GameRunning        => "game_running",
+    EnsureGameRunningOutcome.GameNotRunning     => "game_not_running",
+    EnsureGameRunningOutcome.NoQueueContext     => "no_queue_context",
+    EnsureGameRunningOutcome.NoLinkedGame       => "no_linked_game",
+    EnsureGameRunningOutcome.NoPackageName      => "no_package_name",
+    _                                           => "platform_unsupported"
+  };
+}

--- a/src/GameBot.Service/Services/EnsureGameRunning/IAdbGameOperations.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/IAdbGameOperations.cs
@@ -1,0 +1,13 @@
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+/// <summary>
+/// Narrow ADB interface for game-state operations used by <see cref="EnsureGameRunningActionHandler"/>.
+/// Isolates ADB platform dependency from the handler and enables mocking in tests.
+/// </summary>
+internal interface IAdbGameOperations {
+  /// <summary>Returns the foreground package on the given device, or null if unavailable.</summary>
+  Task<string?> GetForegroundPackageAsync(string deviceSerial, CancellationToken ct = default);
+
+  /// <summary>Launches the app with <paramref name="packageName"/> on the given device (fire-and-forget).</summary>
+  Task LaunchAppAsync(string deviceSerial, string packageName, CancellationToken ct = default);
+}

--- a/src/GameBot.Service/Services/EnsureGameRunning/IEnsureGameRunningActionHandler.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/IEnsureGameRunningActionHandler.cs
@@ -1,0 +1,5 @@
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+internal interface IEnsureGameRunningActionHandler {
+  Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default);
+}

--- a/src/web-ui/src/components/commands/CommandForm.tsx
+++ b/src/web-ui/src/components/commands/CommandForm.tsx
@@ -10,7 +10,7 @@ import './CommandForm.css';
 
 export type StepEntry = {
   id: string;
-  type: 'Command' | 'PrimitiveTap' | 'WaitForImage';
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning';
   targetId?: string;
   primitiveTap?: {
     detectionTarget: DetectionTargetForm;
@@ -69,6 +69,14 @@ const toStepItems = (steps: StepEntry[], commandOpts: SearchableOption[]): Reord
         id: step.id,
         label: `Wait for image: ${imageId}`,
         description: confidence ? `Timeout ${timeoutMs} ms, confidence ${confidence}` : `Timeout ${timeoutMs} ms`,
+      };
+    }
+
+    if (step.type === 'EnsureGameRunning') {
+      return {
+        id: step.id,
+        label: 'Ensure game running',
+        description: 'Checks foreground app; starts game if not running',
       };
     }
 
@@ -328,6 +336,16 @@ export const CommandForm: React.FC<CommandFormProps> = ({
             disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
           >
             Add wait for image step
+          </button>
+        </div>
+
+        <div className="field">
+          <button
+            type="button"
+            onClick={() => addStep({ type: 'EnsureGameRunning' })}
+            disabled={submitting || loading}
+          >
+            Add ensure game running step
           </button>
         </div>
 

--- a/src/web-ui/src/components/queues/GamePickerDialog.tsx
+++ b/src/web-ui/src/components/queues/GamePickerDialog.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { GameDto, listGames } from '../../services/games';
+
+type GamePickerDialogProps = {
+  open: boolean;
+  onSelect: (gameId: string) => void;
+  onClose: () => void;
+};
+
+export const GamePickerDialog: React.FC<GamePickerDialogProps> = ({ open, onSelect, onClose }) => {
+  const [games, setGames] = useState<GameDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    listGames()
+      .then((data) => { setGames(data); setError(undefined); })
+      .catch((err: unknown) => { setGames([]); setError(err instanceof Error ? err.message : 'Failed to load games'); })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <section className="queue-template-section" aria-label="Link game">
+      <h4>Link game</h4>
+      {error && <div className="form-error" role="alert">{error}</div>}
+      {loading && <div className="form-hint">Loading…</div>}
+      {!loading && games.length === 0 && (
+        <div className="form-hint" role="status">No games configured yet.</div>
+      )}
+      <ul className="template-list">
+        {games.map((g) => (
+          <li key={g.id} className="template-row" data-testid="game-row">
+            <span className="template-name">{g.name}</span>
+            <span className="template-actions">
+              <button type="button" onClick={() => onSelect(g.id)}>Select</button>
+            </span>
+          </li>
+        ))}
+      </ul>
+      <div className="queue-template-section-actions">
+        <button type="button" className="btn btn-secondary" onClick={onClose}>Close</button>
+      </div>
+    </section>
+  );
+};

--- a/src/web-ui/src/components/queues/QueueForm.tsx
+++ b/src/web-ui/src/components/queues/QueueForm.tsx
@@ -17,8 +17,10 @@ type QueueFormProps = {
   submitting?: boolean;
   formError?: string;
   fieldErrors?: { name?: string; emulatorSerial?: string };
-  /** Edit-mode only: row 2 — template controls, rendered after the emulator and before cycle execution. */
+  /** Edit-mode only: row 2 — template controls, rendered after the emulator and before game controls. */
   templateControls?: React.ReactNode;
+  /** Edit-mode only: row 3 — game controls, rendered after template controls and before cycle execution. */
+  gameControls?: React.ReactNode;
   /** Edit-mode only: row 4 — queue sequence entries, rendered after cycle execution and before the actions. */
   entries?: React.ReactNode;
 };
@@ -33,6 +35,7 @@ export const QueueForm: React.FC<QueueFormProps> = ({
   formError,
   fieldErrors,
   templateControls,
+  gameControls,
   entries,
 }) => {
   const isEdit = mode === 'edit';
@@ -94,6 +97,8 @@ export const QueueForm: React.FC<QueueFormProps> = ({
       </div>
 
       {isEdit && templateControls}
+
+      {isEdit && gameControls}
 
       <div className="field">
         <label>

--- a/src/web-ui/src/components/queues/QueueGameControls.tsx
+++ b/src/web-ui/src/components/queues/QueueGameControls.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { QueueStatus } from '../../services/queues';
+import { GamePickerDialog } from './GamePickerDialog';
+
+type QueueGameControlsProps = {
+  linkedGameId: string | null;
+  linkedGameName: string | null;
+  status: QueueStatus;
+  onLink: (gameId: string) => void;
+  onUnlink: () => void;
+};
+
+export const QueueGameControls: React.FC<QueueGameControlsProps> = ({
+  linkedGameId,
+  linkedGameName,
+  status,
+  onLink,
+  onUnlink,
+}) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const running = status === 'Running';
+
+  return (
+    <section className="queue-template-controls" aria-label="Queue game">
+      <div className="queue-template-row">
+        <button
+          type="button"
+          className="link-button queue-template-name"
+          onClick={() => setPickerOpen((o) => !o)}
+          aria-expanded={pickerOpen}
+        >
+          {linkedGameName ?? '(no game)'}
+        </button>
+        <button type="button" onClick={() => setPickerOpen((o) => !o)} aria-expanded={pickerOpen}>
+          Link Game
+        </button>
+        <button
+          type="button"
+          onClick={onUnlink}
+          disabled={!linkedGameId || running}
+          title={
+            !linkedGameId
+              ? 'No game linked.'
+              : running
+                ? 'Stop the queue before unlinking a game.'
+                : undefined
+          }
+        >
+          Unlink
+        </button>
+      </div>
+
+      <GamePickerDialog
+        open={pickerOpen}
+        onSelect={(gameId) => {
+          onLink(gameId);
+          setPickerOpen(false);
+        }}
+        onClose={() => setPickerOpen(false)}
+      />
+    </section>
+  );
+};

--- a/src/web-ui/src/features/execution/__tests__/RunningSessionsList.test.tsx
+++ b/src/web-ui/src/features/execution/__tests__/RunningSessionsList.test.tsx
@@ -52,7 +52,7 @@ describe('Running sessions list', () => {
     render(<ExecutionPage />);
 
     const runningSection = await screen.findByRole('region', { name: /Running sessions/i });
-    expect(within(runningSection).getByText(/Session: s-1/i)).toBeInTheDocument();
+    await waitFor(() => expect(within(runningSection).getByText(/Session: s-1/i)).toBeInTheDocument());
     expect(within(runningSection).getByRole('status', { name: /Status: Running/i })).toBeInTheDocument();
   });
 

--- a/src/web-ui/src/pages/CommandsPage.tsx
+++ b/src/web-ui/src/pages/CommandsPage.tsx
@@ -100,6 +100,10 @@ const stepsToDto = (steps: StepEntry[]): CommandStepDto[] => steps.map((s, idx) 
     };
   }
 
+  if (s.type === 'EnsureGameRunning') {
+    return { type: 'EnsureGameRunning', order: idx };
+  }
+
   return {
     type: s.type,
     targetId: s.targetId ?? '',

--- a/src/web-ui/src/pages/CommandsPage.tsx
+++ b/src/web-ui/src/pages/CommandsPage.tsx
@@ -266,7 +266,7 @@ export const CommandsPage: React.FC<CommandsPageProps> = ({ initialCreate, initi
           next.steps = 'Wait for image timeout must be a non-negative integer';
           break;
         }
-      } else if (!step.targetId?.trim()) {
+      } else if (step.type !== 'EnsureGameRunning' && !step.targetId?.trim()) {
         next.steps = 'Command steps require a target';
         break;
       }

--- a/src/web-ui/src/pages/Execution.tsx
+++ b/src/web-ui/src/pages/Execution.tsx
@@ -208,12 +208,18 @@ export const ExecutionPage: React.FC = () => {
       const executedSteps = stepOutcomes.filter((o) => `${o.status ?? ''}`.toLowerCase() === 'executed').length;
 
       if ((accepted ?? 0) <= 0 && stepOutcomes.length > 0 && executedSteps === 0) {
-        const firstReason = stepOutcomes.find((o) => o.reason)?.reason;
+        const firstOutcome = stepOutcomes.find((o) => o.reason || o.status);
+        const firstReason = firstOutcome?.reason ?? firstOutcome?.status;
         const normalizedReason = firstReason ? firstReason.replace(/_/g, ' ') : undefined;
+        const isEnsureGameRunning = stepOutcomes.some((o) => o.stepType === 'ensure-game-running');
         setCommandMessage(undefined);
-        setCommandError(normalizedReason
-          ? `Command did not execute any tap: ${normalizedReason}`
-          : 'Command did not execute any tap.');
+        if (isEnsureGameRunning) {
+          setCommandError(normalizedReason ?? 'Game was not running (launch attempted).');
+        } else {
+          setCommandError(normalizedReason
+            ? `Command did not execute any tap: ${normalizedReason}`
+            : 'Command did not execute any tap.');
+        }
         return;
       }
 

--- a/src/web-ui/src/pages/GamesPage.tsx
+++ b/src/web-ui/src/pages/GamesPage.tsx
@@ -8,9 +8,10 @@ import { useUnsavedChangesPrompt } from '../hooks/useUnsavedChangesPrompt';
 
 type GameFormValue = {
   name: string;
+  packageName: string;
 };
 
-const emptyForm: GameFormValue = { name: '' };
+const emptyForm: GameFormValue = { name: '', packageName: '' };
 
 type GamesPageProps = {
   initialCreate?: boolean;
@@ -59,7 +60,7 @@ export const GamesPage: React.FC<GamesPageProps> = ({ initialCreate, initialEdit
         const g = await getGame(initialEditId);
         setEditingId(initialEditId);
         setCreating(false);
-        setForm({ name: g.name });
+        setForm({ name: g.name, packageName: g.packageName ?? '' });
         setDirty(false);
       } catch (err: any) {
         setErrors({ form: err?.message ?? 'Failed to load game' });
@@ -121,7 +122,7 @@ export const GamesPage: React.FC<GamesPageProps> = ({ initialCreate, initialEdit
                   try {
                     const game = await getGame(g.id);
                     setEditingId(g.id);
-                    setForm({ name: game.name });
+                    setForm({ name: game.name, packageName: game.packageName ?? '' });
                     setDirty(false);
                   } catch (err: any) {
                     setErrors({ form: err?.message ?? 'Failed to load game' });
@@ -145,7 +146,7 @@ export const GamesPage: React.FC<GamesPageProps> = ({ initialCreate, initialEdit
             if (Object.keys(nextErrors).length) { setErrors(nextErrors); return; }
             setSubmitting(true);
             try {
-              await createGame({ name: form.name.trim() });
+              await createGame({ name: form.name.trim(), packageName: form.packageName.trim() || undefined });
               setCreating(false);
               resetForm();
               const data = await listGames();
@@ -171,6 +172,16 @@ export const GamesPage: React.FC<GamesPageProps> = ({ initialCreate, initialEdit
               />
               {errors?.name && <div id="game-name-error" className="field-error" role="alert">{errors.name}</div>}
             </div>
+            <div className="field">
+              <label htmlFor="game-package-name">Package Name</label>
+              <input
+                id="game-package-name"
+                value={form.packageName}
+                onChange={(e) => { setForm({ ...form, packageName: e.target.value }); setErrors(undefined); setDirty(true); }}
+                placeholder="e.g. com.example.game"
+                disabled={submitting || loading}
+              />
+            </div>
           </FormSection>
 
           <FormActions submitting={submitting} onCancel={() => { if (!confirmNavigate()) return; setCreating(false); resetForm(); }}>
@@ -193,7 +204,7 @@ export const GamesPage: React.FC<GamesPageProps> = ({ initialCreate, initialEdit
               if (Object.keys(nextErrors).length) { setErrors(nextErrors); return; }
               setSubmitting(true);
               try {
-                await updateGame(editingId, { name: form.name.trim() });
+                await updateGame(editingId, { name: form.name.trim(), packageName: form.packageName.trim() || undefined });
                 const data = await listGames();
                 setGames(data);
                 setTableMessage('Game updated successfully.');
@@ -219,6 +230,16 @@ export const GamesPage: React.FC<GamesPageProps> = ({ initialCreate, initialEdit
                   disabled={submitting || loading}
                 />
                 {errors?.name && <div id="game-edit-name-error" className="field-error" role="alert">{errors.name}</div>}
+              </div>
+              <div className="field">
+                <label htmlFor="game-edit-package-name">Package Name</label>
+                <input
+                  id="game-edit-package-name"
+                  value={form.packageName}
+                  onChange={(e) => { setForm({ ...form, packageName: e.target.value }); setErrors(undefined); setDirty(true); }}
+                  placeholder="e.g. com.example.game"
+                  disabled={submitting || loading}
+                />
               </div>
             </FormSection>
 

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -11,6 +11,7 @@ import {
   removeQueueEntry,
   replaceQueueEntries,
   setQueueTemplateLink,
+  setQueueGameLink,
   startQueue,
   stopQueue,
 } from '../services/queues';
@@ -18,6 +19,7 @@ import { listSequences, SequenceDto } from '../services/sequences';
 import { QueueForm, QueueFormValue } from '../components/queues/QueueForm';
 import { QueueEntryList } from '../components/queues/QueueEntryList';
 import { QueueTemplateControls } from '../components/queues/QueueTemplateControls';
+import { QueueGameControls } from '../components/queues/QueueGameControls';
 import { ConfirmDeleteModal } from '../components/ConfirmDeleteModal';
 import { saveQueueTemplate, getQueueTemplate, listQueueTemplates } from '../services/queueTemplates';
 import { sameSequenceOrder } from '../lib/sequenceOrder';
@@ -214,6 +216,28 @@ export const QueuesPage: React.FC = () => {
     }
   };
 
+  const handleLinkGame = async (gameId: string) => {
+    if (!detail) return;
+    try {
+      const updated = await setQueueGameLink(detail.id, gameId);
+      setDetail(updated);
+      await refresh();
+    } catch (err: any) {
+      setTableError(err?.message ?? 'Failed to link game');
+    }
+  };
+
+  const handleUnlinkGame = async () => {
+    if (!detail) return;
+    try {
+      const updated = await setQueueGameLink(detail.id, null);
+      setDetail(updated);
+      await refresh();
+    } catch (err: any) {
+      setTableError(err?.message ?? 'Failed to unlink game');
+    }
+  };
+
   // Replace/reload confirmation shown inline within the template controls (where the picker was).
   const templateConfirm = pendingLoad
     ? {
@@ -336,6 +360,15 @@ export const QueuesPage: React.FC = () => {
                 onLoadTemplate={(id) => void handleLoadTemplate(id)}
                 onReload={() => void handleReload()}
                 pendingConfirm={templateConfirm}
+              />
+            }
+            gameControls={
+              <QueueGameControls
+                linkedGameId={detail.linkedGameId}
+                linkedGameName={detail.linkedGameName}
+                status={detail.status}
+                onLink={(gameId) => void handleLinkGame(gameId)}
+                onUnlink={() => void handleUnlinkGame()}
               />
             }
             entries={

--- a/src/web-ui/src/services/commands.ts
+++ b/src/web-ui/src/services/commands.ts
@@ -18,7 +18,7 @@ export type CommandCreate = {
 export type CommandUpdate = CommandCreate;
 
 export type CommandStepDto = {
-  type: 'Command' | 'PrimitiveTap' | 'WaitForImage';
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning';
   targetId?: string;
   order: number;
   primitiveTap?: PrimitiveTapConfigDto;

--- a/src/web-ui/src/services/games.ts
+++ b/src/web-ui/src/services/games.ts
@@ -3,11 +3,13 @@ import { deleteJson, getJson, postJson, putJson } from '../lib/api';
 export type GameDto = {
   id: string;
   name: string;
+  packageName?: string;
   metadata?: Record<string, unknown>;
 };
 
 export type GameCreate = {
   name: string;
+  packageName?: string;
   metadata?: Record<string, unknown>;
 };
 

--- a/src/web-ui/src/services/queues.ts
+++ b/src/web-ui/src/services/queues.ts
@@ -10,6 +10,8 @@ export type QueueDto = {
   status: QueueStatus;
   entryCount: number;
   linkedTemplateId: string | null;
+  linkedGameId: string | null;
+  linkedGameName: string | null;
 };
 
 export type QueueEntryDto = {
@@ -22,6 +24,7 @@ export type QueueEntryDto = {
 export type QueueDetailDto = QueueDto & {
   entries: QueueEntryDto[];
   linkedTemplateName: string | null;
+  // linkedGameId and linkedGameName are inherited from QueueDto
 };
 
 export type QueueCreate = {
@@ -52,6 +55,9 @@ export const replaceQueueEntries = (id: string, sequenceIds: string[]) =>
 
 export const setQueueTemplateLink = (id: string, templateId: string | null) =>
   putJson<QueueDetailDto>(`${base}/${id}/template`, { templateId });
+
+export const setQueueGameLink = (id: string, gameId: string | null) =>
+  putJson<QueueDetailDto>(`${base}/${id}/game`, { gameId });
 
 export const startQueue = (id: string) => postJson<QueueDto>(`${base}/${id}/start`, {});
 export const stopQueue = (id: string) => postJson<QueueDto>(`${base}/${id}/stop`, {});

--- a/tests/unit/Commands/CommandExecutorEnsureGameRunningTests.cs
+++ b/tests/unit/Commands/CommandExecutorEnsureGameRunningTests.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using GameBot.Domain.Sessions;
+using GameBot.Domain.Triggers;
+using GameBot.Domain.Triggers.Evaluators;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services;
+using GameBot.Service.Services.EnsureGameRunning;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+// Test-code analyzer relaxations permitted by the constitution:
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Commands;
+
+public sealed class CommandExecutorEnsureGameRunningTests {
+  // ── Fakes ─────────────────────────────────────────────────────────────────
+
+  private sealed class FakeCommandRepository : ICommandRepository {
+    private readonly Dictionary<string, Command> _cmds = new(StringComparer.Ordinal);
+    public void Seed(Command c) => _cmds[c.Id] = c;
+    public Task<Command> AddAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult(c); }
+    public Task<Command?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.TryGetValue(id, out var c) ? c : null);
+    public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Command>)_cmds.Values.ToList());
+    public Task<Command?> UpdateAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult<Command?>(c); }
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.Remove(id));
+  }
+
+  private sealed class FakeSessionManager : ISessionManager {
+    private readonly EmulatorSession _session;
+    public FakeSessionManager(EmulatorSession session) => _session = session;
+    public int ActiveCount => 1;
+    public bool CanCreateSession => false;
+    public EmulatorSession? GetSession(string id) => id == _session.Id ? _session : null;
+    public EmulatorSession CreateSession(string g, string? s = null) => throw new NotSupportedException();
+    public IReadOnlyCollection<EmulatorSession> ListSessions() => new[] { _session };
+    public bool StopSession(string id) => false;
+    public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+  }
+
+  private sealed class FakeTriggerRepository : ITriggerRepository {
+    public Task<Trigger?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<Trigger?>(null);
+    public Task<IReadOnlyList<Trigger>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Trigger>)Array.Empty<Trigger>());
+    public Task UpsertAsync(Trigger t, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+  }
+
+  private sealed class FakeSessionContextCache : ISessionContextCache {
+    public void SetSessionId(string g, string a, string s) { }
+    public string? GetSessionId(string g, string a) => null;
+    public void ClearSession(string g, string a) { }
+  }
+
+  private sealed class StubHandler : IEnsureGameRunningActionHandler {
+    private readonly EnsureGameRunningActionResult _result;
+    public StubHandler(EnsureGameRunningActionResult result) => _result = result;
+    public Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default) => Task.FromResult(_result);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private static EmulatorSession RunningSession(string id = "session1") =>
+    new() { Id = id, GameId = "queue:q1", Status = SessionStatus.Running, DeviceSerial = "emulator-5554" };
+
+  private static Command EnsureRunningCommand(string id = "cmd1") => new() {
+    Id = id,
+    Name = "EnsureGameRunning",
+    TriggerId = null,
+    Steps = new Collection<CommandStep> {
+      new() { Type = CommandStepType.EnsureGameRunning, TargetId = string.Empty, Order = 1 }
+    }
+  };
+
+  private static CommandExecutor BuildExecutor(IEnsureGameRunningActionHandler? handler, FakeCommandRepository cmds, ISessionManager sessions) =>
+    new(cmds, sessions, new FakeTriggerRepository(),
+        new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+        NullLogger<CommandExecutor>.Instance,
+        new FakeSessionContextCache(),
+        ensureGameRunning: handler);
+
+  // ── Tests ─────────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task EnsureGameRunningSuccessOutcomeReturnsAccepted1AndExecutedStatus() {
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommand());
+    var executor = BuildExecutor(
+      new StubHandler(new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameRunning)),
+      cmds, new FakeSessionManager(RunningSession()));
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(1);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("executed");
+  }
+
+  [Fact]
+  public async Task EnsureGameRunningFailureOutcomeReturnsAccepted0AndGameNotRunningStatus() {
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommand());
+    var executor = BuildExecutor(
+      new StubHandler(new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameNotRunning)),
+      cmds, new FakeSessionManager(RunningSession()));
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("game_not_running");
+  }
+
+  [Fact]
+  public async Task EnsureGameRunningNullHandlerReturnsPlatformUnsupported() {
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommand());
+    var executor = BuildExecutor(null, cmds, new FakeSessionManager(RunningSession()));
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("platform_unsupported");
+  }
+
+  [Fact]
+  public async Task EnsureGameRunningFailureCompletesWithoutThrowing() {
+    // Verifies that a GameNotRunning failure outcome uses `continue` (not throw/return),
+    // so ForceExecuteDetailedAsync returns normally rather than propagating an exception.
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommand());
+    var executor = BuildExecutor(
+      new StubHandler(new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameNotRunning)),
+      cmds, new FakeSessionManager(RunningSession()));
+
+    var act = async () => await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    await act.Should().NotThrowAsync();
+  }
+}

--- a/tests/unit/Domain/PrimitiveActionValidationServiceTests.cs
+++ b/tests/unit/Domain/PrimitiveActionValidationServiceTests.cs
@@ -46,7 +46,8 @@ public sealed class PrimitiveActionValidationServiceTests {
       PrimitiveActionTypes.Key,
       PrimitiveActionTypes.Command,
       PrimitiveActionTypes.ConnectToGame,
-      PrimitiveActionTypes.WaitForImage
+      PrimitiveActionTypes.WaitForImage,
+      PrimitiveActionTypes.EnsureGameRunning
     });
   }
 }

--- a/tests/unit/Emulator/AdbClientForegroundPackageTests.cs
+++ b/tests/unit/Emulator/AdbClientForegroundPackageTests.cs
@@ -1,0 +1,39 @@
+using GameBot.Emulator.Adb;
+using FluentAssertions;
+using Xunit;
+
+namespace GameBot.UnitTests.Emulator;
+
+public class AdbClientForegroundPackageTests {
+  [Fact]
+  public void ParseForegroundPackageReturnsPackageWhenMResumedActivityPresent() {
+    var output = "  mResumedActivity: ActivityRecord{abc u0 com.example.game/.MainActivity t123}";
+    AdbClient.ParseForegroundPackage(output).Should().Be("com.example.game");
+  }
+
+  [Fact]
+  public void ParseForegroundPackageReturnsNullWhenLineAbsent() {
+    var output = "some unrelated dumpsys output\nno activity info here";
+    AdbClient.ParseForegroundPackage(output).Should().BeNull();
+  }
+
+  [Fact]
+  public void ParseForegroundPackageReturnsNullWhenOutputEmpty() {
+    AdbClient.ParseForegroundPackage(string.Empty).Should().BeNull();
+  }
+
+  [Fact]
+  public void ParseForegroundPackageIgnoresNonResumedLinesAndReturnsFirstMatch() {
+    var output =
+      "  mLastPausedActivity: ActivityRecord{xyz u0 com.other.app/.OtherActivity t100}\n" +
+      "  mResumedActivity: ActivityRecord{def u0 com.target.app/.MainActivity t200}\n" +
+      "  mFocusedActivity: ActivityRecord{def u0 com.target.app/.MainActivity t200}";
+    AdbClient.ParseForegroundPackage(output).Should().Be("com.target.app");
+  }
+
+  [Fact]
+  public void ParseForegroundPackageIsCaseInsensitiveForKeyword() {
+    var output = "  mresumedactivity: ActivityRecord{abc u0 com.example.game/.MainActivity t1}";
+    AdbClient.ParseForegroundPackage(output).Should().Be("com.example.game");
+  }
+}

--- a/tests/unit/Services/EnsureGameRunning/EnsureGameRunningActionHandlerTests.cs
+++ b/tests/unit/Services/EnsureGameRunning/EnsureGameRunningActionHandlerTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Games;
+using GameBot.Domain.Queues;
+using GameBot.Domain.Sessions;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services.EnsureGameRunning;
+using Xunit;
+
+// Test-code analyzer relaxations permitted by the constitution:
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Services.EnsureGameRunning;
+
+public sealed class EnsureGameRunningActionHandlerTests {
+  // ── Fakes ─────────────────────────────────────────────────────────────────
+
+  private sealed class FakeSessionManager : ISessionManager {
+    private readonly Dictionary<string, EmulatorSession> _sessions = new(StringComparer.Ordinal);
+    public int ActiveCount => _sessions.Count;
+    public bool CanCreateSession => true;
+    public void Seed(EmulatorSession s) => _sessions[s.Id] = s;
+    public EmulatorSession? GetSession(string id) => _sessions.TryGetValue(id, out var s) ? s : null;
+    public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) => throw new NotSupportedException();
+    public IReadOnlyCollection<EmulatorSession> ListSessions() => _sessions.Values.ToList();
+    public bool StopSession(string id) => _sessions.Remove(id);
+    public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+  }
+
+  private sealed class FakeQueueRepository : IQueueRepository {
+    private readonly Dictionary<string, ExecutionQueue> _items = new(StringComparer.Ordinal);
+    public void Seed(ExecutionQueue q) => _items[q.Id] = q;
+    public Task<ExecutionQueue?> GetAsync(string id) => Task.FromResult(_items.TryGetValue(id, out var q) ? q : null);
+    public Task<IReadOnlyList<ExecutionQueue>> ListAsync() => Task.FromResult((IReadOnlyList<ExecutionQueue>)_items.Values.ToList());
+    public Task<ExecutionQueue> CreateAsync(ExecutionQueue q) { _items[q.Id] = q; return Task.FromResult(q); }
+    public Task<ExecutionQueue> UpdateAsync(ExecutionQueue q) { _items[q.Id] = q; return Task.FromResult(q); }
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(_items.Remove(id));
+  }
+
+  private sealed class FakeGameRepository : IGameRepository {
+    private readonly Dictionary<string, GameArtifact> _items = new(StringComparer.Ordinal);
+    public void Seed(GameArtifact g) => _items[g.Id] = g;
+    public Task<GameArtifact> AddAsync(GameArtifact g, CancellationToken ct = default) { _items[g.Id] = g; return Task.FromResult(g); }
+    public Task<GameArtifact?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult(_items.TryGetValue(id, out var g) ? g : null);
+    public Task<IReadOnlyList<GameArtifact>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<GameArtifact>)_items.Values.ToList());
+    public Task<GameArtifact?> UpdateAsync(GameArtifact g, CancellationToken ct = default) { _items[g.Id] = g; return Task.FromResult<GameArtifact?>(g); }
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_items.Remove(id));
+  }
+
+  private sealed class FakeAdbGameOperations : IAdbGameOperations {
+    public string? ForegroundPackage { get; set; }
+    public List<string> LaunchedPackages { get; } = new();
+    public Task<string?> GetForegroundPackageAsync(string deviceSerial, CancellationToken ct = default) => Task.FromResult(ForegroundPackage);
+    public Task LaunchAppAsync(string deviceSerial, string packageName, CancellationToken ct = default) { LaunchedPackages.Add(packageName); return Task.CompletedTask; }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private static EmulatorSession QueueSession(string sessionId, string queueId, string? serial = "emulator-5554") =>
+    new() { Id = sessionId, GameId = $"queue:{queueId}", Status = SessionStatus.Running, DeviceSerial = serial };
+
+  private static EnsureGameRunningActionHandler BuildHandler(
+    FakeSessionManager sessions, FakeQueueRepository queues, FakeGameRepository games, FakeAdbGameOperations adb) =>
+    new(sessions, queues, games, adb);
+
+  // ── Tests ─────────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task ReturnsNoQueueContextWhenSessionNotFound() {
+    var handler = BuildHandler(new(), new(), new(), new());
+    var result = await handler.ExecuteAsync("missing-session");
+    result.Outcome.Should().Be(EnsureGameRunningOutcome.NoQueueContext);
+    result.IsSuccess.Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task ReturnsNoQueueContextWhenSessionLabelHasNoQueuePrefix() {
+    var sessions = new FakeSessionManager();
+    sessions.Seed(new EmulatorSession { Id = "s1", GameId = "direct-session", Status = SessionStatus.Running });
+    var handler = BuildHandler(sessions, new(), new(), new());
+    var result = await handler.ExecuteAsync("s1");
+    result.Outcome.Should().Be(EnsureGameRunningOutcome.NoQueueContext);
+  }
+
+  [Fact]
+  public async Task ReturnsNoLinkedGameWhenQueueHasNoLinkedGameId() {
+    var sessions = new FakeSessionManager();
+    sessions.Seed(QueueSession("s1", "q1"));
+    var queues = new FakeQueueRepository();
+    queues.Seed(new ExecutionQueue { Id = "q1", Name = "Q", EmulatorSerial = "x" });
+    var handler = BuildHandler(sessions, queues, new(), new());
+    var result = await handler.ExecuteAsync("s1");
+    result.Outcome.Should().Be(EnsureGameRunningOutcome.NoLinkedGame);
+  }
+
+  [Fact]
+  public async Task ReturnsNoPackageNameWhenGameHasNoPackageName() {
+    var sessions = new FakeSessionManager();
+    sessions.Seed(QueueSession("s1", "q1"));
+    var queues = new FakeQueueRepository();
+    queues.Seed(new ExecutionQueue { Id = "q1", Name = "Q", EmulatorSerial = "x", LinkedGameId = "g1" });
+    var games = new FakeGameRepository();
+    games.Seed(new GameArtifact { Id = "g1", Name = "MyGame" });
+    var handler = BuildHandler(sessions, queues, games, new());
+    var result = await handler.ExecuteAsync("s1");
+    result.Outcome.Should().Be(EnsureGameRunningOutcome.NoPackageName);
+  }
+
+  [Fact]
+  public async Task ReturnsGameRunningWhenForegroundPackageMatches() {
+    var sessions = new FakeSessionManager();
+    sessions.Seed(QueueSession("s1", "q1"));
+    var queues = new FakeQueueRepository();
+    queues.Seed(new ExecutionQueue { Id = "q1", Name = "Q", EmulatorSerial = "x", LinkedGameId = "g1" });
+    var games = new FakeGameRepository();
+    games.Seed(new GameArtifact { Id = "g1", Name = "MyGame", PackageName = "com.example.game" });
+    var adb = new FakeAdbGameOperations { ForegroundPackage = "com.example.game" };
+    var handler = BuildHandler(sessions, queues, games, adb);
+
+    var result = await handler.ExecuteAsync("s1");
+
+    result.Outcome.Should().Be(EnsureGameRunningOutcome.GameRunning);
+    result.IsSuccess.Should().BeTrue();
+    result.ReasonCode.Should().Be("game_running");
+    adb.LaunchedPackages.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task ReturnsGameNotRunningAndLaunchesAppWhenForegroundPackageDoesNotMatch() {
+    var sessions = new FakeSessionManager();
+    sessions.Seed(QueueSession("s1", "q1"));
+    var queues = new FakeQueueRepository();
+    queues.Seed(new ExecutionQueue { Id = "q1", Name = "Q", EmulatorSerial = "x", LinkedGameId = "g1" });
+    var games = new FakeGameRepository();
+    games.Seed(new GameArtifact { Id = "g1", Name = "MyGame", PackageName = "com.example.game" });
+    var adb = new FakeAdbGameOperations { ForegroundPackage = "com.other.app" };
+    var handler = BuildHandler(sessions, queues, games, adb);
+
+    var result = await handler.ExecuteAsync("s1");
+
+    result.Outcome.Should().Be(EnsureGameRunningOutcome.GameNotRunning);
+    result.IsSuccess.Should().BeFalse();
+    result.ReasonCode.Should().Be("game_not_running");
+    adb.LaunchedPackages.Should().ContainSingle("com.example.game");
+  }
+}

--- a/tests/unit/Services/EnsureGameRunning/EnsureGameRunningActionHandlerTests.cs
+++ b/tests/unit/Services/EnsureGameRunning/EnsureGameRunningActionHandlerTests.cs
@@ -77,12 +77,14 @@ public sealed class EnsureGameRunningActionHandlerTests {
   }
 
   [Fact]
-  public async Task ReturnsNoQueueContextWhenSessionLabelHasNoQueuePrefix() {
+  public async Task ReturnsNoPackageNameWhenDirectSessionGameNotFound() {
+    // For direct (non-queue) sessions the handler uses session.GameId as the game ID.
+    // When no game with that ID exists the result is NoPackageName.
     var sessions = new FakeSessionManager();
-    sessions.Seed(new EmulatorSession { Id = "s1", GameId = "direct-session", Status = SessionStatus.Running });
+    sessions.Seed(new EmulatorSession { Id = "s1", GameId = "unknown-game-id", Status = SessionStatus.Running });
     var handler = BuildHandler(sessions, new(), new(), new());
     var result = await handler.ExecuteAsync("s1");
-    result.Outcome.Should().Be(EnsureGameRunningOutcome.NoQueueContext);
+    result.Outcome.Should().Be(EnsureGameRunningOutcome.NoPackageName);
   }
 
   [Fact]


### PR DESCRIPTION
## Summary

- New `EnsureGameRunning` command step type that checks whether the linked game is the active foreground app on the emulator; starts it if not and reports failure
- `PackageName` field added to `GameArtifact`; `LinkedGameId` field added to `ExecutionQueue`
- Queue-game link UI: `GamePickerDialog` + `QueueGameControls` in the queue edit form
- Package name field added to the Games create/edit forms
- `PUT /api/queues/{id}/game` endpoint for linking/unlinking a game from a queue
- Game delete blocked (409) when any queue references it
- Works in both queue-run context and direct (connect-to-game) sessions
- 15 new unit tests; 370/370 passing; frontend build clean

## Test plan

- [ ] Configure a game with a package name (Games page → Package Name field)
- [ ] Link a queue to that game (Queue edit form → Link Game)
- [ ] Create a command with an "Add ensure game running step" step; verify it saves
- [ ] Start a session on the Execution page, execute the command — confirm message shows game status (not "did not execute any tap")
- [ ] Run a queue that includes that command as part of a sequence; check execution log shows correct success/failure outcome
- [ ] Verify game cannot be deleted while a queue references it (409 conflict)
- [ ] Run `dotnet test` — all 370 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)