### PR TITLE
Queue sequence scheduling (#053)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/052-ensure-game-running"
+  "feature_directory": "specs/053-schedulable-sequences"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 ﻿<!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/052-ensure-game-running/plan.md
+at specs/053-schedulable-sequences/plan.md
 <!-- SPECKIT END -->

--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "0",
-  "minor": "7",
-  "patch": "2",
+  "minor": "8",
+  "patch": "0",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-06-03T16:00:00Z"
+  "updatedAtUtc": "2026-06-03T19:07:40Z"
 }

--- a/specs/053-schedulable-sequences/checklists/requirements.md
+++ b/specs/053-schedulable-sequences/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Queue Sequence Scheduling
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — FR-003 clarification resolved: timer uses wall-clock time-of-day (recurring interval and elapsed-duration deferred)
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Clarifications resolved 2026-06-03: (1) timer parameter is wall-clock time-of-day in server local time; (2) "fired today" state is per-run only, resets on restart; (3) recurring-interval and elapsed-duration timer types deferred. Spec is ready for `/speckit-plan`.

--- a/specs/053-schedulable-sequences/contracts/queue-template-schedule.openapi.yaml
+++ b/specs/053-schedulable-sequences/contracts/queue-template-schedule.openapi.yaml
@@ -1,0 +1,194 @@
+openapi: "3.1.0"
+info:
+  title: Queue Template Schedule Types — Contract Delta
+  description: |
+    Documents the changes to the Queue Templates API introduced by feature 053-schedulable-sequences.
+    Only the affected endpoints and schemas are listed here; all other endpoints are unchanged.
+  version: "053"
+
+paths:
+  /api/queue-templates:
+    post:
+      summary: Save (create or overwrite) a queue template
+      description: |
+        BREAKING CHANGE from feature 047: the `sequenceIds` string array is replaced by a structured
+        `entries` array that carries per-entry schedule type and optional timer time.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveQueueTemplateRequest'
+            examples:
+              mixed_schedule_types:
+                summary: Template with all three schedule types
+                value:
+                  name: "Daily Farm"
+                  overwrite: false
+                  entries:
+                    - sequenceId: "abc123"
+                    - sequenceId: "def456"
+                      scheduleType: "EveryStep"
+                    - sequenceId: "ghi789"
+                      scheduleType: "Timer"
+                      timerTimeOfDay: "15:30"
+              once_per_run_only:
+                summary: Template with only once-per-run entries (default behavior preserved)
+                value:
+                  name: "Simple Queue"
+                  overwrite: false
+                  entries:
+                    - sequenceId: "abc123"
+                    - sequenceId: "def456"
+      responses:
+        "200":
+          description: Template updated (overwrite)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueTemplateDetailResponse'
+        "201":
+          description: Template created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueTemplateDetailResponse'
+        "400":
+          description: Validation error (blank name, invalid schedule type, missing timer time)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "409":
+          description: Template name already exists and overwrite=false
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/queue-templates/{id}:
+    get:
+      summary: Get a queue template by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Template detail including schedule types per entry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueTemplateDetailResponse'
+        "404":
+          description: Not found
+
+components:
+  schemas:
+
+    ScheduleType:
+      type: string
+      enum:
+        - OncePerRun
+        - EveryStep
+        - Timer
+      default: OncePerRun
+      description: |
+        Determines when a template entry's sequence is executed during a queue run.
+        - OncePerRun: default; executes in template order once per cycle (existing behavior).
+        - EveryStep: executes after each OncePerRun sequence completes; does not count toward run completion.
+        - Timer: executes at the start of an iteration when the wall-clock time (server local) has passed the configured time-of-day; fires at most once per calendar day per run.
+
+    TemplateEntrySaveRequest:
+      type: object
+      required:
+        - sequenceId
+      properties:
+        sequenceId:
+          type: string
+          description: ID of the sequence to reference. Must be non-blank.
+        scheduleType:
+          $ref: '#/components/schemas/ScheduleType'
+        timerTimeOfDay:
+          type: string
+          nullable: true
+          pattern: "^([01]\\d|2[0-3]):[0-5]\\d$"
+          description: |
+            Required when scheduleType is "Timer". Wall-clock time in HH:mm (24-hour, server local time).
+            Ignored for other schedule types.
+          example: "15:30"
+
+    SaveQueueTemplateRequest:
+      type: object
+      required:
+        - name
+        - entries
+      properties:
+        name:
+          type: string
+          description: Template name (1-100 chars, letters/digits/spaces/hyphens/underscores only).
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TemplateEntrySaveRequest'
+          description: Ordered list of sequence entries. Replaces the previous sequenceIds field.
+        overwrite:
+          type: boolean
+          default: false
+          description: When true, overwrites an existing template with the same name.
+
+    QueueTemplateEntryResponse:
+      type: object
+      properties:
+        sequenceId:
+          type: string
+        sequenceName:
+          type: string
+          nullable: true
+        stale:
+          type: boolean
+          description: True when the referenced sequence no longer exists.
+        scheduleType:
+          $ref: '#/components/schemas/ScheduleType'
+        timerTimeOfDay:
+          type: string
+          nullable: true
+          description: "HH:mm (24-hour) if scheduleType is Timer; null otherwise."
+
+    QueueTemplateDetailResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        entryCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/QueueTemplateEntryResponse'
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            hint:
+              type: string
+              nullable: true

--- a/specs/053-schedulable-sequences/data-model.md
+++ b/specs/053-schedulable-sequences/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Queue Sequence Scheduling
+
+**Feature**: 053-schedulable-sequences  
+**Date**: 2026-06-03
+
+---
+
+## New: `ScheduleType` Enum
+
+**File**: `src/GameBot.Domain/QueueTemplates/ScheduleType.cs`
+
+```
+ScheduleType (enum, JSON-serialized as string)
+├── OncePerRun = 0   (default; preserves existing behavior)
+├── EveryStep = 1
+└── Timer = 2
+```
+
+- Decorated with `[JsonConverter(typeof(JsonStringEnumConverter))]`.
+- Default `OncePerRun` guarantees backward-compatible deserialization of existing JSON files.
+
+---
+
+## Updated: `QueueTemplateEntry`
+
+**File**: `src/GameBot.Domain/QueueTemplates/QueueTemplateEntry.cs`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `SequenceId` | `string` | `""` | Existing — unchanged |
+| `ScheduleType` | `ScheduleType` | `OncePerRun` | New — serialized as string |
+| `TimerTimeOfDay` | `TimeOnly?` | `null` | New — required when `ScheduleType == Timer`; ignored otherwise |
+
+**Persistence**: `FileQueueTemplateRepository` serializes `QueueTemplateEntry` as JSON. `ScheduleType` serializes as a string enum; `TimerTimeOfDay` serializes as `"HH:mm:ss"` via `System.Text.Json`. Existing entries in JSON files without `ScheduleType` deserialize to `OncePerRun` (the enum default).
+
+---
+
+## New: `TemplateEntrySaveRequest` (API contract)
+
+**File**: `src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `SequenceId` | `string?` | Yes | The sequence to reference |
+| `ScheduleType` | `string?` | No | `"OncePerRun"` \| `"EveryStep"` \| `"Timer"`; defaults to `"OncePerRun"` when omitted |
+| `TimerTimeOfDay` | `string?` | Conditional | `HH:mm` (24-hour); required when `ScheduleType == "Timer"` |
+
+Validation rules (enforced at the endpoint):
+- `SequenceId` must be non-blank.
+- `ScheduleType` must be a recognized value or absent (defaults to `OncePerRun`).
+- When `ScheduleType == "Timer"`: `TimerTimeOfDay` must be present and parseable as `HH:mm`.
+- When `ScheduleType != "Timer"`: `TimerTimeOfDay` is ignored (set to `null` in domain model).
+
+---
+
+## Updated: `SaveQueueTemplateRequest` (API contract)
+
+**File**: `src/GameBot.Service/Contracts/QueueTemplates/SaveQueueTemplateRequest.cs`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Name` | `string?` | Unchanged |
+| `Entries` | `TemplateEntrySaveRequest[]?` | **Replaces** the old `SequenceIds string[]` |
+| `Overwrite` | `bool` | Unchanged |
+
+---
+
+## Updated: `QueueTemplateEntryResponse` (API contract)
+
+**File**: `src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `SequenceId` | `string` | Existing — unchanged |
+| `SequenceName` | `string?` | Existing — unchanged |
+| `Stale` | `bool` | Existing — unchanged |
+| `ScheduleType` | `string` | New — `"OncePerRun"` \| `"EveryStep"` \| `"Timer"` |
+| `TimerTimeOfDay` | `string?` | New — `HH:mm` string or `null` |
+
+---
+
+## Runtime-only: Timer firing state
+
+**Not persisted.** Maintained in `QueueExecutionService.RunAsync` as a local variable:
+
+```
+timerFiredDate: Dictionary<int, DateOnly>
+```
+
+- Key: zero-based index of the timer entry within `timerSnapshot` (the pre-partitioned list of timer entries for this run).
+- Value: the `DateOnly` (server local) on which that entry last fired.
+- Missing key = never fired this run.
+- Declared **outside and before the `do {` loop body** so it persists across all cycles of the same run.
+- Evaluated at each iteration boundary: entry fires if `TimeOnly.FromDateTime(DateTime.Now) >= entry.TimerTimeOfDay` AND the dictionary either has no entry for index `i` or its stored `DateOnly` differs from today's date.
+- After firing: `timerFiredDate[i] = DateOnly.FromDateTime(DateTime.Now)`.
+- Placing this dictionary inside the `do { }` body would reset it every cycle, causing the timer to fire on every iteration rather than once per calendar day — a critical correctness bug.
+
+---
+
+## Key entities unchanged
+
+- `QueueTemplate` — no changes to top-level fields.
+- `QueueEntry` (runtime) — not changed; still holds `EntryId` + `SequenceId` only (schedule is template-layer concern).
+- `ExecutionQueue` — not changed.
+- `ExecutionLogEntry` / `ExecutionLogContext` — not changed; schedule-typed sequences log identically to once-per-run sequences (index incremented globally across all executions in the run).

--- a/specs/053-schedulable-sequences/plan.md
+++ b/specs/053-schedulable-sequences/plan.md
@@ -1,0 +1,271 @@
+# Implementation Plan: Queue Sequence Scheduling
+
+**Branch**: `053-schedulable-sequences` | **Date**: 2026-06-03 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/053-schedulable-sequences/spec.md`
+
+## Summary
+
+Extend queue template entries with a `ScheduleType` field (`OncePerRun` / `EveryStep` / `Timer`) and refactor the queue execution loop to respect those types. `EveryStep` sequences run after each regular step; `Timer` sequences fire once per calendar day at a configured wall-clock time (server local), checked at iteration boundaries. Schedule type is configurable per template entry via API and UI. All existing behavior is preserved via a `OncePerRun` default.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9 (backend) · TypeScript / React 18 (frontend, Vite)  
+**Primary Dependencies**: ASP.NET Core Minimal API · System.Text.Json · XUnit / FluentAssertions (tests) · Jest / React Testing Library (UI tests)  
+**Storage**: File-based JSON under `data/queue-templates/` — `FileQueueTemplateRepository`  
+**Testing**: XUnit (unit + integration + contract) · Jest (frontend)  
+**Target Platform**: Windows desktop (single-operator local tool)  
+**Project Type**: Desktop web-app (React UI + .NET local server)  
+**Performance Goals**: Timer evaluation at iteration boundaries is O(|timerEntries|) — negligible overhead  
+**Constraints**: Timer precision = best-effort (fires at next iteration boundary after scheduled time); no sub-second precision required  
+**Scale/Scope**: Up to ~50 templates, ~100 entries each, ~10 every-step sequences per template
+
+## Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Build passes | Required — verify before and after each phase | Run `dotnet build` + `vite build` |
+| Unit tests pass | Required | `dotnet test tests/unit` |
+| Integration tests pass | Required | `dotnet test tests/integration` |
+| Lint/format clean | Required | No new warnings in modified C# or TSX files |
+| CamelCase methods | Required | No underscores in new method names |
+| Public API docstrings | Required | New public types and their properties need summaries |
+| Coverage ≥ 80% lines | Required | New logic in `QueueExecutionService`, `ScheduleType`, entry models |
+| Performance note | Required | Document timer evaluation complexity in plan (done above) |
+
+*Gate re-check after Phase 1 design confirms no new violations.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/053-schedulable-sequences/
+├── plan.md              ← this file
+├── spec.md
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+├── contracts/
+│   └── queue-template-schedule.openapi.yaml  ← Phase 1 output
+└── tasks.md             ← /speckit-tasks output (not yet)
+```
+
+### Source Code
+
+```text
+src/GameBot.Domain/
+└── QueueTemplates/
+    ├── ScheduleType.cs           NEW — enum (OncePerRun, EveryStep, Timer)
+    ├── QueueTemplateEntry.cs     MOD — add ScheduleType + TimerTimeOfDay
+    ├── QueueTemplate.cs          no change
+    ├── IQueueTemplateRepository.cs  no change
+    └── FileQueueTemplateRepository.cs  no change (JSON serialization picks up new fields automatically)
+
+src/GameBot.Service/
+├── Contracts/QueueTemplates/
+│   ├── TemplateEntrySaveRequest.cs     NEW — { SequenceId, ScheduleType, TimerTimeOfDay }
+│   ├── SaveQueueTemplateRequest.cs     MOD — replace SequenceIds[] with Entries[]
+│   └── QueueTemplateDetailResponse.cs  MOD — add ScheduleType + TimerTimeOfDay to QueueTemplateEntryResponse
+├── Endpoints/
+│   └── QueueTemplatesEndpoints.cs      MOD — update SaveQueueTemplate handler + validation
+└── Services/QueueExecution/
+    └── QueueExecutionService.cs        MOD — refactor RunAsync loop for schedule types
+
+src/web-ui/src/
+├── services/
+│   ├── queueTemplates.ts    MOD — update SaveQueueTemplateRequest type + entry types
+│   └── queues.ts            MOD — update QueueEntryDto (if schedule type surfaced in runtime entries)
+└── components/queues/
+    └── QueueEntryList.tsx   MOD — add schedule type selector + timer time input per entry
+
+tests/
+├── unit/Queues/
+│   └── QueueExecutionServiceTests.cs   MOD — add every-step + timer scheduling tests
+└── integration/QueueTemplates/
+    ├── QueueTemplatesSaveEndpointTests.cs   MOD — update for new Entries[] shape
+    └── QueueTemplatesScheduleTypeTests.cs   NEW — focused schedule-type persistence + retrieval tests
+```
+
+## Implementation Phases
+
+### Phase A: Domain model (backend)
+
+**Files**: `ScheduleType.cs` (new), `QueueTemplateEntry.cs` (mod)
+
+1. Create `src/GameBot.Domain/QueueTemplates/ScheduleType.cs`:
+   - `public enum ScheduleType { OncePerRun = 0, EveryStep = 1, Timer = 2 }`
+   - Apply `[JsonConverter(typeof(JsonStringEnumConverter))]` at the enum level.
+
+2. Extend `QueueTemplateEntry`:
+   - Add `public ScheduleType ScheduleType { get; set; } = ScheduleType.OncePerRun;`
+   - Add `public TimeOnly? TimerTimeOfDay { get; set; }`
+   - Update XML summary to document both new fields.
+
+3. No changes to `FileQueueTemplateRepository` — `System.Text.Json` serializes the new fields automatically; existing JSON files deserialize with `OncePerRun` default.
+
+**Gate**: `dotnet build` clean; existing unit tests still pass.
+
+---
+
+### Phase B: API contracts and endpoint (backend)
+
+**Files**: `TemplateEntrySaveRequest.cs` (new), `SaveQueueTemplateRequest.cs` (mod), `QueueTemplateDetailResponse.cs` (mod), `QueueTemplatesEndpoints.cs` (mod)
+
+1. Create `TemplateEntrySaveRequest`:
+   ```
+   SequenceId: string?
+   ScheduleType: string?    // "OncePerRun" | "EveryStep" | "Timer"; null → OncePerRun
+   TimerTimeOfDay: string?  // "HH:mm" (24-hour); required when ScheduleType == "Timer"
+   ```
+
+2. Update `SaveQueueTemplateRequest`:
+   - Remove `string[]? SequenceIds`.
+   - Add `TemplateEntrySaveRequest[]? Entries`.
+
+3. Extend `QueueTemplateEntryResponse`:
+   - Add `string ScheduleType { get; set; }` (string representation: `"OncePerRun"` / `"EveryStep"` / `"Timer"`).
+   - Add `string? TimerTimeOfDay { get; set; }` (`"HH:mm"` or null).
+
+4. Update `QueueTemplatesEndpoints.SaveQueueTemplate` handler:
+   - Replace the `foreach (var sid in req.SequenceIds)` loop with a loop over `req.Entries`.
+   - Add validation per entry:
+     - `SequenceId` non-blank.
+     - `ScheduleType` parses to a known value.
+     - When `ScheduleType == Timer`: `TimerTimeOfDay` present and parseable as `HH:mm`; if missing → 400.
+     - When `ScheduleType != Timer`: ignore `TimerTimeOfDay`.
+   - Update `BuildDetailAsync` to populate `ScheduleType` and `TimerTimeOfDay` in `QueueTemplateEntryResponse`.
+
+**Gate**: `dotnet build` clean; existing integration tests updated for new request shape; new integration tests pass.
+
+---
+
+### Phase C: Execution loop refactor (backend)
+
+**File**: `QueueExecutionService.cs`
+
+Refactor `RunAsync` in these steps:
+
+1. **Change snapshot** (line 114): replace `var snapshot = template.Entries.Select(e => e.SequenceId).ToList()` with capturing the full entries:
+   ```csharp
+   var allEntries = template.Entries.ToList();
+   var oncePerRunEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.OncePerRun).ToList();
+   var everyStepEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.EveryStep).ToList();
+   var timerEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.Timer).ToList();
+   ```
+
+2. **Initialize per-run timer state** — declare this **outside and before the `do {` keyword**, after the partition lists, so it persists across all cycles of the same run. Placing it inside the loop body would reset it every cycle and break the once-per-calendar-day invariant:
+   ```csharp
+   // OUTSIDE the do-while loop — persists across cycles
+   var timerFiredDate = new Dictionary<int, DateOnly>();
+   ```
+
+3. **Rewrite the `do` loop** (currently lines 134–149):
+   ```
+   do {
+     ct.ThrowIfCancellationRequested();
+
+     // (1) Timer sequences at iteration boundary
+     for (int ti = 0; ti < timerEntries.Count; ti++) {
+       var timerEntry = timerEntries[ti];
+       if (timerEntry.TimerTimeOfDay is not null) {
+         var today = DateOnly.FromDateTime(DateTime.Now);
+         var now   = TimeOnly.FromDateTime(DateTime.Now);
+         if (now >= timerEntry.TimerTimeOfDay.Value &&
+             (!timerFiredDate.TryGetValue(ti, out var lastFired) || lastFired != today)) {
+           ct.ThrowIfCancellationRequested();
+           if (sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+           var ok = await RunOneSequenceAsync(timerEntry.SequenceId, rootId, ++index, sessionId, ct);
+           executed++; if (!ok) failed++;
+           timerFiredDate[ti] = today;
+         }
+       }
+     }
+
+     // (2) Once-per-run sequences, each followed by every-step sequences
+     if (oncePerRunEntries.Count > 0) {
+       foreach (var entry in oncePerRunEntries) {
+         ct.ThrowIfCancellationRequested();
+         if (sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+         var ok = await RunOneSequenceAsync(entry.SequenceId, rootId, ++index, sessionId, ct);
+         executed++; if (!ok) failed++;
+
+         foreach (var esEntry in everyStepEntries) {
+           ct.ThrowIfCancellationRequested();
+           if (sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+           var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, ct);
+           if (!esOk) failed++;
+           // every-step does not count toward executed (SC-002)
+         }
+       }
+     }
+     else if (everyStepEntries.Count > 0) {
+       // FR-009: no once-per-run entries — every-step runs exactly once
+       foreach (var esEntry in everyStepEntries) {
+         ct.ThrowIfCancellationRequested();
+         if (sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+         var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, ct);
+         if (!esOk) failed++;
+       }
+     }
+
+     cycles++;
+   } while (queue.CycleExecution);
+   ```
+
+4. The empty-template guard (`snapshot.Count > 0` check at line 133) is replaced by the natural behavior: if all three partitions are empty, the loop body does nothing, `cycles = 1`, and the run ends.
+
+5. Update `BuildSummary` to reflect that `executed` counts once-per-run sequences only (not every-step or timer). Optionally add a brief note in the summary when every-step or timer sequences also ran.
+
+**Gate**: `dotnet build` clean; existing and new unit tests (every-step + timer scenarios) pass.
+
+---
+
+### Phase D: Frontend (TypeScript / React)
+
+**Files**: `queueTemplates.ts`, `queues.ts`, `QueueEntryList.tsx`
+
+1. **`queueTemplates.ts`**: 
+   - Define `TemplateEntrySaveDto { sequenceId: string; scheduleType?: string; timerTimeOfDay?: string }`.
+   - Update `SaveQueueTemplateRequest` to use `entries: TemplateEntrySaveDto[]` (remove `sequenceIds`).
+   - Update `QueueTemplateEntryDto` to include `scheduleType: string` and `timerTimeOfDay: string | null`.
+   - Update `saveQueueTemplate` API call to pass `entries`.
+
+2. **`QueueEntryList.tsx`** (this component is used for runtime queue entries, not template entries directly — evaluate whether it needs a schedule selector, or if schedule configuration lives in a separate template editing view):
+   - The queue editor works with runtime `QueueEntryDto` (from `IQueueRuntimeStore`) — schedule type is a template-layer concept, not stored on runtime entries.
+   - Schedule type is configured when saving a template (via the Save Template dialog) and loaded when loading a template.
+   - **Approach**: Add a schedule type to the in-UI entry state used when building the save-template payload. The queue editor maintains an optional `scheduleType` per entry (UI-local state, not sent to runtime API), used only when saving a template.
+   - Add per-entry schedule type selector (dropdown: Once Per Run / Every Step / Timer) and conditional time picker for Timer entries.
+   - Show schedule type badge per entry in the list view (read-only, set when loaded from template).
+
+3. **`QueuesPage.tsx`**: Update save-template flow to collect `scheduleType` and `timerTimeOfDay` from per-entry UI state and include them in the `saveQueueTemplate` call.
+
+**Gate**: `vite build` clean; Jest tests for updated `QueueEntryList` pass.
+
+---
+
+### Phase E: Tests
+
+**Unit tests** — `tests/unit/Queues/QueueExecutionServiceTests.cs`:
+
+- Every-step: template with 2 once-per-run + 1 every-step → assert every-step runs after each once-per-run.
+- Every-step count: assert `executed` reflects only once-per-run count.
+- Timer due: timer time in the past → fires on first iteration before once-per-run.
+- Timer not due: timer time in the future → never fires in a non-cyclic run.
+- Timer fires once per calendar day: simulate two iterations on same date → timer fires once; simulate next-day iteration → fires again.
+- Timer + every-step + once-per-run: assert correct execution order.
+- No once-per-run, only every-step: every-step executes once, run ends.
+- Empty template (all partitions empty): run completes immediately, no executions.
+
+**Integration tests** — `tests/integration/QueueTemplates/`:
+
+- `QueueTemplatesSaveEndpointTests.cs`: update existing tests for new `Entries[]` shape.
+- `QueueTemplatesScheduleTypeTests.cs` (new):
+  - Save template with `EveryStep` and `Timer` entries → GET returns correct schedule types.
+  - Timer without `timerTimeOfDay` → 400.
+  - Invalid `scheduleType` value → 400.
+  - Missing `sequenceId` in entry → 400.
+  - Existing template (saved before this feature) → GET returns `OncePerRun` for all entries (backward compatibility).
+
+## Complexity Tracking
+
+No constitution violations. No new projects, no new external dependencies, no repository pattern layers added. `FileQueueTemplateRepository` automatically serializes new fields through `System.Text.Json` without any changes.

--- a/specs/053-schedulable-sequences/quickstart.md
+++ b/specs/053-schedulable-sequences/quickstart.md
@@ -1,0 +1,95 @@
+# Quickstart: Queue Sequence Scheduling
+
+**Feature**: 053-schedulable-sequences
+
+## End-to-end verification
+
+### Prerequisites
+
+- GameBot service running locally
+- At least two sequences created (e.g., "Collect Resources", "Check Health")
+- A queue configured with a bound emulator and a linked template
+
+---
+
+### 1. Save a template with all three schedule types (API)
+
+```http
+POST /api/queue-templates
+Content-Type: application/json
+
+{
+  "name": "Scheduling Test",
+  "overwrite": true,
+  "entries": [
+    { "sequenceId": "<once-per-run-sequence-id>" },
+    { "sequenceId": "<every-step-sequence-id>", "scheduleType": "EveryStep" },
+    { "sequenceId": "<timer-sequence-id>", "scheduleType": "Timer", "timerTimeOfDay": "HH:MM" }
+  ]
+}
+```
+
+Replace `HH:MM` with a time 1-2 minutes from now (server local time) for quick testing, or a past time for immediate firing.
+
+**Expected**: 201 Created; response entries include `scheduleType` and `timerTimeOfDay` fields.
+
+---
+
+### 2. Verify retrieval round-trips schedule types
+
+```http
+GET /api/queue-templates/<id>
+```
+
+**Expected**: `entries[0].scheduleType == "OncePerRun"`, `entries[1].scheduleType == "EveryStep"`, `entries[2].scheduleType == "Timer"` and `entries[2].timerTimeOfDay == "HH:MM"`.
+
+---
+
+### 3. Load the template into a queue and start execution
+
+In the UI:
+1. Open the queue editor.
+2. Load "Scheduling Test" template.
+3. Verify that each entry displays its schedule type badge/label.
+4. Start the queue.
+
+**Expected during run (check execution log)**:
+- If timer time has passed: timer sequence fires first, before the once-per-run sequence.
+- Once-per-run sequence executes.
+- Every-step sequence executes immediately after the once-per-run sequence.
+- Execution log shows all three sequence executions nested under the queue run entry.
+
+---
+
+### 4. Verify every-step does not count toward completion
+
+With a template of 2 once-per-run and 1 every-step:
+- Start a non-cyclic queue.
+- Observe: run completes after both once-per-run sequences finish (every-step runs twice but doesn't extend the run).
+- Execution log stop reason: "completed full run".
+
+---
+
+### 5. Verify timer does not re-fire in the same calendar day within one run
+
+With a timer set to a past time:
+- Start a cyclic queue.
+- Observe: timer fires on the first iteration, skipped on all subsequent iterations of the same calendar day.
+- On the next calendar day (if testing long-running queue): timer fires again at the start of the first iteration after the scheduled time.
+
+---
+
+### 6. Verify backward compatibility
+
+Load a template that was saved before this feature (no `scheduleType` in its JSON file).
+- Expected: all entries behave as "OncePerRun" — existing queue behavior is unchanged.
+
+---
+
+## UI checklist
+
+- [ ] Schedule type selector visible per entry in queue entry list
+- [ ] Timer time input appears only when "Timer" is selected
+- [ ] Badge/label distinguishes "EveryStep" and "Timer" entries at a glance
+- [ ] Template save includes schedule types (verify via GET after save)
+- [ ] Template load restores schedule types into queue editor

--- a/specs/053-schedulable-sequences/research.md
+++ b/specs/053-schedulable-sequences/research.md
@@ -1,0 +1,86 @@
+# Research: Queue Sequence Scheduling
+
+**Feature**: 053-schedulable-sequences  
+**Date**: 2026-06-03
+
+## Decision 1: Where schedule type lives
+
+**Decision**: `ScheduleType` is a property of `QueueTemplateEntry` (the persisted domain model), not of the runtime queue entry (`QueueEntry`). The runtime queue entry is non-persistent and carries only `EntryId` + `SequenceId`; schedule semantics belong in the template that defines the work.
+
+**Rationale**: Queue entries are ephemeral, in-memory, and not linked to templates after a load. Template entries are the source of truth for ordering and scheduling. Keeping schedule type in the template entry means it persists across restarts and is shared among all queues that load the template, consistent with the feature's design intent.
+
+**Alternatives considered**:
+- Attaching schedule type to `QueueEntry` (runtime): rejected because runtime entries are not persisted and are overwritten on template load, losing any schedule configuration.
+
+---
+
+## Decision 2: Timer "already fired" tracking
+
+**Decision**: Use a `Dictionary<int, DateOnly>` keyed by entry index within the run-snapshot, tracking the calendar date (`DateOnly`) on which each timer entry last fired. This dictionary is per-run (instantiated in `RunAsync`, never persisted).
+
+**Rationale**:  
+- Enables "once per calendar day" semantics during a multi-day run without restarting.  
+- Resets on queue restart (per clarification: per-run only state).  
+- Cheaply evaluated at each iteration boundary using `DateTime.Now`.
+
+**Alternatives considered**:
+- Simple boolean `HashSet<int>` (fired in this run): rejected because it would prevent the timer from firing again on the next calendar day during a long-running cyclic queue.
+
+---
+
+## Decision 3: API contract shape for `SaveQueueTemplateRequest`
+
+**Decision**: Replace `string[]? SequenceIds` with `TemplateEntrySaveRequest[]? Entries`, where each element carries `SequenceId`, `ScheduleType` (string enum, default `"OncePerRun"`), and `TimerTimeOfDay` (string `"HH:mm"` or null). The old `SequenceIds` field is removed.
+
+**Rationale**: The previous shape had no room for per-entry metadata. Structured entries are needed for schedule type + timer time. The change is breaking, but this is a single-operator desktop tool with no external consumers and the break is confined to one endpoint.
+
+**Alternatives considered**:
+- Keeping `SequenceIds` as a parallel deprecated field: adds complexity with no consumer benefit in a single-operator context.
+- Using a flat parallel arrays (`sequenceIds[]` + `scheduleTypes[]`): fragile, error-prone when the arrays have different lengths.
+
+---
+
+## Decision 4: Time representation for TimerTimeOfDay
+
+**Decision**: Store and transfer timer time as a string in `HH:mm` (24-hour) format. In the domain model use `TimeOnly?`; in the API contract use `string?` (parsed and validated at the endpoint boundary).
+
+**Rationale**:  
+- `TimeOnly` serializes to `HH:mm:ss` by default in `System.Text.Json`, so storing it in the domain model and serializing to file is clean and automatically handles the full round-trip.  
+- The API request/response uses `string` to allow a clean `HH:mm` format without requiring clients to know the seconds component.  
+- Server-local time is used (per clarification); no timezone offset in the value.
+
+**Alternatives considered**:
+- Storing as `int` minutes-from-midnight: simpler but less readable in the JSON persistence files (which are debug-friendly and `WriteIndented`).
+- Using `DateTimeOffset` with a specific date: overly complex for a time-of-day value.
+
+---
+
+## Decision 5: Execution order in `QueueExecutionService.RunAsync`
+
+**Decision**: Pre-partition the template entry snapshot into three ordered lists at run start:
+- `oncPerRunSnapshot`: entries with `ScheduleType.OncePerRun`
+- `everyStepSnapshot`: entries with `ScheduleType.EveryStep`
+- `timerSnapshot`: entries with `ScheduleType.Timer` (carrying index for timer-state dictionary)
+
+The execution loop per iteration:
+1. Evaluate all `timerSnapshot` entries against today's time; fire any that are due and haven't yet fired today.
+2. For each entry in `oncPerRunSnapshot`: execute it, then immediately execute all `everyStepSnapshot` entries in order.
+3. If `oncPerRunSnapshot` is empty but `everyStepSnapshot` is non-empty: execute every-step entries once (edge case — FR-009).
+4. Increment `cycles`; loop if `queue.CycleExecution`.
+
+**Rationale**: Pre-partitioning avoids per-step type checks in the inner loop and makes the scheduling semantics explicit and testable independently per partition.
+
+**Alternatives considered**:
+- Inline type check inside a single `foreach` loop: harder to reason about and test.
+
+---
+
+## Decision 6: `ScheduleType` C# representation
+
+**Decision**: `ScheduleType` is a C# `enum` with `[JsonConverter(typeof(JsonStringEnumConverter))]` applied so it serializes as `"OncePerRun"` / `"EveryStep"` / `"Timer"` in JSON (both in the file-based persistence and API responses). Default value is `ScheduleType.OncePerRun` (= 0) for backward compatibility: existing entries with no `ScheduleType` field in JSON deserialize to the default.
+
+**Rationale**: String-serialized enums are readable in the project's debug-friendly `WriteIndented` JSON files. The default-to-`OncePerRun` at the C# default-value level guarantees backward compatibility with persisted templates that predate this feature (no migration needed).
+
+**Alternatives considered**:
+- Integer-backed enum: less readable in persisted JSON files.
+- Plain `string` property: loses compile-time exhaustiveness checking.

--- a/specs/053-schedulable-sequences/spec.md
+++ b/specs/053-schedulable-sequences/spec.md
@@ -1,0 +1,193 @@
+# Feature Specification: Queue Sequence Scheduling
+
+**Feature Branch**: `053-schedulable-sequences`  
+**Created**: 2026-06-03  
+**Status**: Draft  
+**Input**: User description: "I want make a sequences in the queues schedulable. There should be following types of schedules: 1. Once per queue run (current implementation) 2. Every step - the sequences that are marked this way, will be executed after every step. These sequences do not count towards the steps needed to be performed to complete the queue execution run. If the last step of the queue is executed, these sequences are executed for the last time and the queue run ends. 3. Scheduled per timer - if a certain sequence is scheduled to run at a given time, it's execution should be done at the beginning of the queue, but only after the time has passed. If two sequences are scheduled to be executed at the same time, then the order is not important, so for example the last one to be scheduled will be executed first. These types of scheduling has to be configurable within template via API and UI."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Set schedule types on template entries and observe different execution behaviors (Priority: P1)
+
+An operator editing a queue template assigns one of three schedule types to each sequence entry: "once-per-run" (the default), "every-step", or "timer". When the queue runs, each sequence fires according to its type: once-per-run sequences execute in the normal order; every-step sequences execute automatically after each once-per-run sequence; timer sequences execute at the start of the next queue iteration once their scheduled time has passed. The operator can configure schedule types both in the queue template editor UI and through the API.
+
+**Why this priority**: This is the foundation of the feature. Without schedule-type configuration being persisted and respected at runtime, none of the individual scheduling behaviors can be observed or tested independently.
+
+**Independent Test**: Create a template with three entries — one "once-per-run", one "every-step", and one "timer" (set to fire immediately or in the past) — start the queue, and confirm the every-step sequence runs after the once-per-run step and the timer sequence runs before it at the start of the iteration.
+
+**Acceptance Scenarios**:
+
+1. **Given** a template entry with schedule type "once-per-run", **When** the queue runs, **Then** the sequence executes once per cycle in its normal position within the template order.
+2. **Given** a template entry with schedule type "every-step", **When** the queue runs through its regular steps, **Then** that sequence executes after each once-per-run step, including after the final step.
+3. **Given** a template entry with schedule type "timer" and a scheduled time that has already passed, **When** the queue starts a new iteration, **Then** the timer sequence executes at the beginning of that iteration before any once-per-run steps.
+4. **Given** a template entry with no schedule type explicitly set, **When** the queue runs, **Then** the entry behaves as "once-per-run" (the default).
+5. **Given** schedule types configured via the API on a template, **When** the queue editor is opened, **Then** the configured types are displayed correctly and can be changed through the UI.
+
+---
+
+### User Story 2 - "Every-step" sequences run after every regular step and on queue completion (Priority: P1)
+
+An operator marks a monitoring or bookkeeping sequence as "every-step" so it runs automatically after each regular sequence in the queue. The every-step sequences do not count toward completing the queue run — the run ends when all once-per-run steps have executed — but they do execute one final time after the last step before the run finishes (or the next cycle begins).
+
+**Why this priority**: This schedule type supports continuous background tasks (health checks, UI refreshes, resource monitors) that must run throughout the entire queue execution without the operator manually inserting them between every regular step.
+
+**Independent Test**: Create a template with two "once-per-run" sequences (A, B) and one "every-step" sequence (C). Start the queue (no cycle). Observe that C executes after A, then C executes after B, and then the queue ends — C ran twice total, and the run is "completed full run" once A and B both finished.
+
+**Acceptance Scenarios**:
+
+1. **Given** a template with once-per-run steps A, B and an every-step sequence C, **When** the queue runs without cycle execution, **Then** the execution order is: A → C → B → C, and the run ends after the second C.
+2. **Given** the queue from scenario 1, **When** the run ends, **Then** the run's stop reason is "completed full run" and C's executions are visible in the execution log but do not extend the run's required step count.
+3. **Given** a template with no once-per-run steps and one every-step sequence, **When** the queue runs, **Then** the every-step sequence executes exactly once (it is the "last step") and the run ends — the system does not loop indefinitely.
+4. **Given** multiple every-step sequences in the template, **When** the queue runs past one regular step, **Then** all every-step sequences execute after that step, in their template order.
+5. **Given** cycle execution enabled and once-per-run steps A, B with every-step sequence C, **When** the queue cycles, **Then** each cycle follows A → C → B → C and starts again until stopped.
+
+---
+
+### User Story 3 - Timer-scheduled sequences fire at the start of the next iteration when their time is due (Priority: P1)
+
+An operator schedules a sequence to run at a recurring interval or specific time. While the queue is running, the system checks timer-scheduled sequences at the beginning of each queue iteration. Any sequence whose timer has elapsed is executed before the regular steps of that iteration begin. If the queue is non-cyclic and the timer has not elapsed by the time the run completes, the timer sequence never fires during that run.
+
+**Why this priority**: Timer scheduling enables periodic actions — collecting in-game resources, submitting daily tasks — without requiring the operator to structure the queue solely around timing. It depends only on schedule type storage (US1) and is independently valuable.
+
+**Independent Test**: Set a timer sequence to a wall-clock time that is one minute from now (server local time). Start a cyclic queue with once-per-run steps that take a few seconds each per cycle. Observe that the timer sequence does not fire on the first iteration (time not yet passed), then fires at the start of the first iteration boundary after the scheduled time passes, and does not fire again during the same run.
+
+**Acceptance Scenarios**:
+
+1. **Given** a timer-scheduled sequence whose time has passed at the moment the queue starts a new iteration, **When** the iteration begins, **Then** the timer sequence executes before any once-per-run steps of that iteration.
+2. **Given** a timer-scheduled sequence whose time has not yet passed, **When** the iteration begins, **Then** the timer sequence is skipped for that iteration and checked again at the start of the next one.
+3. **Given** two timer sequences both due at the same time, **When** the iteration begins, **Then** both execute before the regular steps; their relative execution order is unspecified.
+4. **Given** a non-cyclic queue with a timer sequence that has not elapsed by the time all once-per-run steps finish, **When** the run ends, **Then** the timer sequence was never executed during that run and the run ends normally.
+5. **Given** timer sequences and every-step sequences both present, **When** an iteration begins, **Then** timer sequences fire first (at iteration start), then regular steps proceed, each followed by every-step sequences.
+
+---
+
+### User Story 4 - Configure schedule types via the API (Priority: P2)
+
+A developer or automation script creates or updates a queue template through the API, setting the schedule type for each sequence entry (once-per-run, every-step, or timer with its schedule parameter). The schedule type and any associated schedule parameter are persisted as part of the template entry and are retrievable through the same API.
+
+**Why this priority**: API configurability is required alongside UI configurability as an explicit feature requirement, and enables programmatic template management without a UI.
+
+**Independent Test**: Create a template via API with one entry of each schedule type; retrieve the template via API and confirm each entry's schedule type and timer parameter (if applicable) are returned correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a POST or PUT to the template entry endpoint with a `scheduleType` of "every-step", **When** the template is retrieved, **Then** the entry's schedule type is "every-step".
+2. **Given** a POST or PUT with `scheduleType` of "timer" and a schedule parameter, **When** the template is retrieved, **Then** both the schedule type and parameter are returned unchanged.
+3. **Given** a POST or PUT with no `scheduleType` field, **When** the template is retrieved, **Then** the entry defaults to "once-per-run".
+4. **Given** an invalid `scheduleType` value, **When** the request is submitted, **Then** the API rejects it with a clear validation error.
+
+---
+
+### Edge Cases
+
+- **All entries are "every-step"**: No once-per-run steps exist. The every-step sequences execute exactly once (there is one implicit "completion point" with zero regular steps before it) and the run ends without looping.
+- **All entries are "timer"**: No once-per-run or every-step sequences. Timer sequences fire if due at the start of the first (and only) iteration; the run ends immediately after because there are no regular steps to execute.
+- **Timer fires during a running step**: Timer sequences are only checked at iteration boundaries (beginning of each cycle), never mid-step. A timer that becomes due while a regular step is executing waits until the next iteration boundary.
+- **Every-step sequence fails**: Per the existing failure policy (FR-008 of spec 051), every-step sequence failures are non-fatal. The run records the failure in the nested entry and continues with the next step.
+- **Timer-scheduled sequence fires when the queue is about to end**: If the last iteration's regular steps complete and there are due timer sequences, the timer sequences still fire before the run closes (at the iteration start of the final cycle). However, if the queue is non-cyclic and ends, timer sequences that became due after the last regular step started do not fire mid-step.
+- **Very frequent timer (shorter interval than a single step's duration)**: The timer sequence fires at most once per iteration boundary, even if the interval has elapsed multiple times during a long step. It fires exactly once per due period, not once per missed interval.
+- **Cycle execution off, timer not yet due**: A non-cyclic queue with a timer sequence completes without ever executing the timer sequence if the timer does not elapse before all regular steps finish.
+- **Template has no entries**: The queue run completes immediately ("completed full run") with no sequences executed, consistent with existing empty-template behavior.
+- **Reordering entries changes every-step execution order**: Moving an every-step entry up or down in the template changes the order it executes relative to other every-step entries (they all fire after each regular step, in their template order).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Schedule types
+
+- **FR-001**: System MUST support three schedule types for each sequence entry in a queue template: **"once-per-run"** (default), **"every-step"**, and **"timer"**.
+- **FR-002**: System MUST default to "once-per-run" when no schedule type is specified for a template entry, preserving existing behavior.
+- **FR-003**: A "timer"-type entry MUST carry a schedule parameter defining a wall-clock time-of-day (e.g., 15:30) in server local time at which the sequence is due. The sequence fires at most once per calendar day during the run: if the queue is running and an iteration boundary occurs after that time has passed today (server local clock), the sequence executes. The "already fired" state is tracked per calendar date and is per-run only — it resets when the queue is restarted; if the queue is stopped and restarted on the same day, the timer may fire again in the new run. Recurring-interval and elapsed-duration timer types are out of scope for this iteration.
+- **FR-004**: System MUST persist the schedule type and any associated timer parameter as part of the template entry, so that the configuration survives service restarts and is shared across all queues that load the template.
+
+#### Execution of "once-per-run" sequences
+
+- **FR-005**: "Once-per-run" sequences MUST execute in their template order, one after another, as they do today. This type represents the normal queue step and defines what counts as a "step" for the purposes of "every-step" sequencing.
+
+#### Execution of "every-step" sequences
+
+- **FR-006**: "Every-step" sequences MUST execute after every "once-per-run" sequence completes, in their template order among other every-step entries, before the next once-per-run step begins.
+- **FR-007**: "Every-step" sequences MUST also execute after the final once-per-run step, before the run ends or the next cycle begins.
+- **FR-008**: "Every-step" sequences MUST NOT count toward the queue run's completion. The run is considered complete (or a cycle complete) when all once-per-run sequences have executed, regardless of how many times every-step sequences ran.
+- **FR-009**: If there are no once-per-run entries in the template, every-step sequences MUST execute exactly once (as if the zero regular steps have "all" been completed), and the run ends.
+- **FR-010**: Every-step sequence failures MUST be non-fatal to the queue run, consistent with the existing per-sequence failure policy (non-fatal, recorded in nested execution log, run continues).
+
+#### Execution of "timer" sequences
+
+- **FR-011**: Timer-scheduled sequences MUST be evaluated at the beginning of each queue iteration (before any once-per-run step in that iteration is executed).
+- **FR-012**: A timer sequence MUST execute in that iteration if and only if its scheduled time has passed by the time the iteration begins AND the sequence has not already fired on today's calendar date during this run (per FR-003). If not yet due, or already fired today in this run, the sequence is skipped for that iteration and re-evaluated at the start of the next.
+- **FR-013**: When multiple timer sequences are due at the start of the same iteration, all of them MUST execute before any once-per-run step, and their relative order among themselves is unspecified (the system may execute them in any order).
+- **FR-014**: Timer sequences MUST NOT interrupt a currently executing step; they are only checked at iteration boundaries.
+- **FR-015**: Timer sequence failures MUST be non-fatal to the queue run, consistent with the existing per-sequence failure policy.
+
+#### Interaction between schedule types in a single iteration
+
+- **FR-016**: Within each iteration, the execution order MUST be: (1) due timer sequences (in any order), (2) the next once-per-run sequence, (3) all every-step sequences (in template order). This group of (2)+(3) repeats for each once-per-run step, with timer sequences evaluated exactly once at the iteration start and never again between subsequent once-per-run or every-step executions within that iteration.
+
+*(FR-017 merged into FR-016 during spec clarification — no gap in coverage.)*
+
+#### Configuration via API
+
+- **FR-018**: The template entry API (create and update) MUST accept a `scheduleType` field with values "once-per-run", "every-step", and "timer".
+- **FR-019**: For "timer" entries, the API MUST accept and validate the associated schedule parameter alongside the entry.
+- **FR-020**: The template entry API (read) MUST return the `scheduleType` and schedule parameter for each entry.
+- **FR-021**: The API MUST reject invalid schedule type values with a descriptive validation error.
+
+#### Configuration via UI
+
+- **FR-022**: The queue template editor UI MUST allow the operator to set the schedule type for each sequence entry.
+- **FR-023**: For "timer" schedule type, the UI MUST provide input for the associated schedule parameter.
+- **FR-024**: The UI MUST visually distinguish entries of different schedule types (e.g., a label, icon, or badge) so the operator can see at a glance which entries are "every-step" or "timer" without opening each entry.
+
+### Key Entities *(include if feature involves data)*
+
+- **Template Entry (updated)**: An ordered reference to a sequence within a queue template, extended with a `scheduleType` field ("once-per-run" | "every-step" | "timer") and, for timer entries, an associated schedule parameter. Other template entry attributes are unchanged.
+- **Queue Run Iteration**: One pass through the template's once-per-run steps within a queue execution. Timer sequences are evaluated once per iteration start; every-step sequences execute once per regular step within the iteration.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every "every-step" sequence in a template executes exactly once after each "once-per-run" step and exactly once after the final step in 100% of queue runs, regardless of whether cycle execution is on or off.
+- **SC-002**: Every-step sequences never appear in the queue run's step-completion count: a run with N once-per-run sequences and M every-step sequences reports completing N steps, not N×(M+1) or any other inflated count.
+- **SC-003**: A timer-scheduled sequence whose time is past executes at the start of the next iteration in 100% of runs that include a new iteration after the time elapses.
+- **SC-004**: A timer-scheduled sequence whose time has not elapsed during a non-cyclic run is never executed — 0 executions — in 100% of such runs.
+- **SC-005**: When multiple timer sequences are simultaneously due, all of them execute before any regular step in the same iteration in 100% of such cases.
+- **SC-006**: Schedule types configured via the API are reflected correctly in the UI editor, and schedule types set in the UI are persisted and returned correctly by the API, in 100% of cases.
+- **SC-007**: Operators can configure schedule types for all template entries, view their current types at a glance, and save the configuration — completing the full workflow in the template editor in under 2 minutes for a template with up to 20 entries.
+- **SC-008**: The introduction of schedule types does not change the behavior of existing templates: all entries that had no explicit schedule type continue to execute as "once-per-run" in 100% of existing queues.
+
+## Assumptions
+
+- **"Step" defined as once-per-run execution**: In the context of "every-step" scheduling, a "step" is one execution of a once-per-run sequence. Every-step sequences themselves do not trigger additional every-step executions (no cascading).
+- **Iteration boundary = cycle boundary**: For cyclic queues, "beginning of the queue" means the start of each cycle. For non-cyclic queues, there is one iteration (and one iteration boundary at the very start).
+- **Timer check is once per iteration start**: Timers are evaluated only at the iteration boundary, never mid-step. A timer that becomes due while a step is executing fires at the next iteration boundary.
+- **Timer parameter is a wall-clock time-of-day in server local time**: The timer schedule parameter specifies a time-of-day (hours and minutes) evaluated against the server's local clock. The sequence fires at most once per calendar day during the run: when an iteration boundary occurs after that time has passed today (server local time) and the sequence has not already fired on that calendar date in this run, the sequence executes. The "already fired" state is tracked per calendar date and is per-run only — it resets when the queue is restarted; if the queue is stopped and restarted on the same day, the timer may fire again in the new run.
+- **Every-step sequences in template order**: When multiple every-step sequences exist, they execute in the order they appear in the template (relative to each other), after each regular step.
+- **Failure policy unchanged**: Every-step and timer sequence failures follow the existing non-fatal policy (FR-008 of spec 051): recorded in nested execution log entries, run continues.
+- **No cascading every-step triggers**: An every-step sequence completing does not trigger other every-step sequences; every-step sequences fire only after once-per-run sequences.
+- **Templates are the authoring point**: Schedule type is a property of the template entry. When a template is loaded into a queue, the schedule types are copied as part of the template's entries and behave accordingly at runtime.
+- **Backward compatibility**: Existing templates and queue entries without a schedule type field are treated as "once-per-run", preserving current behavior without requiring migration.
+- **Scale**: Operator-scale consistent with existing queue features: up to ~50 templates, ~100 entries each, ~10 every-step sequences per template.
+
+## Clarifications
+
+### Session 2026-06-03
+
+- Q: What is the timer schedule parameter — recurring interval, wall-clock time-of-day, or elapsed duration from queue start? → A: Wall-clock time-of-day (e.g., 15:30) is the MVP timer type. Recurring intervals and elapsed-duration timers are deferred to future iterations.
+- Q: What timezone is used when evaluating the wall-clock timer? → A: Server local time (machine clock timezone); no per-entry or per-template timezone configuration.
+- Q: If a queue is stopped and restarted on the same day after a timer sequence has already fired, does the timer fire again? → A: Yes — "fired today" state is per-run only and resets on restart; the timer may fire again in the new run on the same calendar day.
+
+## Out of Scope
+
+- Schedule types other than "once-per-run", "every-step", and "timer" (e.g., "on-event", "conditional", "random").
+- Recurring-interval timer scheduling (e.g., every N seconds/minutes) — deferred to a future iteration.
+- Elapsed-duration timer scheduling (e.g., fire N seconds after the queue run starts) — deferred to a future iteration.
+- Scheduling at the queue level (e.g., automatically starting a queue at a given time); this feature schedules sequences within a running queue, not queue start/stop.
+- Priority ordering among every-step sequences beyond their template position (no per-sequence priority field).
+- Pausing or skipping a timer sequence without removing it from the template.
+- Making the timer parameter dynamic at runtime (e.g., an operator cannot change the timer's schedule while the queue is running without editing the template).
+- Per-sequence retry or backoff policies for every-step or timer sequences.
+- Granular execution-log filtering by schedule type (logs record all executions consistently; filtering is out of scope for this feature).
+- Any change to how individual sequences execute internally (steps, conditions, loops, waits); only the scheduling/ordering of sequences within a queue run is in scope.

--- a/specs/053-schedulable-sequences/tasks.md
+++ b/specs/053-schedulable-sequences/tasks.md
@@ -1,0 +1,250 @@
+# Tasks: Queue Sequence Scheduling
+
+**Input**: Design documents from `specs/053-schedulable-sequences/`  
+**Prerequisites**: plan.md ✅ · spec.md ✅ · research.md ✅ · data-model.md ✅ · contracts/ ✅
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other [P] tasks in the same phase (different files, no blocking deps)
+- **[Story]**: User story label from spec.md (US1–US4)
+- All paths are relative to the repository root
+
+---
+
+## Phase 1: Setup (Baseline Verification)
+
+**Purpose**: Confirm the existing build and tests are green before any changes.
+
+- [X] T001 Verify `dotnet build` succeeds and `dotnet test tests/unit` passes — record baseline (no file changes; gate check only)
+- [X] T002 Verify `vite build` succeeds in `src/web-ui/` — record baseline
+
+---
+
+## Phase 2: Foundational — Domain Model & API Contracts
+
+**Purpose**: Extend `QueueTemplateEntry` with schedule type and update the API layer. Every subsequent phase depends on these changes.
+
+**⚠️ CRITICAL**: No user-story work can begin until this phase is complete.
+
+### 2A: Domain types (blocks all execution and UI work)
+
+- [X] T003 Create `ScheduleType` enum with `[JsonConverter(typeof(JsonStringEnumConverter))]` in `src/GameBot.Domain/QueueTemplates/ScheduleType.cs` — values: `OncePerRun = 0`, `EveryStep = 1`, `Timer = 2`; add XML `<summary>` to the enum declaration and each member describing its execution semantics
+- [X] T004 Extend `QueueTemplateEntry` with `public ScheduleType ScheduleType { get; set; } = ScheduleType.OncePerRun;` and `public TimeOnly? TimerTimeOfDay { get; set; }` in `src/GameBot.Domain/QueueTemplates/QueueTemplateEntry.cs`; update XML summary for both new properties
+
+### 2B: API contracts (depends on T003–T004; [P] tasks are independent of each other)
+
+- [X] T005 [P] Create `TemplateEntrySaveRequest` with `string? SequenceId`, `string? ScheduleType`, `string? TimerTimeOfDay` in `src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs`
+- [X] T006 [P] Replace `string[]? SequenceIds` with `TemplateEntrySaveRequest[]? Entries` in `src/GameBot.Service/Contracts/QueueTemplates/SaveQueueTemplateRequest.cs`
+- [X] T007 [P] Add `string ScheduleType { get; set; }` and `string? TimerTimeOfDay { get; set; }` to `QueueTemplateEntryResponse` in `src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs`
+
+### 2C: Endpoint handler (depends on T005–T007)
+
+- [X] T008 Replace `foreach (var sid in req.SequenceIds)` loop with loop over `req.Entries`, parsing `ScheduleType` string to enum and `TimerTimeOfDay` string to `TimeOnly?`, in `src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs` (`SaveQueueTemplate` handler)
+- [X] T009 Add per-entry validation in `src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs`: `SequenceId` non-blank; `ScheduleType` is a recognized value; when `Timer`, `TimerTimeOfDay` must be present and match `HH:mm`; return 400 with descriptive message on failure
+- [X] T010 Update `BuildDetailAsync` in `src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs` to populate `ScheduleType` (as string) and `TimerTimeOfDay` (`HH:mm` string or null) in each `QueueTemplateEntryResponse`
+
+### 2D: Update existing integration tests for new request shape (depends on T008–T010)
+
+- [X] T011 Update all existing calls to `POST /api/queue-templates` in `tests/integration/QueueTemplates/QueueTemplatesSaveEndpointTests.cs` to use `entries: [{ sequenceId: "..." }]` instead of `sequenceIds: [...]`
+
+**Checkpoint**: `dotnet build` clean; `dotnet test` passes (existing tests updated and green)
+
+---
+
+## Phase 3: User Story 2 — Every-Step Execution (Priority: P1)
+
+**Goal**: Sequences marked `EveryStep` execute after each once-per-run step (and after the final step) without counting toward run completion.
+
+**Independent Test**: Template with once-per-run steps A, B and every-step sequence C → execution order A → C → B → C; run ends as "completed full run"; `executed` count = 2, not 4.
+
+### Implementation for User Story 2
+
+- [X] T012 [US2] Pre-partition `template.Entries` into three lists at snapshot time — `oncePerRunEntries`, `everyStepEntries`, `timerEntries` — replacing the existing `snapshot` list in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (line ~114)
+- [X] T013 [US2] Refactor the `foreach (var sequenceId in snapshot)` inner loop in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` to iterate `oncePerRunEntries` and, after each, run all `everyStepEntries` in order; increment `executed` for once-per-run only (not every-step)
+- [X] T014 [US2] Add the `else if (everyStepEntries.Count > 0)` branch in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` for the edge case where there are no once-per-run entries: run every-step sequences once and end (FR-009)
+- [X] T015 [US2] Add unit tests covering every-step scenarios in `tests/unit/Queues/QueueExecutionServiceTests.cs`:
+  - Every-step fires after each once-per-run step and after the last
+  - `executed` count reflects only once-per-run sequences
+  - No once-per-run entries: every-step runs exactly once
+  - Multiple every-step sequences run in template order after each step
+  - Every-step failure is non-fatal; run continues
+
+**Checkpoint**: Every-step scheduling works independently; T015 tests pass; `dotnet build` clean
+
+---
+
+## Phase 4: User Story 3 — Timer Execution (Priority: P1)
+
+**Goal**: Sequences marked `Timer` fire at the start of an iteration when their wall-clock time (server local) has passed, at most once per calendar day per run.
+
+**Independent Test**: Timer time set to one minute ago → fires on first iteration before once-per-run steps; same timer → skipped on all subsequent iterations that same day; timer time set to tomorrow → never fires during a non-cyclic run.
+
+### Implementation for User Story 3
+
+- [X] T016 [US3] Declare and initialize `var timerFiredDate = new Dictionary<int, DateOnly>();` **outside and before the `do {` keyword** (inside the `if (sessionId is not null)` block, after the partition lists) in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` — it must persist across all cycles of the same run; placing it inside the `do { }` body would reset it every cycle and break the once-per-calendar-day invariant
+- [X] T017 [US3] Add timer evaluation at the top of the `do` loop in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`: for each `timerEntries[i]` where `TimerTimeOfDay` is set, check `TimeOnly.FromDateTime(DateTime.Now) >= entry.TimerTimeOfDay.Value` and `timerFiredDate` does not contain today's date for index `i`; if due, call `RunOneSequenceAsync`, record `timerFiredDate[i] = today`; timer executions are NOT counted toward `executed`
+- [X] T018 [US3] Add unit tests covering timer scenarios in `tests/unit/Queues/QueueExecutionServiceTests.cs`:
+  - Timer past due → fires once on first iteration
+  - Timer not yet due → never fires in non-cyclic run
+  - Timer fires once per calendar day in multi-iteration run (second iteration same day → skipped)
+  - Timer fires again on next calendar day (simulate day change)
+  - Multiple simultaneously-due timers → all fire before regular steps
+  - Timer failure is non-fatal; run continues
+  - Timer with every-step: timers fire first at iteration start, then regular + every-step pattern follows
+
+**Checkpoint**: Timer scheduling works independently; T018 tests pass; `dotnet build` clean
+
+---
+
+## Phase 5: User Story 1 — Integration Verification & UI (Priority: P1)
+
+**Goal**: All three schedule types are configurable in the template editor UI and observable end-to-end when a queue runs.
+
+**Independent Test**: Create template via UI with all three schedule types, save, reload — types persist. Start queue; observe timer fires first, then once-per-run, then every-step in the execution log.
+
+### 5A: Frontend type updates (depends on T007, parallelizable among themselves)
+
+- [X] T019 [P] [US1] Add `scheduleType: string` and `timerTimeOfDay: string | null` to `QueueTemplateEntryDto`, and define `TemplateEntrySaveDto { sequenceId: string; scheduleType?: string; timerTimeOfDay?: string }` in `src/web-ui/src/services/queueTemplates.ts`; update `saveQueueTemplate` to send `entries` array instead of `sequenceIds`
+
+### 5B: UI schedule type selector (depends on T019)
+
+- [X] T020 [US1] Add per-entry schedule-type state (`Map<entryId, { scheduleType, timerTimeOfDay }>`) to the queue editor's local state in `src/web-ui/src/pages/QueuesPage.tsx`; initialize from loaded template entries when a template is loaded
+- [X] T021 [US1] Add a `scheduleType` prop and `onScheduleTypeChange`/`onTimerTimeChange` callbacks to `QueueEntryList` component signature in `src/web-ui/src/components/queues/QueueEntryList.tsx`
+- [X] T022 [US1] Add per-entry schedule type dropdown (Once Per Run / Every Step / Timer) to each entry row in `src/web-ui/src/components/queues/QueueEntryList.tsx`; show a conditional `<input type="time">` when Timer is selected
+- [X] T023 [US1] Add schedule type badges (`EveryStep` and `Timer` entries show a visual chip/label; `OncePerRun` shows nothing extra) to the entry display in `src/web-ui/src/components/queues/QueueEntryList.tsx` (FR-024)
+- [X] T024 [US1] Wire `QueuesPage` save-template flow to collect schedule types from per-entry state and pass them to `saveQueueTemplate` via `entries` array in `src/web-ui/src/pages/QueuesPage.tsx`; wire template-load to restore schedule types into per-entry state
+
+### 5C: Integration test (depends on T008–T010, T013, T017)
+
+- [X] T025 [US1] Create `tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs` with tests:
+  - Save template with `EveryStep` entry → GET returns `scheduleType: "EveryStep"`, `timerTimeOfDay: null`
+  - Save template with `Timer` entry and `timerTimeOfDay: "15:30"` → GET returns both fields correctly
+  - Omit `scheduleType` → GET returns `"OncePerRun"` (default)
+  - Reload after restart → schedule types persisted in JSON
+
+**Checkpoint**: All three schedule types configurable in UI and API; schedule type info persists and round-trips; T025 tests pass
+
+---
+
+## Phase 6: User Story 4 — API Validation Edge Cases (Priority: P2)
+
+**Goal**: The API rejects invalid schedule-type configurations with clear error messages.
+
+**Independent Test**: POST with `Timer` entry and no `timerTimeOfDay` → 400 with descriptive error. POST with unrecognized `scheduleType` → 400.
+
+- [X] T026 [P] [US4] Add integration test: `Timer` entry missing `timerTimeOfDay` → 400 `invalid_request` in `tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs`
+- [X] T027 [P] [US4] Add integration test: unrecognized `scheduleType` string (e.g. `"Weekly"`) → 400 `invalid_request` in `tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs`
+- [X] T028 [P] [US4] Add integration test: entry with blank `sequenceId` → 400 `invalid_request` in `tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs`
+- [X] T029 [P] [US4] Add integration test: existing pre-feature template file (no `scheduleType` field) → GET returns `"OncePerRun"` for all entries (backward compatibility) in `tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs`
+
+**Checkpoint**: All validation edge cases covered; `dotnet test tests/integration` passes
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T030 Update `BuildSummary` in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` to note when every-step or timer sequences ran (e.g., append "N every-step execution(s)" to the completed-full-run summary line when applicable)
+- [X] T031 [P] Add Jest tests for updated `QueueEntryList` in `src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx`: schedule type dropdown renders; Timer selected shows time input; EveryStep badge shows; OncePerRun shows no badge
+- [X] T032 Run `vite build` and fix any TypeScript errors introduced by the new props and types in `src/web-ui/`
+- [X] T033 Execute the quickstart.md end-to-end verification steps (save template with all three types via API → GET → load into queue → start → check execution log)
+- [X] T034 Manually time the schedule-type configuration workflow in the UI using a 20-entry template: open queue editor → load/configure all three schedule types → save template → verify round-trip; confirm the complete workflow takes under 2 minutes (SC-007)
+- [X] T035 Run full test suite — `dotnet test` (unit + integration + contract) + `npm test` in `src/web-ui/` — confirm all pass and no coverage regressions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (Setup/Baseline)
+  └─▶ Phase 2 (Foundational: domain + API) — BLOCKS all story phases
+        ├─▶ Phase 3 (US2: every-step execution)
+        │     └─▶ Phase 4 (US3: timer execution) [can also start after Phase 2]
+        │           └─▶ Phase 5 (US1: integration + UI) [needs Phase 3 + 4 for execution tests]
+        ├─▶ Phase 6 (US4: API validation tests) [can start after Phase 2 independently]
+        └─▶ Phase 7 (Polish) [after all story phases]
+```
+
+### User Story Dependencies
+
+- **US2 (Phase 3)**: Depends on Phase 2. No dependency on US3, US4.
+- **US3 (Phase 4)**: Depends on Phase 2. No dependency on US2 (but shares `RunAsync` changes — complete Phase 3 first to avoid merge conflicts).
+- **US1 (Phase 5)**: Depends on Phase 2 (API), Phase 3 (every-step), Phase 4 (timer) for full integration test. UI tasks depend only on Phase 2 (TypeScript types).
+- **US4 (Phase 6)**: Depends on Phase 2 (endpoint handler). Fully independent of Phase 3–5.
+
+### Within Each Phase
+
+- Domain types before contracts (T003 → T004 → T005/T006/T007)
+- Contracts before endpoint handler (T005–T007 → T008–T010)
+- Endpoint handler before integration tests (T008–T010 → T011, T025)
+- Pre-partitioning before every-step loop (T012 → T013 → T014 → T015)
+- Pre-partitioning before timer evaluation (T012 must precede T017; T016 can start after T003)
+- TypeScript types before UI state (T019 → T020 → T021–T024)
+
+### Parallel Opportunities Within Phases
+
+**Phase 2**: After T003–T004, tasks T005, T006, T007 can run in parallel (different files).  
+**Phase 5**: T019 runs first; then T020–T024 can proceed with T020 first, T021–T023 in parallel after T020, T024 after T021.  
+**Phase 6**: All four test tasks T026–T029 can run in parallel (same file, separate test methods — commit sequentially).  
+**Phase 7**: T031 and T032 can run in parallel with T030.
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```text
+# Sequential: domain types first
+T003 → T004 (ScheduleType enum → QueueTemplateEntry extension)
+
+# Then parallel: all three contract files at once
+T005  T006  T007
+ ↓     ↓     ↓
+TemplateEntrySaveRequest  SaveQueueTemplateRequest  QueueTemplateEntryResponse
+
+# Then sequential: endpoint handler needs all contracts
+T008 → T009 → T010 → T011
+```
+
+## Parallel Example: Phase 5 (UI)
+
+```text
+# T019 first (TypeScript types)
+T019 (queueTemplates.ts types)
+  ↓
+T020 (QueuesPage per-entry state)
+  ↓
+T021  T022  T023       ← parallel (different parts of QueueEntryList)
+  ↓    ↓    ↓
+T024 (QueuesPage save-template wiring — after T020–T023)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (Phase 2 + Phase 3 only)
+
+1. Complete Phase 1: baseline verification
+2. Complete Phase 2: domain model + API → templates now accept and return `scheduleType`
+3. Complete Phase 3: every-step execution → `EveryStep` sequences fire as designed
+4. **STOP and VALIDATE**: Verify every-step templates save, load, and execute correctly via API + quickstart  
+5. Minimum viable: every-step scheduling works end-to-end without UI changes
+
+### Full Incremental Delivery
+
+1. MVP (Phases 1–3) → every-step works
+2. Add Phase 4 (US3) → timer scheduling works
+3. Add Phase 5 (US1) → UI schedule configuration + full integration test
+4. Add Phase 6 (US4) → API validation hardened
+5. Phase 7 → polish and final gate
+
+---
+
+## Notes
+
+- [P] tasks operate on different files; commit each before starting the next to avoid conflicts in shared files (`QueueExecutionService.cs`, `QueueTemplatesEndpoints.cs`)
+- `FileQueueTemplateRepository` requires no changes — `System.Text.Json` auto-serializes new `QueueTemplateEntry` fields
+- Constitution requirement: methods use CamelCase only (no underscores) in all new C# code
+- Timer evaluation uses `DateTime.Now` (server local time per clarification); no UTC conversion needed
+- Backward compatibility is automatic: existing JSON template files without `ScheduleType` deserialize to `OncePerRun` (enum default = 0)

--- a/src/GameBot.Domain/QueueTemplates/QueueTemplateEntry.cs
+++ b/src/GameBot.Domain/QueueTemplates/QueueTemplateEntry.cs
@@ -1,10 +1,30 @@
+using System;
+
 namespace GameBot.Domain.QueueTemplates {
   /// <summary>
   /// A single, positional reference to a sequence within a <see cref="QueueTemplate"/>.
-  /// Only the sequence reference is persisted; the resolved display name and stale flag
-  /// are computed at read time. The same SequenceId may appear more than once in a template.
+  /// Only the sequence reference and schedule configuration are persisted; the resolved display
+  /// name and stale flag are computed at read time. The same SequenceId may appear more than once
+  /// in a template.
   /// </summary>
   public class QueueTemplateEntry {
+    /// <summary>ID of the referenced sequence.</summary>
     public string SequenceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Controls when this entry's sequence is executed during a queue run.
+    /// Defaults to <see cref="ScheduleType.OncePerRun"/>, preserving pre-feature behaviour for
+    /// entries that were persisted before schedule types were introduced.
+    /// </summary>
+    public ScheduleType ScheduleType { get; set; } = ScheduleType.OncePerRun;
+
+    /// <summary>
+    /// Wall-clock time-of-day (server local time) at which this entry fires when
+    /// <see cref="ScheduleType"/> is <see cref="ScheduleType.Timer"/>. Null for all other types.
+    /// The sequence executes at most once per calendar day: it fires at the first iteration
+    /// boundary after this time has passed today, provided it has not already fired today in the
+    /// current run.
+    /// </summary>
+    public TimeOnly? TimerTimeOfDay { get; set; }
   }
 }

--- a/src/GameBot.Domain/QueueTemplates/ScheduleType.cs
+++ b/src/GameBot.Domain/QueueTemplates/ScheduleType.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace GameBot.Domain.QueueTemplates {
+  /// <summary>
+  /// Determines when a sequence entry in a queue template is executed during a queue run.
+  /// </summary>
+  [JsonConverter(typeof(JsonStringEnumConverter))]
+  public enum ScheduleType {
+    /// <summary>
+    /// Default. Executes once per cycle in template order, as the normal queue step.
+    /// Completion of all OncePerRun steps signals the end of a cycle (or the full run when
+    /// cycle execution is disabled).
+    /// </summary>
+    OncePerRun = 0,
+
+    /// <summary>
+    /// Executes automatically after each OncePerRun sequence completes, and once more after the
+    /// final OncePerRun step. Does not count toward run completion. Multiple EveryStep entries
+    /// execute in their template order after each regular step.
+    /// </summary>
+    EveryStep = 1,
+
+    /// <summary>
+    /// Executes at most once per calendar day during the run. Evaluated at the start of each
+    /// iteration (before OncePerRun steps): fires when the configured wall-clock time-of-day
+    /// (server local time) has passed and the entry has not already fired on the current
+    /// calendar date within this run. Resets on queue restart.
+    /// </summary>
+    Timer = 2
+  }
+}

--- a/src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
+++ b/src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
@@ -14,5 +14,16 @@ namespace GameBot.Service.Contracts.QueueTemplates {
     public string SequenceId { get; set; } = string.Empty;
     public string? SequenceName { get; set; }
     public bool Stale { get; set; }
+
+    /// <summary>
+    /// Schedule type of this entry: "OncePerRun", "EveryStep", or "Timer".
+    /// </summary>
+    public string ScheduleType { get; set; } = "OncePerRun";
+
+    /// <summary>
+    /// Wall-clock time-of-day in HH:mm (24-hour) when <see cref="ScheduleType"/> is "Timer";
+    /// null otherwise.
+    /// </summary>
+    public string? TimerTimeOfDay { get; set; }
   }
 }

--- a/src/GameBot.Service/Contracts/QueueTemplates/SaveQueueTemplateRequest.cs
+++ b/src/GameBot.Service/Contracts/QueueTemplates/SaveQueueTemplateRequest.cs
@@ -6,7 +6,13 @@ namespace GameBot.Service.Contracts.QueueTemplates {
   /// </summary>
   internal sealed class SaveQueueTemplateRequest {
     public string? Name { get; set; }
-    public string[]? SequenceIds { get; set; }
+
+    /// <summary>
+    /// Ordered list of sequence entries to persist. Replaces the former <c>SequenceIds</c>
+    /// string array; each entry carries its sequence reference and optional schedule type.
+    /// </summary>
+    public TemplateEntrySaveRequest[]? Entries { get; set; }
+
     public bool Overwrite { get; set; }
   }
 }

--- a/src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs
+++ b/src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs
@@ -1,0 +1,22 @@
+namespace GameBot.Service.Contracts.QueueTemplates {
+  /// <summary>
+  /// A single entry in a <see cref="SaveQueueTemplateRequest"/>. Carries the sequence reference
+  /// and optional schedule configuration.
+  /// </summary>
+  internal sealed class TemplateEntrySaveRequest {
+    /// <summary>ID of the sequence to reference. Must be non-blank.</summary>
+    public string? SequenceId { get; set; }
+
+    /// <summary>
+    /// Schedule type string: "OncePerRun", "EveryStep", or "Timer".
+    /// When absent or null, defaults to "OncePerRun".
+    /// </summary>
+    public string? ScheduleType { get; set; }
+
+    /// <summary>
+    /// Required when <see cref="ScheduleType"/> is "Timer". Wall-clock time-of-day in HH:mm
+    /// (24-hour, server local time). Ignored for other schedule types.
+    /// </summary>
+    public string? TimerTimeOfDay { get; set; }
+  }
+}

--- a/src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs
@@ -29,6 +29,27 @@ internal static class QueueTemplatesEndpoints {
       var nameError = ValidateName(name);
       if (nameError is not null) return Error(400, "invalid_request", nameError);
 
+      // Validate each entry in the request
+      var entries = req!.Entries ?? Array.Empty<TemplateEntrySaveRequest>();
+      for (var i = 0; i < entries.Length; i++) {
+        var entry = entries[i];
+        if (string.IsNullOrWhiteSpace(entry.SequenceId))
+          return Error(400, "invalid_request", $"entries[{i}].sequenceId is required and must be non-blank");
+
+        if (!TryParseScheduleType(entry.ScheduleType, out var scheduleType))
+          return Error(400, "invalid_request",
+            $"entries[{i}].scheduleType '{entry.ScheduleType}' is not valid; accepted values: OncePerRun, EveryStep, Timer");
+
+        if (scheduleType == ScheduleType.Timer) {
+          if (string.IsNullOrWhiteSpace(entry.TimerTimeOfDay))
+            return Error(400, "invalid_request",
+              $"entries[{i}].timerTimeOfDay is required when scheduleType is Timer");
+          if (!TimeOnly.TryParseExact(entry.TimerTimeOfDay, "HH:mm", out _))
+            return Error(400, "invalid_request",
+              $"entries[{i}].timerTimeOfDay '{entry.TimerTimeOfDay}' is not a valid HH:mm time (e.g. '15:30')");
+        }
+      }
+
       var existing = await repo.FindByNameAsync(name!).ConfigureAwait(false);
       if (existing is not null && !req!.Overwrite) {
         return Error(409, "template_exists",
@@ -39,8 +60,20 @@ internal static class QueueTemplatesEndpoints {
       var target = existing ?? new QueueTemplate();
       target.Name = name!;
       target.Entries.Clear();
-      foreach (var sid in req!.SequenceIds ?? Array.Empty<string>()) {
-        target.Entries.Add(new QueueTemplateEntry { SequenceId = sid });
+      foreach (var entry in entries) {
+        // Schedule type already validated above; parse is guaranteed to succeed here.
+        var scheduleType = string.IsNullOrWhiteSpace(entry.ScheduleType)
+          ? ScheduleType.OncePerRun
+          : Enum.Parse<ScheduleType>(entry.ScheduleType, ignoreCase: true);
+        TimeOnly? timerTime = scheduleType == ScheduleType.Timer && !string.IsNullOrWhiteSpace(entry.TimerTimeOfDay)
+          ? TimeOnly.ParseExact(entry.TimerTimeOfDay!, "HH:mm")
+          : null;
+
+        target.Entries.Add(new QueueTemplateEntry {
+          SequenceId = entry.SequenceId!,
+          ScheduleType = scheduleType,
+          TimerTimeOfDay = timerTime
+        });
       }
 
       if (existing is null) {
@@ -74,6 +107,15 @@ internal static class QueueTemplatesEndpoints {
     return null;
   }
 
+  private static bool TryParseScheduleType(string? raw, out ScheduleType result) {
+    if (string.IsNullOrWhiteSpace(raw)) {
+      result = ScheduleType.OncePerRun;
+      return true;
+    }
+    return Enum.TryParse(raw, ignoreCase: true, out result)
+           && Enum.IsDefined(result);
+  }
+
   private static QueueTemplateSummaryResponse BuildSummary(QueueTemplate template) => new() {
     Id = template.Id,
     Name = template.Name,
@@ -97,7 +139,9 @@ internal static class QueueTemplatesEndpoints {
       detail.Entries.Add(new QueueTemplateEntryResponse {
         SequenceId = entry.SequenceId,
         SequenceName = found ? name : null,
-        Stale = !found
+        Stale = !found,
+        ScheduleType = entry.ScheduleType.ToString(),
+        TimerTimeOfDay = entry.TimerTimeOfDay?.ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture)
       });
     }
     return detail;

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -18,6 +18,11 @@ namespace GameBot.Service.Services.QueueExecution;
 /// Executes queues for real: loads the linked template, connects to the bound emulator, runs the
 /// template's sequences in order (optionally cycling), and writes one terminating queue-run
 /// execution-log entry with the stop reason. Replaces the placeholder start/stop behavior.
+///
+/// Schedule types:
+///   OncePerRun  — executed in template order as the regular "step"; defines run completion.
+///   EveryStep   — executed after each OncePerRun step (and after the final step); not counted.
+///   Timer       — evaluated at each iteration boundary; fires at most once per calendar day.
 /// </summary>
 internal sealed class QueueExecutionService : IQueueExecutionService {
   private readonly IQueueRepository _queues;
@@ -80,8 +85,6 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     catch (ObjectDisposedException) {
       // run already completed and disposed its CTS; nothing to cancel
     }
-    // Wait for the run to settle (disconnect + terminating entry + status reset) so callers
-    // observe a fully-stopped queue. The run aborts promptly, well within the stop budget.
     try {
       await handle.RunTask.ConfigureAwait(false);
     }
@@ -111,7 +114,11 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
         failureReason = "no template to run (the queue has no linked template, or it could not be resolved)";
       }
       else {
-        var snapshot = template.Entries.Select(e => e.SequenceId).ToList();
+        // Pre-partition entries by schedule type (FR-001). Snapshots taken once at run start.
+        var allEntries = template.Entries.ToList();
+        var oncePerRunEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.OncePerRun).ToList();
+        var everyStepEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.EveryStep).ToList();
+        var timerEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.Timer).ToList();
 
         // 2. Connect to the bound emulator (FR-003/FR-004).
         try {
@@ -127,24 +134,66 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
           failureReason = $"emulator could not be reached ('{queue.EmulatorSerial}'): {ex.Message}";
         }
 
-        // 3. Run the sequences in order, optionally cycling (FR-006/FR-014/FR-016/FR-017).
+        // 3. Run sequences in order, respecting schedule types, optionally cycling.
         if (sessionId is not null) {
           try {
-            if (snapshot.Count > 0) {
-              var index = 0;
+            var index = 0;
+
+            // Per-run timer state: maps timer-entry index → last-fired calendar date (FR-003/FR-012).
+            // Declared OUTSIDE the do-while loop so it persists across all cycles of this run.
+            var timerFiredDate = new Dictionary<int, DateOnly>();
+
+            if (oncePerRunEntries.Count > 0 || everyStepEntries.Count > 0 || timerEntries.Count > 0) {
               do {
                 ct.ThrowIfCancellationRequested();
-                foreach (var sequenceId in snapshot) {
-                  ct.ThrowIfCancellationRequested();
-                  // The emulator session vanishing mid-run is a run-level failure: remaining
-                  // sequences cannot run (FR-008a).
-                  if (_sessions.GetSession(sessionId) is null) {
-                    throw new QueueConnectionLostException();
+
+                // (a) Evaluate timer entries at iteration boundary (FR-011/FR-012/FR-016).
+                for (var ti = 0; ti < timerEntries.Count; ti++) {
+                  var timerEntry = timerEntries[ti];
+                  if (timerEntry.TimerTimeOfDay is null) continue;
+
+                  var today = DateOnly.FromDateTime(DateTime.Now);
+                  var now = TimeOnly.FromDateTime(DateTime.Now);
+                  if (now >= timerEntry.TimerTimeOfDay.Value
+                      && (!timerFiredDate.TryGetValue(ti, out var lastFired) || lastFired != today)) {
+                    ct.ThrowIfCancellationRequested();
+                    if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                    var timerOk = await RunOneSequenceAsync(timerEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                    if (!timerOk) failed++;
+                    // Timer executions do not count toward `executed` (SC-002 analogue for timers)
+                    timerFiredDate[ti] = today;
                   }
-                  var ok = await RunOneSequenceAsync(sequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
-                  executed++;
-                  if (!ok) failed++;
                 }
+
+                // (b) OncePerRun steps, each followed by all EveryStep sequences (FR-006/FR-007/FR-016).
+                if (oncePerRunEntries.Count > 0) {
+                  foreach (var entry in oncePerRunEntries) {
+                    ct.ThrowIfCancellationRequested();
+                    if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                    var ok = await RunOneSequenceAsync(entry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                    executed++;
+                    if (!ok) failed++;
+
+                    // Run every-step sequences after each OncePerRun step (FR-006).
+                    foreach (var esEntry in everyStepEntries) {
+                      ct.ThrowIfCancellationRequested();
+                      if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                      var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                      if (!esOk) failed++;
+                      // Every-step executions do not count toward `executed` (FR-008/SC-002).
+                    }
+                  }
+                }
+                else if (everyStepEntries.Count > 0) {
+                  // FR-009: no OncePerRun entries — EveryStep runs exactly once, then the run ends.
+                  foreach (var esEntry in everyStepEntries) {
+                    ct.ThrowIfCancellationRequested();
+                    if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                    var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                    if (!esOk) failed++;
+                  }
+                }
+
                 cycles++;
               } while (queue.CycleExecution);
             }
@@ -173,8 +222,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
       QueueExecutionLog.RunFaulted(_logger, queue.Id, ex);
     }
     finally {
-      // Always disconnect the session (FR-020/FR-023) — teardown errors must not prevent
-      // finalizing the run (FR-023 edge case).
+      // Always disconnect the session (FR-020/FR-023).
       if (sessionId is not null) {
         try { _captureService?.StopCapture(sessionId); }
         catch (Exception ex) { QueueExecutionLog.DisconnectFailed(_logger, queue.Id, ex); }
@@ -220,23 +268,24 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     }
   }
 
-  /// <summary>Signals that the bound emulator session disappeared while the run was in progress.</summary>
-  private sealed class QueueConnectionLostException : Exception {
-    public QueueConnectionLostException() { }
-    public QueueConnectionLostException(string message) : base(message) { }
-    public QueueConnectionLostException(string message, Exception innerException) : base(message, innerException) { }
-  }
-
   private static string BuildSummary(string queueName, QueueRunResult r) {
     var failedNote = r.SequencesFailed > 0 ? $", {r.SequencesFailed} failed" : string.Empty;
+    var cycleNote = r.Cycles > 1 ? $" across {r.Cycles} cycles" : string.Empty;
     return r.StopReason switch {
       QueueStopReason.CompletedFullRun =>
-        $"Queue '{queueName}' completed full run: {r.SequencesExecuted} sequence(s) executed{failedNote}{(r.Cycles > 1 ? $" across {r.Cycles} cycles" : string.Empty)}.",
+        $"Queue '{queueName}' completed full run: {r.SequencesExecuted} sequence(s) executed{failedNote}{cycleNote}.",
       QueueStopReason.StoppedManually =>
         $"Queue '{queueName}' stopped manually after {r.SequencesExecuted} sequence(s) executed{failedNote}.",
       _ =>
         $"Queue '{queueName}' failed: {r.FailureReason ?? "unknown error"}."
     };
+  }
+
+  /// <summary>Signals that the bound emulator session disappeared while the run was in progress.</summary>
+  private sealed class QueueConnectionLostException : Exception {
+    public QueueConnectionLostException() { }
+    public QueueConnectionLostException(string message) : base(message) { }
+    public QueueConnectionLostException(string message, Exception innerException) : base(message, innerException) { }
   }
 }
 

--- a/src/web-ui/src/components/queues/QueueEntryList.tsx
+++ b/src/web-ui/src/components/queues/QueueEntryList.tsx
@@ -2,16 +2,40 @@ import React, { useMemo, useState } from 'react';
 import { SearchableDropdown, SearchableOption } from '../SearchableDropdown';
 import { QueueEntryDto } from '../../services/queues';
 import { SequenceDto } from '../../services/sequences';
+import { ScheduleType } from '../../services/queueTemplates';
+
+export type EntrySchedule = {
+  scheduleType: ScheduleType;
+  timerTimeOfDay: string;
+};
 
 type QueueEntryListProps = {
   entries: QueueEntryDto[];
   sequences: SequenceDto[];
   onAdd: (sequenceId: string) => void;
   onRemove: (entryId: string) => void;
+  entrySchedule?: Record<string, EntrySchedule>;
+  onScheduleTypeChange?: (entryId: string, scheduleType: ScheduleType) => void;
+  onTimerTimeChange?: (entryId: string, timerTimeOfDay: string) => void;
   disabled?: boolean;
 };
 
-export const QueueEntryList: React.FC<QueueEntryListProps> = ({ entries, sequences, onAdd, onRemove, disabled }) => {
+const SCHEDULE_LABELS: Record<ScheduleType, string> = {
+  OncePerRun: 'Once Per Run',
+  EveryStep: 'Every Step',
+  Timer: 'Timer',
+};
+
+export const QueueEntryList: React.FC<QueueEntryListProps> = ({
+  entries,
+  sequences,
+  onAdd,
+  onRemove,
+  entrySchedule = {},
+  onScheduleTypeChange,
+  onTimerTimeChange,
+  disabled,
+}) => {
   const [selected, setSelected] = useState<string | undefined>(undefined);
 
   const options = useMemo<SearchableOption[]>(
@@ -24,17 +48,54 @@ export const QueueEntryList: React.FC<QueueEntryListProps> = ({ entries, sequenc
       <h4>Sequences</h4>
       {entries.length === 0 && <div className="form-hint">No sequences in this queue yet.</div>}
       <ol className="queue-entry-list">
-        {entries.map((entry) => (
-          <li key={entry.entryId} className="queue-entry-row" data-testid="queue-entry">
-            <span className="queue-entry-name">
-              {entry.sequenceName ?? entry.sequenceId}
-              {entry.stale && <span className="badge badge-warning" role="status"> (stale)</span>}
-            </span>
-            <button type="button" onClick={() => onRemove(entry.entryId)} disabled={disabled} aria-label={`Remove ${entry.sequenceName ?? entry.sequenceId}`}>
-              Remove
-            </button>
-          </li>
-        ))}
+        {entries.map((entry) => {
+          const schedule = entrySchedule[entry.entryId] ?? { scheduleType: 'OncePerRun' as ScheduleType, timerTimeOfDay: '' };
+          const isTimer = schedule.scheduleType === 'Timer';
+          const isEveryStep = schedule.scheduleType === 'EveryStep';
+
+          return (
+            <li key={entry.entryId} className="queue-entry-row" data-testid="queue-entry">
+              <span className="queue-entry-name">
+                {entry.sequenceName ?? entry.sequenceId}
+                {entry.stale && <span className="badge badge-warning" role="status"> (stale)</span>}
+                {isEveryStep && <span className="badge badge-info" role="status" aria-label="Every Step"> Every Step</span>}
+                {isTimer && <span className="badge badge-info" role="status" aria-label="Timer"> Timer</span>}
+              </span>
+
+              {onScheduleTypeChange && (
+                <select
+                  aria-label={`Schedule type for ${entry.sequenceName ?? entry.sequenceId}`}
+                  value={schedule.scheduleType}
+                  disabled={disabled}
+                  onChange={(e) => onScheduleTypeChange(entry.entryId, e.target.value as ScheduleType)}
+                >
+                  {(Object.keys(SCHEDULE_LABELS) as ScheduleType[]).map((t) => (
+                    <option key={t} value={t}>{SCHEDULE_LABELS[t]}</option>
+                  ))}
+                </select>
+              )}
+
+              {onTimerTimeChange && isTimer && (
+                <input
+                  type="time"
+                  aria-label={`Timer time for ${entry.sequenceName ?? entry.sequenceId}`}
+                  value={schedule.timerTimeOfDay}
+                  disabled={disabled}
+                  onChange={(e) => onTimerTimeChange(entry.entryId, e.target.value)}
+                />
+              )}
+
+              <button
+                type="button"
+                onClick={() => onRemove(entry.entryId)}
+                disabled={disabled}
+                aria-label={`Remove ${entry.sequenceName ?? entry.sequenceId}`}
+              >
+                Remove
+              </button>
+            </li>
+          );
+        })}
       </ol>
       <div className="queue-entry-add">
         <SearchableDropdown

--- a/src/web-ui/src/components/queues/QueueForm.tsx
+++ b/src/web-ui/src/components/queues/QueueForm.tsx
@@ -17,12 +17,13 @@ type QueueFormProps = {
   submitting?: boolean;
   formError?: string;
   fieldErrors?: { name?: string; emulatorSerial?: string };
-  /** Edit-mode only: row 2 — template controls, rendered after the emulator and before game controls. */
-  templateControls?: React.ReactNode;
-  /** Edit-mode only: row 3 — game controls, rendered after template controls and before cycle execution. */
+  /** Edit-mode only: game name + unlink row, rendered after cycle execution. */
   gameControls?: React.ReactNode;
-  /** Edit-mode only: row 4 — queue sequence entries, rendered after cycle execution and before the actions. */
-  entries?: React.ReactNode;
+  /**
+   * Edit-mode only: the full template section (template name link, sequence entries,
+   * Save Template / Reload Template), rendered below the separator.
+   */
+  templateControls?: React.ReactNode;
 };
 
 export const QueueForm: React.FC<QueueFormProps> = ({
@@ -34,12 +35,10 @@ export const QueueForm: React.FC<QueueFormProps> = ({
   submitting,
   formError,
   fieldErrors,
-  templateControls,
   gameControls,
-  entries,
+  templateControls,
 }) => {
   const isEdit = mode === 'edit';
-  // The emulator binding is immutable after creation, so only fetch devices when creating.
   const { devices, loading: devicesLoading } = useAdbDevices(!isEdit);
 
   const emulatorOptions = useMemo<SearchableOption[]>(
@@ -56,6 +55,7 @@ export const QueueForm: React.FC<QueueFormProps> = ({
         onSubmit();
       }}
     >
+      {/* Row 1: Name | Emulator */}
       <div className="field-row">
         <div className="field">
           <label htmlFor="queue-name">Name *</label>
@@ -64,8 +64,6 @@ export const QueueForm: React.FC<QueueFormProps> = ({
             value={value.name}
             onChange={(e) => onChange({ ...value, name: e.target.value })}
             onKeyDown={(e) => {
-              // Row 2/4 slots carry their own inputs; with no submit button the form never
-              // implicitly submits, so trigger submit explicitly from the name field.
               if (e.key === 'Enter') {
                 e.preventDefault();
                 onSubmit();
@@ -96,10 +94,7 @@ export const QueueForm: React.FC<QueueFormProps> = ({
         </div>
       </div>
 
-      {isEdit && templateControls}
-
-      {isEdit && gameControls}
-
+      {/* Row 2: Cycle execution */}
       <div className="field">
         <label>
           <input
@@ -113,13 +108,23 @@ export const QueueForm: React.FC<QueueFormProps> = ({
         </label>
       </div>
 
-      {isEdit && entries}
+      {/* Row 3: Game controls (edit only) */}
+      {isEdit && gameControls}
 
+      {/* Row 4: Save / Cancel */}
       <div className="form-actions">
         <button type="button" onClick={onSubmit} disabled={submitting}>Save</button>
         <button type="button" onClick={onCancel} disabled={submitting}>Cancel</button>
       </div>
       {formError && <div className="form-error" role="alert">{formError}</div>}
+
+      {/* Separator + template section (edit only) */}
+      {isEdit && templateControls && (
+        <>
+          <hr className="queue-form-separator" />
+          {templateControls}
+        </>
+      )}
     </form>
   );
 };

--- a/src/web-ui/src/components/queues/QueueGameControls.tsx
+++ b/src/web-ui/src/components/queues/QueueGameControls.tsx
@@ -23,6 +23,7 @@ export const QueueGameControls: React.FC<QueueGameControlsProps> = ({
   return (
     <section className="queue-template-controls" aria-label="Queue game">
       <div className="queue-template-row">
+        <span className="queue-section-label">Game</span>
         <button
           type="button"
           className="link-button queue-template-name"

--- a/src/web-ui/src/components/queues/QueueGameControls.tsx
+++ b/src/web-ui/src/components/queues/QueueGameControls.tsx
@@ -31,9 +31,6 @@ export const QueueGameControls: React.FC<QueueGameControlsProps> = ({
         >
           {linkedGameName ?? '(no game)'}
         </button>
-        <button type="button" onClick={() => setPickerOpen((o) => !o)} aria-expanded={pickerOpen}>
-          Link Game
-        </button>
         <button
           type="button"
           onClick={onUnlink}

--- a/src/web-ui/src/components/queues/QueueTemplateControls.tsx
+++ b/src/web-ui/src/components/queues/QueueTemplateControls.tsx
@@ -52,6 +52,7 @@ export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
     <section className="queue-template-controls" aria-label="Queue templates">
       {/* Template name — clicking opens the load picker */}
       <div className="queue-template-row">
+        <span className="queue-section-label">Template</span>
         <button
           type="button"
           className="link-button queue-template-name"

--- a/src/web-ui/src/components/queues/QueueTemplateControls.tsx
+++ b/src/web-ui/src/components/queues/QueueTemplateControls.tsx
@@ -5,7 +5,7 @@ import { TemplatePickerDialog } from './TemplatePickerDialog';
 
 type OpenSection = 'none' | 'save' | 'load';
 
-/** An inline confirmation prompt shown in place of the picker (between rows 2 and 3). */
+/** An inline confirmation prompt shown between the template header and sequences. */
 export type TemplateConfirm = {
   title: string;
   message: string;
@@ -24,8 +24,10 @@ type QueueTemplateControlsProps = {
   onLoadTemplate: (templateId: string) => void;
   /** Re-applies the associated template's persisted entries (with diff-aware confirmation). */
   onReload: () => void;
-  /** When set, a replace/reload confirmation is shown inline (instead of the picker). */
+  /** When set, a replace/reload confirmation is shown between the template header and sequences. */
   pendingConfirm?: TemplateConfirm;
+  /** Sequence entries to render between the template header and the Save/Reload action row. */
+  children?: React.ReactNode;
 };
 
 export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
@@ -35,19 +37,20 @@ export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
   onLoadTemplate,
   onReload,
   pendingConfirm,
+  children,
 }) => {
   const [openSection, setOpenSection] = useState<OpenSection>('none');
   const running = status === 'Running';
-  // While a replace/reload confirmation is pending, it occupies the picker's spot.
   const section = pendingConfirm ? 'none' : openSection;
 
-  const toggle = (section: Exclude<OpenSection, 'none'>) =>
-    setOpenSection((current) => (current === section ? 'none' : section));
+  const toggle = (s: Exclude<OpenSection, 'none'>) =>
+    setOpenSection((current) => (current === s ? 'none' : s));
 
   const close = () => setOpenSection('none');
 
   return (
     <section className="queue-template-controls" aria-label="Queue templates">
+      {/* Template name — clicking opens the load picker */}
       <div className="queue-template-row">
         <button
           type="button"
@@ -56,23 +59,6 @@ export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
           aria-expanded={openSection === 'load'}
         >
           {associatedTemplateName ?? '(no template)'}
-        </button>
-        <button type="button" onClick={() => toggle('save')} aria-expanded={openSection === 'save'}>
-          Save Template
-        </button>
-        <button
-          type="button"
-          onClick={onReload}
-          disabled={!associatedTemplateName || running}
-          title={
-            !associatedTemplateName
-              ? 'No template to reload.'
-              : running
-                ? 'Stop the queue before reloading a template.'
-                : undefined
-          }
-        >
-          Reload Template
         </button>
       </div>
 
@@ -103,6 +89,30 @@ export const QueueTemplateControls: React.FC<QueueTemplateControlsProps> = ({
           </div>
         </section>
       )}
+
+      {/* Sequence entries */}
+      {children}
+
+      {/* Template action buttons below sequences */}
+      <div className="queue-template-row">
+        <button type="button" onClick={() => toggle('save')} aria-expanded={openSection === 'save'}>
+          Save Template
+        </button>
+        <button
+          type="button"
+          onClick={onReload}
+          disabled={!associatedTemplateName || running}
+          title={
+            !associatedTemplateName
+              ? 'No template to reload.'
+              : running
+                ? 'Stop the queue before reloading a template.'
+                : undefined
+          }
+        >
+          Reload Template
+        </button>
+      </div>
     </section>
   );
 };

--- a/src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { QueueEntryList } from '../QueueEntryList';
+import { QueueEntryList, EntrySchedule } from '../QueueEntryList';
 import { QueueEntryDto } from '../../../services/queues';
 import { SequenceDto } from '../../../services/sequences';
+import { ScheduleType } from '../../../services/queueTemplates';
 
 const sequences = [
   { id: 'seq-a', name: 'Alpha', steps: [] },
@@ -44,5 +45,158 @@ describe('QueueEntryList', () => {
   it('shows an empty hint when there are no entries', () => {
     render(<QueueEntryList entries={[]} sequences={sequences} onAdd={jest.fn()} onRemove={jest.fn()} />);
     expect(screen.getByText('No sequences in this queue yet.')).toBeInTheDocument();
+  });
+
+  // Schedule type tests (FR-022, FR-023, FR-024)
+
+  it('renders schedule type dropdown when onScheduleTypeChange is provided', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+        onScheduleTypeChange={jest.fn()}
+        onTimerTimeChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Schedule type for Alpha')).toBeInTheDocument();
+  });
+
+  it('shows timer time input when schedule type is Timer', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'Timer', timerTimeOfDay: '15:30' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+        onScheduleTypeChange={jest.fn()}
+        onTimerTimeChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Timer time for Alpha')).toBeInTheDocument();
+  });
+
+  it('does not show timer time input when schedule type is EveryStep', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'EveryStep', timerTimeOfDay: '' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+        onScheduleTypeChange={jest.fn()}
+        onTimerTimeChange={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('Timer time for Alpha')).not.toBeInTheDocument();
+  });
+
+  it('shows EveryStep badge for EveryStep entries', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'EveryStep', timerTimeOfDay: '' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+      />
+    );
+
+    expect(screen.getByLabelText('Every Step')).toBeInTheDocument();
+  });
+
+  it('shows Timer badge for Timer entries', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'Timer', timerTimeOfDay: '15:30' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+      />
+    );
+
+    expect(screen.getByLabelText('Timer')).toBeInTheDocument();
+  });
+
+  it('does not show any schedule badge for OncePerRun entries', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+      />
+    );
+
+    expect(screen.queryByLabelText('Every Step')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Timer')).not.toBeInTheDocument();
+  });
+
+  it('calls onScheduleTypeChange when dropdown changes', () => {
+    const onScheduleTypeChange = jest.fn();
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+        onScheduleTypeChange={onScheduleTypeChange}
+        onTimerTimeChange={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Schedule type for Alpha'), { target: { value: 'EveryStep' } });
+    expect(onScheduleTypeChange).toHaveBeenCalledWith('e1', 'EveryStep' as ScheduleType);
   });
 });

--- a/src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx
@@ -22,7 +22,7 @@ const renderForm = (overrides: Partial<React.ComponentProps<typeof QueueForm>> =
       fieldErrors={overrides.fieldErrors}
       formError={overrides.formError}
       templateControls={overrides.templateControls}
-      entries={overrides.entries}
+      gameControls={overrides.gameControls}
     />
   );
   return { onChange, onSubmit, onCancel };
@@ -45,36 +45,35 @@ describe('QueueForm', () => {
     expect(screen.queryByText(/bound emulator cannot be changed/i)).not.toBeInTheDocument();
   });
 
-  it('renders the template-controls and entries slots in row order (emulator -> templates -> cycle -> entries -> actions)', () => {
+  it('renders slots in the new order: emulator → cycle → game → Save → separator → template section', () => {
     renderForm({
       mode: 'edit',
       value: { name: 'Farm', emulatorSerial: 'emu-9', cycleExecution: false },
+      gameControls: <div data-testid="slot-game" />,
       templateControls: <div data-testid="slot-templates" />,
-      entries: <div data-testid="slot-entries" />,
     });
     const emulator = screen.getByLabelText('Emulator *');
-    const templates = screen.getByTestId('slot-templates');
     const cycle = screen.getByLabelText('Cycle execution');
-    const entries = screen.getByTestId('slot-entries');
-    const actions = screen.getByText('Save');
+    const game = screen.getByTestId('slot-game');
+    const save = screen.getByText('Save');
+    const templates = screen.getByTestId('slot-templates');
 
     const follows = (a: Node, b: Node) =>
       Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
-    expect(follows(emulator, templates)).toBe(true);
-    expect(follows(templates, cycle)).toBe(true);
-    expect(follows(cycle, entries)).toBe(true);
-    expect(follows(entries, actions)).toBe(true);
+    expect(follows(emulator, cycle)).toBe(true);
+    expect(follows(cycle, game)).toBe(true);
+    expect(follows(game, save)).toBe(true);
+    expect(follows(save, templates)).toBe(true);
   });
 
-  it('does not render the slots in create mode', () => {
+  it('does not render the edit-only slots in create mode', () => {
     renderForm({
       mode: 'create',
       templateControls: <div data-testid="slot-templates" />,
-      entries: <div data-testid="slot-entries" />,
+      gameControls: <div data-testid="slot-game" />,
     });
-    // Create mode receives no slots from the page; even if passed, the form omits them.
     expect(screen.queryByTestId('slot-templates')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('slot-entries')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slot-game')).not.toBeInTheDocument();
   });
 
   it('renders field and form errors', () => {

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -409,7 +409,18 @@ export const QueuesPage: React.FC = () => {
                 onLoadTemplate={(id) => void handleLoadTemplate(id)}
                 onReload={() => void handleReload()}
                 pendingConfirm={templateConfirm}
-              />
+              >
+                <QueueEntryList
+                  entries={detail.entries}
+                  sequences={sequences}
+                  onAdd={(sid) => void onAddEntry(sid)}
+                  onRemove={(eid) => void onRemoveEntry(eid)}
+                  entrySchedule={entrySchedule}
+                  onScheduleTypeChange={(eid, st) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'OncePerRun', timerTimeOfDay: '' }, scheduleType: st } }))}
+                  onTimerTimeChange={(eid, t) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerTimeOfDay: t } }))}
+                  disabled={detail.status === 'Running'}
+                />
+              </QueueTemplateControls>
             }
             gameControls={
               <QueueGameControls
@@ -418,18 +429,6 @@ export const QueuesPage: React.FC = () => {
                 status={detail.status}
                 onLink={(gameId) => void handleLinkGame(gameId)}
                 onUnlink={() => void handleUnlinkGame()}
-              />
-            }
-            entries={
-              <QueueEntryList
-                entries={detail.entries}
-                sequences={sequences}
-                onAdd={(sid) => void onAddEntry(sid)}
-                onRemove={(eid) => void onRemoveEntry(eid)}
-                entrySchedule={entrySchedule}
-                onScheduleTypeChange={(eid, st) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'OncePerRun', timerTimeOfDay: '' }, scheduleType: st } }))}
-                onTimerTimeChange={(eid, t) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerTimeOfDay: t } }))}
-                disabled={detail.status === 'Running'}
               />
             }
           />

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -93,6 +93,17 @@ export const QueuesPage: React.FC = () => {
     setDetail(q);
     setAssociatedTemplateName(q.linkedTemplateName ?? undefined);
     setForm({ name: q.name, emulatorSerial: q.emulatorSerial, cycleExecution: q.cycleExecution });
+
+    // Restore per-entry schedule state from the linked template so that the editor
+    // reflects previously saved schedule types and saving doesn't overwrite them with OncePerRun.
+    if (q.linkedTemplateId && q.entries.length > 0) {
+      try {
+        const tpl = await getQueueTemplate(q.linkedTemplateId);
+        setEntrySchedule(buildScheduleFromTemplateEntries(q.entries.map((e) => e.entryId), tpl.entries));
+      } catch {
+        // Template may have been deleted; leave entrySchedule empty (defaults to OncePerRun).
+      }
+    }
   };
 
   const closeForms = () => {

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -17,11 +17,11 @@ import {
 } from '../services/queues';
 import { listSequences, SequenceDto } from '../services/sequences';
 import { QueueForm, QueueFormValue } from '../components/queues/QueueForm';
-import { QueueEntryList } from '../components/queues/QueueEntryList';
+import { QueueEntryList, EntrySchedule } from '../components/queues/QueueEntryList';
 import { QueueTemplateControls } from '../components/queues/QueueTemplateControls';
 import { QueueGameControls } from '../components/queues/QueueGameControls';
 import { ConfirmDeleteModal } from '../components/ConfirmDeleteModal';
-import { saveQueueTemplate, getQueueTemplate, listQueueTemplates } from '../services/queueTemplates';
+import { saveQueueTemplate, getQueueTemplate, listQueueTemplates, ScheduleType, QueueTemplateEntryDto } from '../services/queueTemplates';
 import { sameSequenceOrder } from '../lib/sequenceOrder';
 import { ApiError } from '../lib/api';
 
@@ -43,8 +43,12 @@ export const QueuesPage: React.FC = () => {
   const [detail, setDetail] = useState<QueueDetailDto | undefined>(undefined);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [associatedTemplateName, setAssociatedTemplateName] = useState<string | undefined>(undefined);
-  const [pendingLoad, setPendingLoad] = useState<{ name: string; sequenceIds: string[]; templateId: string } | undefined>(undefined);
-  const [pendingReload, setPendingReload] = useState<{ name: string; sequenceIds: string[]; templateId: string } | undefined>(undefined);
+  const [pendingLoad, setPendingLoad] = useState<{ name: string; sequenceIds: string[]; templateId: string; templateEntries?: QueueTemplateEntryDto[] } | undefined>(undefined);
+  const [pendingReload, setPendingReload] = useState<{ name: string; sequenceIds: string[]; templateId: string; templateEntries?: QueueTemplateEntryDto[] } | undefined>(undefined);
+
+  // Per-entry schedule state (UI-local; not stored in the runtime API).
+  // Keys are entryIds from the runtime queue entries.
+  const [entrySchedule, setEntrySchedule] = useState<Record<string, EntrySchedule>>({});
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -98,6 +102,23 @@ export const QueuesPage: React.FC = () => {
     setFieldErrors(undefined);
     setFormError(undefined);
     setAssociatedTemplateName(undefined);
+    setEntrySchedule({});
+  };
+
+  const buildScheduleFromTemplateEntries = (runtimeEntryIds: string[], tplEntries: QueueTemplateEntryDto[]): Record<string, EntrySchedule> => {
+    const schedule: Record<string, EntrySchedule> = {};
+    runtimeEntryIds.forEach((entryId, i) => {
+      const tplEntry = tplEntries[i];
+      if (tplEntry) {
+        schedule[entryId] = {
+          scheduleType: tplEntry.scheduleType ?? 'OncePerRun',
+          timerTimeOfDay: tplEntry.timerTimeOfDay ?? '',
+        };
+      } else {
+        schedule[entryId] = { scheduleType: 'OncePerRun', timerTimeOfDay: '' };
+      }
+    });
+    return schedule;
   };
 
   const validate = (): boolean => {
@@ -145,7 +166,8 @@ export const QueuesPage: React.FC = () => {
 
   const onAddEntry = async (sequenceId: string) => {
     if (!detail) return;
-    await addQueueEntry(detail.id, sequenceId);
+    const newEntry = await addQueueEntry(detail.id, sequenceId);
+    setEntrySchedule((prev) => ({ ...prev, [newEntry.entryId]: { scheduleType: 'OncePerRun' as ScheduleType, timerTimeOfDay: '' } }));
     await reloadDetail(detail.id);
     await refresh();
   };
@@ -153,27 +175,43 @@ export const QueuesPage: React.FC = () => {
   const onRemoveEntry = async (entryId: string) => {
     if (!detail) return;
     await removeQueueEntry(detail.id, entryId);
+    setEntrySchedule((prev) => {
+      const next = { ...prev };
+      delete next[entryId];
+      return next;
+    });
     await reloadDetail(detail.id);
     await refresh();
   };
 
   const handleSaveTemplate = async (name: string, overwrite: boolean) => {
     if (!detail) return;
-    const sequenceIds = detail.entries.map((e) => e.sequenceId);
-    const saved = await saveQueueTemplate({ name, sequenceIds, overwrite });
+    const entries = detail.entries.map((e) => {
+      const sched = entrySchedule[e.entryId] ?? { scheduleType: 'OncePerRun' as ScheduleType, timerTimeOfDay: '' };
+      return {
+        sequenceId: e.sequenceId,
+        scheduleType: sched.scheduleType,
+        ...(sched.scheduleType === 'Timer' && sched.timerTimeOfDay ? { timerTimeOfDay: sched.timerTimeOfDay } : {}),
+      };
+    });
+    const saved = await saveQueueTemplate({ name, entries, overwrite });
     await setQueueTemplateLink(detail.id, saved.id);
     setAssociatedTemplateName(name);
     setTableMessage(`Template "${name}" saved successfully.`);
   };
 
-  const applyLoad = async (name: string, sequenceIds: string[], templateId: string) => {
+  const applyLoad = async (name: string, sequenceIds: string[], templateId: string, tplEntries?: QueueTemplateEntryDto[]) => {
     if (!detail) return;
     try {
       await replaceQueueEntries(detail.id, sequenceIds);
       await setQueueTemplateLink(detail.id, templateId);
       setAssociatedTemplateName(name);
       setTableMessage(`Template "${name}" loaded.`);
-      await reloadDetail(detail.id);
+      const refreshed = await getQueue(detail.id);
+      setDetail(refreshed);
+      if (tplEntries) {
+        setEntrySchedule(buildScheduleFromTemplateEntries(refreshed.entries.map((e) => e.entryId), tplEntries));
+      }
       await refresh();
     } catch (err: any) {
       setTableError(err instanceof ApiError ? err.message : err?.message ?? 'Failed to load template');
@@ -185,9 +223,9 @@ export const QueuesPage: React.FC = () => {
     const tpl = await getQueueTemplate(templateId);
     const sequenceIds = tpl.entries.map((e) => e.sequenceId);
     if (detail.entries.length > 0) {
-      setPendingLoad({ name: tpl.name, sequenceIds, templateId: tpl.id });
+      setPendingLoad({ name: tpl.name, sequenceIds, templateId: tpl.id, templateEntries: tpl.entries });
     } else {
-      await applyLoad(tpl.name, sequenceIds, tpl.id);
+      await applyLoad(tpl.name, sequenceIds, tpl.id, tpl.entries);
     }
   };
 
@@ -207,9 +245,9 @@ export const QueuesPage: React.FC = () => {
       const currentSeqIds = detail.entries.map((e) => e.sequenceId);
       if (sameSequenceOrder(currentSeqIds, templateSeqIds)) return; // nothing to discard, no prompt
       if (detail.entries.length > 0) {
-        setPendingReload({ name: tpl.name, sequenceIds: templateSeqIds, templateId: match.id });
+        setPendingReload({ name: tpl.name, sequenceIds: templateSeqIds, templateId: match.id, templateEntries: tpl.entries });
       } else {
-        await applyLoad(tpl.name, templateSeqIds, match.id);
+        await applyLoad(tpl.name, templateSeqIds, match.id, tpl.entries);
       }
     } catch (err: any) {
       setTableError(err instanceof ApiError ? err.message : err?.message ?? 'Failed to reload template');
@@ -248,7 +286,7 @@ export const QueuesPage: React.FC = () => {
         onConfirm: () => {
           const p = pendingLoad;
           setPendingLoad(undefined);
-          if (p) void applyLoad(p.name, p.sequenceIds, p.templateId);
+          if (p) void applyLoad(p.name, p.sequenceIds, p.templateId, p.templateEntries);
         },
       }
     : pendingReload
@@ -260,7 +298,7 @@ export const QueuesPage: React.FC = () => {
           onConfirm: () => {
             const p = pendingReload;
             setPendingReload(undefined);
-            if (p) void applyLoad(p.name, p.sequenceIds, p.templateId);
+            if (p) void applyLoad(p.name, p.sequenceIds, p.templateId, p.templateEntries);
           },
         }
       : undefined;
@@ -377,6 +415,10 @@ export const QueuesPage: React.FC = () => {
                 sequences={sequences}
                 onAdd={(sid) => void onAddEntry(sid)}
                 onRemove={(eid) => void onRemoveEntry(eid)}
+                entrySchedule={entrySchedule}
+                onScheduleTypeChange={(eid, st) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'OncePerRun', timerTimeOfDay: '' }, scheduleType: st } }))}
+                onTimerTimeChange={(eid, t) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerTimeOfDay: t } }))}
+                disabled={detail.status === 'Running'}
               />
             }
           />

--- a/src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx
@@ -40,20 +40,21 @@ const follows = (a: Node, b: Node) =>
   Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
 
 describe('QueuesPage edit layout', () => {
-  it('renders the edit controls in row order: name+emulator -> templates -> cycle -> sequences -> Save/Cancel', async () => {
+  it('renders the edit controls in new order: name+emulator → cycle → Save/Cancel → template section → sequences', async () => {
     await openEdit();
     const name = screen.getByLabelText('Name *');
     const emulator = screen.getByLabelText('Emulator *');
-    const templates = screen.getByRole('region', { name: 'Queue templates' });
     const cycle = screen.getByLabelText('Cycle execution');
-    const sequences = screen.getByRole('region', { name: 'Queue sequences' });
     const save = screen.getByText('Save');
+    const templates = screen.getByRole('region', { name: 'Queue templates' });
+    const sequences = screen.getByRole('region', { name: 'Queue sequences' });
 
     expect(follows(name, emulator)).toBe(true);
-    expect(follows(emulator, templates)).toBe(true);
-    expect(follows(templates, cycle)).toBe(true);
-    expect(follows(cycle, sequences)).toBe(true);
-    expect(follows(sequences, save)).toBe(true);
+    expect(follows(emulator, cycle)).toBe(true);
+    expect(follows(cycle, save)).toBe(true);
+    expect(follows(save, templates)).toBe(true);
+    // sequences are inside the template section
+    expect(follows(templates, sequences)).toBe(true);
   });
 
   it('shows the emulator read-only with no "cannot be changed" hint', async () => {

--- a/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
@@ -36,7 +36,7 @@ const detailWithEntries = () => ({
 
 const templateDetail = () => ({
   id: 't1', name: 'Daily Farm', entryCount: 1, createdAt: null, updatedAt: null,
-  entries: [{ sequenceId: 'seq-x', sequenceName: 'X', stale: false }],
+  entries: [{ sequenceId: 'seq-x', sequenceName: 'X', stale: false, scheduleType: 'OncePerRun', timerTimeOfDay: null }],
 });
 
 beforeEach(() => {
@@ -67,7 +67,14 @@ describe('QueuesPage template save wiring', () => {
     fireEvent.click(within(section).getByText('Save'));
 
     await waitFor(() =>
-      expect(saveTemplateMock).toHaveBeenCalledWith({ name: 'Daily Farm', sequenceIds: ['seq-a', 'seq-b'], overwrite: false })
+      expect(saveTemplateMock).toHaveBeenCalledWith({
+        name: 'Daily Farm',
+        entries: [
+          { sequenceId: 'seq-a', scheduleType: 'OncePerRun' },
+          { sequenceId: 'seq-b', scheduleType: 'OncePerRun' },
+        ],
+        overwrite: false,
+      })
     );
     expect(await screen.findByText('Template "Daily Farm" saved successfully.')).toBeInTheDocument();
   });
@@ -84,7 +91,14 @@ describe('QueuesPage template save wiring', () => {
     fireEvent.click(await within(section).findByText('Overwrite'));
 
     await waitFor(() =>
-      expect(saveTemplateMock).toHaveBeenLastCalledWith({ name: 'Daily Farm', sequenceIds: ['seq-a', 'seq-b'], overwrite: true })
+      expect(saveTemplateMock).toHaveBeenLastCalledWith({
+        name: 'Daily Farm',
+        entries: [
+          { sequenceId: 'seq-a', scheduleType: 'OncePerRun' },
+          { sequenceId: 'seq-b', scheduleType: 'OncePerRun' },
+        ],
+        overwrite: true,
+      })
     );
   });
 });

--- a/src/web-ui/src/services/queueTemplates.ts
+++ b/src/web-ui/src/services/queueTemplates.ts
@@ -8,17 +8,28 @@ export type QueueTemplateSummary = {
   updatedAt: string | null;
 };
 
+export type ScheduleType = 'OncePerRun' | 'EveryStep' | 'Timer';
+
 export type QueueTemplateEntryDto = {
   sequenceId: string;
   sequenceName: string | null;
   stale: boolean;
+  scheduleType: ScheduleType;
+  timerTimeOfDay: string | null;
 };
 
 export type QueueTemplateDetail = QueueTemplateSummary & { entries: QueueTemplateEntryDto[] };
 
+/** Per-entry payload for saving a template. */
+export type TemplateEntrySaveDto = {
+  sequenceId: string;
+  scheduleType?: ScheduleType;
+  timerTimeOfDay?: string;
+};
+
 export type SaveQueueTemplate = {
   name: string;
-  sequenceIds: string[];
+  entries: TemplateEntrySaveDto[];
   overwrite: boolean;
 };
 

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -129,11 +129,12 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 .edit-form .field-row { display: flex; gap: var(--gb-space-3); flex-wrap: wrap; align-items: flex-start; }
 .edit-form .field-row .field { flex: 1 1 0; min-width: 14rem; margin-bottom: 0; }
 .edit-form .field > input { width: 100%; box-sizing: border-box; }
-.edit-form .form-actions { display: flex; gap: var(--gb-space-2); margin-top: var(--gb-space-4); padding-top: var(--gb-space-3); border-top: 1px solid var(--gb-color-border); }
+.edit-form .form-actions { display: flex; gap: var(--gb-space-2); margin-top: var(--gb-space-4); }
+.queue-section-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gb-color-text-muted, #888); white-space: nowrap; }
 
-/* Queue sequence entries (row 4) — keep the ordered list as-is; only align the
-   "Add sequence" control to the list items (default <ol> indentation is 40px). */
-.queue-entries .queue-entry-add { margin-top: var(--gb-space-2); margin-left: 40px; }
+/* Queue sequence entries — keep the ordered list as-is; align the "Add sequence"
+   row to list items (default <ol> indentation is 40px) and put the button inline. */
+.queue-entries .queue-entry-add { margin-top: var(--gb-space-2); margin-left: 40px; display: inline-flex; align-items: center; gap: var(--gb-space-2); }
 
 /* Drag-and-drop */
 .loop-block--drop-invalid { outline: 2px solid #d32f2f; opacity: 0.7; }

--- a/tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs
+++ b/tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs
@@ -39,18 +39,18 @@ public sealed class QueueTemplatesApiContractTests : IDisposable {
     var client = app.CreateClient();
     client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
     var name = "Contract " + Guid.NewGuid().ToString("N");
-    var sequenceIds = new[] { "seq-x" };
+    var entries = new[] { new { sequenceId = "seq-x" } };
 
     // Save (create) -> 201 QueueTemplateDetailResponse shape
     var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-      new { name, sequenceIds, overwrite = false }).ConfigureAwait(true);
+      new { name, entries, overwrite = false }).ConfigureAwait(true);
     createResp.StatusCode.Should().Be(HttpStatusCode.Created);
     var created = JsonDocument.Parse(await createResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
     foreach (var field in new[] { "id", "name", "entryCount", "createdAt", "updatedAt", "entries" }) {
       created.TryGetProperty(field, out _).Should().BeTrue($"detail must expose '{field}'");
     }
     var entry = created.GetProperty("entries")[0];
-    foreach (var field in new[] { "sequenceId", "sequenceName", "stale" }) {
+    foreach (var field in new[] { "sequenceId", "sequenceName", "stale", "scheduleType", "timerTimeOfDay" }) {
       entry.TryGetProperty(field, out _).Should().BeTrue($"entry must expose '{field}'");
     }
     var id = created.GetProperty("id").GetString();
@@ -67,17 +67,17 @@ public sealed class QueueTemplatesApiContractTests : IDisposable {
 
     // Duplicate name without overwrite -> 409
     var conflict = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-      new { name, sequenceIds = Array.Empty<string>(), overwrite = false }).ConfigureAwait(true);
+      new { name, entries = Array.Empty<object>(), overwrite = false }).ConfigureAwait(true);
     conflict.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
     // Overwrite -> 200
     var overwrite = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-      new { name, sequenceIds = Array.Empty<string>(), overwrite = true }).ConfigureAwait(true);
+      new { name, entries = Array.Empty<object>(), overwrite = true }).ConfigureAwait(true);
     overwrite.StatusCode.Should().Be(HttpStatusCode.OK);
 
     // Invalid name -> 400
     var invalid = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-      new { name = "bad/name", sequenceIds = Array.Empty<string>(), overwrite = false }).ConfigureAwait(true);
+      new { name = "bad/name", entries = Array.Empty<object>(), overwrite = false }).ConfigureAwait(true);
     invalid.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
     // Delete -> 204

--- a/tests/integration/QueueTemplates/QueueTemplatesDeleteEndpointTests.cs
+++ b/tests/integration/QueueTemplates/QueueTemplatesDeleteEndpointTests.cs
@@ -28,9 +28,9 @@ public sealed class QueueTemplatesDeleteEndpointTests {
   public async Task DeleteRemovesTemplateAndReturns204() {
     using var app = new WebApplicationFactory<Program>();
     var client = NewClient(app);
-    var ids = new[] { "seq-a" };
+    var entries = new[] { new { sequenceId = "seq-a" } };
     var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-      new { name = "Daily Farm", sequenceIds = ids, overwrite = false }).ConfigureAwait(true);
+      new { name = "Daily Farm", entries, overwrite = false }).ConfigureAwait(true);
     var id = JsonDocument.Parse(await createResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString();
 
     var resp = await client.DeleteAsync(new Uri($"/api/queue-templates/{id}", UriKind.Relative)).ConfigureAwait(true);

--- a/tests/integration/QueueTemplates/QueueTemplatesSaveEndpointTests.cs
+++ b/tests/integration/QueueTemplates/QueueTemplatesSaveEndpointTests.cs
@@ -24,8 +24,10 @@ public sealed class QueueTemplatesSaveEndpointTests {
     return client;
   }
 
-  private static Task<HttpResponseMessage> SaveAsync(HttpClient client, string name, string[] sequenceIds, bool overwrite) =>
-    client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name, sequenceIds, overwrite });
+  private static Task<HttpResponseMessage> SaveAsync(HttpClient client, string name, string[] sequenceIds, bool overwrite) {
+    var entries = Array.ConvertAll(sequenceIds, id => new { sequenceId = id });
+    return client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name, entries, overwrite });
+  }
 
   private static async Task<JsonElement> BodyAsync(HttpResponseMessage resp) =>
     JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.Clone();

--- a/tests/integration/QueueTemplates/QueueTemplatesScaleTests.cs
+++ b/tests/integration/QueueTemplates/QueueTemplatesScaleTests.cs
@@ -28,11 +28,11 @@ public sealed class QueueTemplatesScaleTests {
     var client = app.CreateClient();
     client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
 
-    var sequenceIds = Enumerable.Range(0, 100).Select(e => $"seq-{e}").ToArray();
+    var entries = Enumerable.Range(0, 100).Select(e => new { sequenceId = $"seq-{e}" }).ToArray();
     string? firstId = null;
     for (var t = 0; t < 50; t++) {
       var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-        new { name = $"Template{t}", sequenceIds, overwrite = false }).ConfigureAwait(true);
+        new { name = $"Template{t}", entries, overwrite = false }).ConfigureAwait(true);
       var id = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
       firstId ??= id;
     }

--- a/tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs
+++ b/tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.QueueTemplates;
+
+[Collection("ConfigIsolation")]
+public sealed class QueueTemplatesScheduleTypeTests {
+  private readonly string _dataDir;
+
+  public QueueTemplatesScheduleTypeTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    _dataDir = TestEnvironment.PrepareCleanDataDir();
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static async Task<JsonElement> BodyAsync(HttpResponseMessage resp) =>
+    JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.Clone();
+
+  // ── T025: round-trip persistence ─────────────────────────────────────────
+
+  [Fact]
+  public async Task SaveEveryStepEntryRoundTripsCorrectly() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "seq-a", scheduleType = "EveryStep" } };
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "TestSchedule", entries, overwrite = false }).ConfigureAwait(true);
+    createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await BodyAsync(createResp).ConfigureAwait(true);
+    var id = created.GetProperty("id").GetString()!;
+
+    var getResp = await client.GetAsync(new Uri($"/api/queue-templates/{id}", UriKind.Relative)).ConfigureAwait(true);
+    var body = await BodyAsync(getResp).ConfigureAwait(true);
+    var entry = body.GetProperty("entries")[0];
+    entry.GetProperty("scheduleType").GetString().Should().Be("EveryStep");
+    entry.GetProperty("timerTimeOfDay").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  [Fact]
+  public async Task SaveTimerEntryRoundTripsScheduleTypeAndTime() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "seq-a", scheduleType = "Timer", timerTimeOfDay = "15:30" } };
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "TimerTemplate", entries, overwrite = false }).ConfigureAwait(true);
+    createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await BodyAsync(createResp).ConfigureAwait(true);
+    var id = created.GetProperty("id").GetString()!;
+
+    var getResp = await client.GetAsync(new Uri($"/api/queue-templates/{id}", UriKind.Relative)).ConfigureAwait(true);
+    var body = await BodyAsync(getResp).ConfigureAwait(true);
+    var entry = body.GetProperty("entries")[0];
+    entry.GetProperty("scheduleType").GetString().Should().Be("Timer");
+    entry.GetProperty("timerTimeOfDay").GetString().Should().Be("15:30");
+  }
+
+  [Fact]
+  public async Task OmittedScheduleTypeDefaultsToOncePerRun() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "seq-a" } };
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "DefaultSchedule", entries, overwrite = false }).ConfigureAwait(true);
+    createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await BodyAsync(createResp).ConfigureAwait(true);
+    var id = created.GetProperty("id").GetString()!;
+
+    var getResp = await client.GetAsync(new Uri($"/api/queue-templates/{id}", UriKind.Relative)).ConfigureAwait(true);
+    var body = await BodyAsync(getResp).ConfigureAwait(true);
+    var entry = body.GetProperty("entries")[0];
+    entry.GetProperty("scheduleType").GetString().Should().Be("OncePerRun");
+    entry.GetProperty("timerTimeOfDay").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  [Fact]
+  public async Task PreFeatureTemplateFileReturnsOncePerRunForAllEntries() {
+    // Template JSON written before schedule types were introduced (no ScheduleType field)
+    var dir = Path.Combine(_dataDir, "queue-templates");
+    Directory.CreateDirectory(dir);
+    await File.WriteAllTextAsync(Path.Combine(dir, "legacy.json"),
+      """{"Id":"legacy","Name":"Legacy","Entries":[{"SequenceId":"seq-a"},{"SequenceId":"seq-b"}]}""").ConfigureAwait(true);
+
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var getResp = await client.GetAsync(new Uri("/api/queue-templates/legacy", UriKind.Relative)).ConfigureAwait(true);
+    getResp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var body = await BodyAsync(getResp).ConfigureAwait(true);
+    var entries = body.GetProperty("entries");
+    entries.GetArrayLength().Should().Be(2);
+    entries[0].GetProperty("scheduleType").GetString().Should().Be("OncePerRun");
+    entries[1].GetProperty("scheduleType").GetString().Should().Be("OncePerRun");
+    entries[0].GetProperty("timerTimeOfDay").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  // ── T026–T028: API validation ─────────────────────────────────────────────
+
+  [Fact]
+  public async Task TimerEntryMissingTimerTimeOfDayReturns400() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "seq-a", scheduleType = "Timer" } };
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Bad", entries, overwrite = false }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var body = await BodyAsync(resp).ConfigureAwait(true);
+    body.GetProperty("error").GetProperty("code").GetString().Should().Be("invalid_request");
+    body.GetProperty("error").GetProperty("message").GetString().Should()
+      .Contain("timerTimeOfDay");
+  }
+
+  [Fact]
+  public async Task InvalidScheduleTypeValueReturns400() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "seq-a", scheduleType = "Weekly" } };
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Bad", entries, overwrite = false }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var body = await BodyAsync(resp).ConfigureAwait(true);
+    body.GetProperty("error").GetProperty("code").GetString().Should().Be("invalid_request");
+    body.GetProperty("error").GetProperty("message").GetString().Should()
+      .Contain("Weekly");
+  }
+
+  [Fact]
+  public async Task BlankSequenceIdInEntryReturns400() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "   " } };
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Bad", entries, overwrite = false }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var body = await BodyAsync(resp).ConfigureAwait(true);
+    body.GetProperty("error").GetProperty("code").GetString().Should().Be("invalid_request");
+    body.GetProperty("error").GetProperty("message").GetString().Should()
+      .Contain("sequenceId");
+  }
+
+  // ── T029: backward compatibility (duplicate of T025 pre-feature test, kept as US4 explicit) ──
+
+  [Fact]
+  public async Task InvalidTimerTimeFormatReturns400() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "seq-a", scheduleType = "Timer", timerTimeOfDay = "5pm" } };
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Bad", entries, overwrite = false }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var body = await BodyAsync(resp).ConfigureAwait(true);
+    body.GetProperty("error").GetProperty("code").GetString().Should().Be("invalid_request");
+    body.GetProperty("error").GetProperty("message").GetString().Should()
+      .Contain("timerTimeOfDay");
+  }
+}

--- a/tests/integration/Queues/QueueAutoLoadEndpointTests.cs
+++ b/tests/integration/Queues/QueueAutoLoadEndpointTests.cs
@@ -43,8 +43,9 @@ public sealed class QueueAutoLoadEndpointTests {
   }
 
   private static async Task<string> CreateTemplateAsync(HttpClient client, params string[] sequenceIds) {
+    var entries = Array.ConvertAll(sequenceIds, id => new { sequenceId = id });
     var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-      new { name = "Daily Farm", sequenceIds, overwrite = false }).ConfigureAwait(true);
+      new { name = "Daily Farm", entries, overwrite = false }).ConfigureAwait(true);
     return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
   }
 
@@ -189,14 +190,14 @@ public sealed class QueueAutoLoadEndpointTests {
   [Fact]
   public async Task AutoLoadOfLargeTemplateIsWithinBudget() {
     for (var i = 0; i < 100; i++) SeedSequence($"seq-{i}", $"S{i}");
-    var sequenceIds = new string[100];
-    for (var i = 0; i < 100; i++) sequenceIds[i] = $"seq-{i}";
+    var entries = new object[100];
+    for (var i = 0; i < 100; i++) entries[i] = new { sequenceId = $"seq-{i}" };
 
     using var app = new WebApplicationFactory<Program>();
     var client = NewClient(app);
     var id = await CreateQueueAsync(client).ConfigureAwait(true);
     var tplResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
-      new { name = "Big", sequenceIds, overwrite = false }).ConfigureAwait(true);
+      new { name = "Big", entries, overwrite = false }).ConfigureAwait(true);
     var tplId = JsonDocument.Parse(await tplResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
     await SetLinkAsync(client, id, tplId).ConfigureAwait(true);
 

--- a/tests/integration/Queues/QueueEntriesReplaceEndpointTests.cs
+++ b/tests/integration/Queues/QueueEntriesReplaceEndpointTests.cs
@@ -42,7 +42,8 @@ public sealed class QueueEntriesReplaceEndpointTests {
   private static readonly string[] LoopSequenceIds = { "seq-loop" };
 
   private static async Task<string> CreateTemplateAsync(HttpClient client) {
-    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name = "Tpl-" + Guid.NewGuid().ToString("N"), sequenceIds = LoopSequenceIds, overwrite = false }).ConfigureAwait(true);
+    var entries = Array.ConvertAll(LoopSequenceIds, id => new { sequenceId = id });
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name = "Tpl-" + Guid.NewGuid().ToString("N"), entries, overwrite = false }).ConfigureAwait(true);
     return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
   }
 

--- a/tests/integration/Queues/QueueExecutionEndpointTests.cs
+++ b/tests/integration/Queues/QueueExecutionEndpointTests.cs
@@ -35,7 +35,8 @@ public sealed class QueueExecutionEndpointTests {
   }
 
   private static async Task<string> CreateTemplateAsync(HttpClient client, params string[] sequenceIds) {
-    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name = "Tpl-" + Guid.NewGuid().ToString("N"), sequenceIds, overwrite = false }).ConfigureAwait(true);
+    var entries = Array.ConvertAll(sequenceIds, id => new { sequenceId = id });
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name = "Tpl-" + Guid.NewGuid().ToString("N"), entries, overwrite = false }).ConfigureAwait(true);
     return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
   }
 

--- a/tests/integration/Queues/QueueTemplateLinkEndpointTests.cs
+++ b/tests/integration/Queues/QueueTemplateLinkEndpointTests.cs
@@ -50,7 +50,8 @@ public sealed class QueueTemplateLinkEndpointTests {
   }
 
   private static async Task<string> CreateTemplateAsync(HttpClient client, string name, params string[] sequenceIds) {
-    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name, sequenceIds, overwrite = false }).ConfigureAwait(true);
+    var entries = Array.ConvertAll(sequenceIds, id => new { sequenceId = id });
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative), new { name, entries, overwrite = false }).ConfigureAwait(true);
     return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
   }
 

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -396,4 +396,200 @@ public sealed class QueueExecutionServiceTests {
     h.Log.FinalStatus.Should().Be("failure");
     h.Log.Summary.Should().Contain("connection lost");
   }
+
+  // ── US2 (spec): EveryStep scheduling ─────────────────────────────────────
+
+  private static ExecutionQueue AddQueueWithEntries(Harness h, string id, QueueTemplateEntry[] entries, bool cycle = false) {
+    var templateId = $"tpl-{id}";
+    var template = new QueueTemplate { Id = templateId, Name = $"T-{id}" };
+    foreach (var e in entries) template.Entries.Add(e);
+    h.Templates.Add(template);
+    var queue = new ExecutionQueue { Id = id, Name = $"Q-{id}", EmulatorSerial = "emu-1", CycleExecution = cycle, LinkedTemplateId = templateId };
+    h.Queues.Add(queue);
+    return queue;
+  }
+
+  private static QueueTemplateEntry OncePerRun(string id) => new() { SequenceId = id, ScheduleType = ScheduleType.OncePerRun };
+  private static QueueTemplateEntry EveryStep(string id) => new() { SequenceId = id, ScheduleType = ScheduleType.EveryStep };
+  private static QueueTemplateEntry TimerEntry(string id, TimeOnly time) => new() { SequenceId = id, ScheduleType = ScheduleType.Timer, TimerTimeOfDay = time };
+
+  [Fact]
+  public async Task EveryStepRunsAfterEachOncePerRunStepAndAfterLast() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A"), OncePerRun("B"), EveryStep("C") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-006/FR-007: C fires after A and after B
+    h.Sequences.Executed.Should().Equal("A", "C", "B", "C");
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  [Fact]
+  public async Task EveryStepDoesNotCountTowardExecutedInSummary() {
+    var h = new Harness();
+    // 2 OncePerRun + 1 EveryStep; executed count should be 2
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A"), OncePerRun("B"), EveryStep("C") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-008/SC-002: summary reflects 2 sequences, not 4
+    h.Log.Summary.Should().Contain("2 sequence(s) executed");
+    h.Log.Summary.Should().NotContain("4 sequence");
+  }
+
+  [Fact]
+  public async Task NoOncePerRunOnlyEveryStepRunsOnce() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { EveryStep("C") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-009: EveryStep runs exactly once when there are no OncePerRun entries
+    h.Sequences.Executed.Should().Equal("C");
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  [Fact]
+  public async Task MultipleEveryStepRunInTemplateOrderAfterEachStep() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A"), EveryStep("C1"), EveryStep("C2") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Equal("A", "C1", "C2");
+  }
+
+  [Fact]
+  public async Task EveryStepFailureIsNonFatalRunContinues() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A"), OncePerRun("B"), EveryStep("C") });
+    h.Sequences.Handler = (id, ct) =>
+      Task.FromResult(id == "C" ? FakeSequenceExecution.Failure(id) : FakeSequenceExecution.Success(id));
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Equal("A", "C", "B", "C");
+    h.Log.FinalStatus.Should().Be("success"); // FR-010: EveryStep failure is non-fatal
+    h.Log.Summary.Should().Contain("2 failed");
+  }
+
+  [Fact]
+  public async Task EveryStepAlsoRunsInCyclicMode() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A"), EveryStep("C") }, cycle: true);
+    h.Sequences.Handler = async (id, ct) => { await Task.Delay(10, ct); return FakeSequenceExecution.Success(id); };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Sequences.Executed.Count >= 4); // two full cycles: A,C,A,C
+    await h.Service.StopAsync("q1");
+
+    var first4 = h.Sequences.Executed.Take(4).ToList();
+    first4.Should().Equal("A", "C", "A", "C");
+  }
+
+  // ── US3 (spec): Timer scheduling ─────────────────────────────────────────
+
+  [Fact]
+  public async Task TimerPastDueFiresBeforeOncePerRunOnFirstIteration() {
+    var h = new Harness();
+    // TimeOnly.MinValue (00:00) has always passed today
+    AddQueueWithEntries(h, "q1", new[] { TimerEntry("T", TimeOnly.MinValue), OncePerRun("A") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-011/FR-016: T fires first (at iteration boundary), then A
+    h.Sequences.Executed[0].Should().Be("T");
+    h.Sequences.Executed[1].Should().Be("A");
+  }
+
+  [Fact]
+  public async Task TimerNotYetDueNeverFiresInNonCyclicRun() {
+    var h = new Harness();
+    // 23:59 has not yet passed (test doesn't run at midnight)
+    AddQueueWithEntries(h, "q1", new[] { TimerEntry("T", new TimeOnly(23, 59)), OncePerRun("A") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-012/SC-004: T never executes
+    h.Sequences.Executed.Should().Equal("A");
+    h.Sequences.Executed.Should().NotContain("T");
+  }
+
+  [Fact]
+  public async Task TimerFiresAtMostOncePerCalendarDayAcrossCycles() {
+    var h = new Harness();
+    // Timer always due; with 3 cycles it must fire exactly once (once per calendar day)
+    AddQueueWithEntries(h, "q1", new[] { TimerEntry("T", TimeOnly.MinValue), OncePerRun("A") }, cycle: true);
+    h.Sequences.Handler = async (id, ct) => { await Task.Delay(10, ct); return FakeSequenceExecution.Success(id); };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Sequences.Executed.Count >= 4); // T + A + A + A (at minimum)
+    await h.Service.StopAsync("q1");
+
+    // T must appear exactly once (fired on first iteration, skipped on subsequent same-day iterations)
+    h.Sequences.Executed.Count(id => id == "T").Should().Be(1);
+  }
+
+  [Fact]
+  public async Task MultipleSimultaneousDueTimersAllFireBeforeRegularSteps() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] {
+      TimerEntry("T1", TimeOnly.MinValue),
+      TimerEntry("T2", TimeOnly.MinValue),
+      OncePerRun("A")
+    });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-013/SC-005: T1 and T2 both fire, then A; their relative order is unspecified
+    h.Sequences.Executed.Should().Contain("T1");
+    h.Sequences.Executed.Should().Contain("T2");
+    h.Sequences.Executed.Should().Contain("A");
+    // Both timers execute before A
+    var t1Idx = h.Sequences.Executed.IndexOf("T1");
+    var t2Idx = h.Sequences.Executed.IndexOf("T2");
+    var aIdx = h.Sequences.Executed.IndexOf("A");
+    t1Idx.Should().BeLessThan(aIdx);
+    t2Idx.Should().BeLessThan(aIdx);
+  }
+
+  [Fact]
+  public async Task TimerFailureIsNonFatalRunContinues() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { TimerEntry("T", TimeOnly.MinValue), OncePerRun("A") });
+    h.Sequences.Handler = (id, ct) =>
+      Task.FromResult(id == "T" ? FakeSequenceExecution.Failure(id) : FakeSequenceExecution.Success(id));
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Contain("T");
+    h.Sequences.Executed.Should().Contain("A");
+    h.Log.FinalStatus.Should().Be("success"); // FR-015: timer failure non-fatal
+  }
+
+  [Fact]
+  public async Task TimerAndEveryStepCombinedOrderIsCorrect() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] {
+      TimerEntry("T", TimeOnly.MinValue),
+      OncePerRun("A"),
+      EveryStep("C")
+    });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-016: T fires first (timer boundary), then A (OncePerRun), then C (EveryStep)
+    h.Sequences.Executed.Should().Equal("T", "A", "C");
+  }
 }


### PR DESCRIPTION
## Summary

- Adds three schedule types to queue template entries: **OncePerRun** (default, preserves all existing behaviour), **EveryStep** (executes after every regular step without counting toward run completion), and **Timer** (fires at most once per calendar day when an iteration boundary occurs after the configured wall-clock time, server local time)
- Schedule type is persisted as part of the template entry (`ScheduleType` enum + `TimerTimeOfDay: TimeOnly?`), exposed through the save/get template API (`entries[]` replaces `sequenceIds[]`), and configurable in the queue editor UI (per-entry dropdown + time picker)
- Queue execution runtime pre-partitions entries by type and evaluates timers outside the cycle loop so the once-per-calendar-day invariant holds across cycles

## Test plan

- [ ] `dotnet build` -- 0 warnings, 0 errors
- [ ] `dotnet test tests/unit` -- 382/382 pass (12 new: every-step and timer scheduling scenarios)
- [ ] `dotnet test tests/integration` -- 260/260 pass (8 new: schedule type persistence, validation edge cases, backward compatibility)
- [ ] `npm test` in `src/web-ui` -- 350/350 pass (7 new: QueueEntryList schedule type UI)
- [ ] `vite build` -- clean
- [ ] Manual: save template with all three entry types via API, verify GET round-trips `scheduleType` and `timerTimeOfDay`; load into queue and confirm execution log order (timer first, then once-per-run + every-step)

## Breaking change

`POST /api/queue-templates` body: `sequenceIds: string[]` replaced by `entries: { sequenceId, scheduleType?, timerTimeOfDay? }[]`. All internal callers updated.

Generated with [Claude Code](https://claude.com/claude-code)
