### PR TITLE
Command editor rework: action-first selector with per-action panels (#053)

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -27,6 +27,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-03
 - Existing file-backed JSON command repository under `data/commands` and existing file-backed execution-log repository under `data/execution-logs`; no new persistence store (001-wait-for-image)
 - Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence repository and runner, existing execution-log service, React/Vite authoring UI, existing command repository contracts (001-fix-sequence-step-names)
 - File-backed JSON under `data/commands/sequences`, `data/commands`, and `data/execution-logs` (001-fix-sequence-step-names)
+- TypeScript 5.x / React 18 + React Testing Library, Jest, @dnd-kit/core, @dnd-kit/sortable (053-command-editor-rework)
+- N/A (UI-only change) (053-command-editor-rework)
 
 - Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence/command services, existing image detection pipeline, existing execution-log services/repositories, React 18 + Vite 5 UI stack (030-sequence-conditional-logic)
 
@@ -47,9 +49,9 @@ npm test; npm run lint
 Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18: Follow standard conventions
 
 ## Recent Changes
+- 053-command-editor-rework: Added TypeScript 5.x / React 18 + React Testing Library, Jest, @dnd-kit/core, @dnd-kit/sortable
 - 001-fix-sequence-step-names: Added Backend C# 13 / .NET 9, Frontend TypeScript ES2020 / React 18 + ASP.NET Core Minimal API, existing `GameBot.Domain` sequence repository and runner, existing execution-log service, React/Vite authoring UI, existing command repository contracts
 - 001-wait-for-image: Added C# 13 / .NET 9 (backend), TypeScript ES2020 / React 18 (web UI) + ASP.NET Core Minimal API, existing `GameBot.Domain` command/action/logging models, `CommandExecutor`, existing detection pipeline (`IReferenceImageStore`, `IScreenSource`, `ITemplateMatcher`), existing web-ui command authoring and execution-log APIs
-- 001-primitive-actions-refactor: Added Backend C# 13 / .NET 9; Frontend TypeScript ES2020 / React 18 (Vite 5) + ASP.NET Core Minimal API, GameBot.Domain repositories/services, System.Text.Json, existing OpenCvSharp/ADB/session services, React + existing web-ui toolchain
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/052-ensure-game-running"
+  "feature_directory": "specs/053-command-editor-rework"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
-﻿<!-- SPECKIT START -->
+﻿When running PowerShell commands, always use absolute paths. Never prepend `cd <dir>;` before a script — use the full absolute path to the script directly, e.g. `& "c:\src\GameBot\.specify\scripts\powershell\setup-tasks.ps1"` not `cd c:\src\GameBot; & ".specify\scripts\powershell\setup-tasks.ps1"`.
+
+<!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/052-ensure-game-running/plan.md
+at specs/053-command-editor-rework/plan.md
 <!-- SPECKIT END -->

--- a/specs/053-command-editor-rework/checklists/requirements.md
+++ b/specs/053-command-editor-rework/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Command Editor Rework
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Specification is ready for `/speckit-plan`.

--- a/specs/053-command-editor-rework/data-model.md
+++ b/specs/053-command-editor-rework/data-model.md
@@ -1,0 +1,71 @@
+# Data Model: Command Editor Rework
+
+This feature is a pure UI refactoring. No new backend entities or API changes are introduced. The section below documents the **frontend state model** changes that govern the new panel-based interaction.
+
+---
+
+## CommandForm State (revised)
+
+| Field | Type | Description |
+|---|---|---|
+| `pendingActionType` | `'PrimitiveTap' \| 'WaitForImage' \| 'EnsureGameRunning' \| ''` | Which add/edit panel is currently open. `''` = panel hidden, selector blank. Matches `ActionTypeSelectorProps.value` directly — no conversion needed. |
+| `editingStepId` | `string \| null` | `null` when adding a new step; set to a step's `id` when editing an existing one. |
+
+**Removed fields** (replaced by the above):
+- `pendingCommandId`
+- `pendingPrimitiveReferenceImageId`
+- `primitiveTapStale`
+- `pendingPrimitiveConfidence`
+- `pendingPrimitiveOffsetX`
+- `pendingPrimitiveOffsetY`
+- `pendingWaitReferenceImageId`
+- `pendingWaitConfidence`
+- `pendingWaitTimeoutMs`
+
+---
+
+## TapPanel Internal State
+
+Managed inside `TapPanel` component; not visible to parent until `onConfirm` fires.
+
+| Field | Type | Required | Default |
+|---|---|---|---|
+| `referenceImageId` | `string` | Yes | `''` |
+| `confidence` | `string` | No | `''` |
+| `offsetX` | `string` | No | `'0'` |
+| `offsetY` | `string` | No | `'0'` |
+| `stale` | `boolean` | — | `false` |
+
+**Validation**: `referenceImageId` must be non-empty and not stale before `onConfirm` is allowed.
+
+---
+
+## WaitForImagePanel Internal State
+
+| Field | Type | Required | Default |
+|---|---|---|---|
+| `timeoutMs` | `string` | Yes | `'1000'` |
+| `referenceImageId` | `string` | No | `''` |
+| `confidence` | `string` | No | `''` |
+
+**Validation**: `timeoutMs` must be a non-negative integer string before `onConfirm` is allowed.
+
+**Staleness decision**: WaitForImagePanel does **not** track a `stale` flag. The `referenceImageId` field is optional and advisory — a stale or missing image reference does not block confirm (unlike TapPanel where the image is required). If the user mounts a WaitForImage step with a deleted image reference the panel will display an empty image selector; the user may leave it blank (timeout-only) or pick a new image. This is consistent with the "optional image" semantics of WaitForImage.
+
+---
+
+## EnsureGameRunningPanel Internal State
+
+No configurable fields. Panel only shows a description and a confirm button.
+
+---
+
+## Unchanged Entities
+
+| Entity | Change |
+|---|---|
+| `StepEntry` | Unchanged; `'PrimitiveTap'` discriminant stays |
+| `DetectionTargetForm` | Unchanged |
+| `CommandFormValue` | Unchanged |
+| All backend DTOs | Unchanged |
+| `commandOptions` prop on `CommandForm` | Retained (needed to display existing Command steps) |

--- a/specs/053-command-editor-rework/plan.md
+++ b/specs/053-command-editor-rework/plan.md
@@ -1,0 +1,251 @@
+# Implementation Plan: Command Editor Rework
+
+**Branch**: `053-command-editor-rework` | **Date**: 2026-06-04 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/053-command-editor-rework/spec.md`
+
+## Summary
+
+Replace the flat "all-fields-always-visible" step-addition controls in `CommandForm` with an action-first selector that opens a dedicated attribute panel per primitive action type (Tap, Wait for Image, Ensure Game Running). Add in-place step editing by clicking an existing step. Remove the "Add command" step type from the UI. Pure frontend change — no backend or API modifications.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x / React 18  
+**Primary Dependencies**: React Testing Library, Jest, @dnd-kit/core, @dnd-kit/sortable  
+**Storage**: N/A (UI-only change)  
+**Testing**: Jest + React Testing Library (existing pattern in `src/web-ui/src/components/__tests__/` and `src/web-ui/src/features/authoring/__tests__/`)  
+**Target Platform**: Web (Vite + browser)  
+**Project Type**: Web application frontend  
+**Performance Goals**: Panel open/close completes within one frame (≤ 16 ms) under standard dev-machine conditions; no async work introduced; no new network requests on panel open/close  
+**Constraints**: No backend changes; `StepEntry.type` discriminant values unchanged for API compatibility  
+**Scale/Scope**: 2 modified files, 3 new panel components, 1 updated list component
+
+## Constitution Check
+
+| Gate | Status | Notes |
+|---|---|---|
+| Lint/format zero errors | Required | Run `vite build` + Jest as quality gate per project conventions |
+| No new high/critical static analysis issues | Required | Applies to new panel components |
+| Unit tests ≥ 80% line / ≥ 70% branch for touched areas | Required | New panel components and updated `CommandForm` must be covered |
+| CamelCase method names only (no underscores) | Required | Applies to all new helper functions |
+| No implementation may proceed past a red build/test | Hard stop | |
+| UX: updated label "Tap" reflected in step list display and validation messages | Required | Consistency principle |
+
+No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/053-command-editor-rework/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── checklists/
+│   └── requirements.md
+└── tasks.md             ← Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (affected paths)
+
+```text
+src/web-ui/src/
+├── components/
+│   ├── commands/
+│   │   ├── CommandForm.tsx                     ← MODIFY (major refactor)
+│   │   ├── CommandForm.css                     ← MODIFY (panel styles)
+│   │   ├── ActionTypeSelector.tsx              ← NEW
+│   │   ├── TapPanel.tsx                        ← NEW
+│   │   ├── WaitForImagePanel.tsx               ← NEW
+│   │   └── EnsureGameRunningPanel.tsx          ← NEW
+│   └── SortableSequenceStepList.tsx            ← MODIFY (add onEdit prop)
+└── features/
+    └── authoring/
+        └── __tests__/
+            └── CommandForm.zoom.test.tsx       ← MODIFY (update for new controls)
+
+src/web-ui/src/components/commands/__tests__/  ← NEW directory
+    ├── TapPanel.test.tsx                       ← NEW
+    ├── WaitForImagePanel.test.tsx              ← NEW
+    ├── EnsureGameRunningPanel.test.tsx         ← NEW
+    ├── ActionTypeSelector.test.tsx             ← NEW
+    └── CommandForm.steps.test.tsx              ← NEW
+```
+
+**Structure Decision**: Single web application frontend. New components colocate with the existing `commands/` folder. Tests follow the existing `__tests__/` subdirectory pattern.
+
+## Implementation Phases
+
+### Phase A — New Panel Components
+
+Create the three action-specific panel components and the action type selector. Each panel is self-contained and manages its own form state.
+
+**A1 — `ActionTypeSelector`**
+
+A `<select>` with a blank first option followed by: Tap, Wait for Image, Ensure Game Running.
+
+Props:
+```ts
+type ActionTypeSelectorProps = {
+  value: 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | '';
+  onChange: (next: 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | '') => void;
+  disabled?: boolean;
+};
+```
+
+**A2 — `TapPanel`**
+
+Props:
+```ts
+type TapPanelProps = {
+  initialValue?: { referenceImageId: string; confidence?: string; offsetX?: string; offsetY?: string };
+  onConfirm: (value: { referenceImageId: string; confidence?: string; offsetX?: string; offsetY?: string }) => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+```
+
+Renders: image selector (required), confidence (optional, 0–1), offsetX (optional), offsetY (optional), Add/Save button, Cancel button.
+
+Validation:
+- Blocks confirm if `referenceImageId` is empty or stale. Error text: **"Reference image is required."**
+- If `confidence` is non-empty, must satisfy `0 ≤ parseFloat(confidence) ≤ 1`. Error text: **"Confidence must be a number between 0 and 1."** (If blank, skip this check — the field is optional.)
+
+**A3 — `WaitForImagePanel`**
+
+Props:
+```ts
+type WaitForImagePanelProps = {
+  initialValue?: { timeoutMs?: string; referenceImageId?: string; confidence?: string };
+  onConfirm: (value: { timeoutMs: string; referenceImageId?: string; confidence?: string }) => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+```
+
+Renders: timeoutMs input (required), image selector (optional), confidence (optional), Add/Save button, Cancel button.
+
+Validation:
+- Blocks confirm if `timeoutMs` is empty or not a non-negative integer (i.e., `/^\d+$/` fails). Error text: **"Timeout must be a non-negative whole number (ms)."**
+- If `confidence` is non-empty, must satisfy `0 ≤ parseFloat(confidence) ≤ 1`. Error text: **"Confidence must be a number between 0 and 1."** (If blank, skip — field is optional.)
+
+**A4 — `EnsureGameRunningPanel`**
+
+Props:
+```ts
+type EnsureGameRunningPanelProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+```
+
+Renders: descriptive text ("Checks that the game is in the foreground; starts it if not running."), Add button, Cancel button. No input fields.
+
+---
+
+### Phase B — Update `SortableSequenceStepList`
+
+Add an optional `onEdit` callback prop:
+
+```ts
+type SortableSequenceStepListProps = {
+  // existing props...
+  onEdit?: (item: ReorderableListItem) => void;
+};
+```
+
+When `onEdit` is provided, render an "Edit" button in `.reorderable-list__controls` for each item alongside the existing "Delete" button. Clicking calls `onEdit(item)`.
+
+---
+
+### Phase C — Refactor `CommandForm`
+
+**C1 — State changes**
+
+Remove all `pendingX` useState hooks. Add:
+```ts
+const [pendingActionType, setPendingActionType] = useState<'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | ''>('');
+const [editingStepId, setEditingStepId] = useState<string | null>(null);
+```
+
+**C2 — Remove Command step addition UI**
+
+Delete the `SearchableDropdown` and "Add command step" button from the JSX. Retain the `commandOptions` prop (still needed to render existing Command steps in `toStepItems`).
+
+**C3 — Replace flat add-controls with selector + panel**
+
+In the Steps `FormSection`, render:
+1. `ActionTypeSelector` bound to `pendingActionType` / `setPendingActionType`.
+2. Conditionally render the matching panel based on `pendingActionType`:
+   - `'PrimitiveTap'` → `TapPanel`
+   - `'WaitForImage'` → `WaitForImagePanel`
+   - `'EnsureGameRunning'` → `EnsureGameRunningPanel`
+   - `''` → nothing
+3. Each panel's `onConfirm` appends (add mode) or updates (edit mode) the relevant step, then resets `pendingActionType` to `''` and `editingStepId` to `null`.
+4. Each panel's `onCancel` resets both fields without modifying steps.
+
+**C4 — Edit flow**
+
+Pass `onEdit` to `SortableSequenceStepList`. When triggered:
+```ts
+const EDITABLE_TYPES = new Set(['PrimitiveTap', 'WaitForImage', 'EnsureGameRunning']);
+
+const handleEditStep = (item: ReorderableListItem) => {
+  const step = value.steps.find(s => s.id === item.id);
+  if (!step || !EDITABLE_TYPES.has(step.type)) return; // Command steps have no panel
+  setEditingStepId(step.id);
+  setPendingActionType(step.type as 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning');
+};
+```
+The guard prevents Command-type steps from entering edit mode (they have no attribute panel). The panel reads `initialValue` from the matching step in `value.steps` (looked up by `editingStepId`). On confirm, the step is replaced in `value.steps` at its current index.
+
+**C5 — Update `toStepItems` label**
+
+Change `"Primitive tap: ..."` → `"Tap: ..."`.
+
+**C6 — Update validation messages in `CommandsPage`**
+
+Change `"Primitive tap steps require..."` → `"Tap steps require..."`.
+
+**C7 — Update `FormSection` description**
+
+Change the Steps section description from `"Choose command or primitive tap steps..."` to `"Select an action type to add or edit steps."`.
+
+---
+
+### Phase D — Tests
+
+**D1 — New tests for each panel component** (`TapPanel.test.tsx`, `WaitForImagePanel.test.tsx`, `EnsureGameRunningPanel.test.tsx`):
+- Renders correct fields only
+- Confirm blocked when required fields missing
+- Confirm fires with correct values
+- Cancel fires without calling onConfirm
+- initialValue pre-fills fields
+
+**D2 — `ActionTypeSelector.test.tsx`**:
+- Renders three options plus blank
+- onChange fires with correct type string
+- Blank option produces empty string
+
+**D3 — `CommandForm.steps.test.tsx`** (add-flow, edit-flow, panel switching):
+- Selecting action type shows correct panel
+- Switching action clears previous panel state
+- Adding a step resets selector to blank
+- Clicking a step opens its panel pre-filled
+- Editing a step updates it in place
+- "Add command" UI is absent
+- Step list labels show "Tap: ..." not "Primitive tap: ..."
+- Existing Command steps still render and their Delete button fires (`onDelete` called); their Edit button is a no-op (clicking does not open any panel)
+- `handleEditStep` with a Command-type step leaves `pendingActionType` as `''` and `editingStepId` as `null`
+
+**D4 — Update `CommandForm.zoom.test.tsx`**:
+- Remove references to old `pendingX` controls
+- Retain Detection section field assertions (unchanged)
+- Update or remove step-panel-specific selectors
+
+---
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification required.

--- a/specs/053-command-editor-rework/research.md
+++ b/specs/053-command-editor-rework/research.md
@@ -1,0 +1,63 @@
+# Research: Command Editor Rework
+
+## Decision: Panel-per-action-type via controlled sub-components
+
+**Decision**: Each primitive action type (Tap, WaitForImage, EnsureGameRunning) becomes its own small React component that manages its own form state internally. The parent `CommandForm` only tracks which panel is currently open (`pendingActionType`) and which step is being edited (`editingStepId`), replacing the current flood of individual `pendingX` useState hooks.
+
+**Rationale**: Isolating form state per panel keeps each panel self-contained, makes the add-flow and edit-flow symmetric (both open the same panel component), and eliminates the risk of stale values from one action type bleeding into another.
+
+**Alternatives considered**: Keeping all state in `CommandForm` (flat approach) — rejected because it requires even more top-level state as actions grow. Single generic `ActionPanel` with conditional fields — rejected because it recreates the current clutter problem inside one component.
+
+---
+
+## Decision: ActionTypeSelector is a standalone component
+
+**Decision**: A new `ActionTypeSelector` component renders a `<select>` (or equivalent) listing the three valid primitive actions. It is rendered above the step list. Selecting an action calls `onChange`; selecting the blank option closes the panel.
+
+**Rationale**: Separates the "what to add" choice from the "fill in details" panel, matching the spec's action-first flow.
+
+---
+
+## Decision: Edit flow reuses the same panel components as add flow
+
+**Decision**: When the user clicks an existing step, `CommandForm` sets `editingStepId` (the id of the step being edited) and `pendingActionType` (derived from that step's type). The panel renders with the step's current values as `initialValue` props. On confirm, the step is updated in-place by id; on cancel, edit mode is cleared.
+
+**Rationale**: Reusing add panels for editing avoids a separate edit-panel component per action type, keeps the surface area small, and satisfies FR-011.
+
+---
+
+## Decision: SortableSequenceStepList receives an onEdit callback
+
+**Decision**: `SortableSequenceStepList` gains an optional `onEdit: (item: ReorderableListItem) => void` prop. Each step item renders an "Edit" button alongside the existing "Delete" button that calls `onEdit(item)`.
+
+**Rationale**: Minimal change to the list component; the parent (`CommandForm`) owns the edit routing logic.
+
+---
+
+## Decision: Label change — "PrimitiveTap" → "Tap" in display and validation messages
+
+**Decision**: The `toStepItems()` helper changes label from `"Primitive tap: {imageId}"` to `"Tap: {imageId}"`. Error messages and step section description are updated accordingly. The underlying `StepEntry.type` discriminant value `'PrimitiveTap'` stays unchanged to maintain API/DTO compatibility.
+
+**Rationale**: User-facing rename only; no backend changes needed.
+
+---
+
+## Decision: Command step addition removed from UI; existing Command steps remain renderable
+
+**Decision**: Remove the `SearchableDropdown` / "Add command step" button from `CommandForm`. The `commandOptions` prop and the `Command` branch in `toStepItems()` are retained so existing Command steps already saved in the database still display and can be deleted. No data migration is needed.
+
+**Rationale**: Matches FR-001 and the Assumptions in the spec.
+
+---
+
+## Decision: No new API endpoints or data model changes
+
+**Decision**: This is a pure frontend/UI change. All existing DTOs, endpoints, and `StepEntry` type shapes remain untouched.
+
+**Rationale**: The backend already supports all three primitive action types.
+
+---
+
+## Performance Goals
+
+Panel open/close is instant state toggle; no async work. No performance budget declaration needed beyond standard React render expectations for a small form.

--- a/specs/053-command-editor-rework/spec.md
+++ b/specs/053-command-editor-rework/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Command Editor Rework
+
+**Feature Branch**: `053-command-editor-rework`
+**Created**: 2026-06-04
+**Status**: Draft
+**Input**: User description: "Let's rework and extend command creation/editing. I want to be able to specify all primitive actions. Different primitive actions have different attributes, which clutter the ui enormously, so let me select the action first, which will open a panel with corresponding attributes. Create one panel for each action. Remove all current controls: Add command (remove completely, it's not needed), primitive tap (rename to Tap, use attributes for the panel), wait for image (use attributes) and ensure game running."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Select Action Then Fill Panel (Priority: P1)
+
+A user editing a command wants to add a new step. Instead of all action fields cluttering the screen at once, they first choose which primitive action they want from a selector. Once chosen, a dedicated panel appears showing only the fields relevant to that action.
+
+**Why this priority**: This is the core interaction redesign. All other stories depend on this flow working correctly.
+
+**Independent Test**: Open command edit view, click add-step selector, pick any action, confirm only that action's panel appears with its attributes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the command editor is open, **When** the user opens the add-step selector, **Then** they see the three primitive action options: Tap, Wait for Image, Ensure Game Running — with no Command option visible.
+2. **Given** an action is selected from the selector, **When** the panel opens, **Then** only the attributes for that specific action are shown, with no fields from other action types visible.
+3. **Given** a panel is open for one action, **When** the user picks a different action, **Then** the previous panel closes and the new action's panel opens.
+4. **Given** a step was just confirmed and added, **When** the add-step area is inspected, **Then** the selector shows blank and no panel is visible.
+5. **Given** an existing step is in the step list, **When** the user clicks on it, **Then** the step's attribute panel opens pre-filled with the step's current values.
+
+---
+
+### User Story 2 - Tap Panel (Priority: P2)
+
+A user selects "Tap" and sees a focused panel with the four Tap-specific attributes: reference image, confidence, horizontal offset, and vertical offset.
+
+**Why this priority**: Tap is the most commonly used primitive action; its panel must be clean and complete.
+
+**Independent Test**: Select Tap, verify the panel shows reference image selector (required), confidence input, offsetX input, and offsetY input — and nothing else.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Tap panel is open, **When** the user selects a reference image and submits, **Then** a Tap step is added to the command with the chosen image and default confidence/offsets.
+2. **Given** the Tap panel is open, **When** the user leaves the reference image empty and submits, **Then** submission is blocked and a validation error indicates the image is required.
+3. **Given** the Tap panel is open, **When** the user fills confidence, offsetX, and offsetY and submits, **Then** all four values are saved on the step.
+
+---
+
+### User Story 3 - Wait for Image Panel (Priority: P2)
+
+A user selects "Wait for Image" and sees a focused panel with timeout (required) and an optional image with confidence.
+
+**Why this priority**: WaitForImage is the second most used primitive; its panel must clearly show which fields are optional vs. required.
+
+**Independent Test**: Select Wait for Image, verify the panel shows timeoutMs input (required), optional reference image selector, and optional confidence input.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Wait for Image panel is open, **When** the user enters a timeout and no image and submits, **Then** a WaitForImage step is added that waits purely for the duration.
+2. **Given** the Wait for Image panel is open, **When** the user leaves the timeout empty and submits, **Then** submission is blocked and a validation error indicates timeout is required.
+3. **Given** the Wait for Image panel is open, **When** the user provides a timeout, an image, and a confidence and submits, **Then** all three values are saved on the step.
+
+---
+
+### User Story 4 - Ensure Game Running Panel (Priority: P3)
+
+A user selects "Ensure Game Running" and sees a minimal panel (no configurable attributes) with just a confirm/add button.
+
+**Why this priority**: No attributes to configure; the panel is trivially simple but must exist for consistency.
+
+**Independent Test**: Select Ensure Game Running, verify the panel shows a description of the action and an add/confirm control — no input fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Ensure Game Running panel is open, **When** the user confirms, **Then** an EnsureGameRunning step is added to the command.
+2. **Given** the Ensure Game Running panel is open, **When** it is displayed, **Then** no input fields are shown (the action has no configurable attributes).
+
+---
+
+### Edge Cases
+
+- What happens when a user opens a panel, partially fills it, then switches to a different action? Panel state should reset so stale values from the previous action are not carried over.
+- What happens when an existing step of a type that no longer has a UI entry point (Command) is displayed in the step list? It should still render and be deletable, but cannot be added via the new UI.
+- What happens when an image referenced by an existing Tap or Wait for Image step is deleted? The step list should indicate the reference is stale (existing staleness behaviour preserved).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The step-addition UI MUST present a selector listing exactly three choices: Tap, Wait for Image, and Ensure Game Running. The "Add command" (Command step type) option MUST be removed entirely and not appear in any form.
+- **FR-002**: Selecting an action from the selector MUST open a dedicated attribute panel for that action only. Panels for other actions MUST NOT be visible simultaneously.
+- **FR-003**: The Tap panel MUST display: a required reference image selector, an optional confidence field (0–1), an optional offsetX field (integer pixels), and an optional offsetY field (integer pixels). No other fields may appear.
+- **FR-004**: The Wait for Image panel MUST display: a required timeout field (non-negative milliseconds), an optional reference image selector, and an optional confidence field (0–1). No other fields may appear.
+- **FR-005**: The Ensure Game Running panel MUST display a description of the action and a confirm/add control. It MUST NOT display any input fields.
+- **FR-006**: Switching the action selector to a different action MUST clear/reset any partially entered data from the previously open panel before showing the new panel.
+- **FR-007**: Submitting a Tap step MUST be blocked if the reference image is not selected; the panel MUST show a validation error indicating the image is required.
+- **FR-008**: Submitting a Wait for Image step MUST be blocked if the timeout field is empty or invalid; the panel MUST show a validation error.
+- **FR-009**: Successfully confirming an action in a panel MUST append the new step to the command's step list and reset the selector to blank (panel hides), ready for the user to pick the next action.
+- **FR-010**: Existing steps of all types (including Command steps created before this change) MUST continue to render in the step list with their current display text and remain deletable.
+- **FR-011**: Clicking an existing step in the step list MUST open its corresponding attribute panel pre-filled with that step's current values, allowing the user to edit and save changes in place.
+
+### Key Entities
+
+- **Command**: A named sequence of steps; unchanged except that new steps can only be Tap, Wait for Image, or Ensure Game Running.
+- **Step**: A single action in a command sequence; discriminated by action type, each type has its own attribute set.
+- **Attribute Panel**: A UI region tied to one specific action type; visible only when that action is selected; contains only that action's input fields.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can add any of the three supported primitive action steps (Tap, Wait for Image, Ensure Game Running) without seeing unrelated fields from the other two actions at any point during input.
+- **SC-002**: The command editor shows zero fields from removed action types (Command step addition) in the add-step area.
+- **SC-003**: Each action panel contains exactly the fields documented for that action in FR-003 through FR-005 — no more, no fewer.
+- **SC-004**: Validation prevents saving incomplete steps (missing required fields) for all three action types; each error clearly identifies which field is missing.
+- **SC-005**: Switching between action types while a panel is partially filled does not carry stale field values into the newly selected panel.
+- **SC-006**: After a step is successfully added, the add-step selector returns to its blank state with no panel visible; the user must explicitly choose an action type to add another step.
+- **SC-007**: Clicking any existing step in the step list opens that step's attribute panel pre-filled; the user can modify values and save without deleting and re-adding the step.
+
+## Clarifications
+
+### Session 2026-06-04
+
+- Q: When a user wants to change an attribute on an existing step, what should happen? → A: Clicking the step opens its attribute panel pre-filled for in-place editing.
+- Q: After adding a step, what is the state of the add-step area? → A: Selector resets to blank; panel closes.
+
+## Assumptions
+
+- The "Command" step type (referencing another command by ID) will no longer be addable via the UI but will remain in the data model and will still display and be deletable in the step list if previously created.
+- The existing "Detection" section of the command form (used for game-detection, not step creation) is out of scope for this feature and remains unchanged.
+- Display names follow the user's stated naming: "Tap" (not "Primitive Tap"), "Wait for Image", "Ensure Game Running".
+- Existing validation rules (e.g., staleness checking for image references, confidence range 0–1) are preserved.

--- a/specs/053-command-editor-rework/tasks.md
+++ b/specs/053-command-editor-rework/tasks.md
@@ -1,0 +1,228 @@
+﻿---
+description: "Task list for Command Editor Rework"
+---
+
+# Tasks: Command Editor Rework
+
+**Input**: Design documents from `specs/053-command-editor-rework/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Tests**: INCLUDED. The plan's Phase D and the constitution coverage gate (unit tests â‰¥ 80% line / â‰¥ 70% branch for touched areas) make tests required for this feature.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- Web application frontend. Source root: `src/web-ui/src/`
+- Components: `src/web-ui/src/components/commands/`
+- Tests colocate in `__tests__/` subdirectories next to the code under test
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project scaffolding and baseline understanding
+
+- [X] T001 [P] Create the new test directory `src/web-ui/src/components/commands/__tests__/` (add a `.gitkeep` if needed so the empty dir is tracked).
+- [X] T002 Establish baseline by reading `src/web-ui/src/components/commands/CommandForm.tsx`, `src/web-ui/src/components/SortableSequenceStepList.tsx`, and `src/web-ui/src/pages/CommandsPage.tsx`: record the current `pendingX` useState names, the `StepEntry` discriminant values, the `toStepItems` label strings, `commandOptions` prop usage, and the validation message strings (e.g. "Primitive tap steps requireâ€¦") that later tasks must change.
+
+**Checkpoint**: Source layout and current state shape understood; new test directory exists. Run `vite build && jest` to confirm the baseline is green before proceeding.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared component change that the edit flow and panel wiring depend on
+
+**âš ï¸ CRITICAL**: Complete before user-story panel wiring relies on it
+
+- [X] T003 Add an optional `onEdit?: (item: ReorderableListItem) => void` prop to `src/web-ui/src/components/SortableSequenceStepList.tsx`; when provided, render an "Edit" button in `.reorderable-list__controls` alongside the existing "Delete" button that calls `onEdit(item)`. Leave behaviour unchanged when `onEdit` is absent.
+- [X] T004 [P] Update `src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx` to cover the new `onEdit` behaviour: Edit button renders only when `onEdit` is supplied, and clicking it fires `onEdit` with the correct item.
+
+**Checkpoint**: Step list can surface an Edit affordance; ready for CommandForm scaffolding and panels. Run `vite build && jest` â€” must be green before US1 work begins.
+
+---
+
+## Phase 3: User Story 1 - Select Action Then Fill Panel (Priority: P1) ðŸŽ¯ MVP
+
+**Goal**: Replace the flat always-visible step controls with an action-first selector and the CommandForm scaffolding (state, edit routing, panel slot) that every panel plugs into. Remove the "Add command" step-addition UI and apply the "Tap" rename in display/validation text.
+
+**Independent Test**: Open the command editor â€” the add-step selector lists exactly Tap, Wait for Image, Ensure Game Running (no Command option); selecting an action clears any previously open panel; clicking an existing step routes into edit mode; after a confirm the selector returns to blank. (Full "panel appears" verification completes once the first panel from US2 is wired.)
+
+### Tests for User Story 1
+
+- [X] T005 [P] [US1] Create `src/web-ui/src/components/commands/__tests__/ActionTypeSelector.test.tsx`: renders a blank first option plus exactly Tap / Wait for Image / Ensure Game Running; `onChange` fires with `'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning'`; the blank option yields `''`.
+- [X] T006 [P] [US1] Create `src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx` (scaffolding scenarios): selector shows the three options and no "Add command" UI (FR-001, SC-002); switching action type resets panel state (FR-006, SC-005); after confirm the selector returns to blank (FR-009, SC-006); clicking a primitive-action step opens edit mode (FR-011); step list labels read "Tap: â€¦" not "Primitive tap: â€¦"; mount CommandForm with an existing Command-type step and assert it renders in the list and its Delete button fires (FR-010, U2); assert clicking a Command step's Edit button does NOT open any panel and leaves `pendingActionType` as `''` (I2 guard).
+
+### Implementation for User Story 1
+
+- [X] T007 [P] [US1] Create `src/web-ui/src/components/commands/ActionTypeSelector.tsx` â€” a `<select>` with a blank first option followed by Tap, Wait for Image, Ensure Game Running, typed per plan (`value`/`onChange`/`disabled` props over `'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | ''`).
+- [X] T008 [US1] Refactor `src/web-ui/src/components/commands/CommandForm.tsx` state: remove `pendingCommandId`, `pendingPrimitiveReferenceImageId`, `primitiveTapStale`, `pendingPrimitiveConfidence`, `pendingPrimitiveOffsetX`, `pendingPrimitiveOffsetY`, `pendingWaitReferenceImageId`, `pendingWaitConfidence`, `pendingWaitTimeoutMs`; add `pendingActionType` and `editingStepId` state per data-model.md.
+- [X] T009 [US1] In `src/web-ui/src/components/commands/CommandForm.tsx`, remove the "Add command" `SearchableDropdown` and its add button from the JSX; retain the `commandOptions` prop and the `Command` branch in `toStepItems` so existing Command steps still render and stay deletable (FR-010).
+- [X] T010 [US1] In `src/web-ui/src/components/commands/CommandForm.tsx`, render `ActionTypeSelector` bound to `pendingActionType`/`setPendingActionType` in the Steps `FormSection`, plus an empty conditional panel slot (no panel components imported yet â€” US2â€“US4 fill it). Selecting a different action resets `editingStepId` to `null` so stale state cannot bleed across types (FR-002, FR-006).
+- [X] T011 [US1] In `src/web-ui/src/components/commands/CommandForm.tsx`, add `handleEditStep(item)` and pass `onEdit={handleEditStep}` to `SortableSequenceStepList`; on edit, look up the step by id and guard: if `step.type` is not in `{'PrimitiveTap', 'WaitForImage', 'EnsureGameRunning'}` (e.g. it is `'Command'`), return immediately without changing state â€” Command steps have no panel (plan C4, I2 fix). For supported types, set `editingStepId` and `pendingActionType` so the matching panel opens pre-filled (FR-011, SC-007).
+- [X] T012 [US1] In `src/web-ui/src/components/commands/CommandForm.tsx`, change the `toStepItems` label `"Primitive tap: â€¦"` â†’ `"Tap: â€¦"` and update the Steps `FormSection` description to "Select an action type to add or edit steps." (plan C5, C7).
+- [X] T013 [US1] In `src/web-ui/src/pages/CommandsPage.tsx`, change the validation message `"Primitive tap steps requireâ€¦"` â†’ `"Tap steps requireâ€¦"` (plan C6, SC-004 wording consistency).
+- [X] T014 [US1] Update `src/web-ui/src/features/authoring/__tests__/CommandForm.zoom.test.tsx`: remove references to the removed `pendingX` controls and the "Add command" UI, retain the unchanged Detection-section assertions, and update step-panel selectors to the new selector-based controls.
+- [X] T015 [P] [US1] Add base panel/selector styling to `src/web-ui/src/components/commands/CommandForm.css` for the action selector and the shared panel container (reused by all three panels in US2â€“US4).
+
+**Checkpoint**: Selector, edit routing, Command-removal, and renames are in place and compile; the panel slot is empty until US2 wires the first panel. Run `vite build && jest` â€” must be green before US2 work begins.
+
+---
+
+## Phase 4: User Story 2 - Tap Panel (Priority: P2)
+
+**Goal**: A focused Tap panel exposing exactly reference image (required), confidence, offsetX, offsetY â€” wired into CommandForm for add and in-place edit.
+
+**Independent Test**: Select Tap â†’ panel shows only the four Tap fields; submitting with an empty/stale reference image is blocked with a "image required" error; submitting with all four values saves them on the step; clicking an existing Tap step reopens the panel pre-filled.
+
+### Tests for User Story 2
+
+- [X] T016 [P] [US2] Create `src/web-ui/src/components/commands/__tests__/TapPanel.test.tsx`: renders only image/confidence/offsetX/offsetY (FR-003, SC-003); confirm blocked when `referenceImageId` empty with error text "Reference image is required." (FR-007, SC-004, U4); confirm blocked when `referenceImageId` stale with same error (FR-007); confirm blocked when `confidence` non-empty and outside 0â€“1 with error text "Confidence must be a number between 0 and 1." (U1); confirm fires with all four values when valid; cancel does not call `onConfirm`; `initialValue` pre-fills fields.
+
+### Implementation for User Story 2
+
+- [X] T017 [P] [US2] Create `src/web-ui/src/components/commands/TapPanel.tsx` per plan A2 / data-model: internal state `referenceImageId` (required, default `''`), `confidence` (default `''`), `offsetX`/`offsetY` (default `'0'`), `stale`; renders image selector + three optional inputs + Add/Save + Cancel; blocks confirm when image empty or stale (error: "Reference image is required."); blocks confirm when confidence non-empty and outside 0â€“1 (error: "Confidence must be a number between 0 and 1.").
+- [X] T018 [US2] Wire `TapPanel` into `src/web-ui/src/components/commands/CommandForm.tsx`: render it when `pendingActionType === 'PrimitiveTap'`, feeding `initialValue` from the step looked up by `editingStepId`; `onConfirm` appends a new `PrimitiveTap` step (add mode) or replaces it at its current index (edit mode), then resets `pendingActionType`/`editingStepId`; `onCancel` resets both without changing steps.
+- [X] T019 [US2] Extend `src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx` with the Tap add-and-edit flow end-to-end (select Tap â†’ fill â†’ add â†’ step appears as "Tap: â€¦"; click it â†’ panel pre-filled â†’ save updates in place), satisfying the remaining US1 acceptance scenario 2/5 now that a panel exists.
+
+**Checkpoint**: Tap steps can be added and edited end-to-end. **MVP reached (US1 + US2).** Run `vite build && jest` â€” must be green before US3 work begins.
+
+---
+
+## Phase 5: User Story 3 - Wait for Image Panel (Priority: P2)
+
+**Goal**: A Wait for Image panel exposing timeout (required) plus optional reference image and confidence â€” wired into CommandForm for add and edit.
+
+**Independent Test**: Select Wait for Image â†’ panel shows timeoutMs (required), optional image, optional confidence; empty/invalid timeout blocks submit with an error; timeout-only adds a duration-only wait; timeout + image + confidence saves all three; existing WaitForImage step reopens pre-filled.
+
+### Tests for User Story 3
+
+- [X] T020 [P] [US3] Create `src/web-ui/src/components/commands/__tests__/WaitForImagePanel.test.tsx`: renders only timeoutMs/image/confidence, no `stale` blocking (FR-004, SC-003, U3); confirm blocked when `timeoutMs` empty with error text "Timeout must be a non-negative whole number (ms)." (FR-008, SC-004, U4); confirm blocked when `timeoutMs` non-integer (same error); confirm blocked when `confidence` non-empty and outside 0â€“1 with error text "Confidence must be a number between 0 and 1." (U1); confirm fires with provided values; cancel does not call `onConfirm`; `initialValue` pre-fills fields; a stale or empty `referenceImageId` does not block confirm (staleness is advisory for optional image â€” U3).
+
+### Implementation for User Story 3
+
+- [X] T021 [P] [US3] Create `src/web-ui/src/components/commands/WaitForImagePanel.tsx` per plan A3 / data-model: internal state `timeoutMs` (required, default `'1000'`), `referenceImageId` (default `''`), `confidence` (default `''`); no `stale` field (optional image is advisory â€” U3); renders timeout input + optional image selector + optional confidence + Add/Save + Cancel; blocks confirm unless `timeoutMs` is a non-negative integer string (error: "Timeout must be a non-negative whole number (ms)."); blocks confirm when confidence non-empty and outside 0â€“1 (error: "Confidence must be a number between 0 and 1.").
+- [X] T022 [US3] Wire `WaitForImagePanel` into `src/web-ui/src/components/commands/CommandForm.tsx`: render it when `pendingActionType === 'WaitForImage'` with `initialValue` from the edited step; `onConfirm` appends/updates a `WaitForImage` step then resets pending state; `onCancel` resets without changing steps.
+- [X] T023 [US3] Extend `src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx` with the Wait for Image add-and-edit flow end-to-end.
+
+**Checkpoint**: Tap and Wait for Image both work independently end-to-end. Run `vite build && jest` â€” must be green before US4 work begins.
+
+---
+
+## Phase 6: User Story 4 - Ensure Game Running Panel (Priority: P3)
+
+**Goal**: A minimal Ensure Game Running panel â€” description text and a confirm button, no input fields â€” wired into CommandForm.
+
+**Independent Test**: Select Ensure Game Running â†’ panel shows descriptive text and an Add control with zero input fields; confirming adds an EnsureGameRunning step.
+
+### Tests for User Story 4
+
+- [X] T024 [P] [US4] Create `src/web-ui/src/components/commands/__tests__/EnsureGameRunningPanel.test.tsx`: renders description text and an Add control with no input fields (FR-005, SC-003); confirm fires `onConfirm`; cancel does not.
+
+### Implementation for User Story 4
+
+- [X] T025 [P] [US4] Create `src/web-ui/src/components/commands/EnsureGameRunningPanel.tsx` per plan A4: descriptive text ("Checks that the game is in the foreground; starts it if not running."), Add button, Cancel button, no inputs.
+- [X] T026 [US4] Wire `EnsureGameRunningPanel` into `src/web-ui/src/components/commands/CommandForm.tsx`: render it when `pendingActionType === 'EnsureGameRunning'`; `onConfirm` appends an `EnsureGameRunning` step (edit mode is a no-op confirm since it has no attributes) then resets pending state; `onCancel` resets without changing steps.
+- [X] T027 [US4] Extend `src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx` with the Ensure Game Running add flow.
+
+**Checkpoint**: All three primitive action panels are addable/editable; the add-step area never shows fields from removed/other action types (SC-001). Run `vite build && jest` â€” must be green before Polish phase.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency sweep and quality gate
+
+- [X] T028 [P] Per-panel styling pass in `src/web-ui/src/components/commands/CommandForm.css` (validation-error text, button rows) so all three panels render consistently with the base styles from T015.
+- [X] T029 Grep the web-ui source for any remaining "Primitive tap" / "Primitive Tap" user-facing strings and confirm only the `'PrimitiveTap'` discriminant value remains (no display/validation text), preserving API/DTO compatibility (research decision; plan constraint).
+- [X] T030 Run the project quality gate from `src/web-ui`: `vite build` then `jest`. Fix any failures; do not leave a red build/test (constitution hard stop). Confirm coverage on touched areas meets the gate.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies â€” start immediately.
+- **Foundational (Phase 2)**: Depends on Setup. The `onEdit` list change (T003/T004) is a prerequisite for US1's edit routing (T011).
+- **User Story 1 (Phase 3)**: Depends on Foundational. Provides the selector + CommandForm scaffolding + panel slot that US2â€“US4 plug into; therefore US1 scaffolding precedes the panel-wiring tasks of US2â€“US4.
+- **User Story 2 (Phase 4)**: Panel component (T016/T017) is independent and can be built in parallel with US1; its CommandForm wiring (T018) depends on the US1 slot (T010).
+- **User Story 3 (Phase 5)**: Same shape as US2 â€” panel independent; wiring depends on US1 slot.
+- **User Story 4 (Phase 6)**: Same shape as US2 â€” panel independent; wiring depends on US1 slot.
+- **Polish (Phase 7)**: Depends on all desired stories being complete.
+
+### Story Independence Notes
+
+- Each panel component (TapPanel, WaitForImagePanel, EnsureGameRunningPanel) is a self-contained, independently unit-testable leaf with `onConfirm`/`onCancel` â€” its test task (T016/T020/T024) and creation task (T017/T021/T025) have no cross-story dependency.
+- The integration (wiring) tasks for each panel share the single file `CommandForm.tsx`, so T018, T022, T026 are **not** parallel with each other.
+- US1's full "panel appears" acceptance (scenario 2) is exercised once the first panel is wired (T019), which is why MVP is **US1 + US2**, not US1 alone.
+
+### Within Each User Story
+
+- Tests are written to fail first, then implementation makes them pass.
+- Panel component creation before its CommandForm wiring.
+- CommandForm wiring before the end-to-end flow test extension.
+
+### Parallel Opportunities
+
+- T001 and the baseline read (T002) â€” T001 is [P].
+- Panel components T017, T021, T025 are different files â†’ fully parallel.
+- Panel unit tests T016, T020, T024 are different files â†’ fully parallel, and parallel with their own component creation only if written test-first against the agreed prop contracts in plan.md.
+- ActionTypeSelector (T007) and base CSS (T015) are parallel with the CommandForm refactor tasks.
+- **Not parallel**: all tasks touching `CommandForm.tsx` (T008â€“T013, T018, T022, T026) and all tasks touching `CommandForm.steps.test.tsx` (T006, T019, T023, T027) â€” same files, sequential.
+
+---
+
+## Parallel Example: Panel Components (US2 / US3 / US4)
+
+```text
+# Different files, no shared state â€” build the three panels in parallel:
+Task: "Create src/web-ui/src/components/commands/TapPanel.tsx"              (T017)
+Task: "Create src/web-ui/src/components/commands/WaitForImagePanel.tsx"     (T021)
+Task: "Create src/web-ui/src/components/commands/EnsureGameRunningPanel.tsx" (T025)
+
+# And their unit tests in parallel:
+Task: "TapPanel.test.tsx"              (T016)
+Task: "WaitForImagePanel.test.tsx"     (T020)
+Task: "EnsureGameRunningPanel.test.tsx" (T024)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + User Story 2)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational (`onEdit` on the step list).
+3. Complete Phase 3: US1 scaffolding (selector, state, edit routing, Command removal, renames).
+4. Complete Phase 4: US2 Tap panel + wiring.
+5. **STOP and VALIDATE**: add and edit a Tap step end-to-end; confirm no "Add command" UI and no stale fields. This is the demoable MVP.
+
+### Incremental Delivery
+
+1. Setup + Foundational â†’ list supports Edit.
+2. US1 + US2 â†’ selector flow with Tap panel (MVP).
+3. US3 â†’ Wait for Image panel.
+4. US4 â†’ Ensure Game Running panel.
+5. Polish â†’ consistency sweep + green `vite build` + `jest`.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies.
+- `StepEntry.type` discriminant values (including `'PrimitiveTap'`) are unchanged for API/DTO compatibility â€” only display/validation text is renamed.
+- The real green gate for this repo is `vite build` + `jest` (lint and `tsc --noEmit` carry pre-existing failures), per project conventions. Each phase checkpoint requires a green gate before the next phase starts.
+- `pendingActionType` uses `''` (empty string) as the "no panel open" sentinel â€” not `null`. This matches `ActionTypeSelectorProps.value` directly (I1 fix).
+- WaitForImagePanel has no `stale` field â€” its optional `referenceImageId` is advisory; a stale/deleted image reference does not block confirm (U3 decision).
+- `handleEditStep` guards against `step.type === 'Command'` with an early return â€” Command steps have no panel (I2 fix).
+- Confidence range validation (0â€“1) applies when the field is non-empty in both TapPanel and WaitForImagePanel (U1 decision).
+- Commit after each task or logical group; never proceed past a red build/test.

--- a/src/web-ui/src/components/SortableSequenceStepList.tsx
+++ b/src/web-ui/src/components/SortableSequenceStepList.tsx
@@ -7,6 +7,7 @@ import type { ReorderableListItem } from './ReorderableList';
 type SortableSequenceStepListProps = {
   items: ReorderableListItem[];
   onDelete: (item: ReorderableListItem) => void;
+  onEdit?: (item: ReorderableListItem) => void;
   disabled?: boolean;
   emptyMessage?: string;
   activeId?: string | null;
@@ -16,6 +17,7 @@ type SortableSequenceStepListProps = {
 export const SortableSequenceStepList: React.FC<SortableSequenceStepListProps> = ({
   items,
   onDelete,
+  onEdit,
   disabled,
   emptyMessage = 'No steps added yet.',
   activeId,
@@ -42,6 +44,7 @@ export const SortableSequenceStepList: React.FC<SortableSequenceStepListProps> =
                   {item.details && <div className="reorderable-list__details">{item.details}</div>}
                 </div>
                 <div className="reorderable-list__controls">
+                  {onEdit && <button type="button" onClick={() => onEdit(item)} disabled={disabled}>Edit</button>}
                   <button type="button" onClick={() => onDelete(item)} disabled={disabled}>Delete</button>
                 </div>
               </SortableStepItem>

--- a/src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx
+++ b/src/web-ui/src/components/__tests__/SortableSequenceStepList.test.tsx
@@ -62,6 +62,28 @@ describe('SortableSequenceStepList', () => {
     screen.getAllByText('Delete').forEach((btn) => expect(btn).toBeDisabled());
   });
 
+  it('does not render Edit buttons when onEdit is not supplied', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} />);
+    expect(screen.queryByText('Edit')).toBeNull();
+  });
+
+  it('renders an Edit button for each item when onEdit is supplied', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} onEdit={() => {}} />);
+    expect(screen.getAllByText('Edit')).toHaveLength(items.length);
+  });
+
+  it('calls onEdit with the correct item when Edit is clicked', () => {
+    const onEdit = jest.fn();
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} onEdit={onEdit} />);
+    fireEvent.click(screen.getAllByText('Edit')[1]);
+    expect(onEdit).toHaveBeenCalledWith(items[1]);
+  });
+
+  it('Edit buttons are disabled when disabled prop is true', () => {
+    render(<SortableSequenceStepList items={items} onDelete={() => {}} onEdit={() => {}} disabled />);
+    screen.getAllByText('Edit').forEach((btn) => expect(btn).toBeDisabled());
+  });
+
   it('renders a drag handle for each item', () => {
     render(<SortableSequenceStepList items={items} onDelete={() => {}} />);
     expect(screen.getAllByLabelText('Drag to reorder')).toHaveLength(items.length);

--- a/src/web-ui/src/components/commands/ActionTypeSelector.tsx
+++ b/src/web-ui/src/components/commands/ActionTypeSelector.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export type PrimitiveActionType = 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning';
+
+export type ActionTypeSelectorProps = {
+  value: PrimitiveActionType | '';
+  onChange: (next: PrimitiveActionType | '') => void;
+  disabled?: boolean;
+};
+
+export const ActionTypeSelector: React.FC<ActionTypeSelectorProps> = ({ value, onChange, disabled }) => {
+  return (
+    <div className="field">
+      <label htmlFor="action-type-selector">Action type</label>
+      <select
+        id="action-type-selector"
+        value={value}
+        onChange={(e) => onChange(e.target.value as PrimitiveActionType | '')}
+        disabled={disabled}
+      >
+        <option value="">— Select an action —</option>
+        <option value="PrimitiveTap">Tap</option>
+        <option value="WaitForImage">Wait for Image</option>
+        <option value="EnsureGameRunning">Ensure Game Running</option>
+      </select>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/commands/CommandForm.css
+++ b/src/web-ui/src/components/commands/CommandForm.css
@@ -149,7 +149,7 @@
 .command-form .reorderable-list__controls {
   display: flex;
   gap: var(--gb-space-2);
-  flex-wrap: wrap;
+  flex-shrink: 0;
   justify-content: flex-end;
 }
 

--- a/src/web-ui/src/components/commands/CommandForm.css
+++ b/src/web-ui/src/components/commands/CommandForm.css
@@ -162,6 +162,35 @@
   border-top: 1px solid var(--gb-color-border);
 }
 
+/* ── Action panels ─────────────────────────────────────────────────── */
+
+.command-form .action-panel {
+  display: grid;
+  gap: var(--gb-space-3);
+  padding: var(--gb-space-3) var(--gb-space-4);
+  border: 1px solid var(--gb-color-border-strong);
+  border-radius: var(--gb-radius-md);
+  background: var(--gb-color-surface-alt);
+}
+
+.command-form .action-panel__description {
+  margin: 0;
+  color: var(--gb-color-text);
+  line-height: 1.5;
+}
+
+.command-form .action-panel__controls {
+  display: flex;
+  gap: var(--gb-space-2);
+  flex-wrap: wrap;
+}
+
+.command-form .action-panel .field-error {
+  color: var(--gb-color-danger);
+  font-weight: 600;
+  margin-top: 2px;
+}
+
 @media (min-width: 1280px) {
   .command-form {
     padding: 20px 24px;

--- a/src/web-ui/src/components/commands/CommandForm.tsx
+++ b/src/web-ui/src/components/commands/CommandForm.tsx
@@ -3,9 +3,13 @@ import { ImageSelectorDropdown } from '../images/ImageSelectorDropdown';
 import { DndContext, DragEndEvent, DragOverEvent, DragStartEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 import { FormActions, FormSection } from '../unified/FormLayout';
-import { SearchableDropdown, SearchableOption } from '../SearchableDropdown';
+import type { SearchableOption } from '../SearchableDropdown';
 import type { ReorderableListItem } from '../ReorderableList';
 import { SortableSequenceStepList } from '../SortableSequenceStepList';
+import { ActionTypeSelector, PrimitiveActionType } from './ActionTypeSelector';
+import { TapPanel } from './TapPanel';
+import { WaitForImagePanel } from './WaitForImagePanel';
+import { EnsureGameRunningPanel } from './EnsureGameRunningPanel';
 import './CommandForm.css';
 
 export type StepEntry = {
@@ -56,7 +60,7 @@ const toStepItems = (steps: StepEntry[], commandOpts: SearchableOption[]): Reord
       const offsetY = step.primitiveTap?.detectionTarget.offsetY ?? '0';
       return {
         id: step.id,
-        label: `Primitive tap: ${imageId}`,
+        label: `Tap: ${imageId}`,
         description: `Offset (${offsetX}, ${offsetY})`,
       };
     }
@@ -90,6 +94,8 @@ const toStepItems = (steps: StepEntry[], commandOpts: SearchableOption[]): Reord
   });
 };
 
+const EDITABLE_TYPES = new Set<string>(['PrimitiveTap', 'WaitForImage', 'EnsureGameRunning']);
+
 export const CommandForm: React.FC<CommandFormProps> = ({
   value,
   commandOptions,
@@ -100,30 +106,58 @@ export const CommandForm: React.FC<CommandFormProps> = ({
   onSubmit,
   onCancel,
 }) => {
-  const [pendingCommandId, setPendingCommandId] = useState<string | undefined>(undefined);
-  const [pendingPrimitiveReferenceImageId, setPendingPrimitiveReferenceImageId] = useState('');
-  const [primitiveTapStale, setPrimitiveTapStale] = useState(false);
-  const [pendingPrimitiveConfidence, setPendingPrimitiveConfidence] = useState('');
-  const [pendingPrimitiveOffsetX, setPendingPrimitiveOffsetX] = useState('0');
-  const [pendingPrimitiveOffsetY, setPendingPrimitiveOffsetY] = useState('0');
-  const [pendingWaitReferenceImageId, setPendingWaitReferenceImageId] = useState('');
-  const [pendingWaitConfidence, setPendingWaitConfidence] = useState('');
-  const [pendingWaitTimeoutMs, setPendingWaitTimeoutMs] = useState('1000');
+  const [pendingActionType, setPendingActionType] = useState<PrimitiveActionType | ''>('');
+  const [editingStepId, setEditingStepId] = useState<string | null>(null);
   const [activeStepId, setActiveStepId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
-
   const stepItems = useMemo(() => toStepItems(value.steps, commandOptions), [value.steps, commandOptions]);
 
   const addStep = (step: Omit<StepEntry, 'id'>) => {
-    const next = [...value.steps, { ...step, id: makeId() }];
+    onChange({ ...value, steps: [...value.steps, { ...step, id: makeId() }] });
+  };
+
+  const updateStep = (id: string, step: Omit<StepEntry, 'id'>) => {
+    const idx = value.steps.findIndex((s) => s.id === id);
+    if (idx === -1) return;
+    const next = [...value.steps];
+    next[idx] = { ...step, id };
     onChange({ ...value, steps: next });
   };
 
   const removeStep = (itemId: string) => {
     onChange({ ...value, steps: value.steps.filter((s) => s.id !== itemId) });
   };
+
+  const handleActionTypeChange = (next: PrimitiveActionType | '') => {
+    setPendingActionType(next);
+    setEditingStepId(null);
+  };
+
+  const handleEditStep = (item: ReorderableListItem) => {
+    const step = value.steps.find((s) => s.id === item.id);
+    if (!step || !EDITABLE_TYPES.has(step.type)) return;
+    setEditingStepId(step.id);
+    setPendingActionType(step.type as PrimitiveActionType);
+  };
+
+  const handlePanelConfirm = (step: Omit<StepEntry, 'id'>) => {
+    if (editingStepId) {
+      updateStep(editingStepId, step);
+    } else {
+      addStep(step);
+    }
+    setPendingActionType('');
+    setEditingStepId(null);
+  };
+
+  const handlePanelCancel = () => {
+    setPendingActionType('');
+    setEditingStepId(null);
+  };
+
+  const editingStep = editingStepId ? value.steps.find((s) => s.id === editingStepId) : undefined;
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveStepId(event.active.id as string);
@@ -174,180 +208,61 @@ export const CommandForm: React.FC<CommandFormProps> = ({
         </div>
       </FormSection>
 
-      <FormSection title="Steps" description="Choose command or primitive tap steps and set their order." id="command-steps">
-
-        <SearchableDropdown
-          id="command-commands-dropdown"
-          label="Add command"
-          options={commandOptions}
-          value={pendingCommandId}
-          onChange={setPendingCommandId}
+      <FormSection title="Steps" description="Select an action type to add or edit steps." id="command-steps">
+        <ActionTypeSelector
+          value={pendingActionType}
+          onChange={handleActionTypeChange}
           disabled={submitting || loading}
-          placeholder="Select a command"
         />
-        <div className="field">
-          <button
-            type="button"
-            onClick={() => {
-              if (!pendingCommandId) return;
-              addStep({ type: 'Command', targetId: pendingCommandId });
-              setPendingCommandId(undefined);
-            }}
-            disabled={submitting || loading || !pendingCommandId}
-          >
-            Add command step
-          </button>
-        </div>
 
-        <div className="field grid-3">
-          <div>
-            <ImageSelectorDropdown
-              id="command-primitive-reference"
-              label="Primitive tap image ID"
-              value={pendingPrimitiveReferenceImageId}
-              onChange={setPendingPrimitiveReferenceImageId}
-              required
-              onStaleChange={setPrimitiveTapStale}
-              error={primitiveTapStale ? 'Selected image no longer exists — please choose a valid image' : undefined}
-              disabled={submitting || loading}
-            />
-          </div>
-          <div>
-            <label htmlFor="command-primitive-confidence">Primitive confidence (0-1)</label>
-            <input
-              id="command-primitive-confidence"
-              type="number"
-              step="0.01"
-              min="0"
-              max="1"
-              value={pendingPrimitiveConfidence}
-              onChange={(e) => setPendingPrimitiveConfidence(e.target.value)}
-              disabled={submitting || loading}
-            />
-          </div>
-          <div>
-            <label htmlFor="command-primitive-offset-x">Primitive offset X</label>
-            <input
-              id="command-primitive-offset-x"
-              type="number"
-              value={pendingPrimitiveOffsetX}
-              onChange={(e) => setPendingPrimitiveOffsetX(e.target.value)}
-              disabled={submitting || loading}
-            />
-          </div>
-        </div>
-        <div className="field">
-          <label htmlFor="command-primitive-offset-y">Primitive offset Y</label>
-          <input
-            id="command-primitive-offset-y"
-            type="number"
-            value={pendingPrimitiveOffsetY}
-            onChange={(e) => setPendingPrimitiveOffsetY(e.target.value)}
-            disabled={submitting || loading}
-          />
-        </div>
-        <div className="field">
-          <button
-            type="button"
-            onClick={() => {
-              const imageId = pendingPrimitiveReferenceImageId.trim();
-              if (!imageId) return;
-              addStep({
+        {pendingActionType === 'PrimitiveTap' && (
+          <TapPanel
+            initialValue={editingStep?.primitiveTap?.detectionTarget}
+            onConfirm={(tapValue) =>
+              handlePanelConfirm({
                 type: 'PrimitiveTap',
-                primitiveTap: {
-                  detectionTarget: {
-                    referenceImageId: imageId,
-                    confidence: pendingPrimitiveConfidence || undefined,
-                    offsetX: pendingPrimitiveOffsetX || undefined,
-                    offsetY: pendingPrimitiveOffsetY || undefined,
-                  }
-                }
-              });
-              setPendingPrimitiveReferenceImageId('');
-              setPendingPrimitiveConfidence('');
-              setPendingPrimitiveOffsetX('0');
-              setPendingPrimitiveOffsetY('0');
-            }}
-            disabled={submitting || loading || !pendingPrimitiveReferenceImageId.trim() || primitiveTapStale}
-          >
-            Add primitive tap step
-          </button>
-        </div>
+                primitiveTap: { detectionTarget: tapValue },
+              })
+            }
+            onCancel={handlePanelCancel}
+            disabled={submitting}
+          />
+        )}
 
-        <div className="field grid-3">
-          <div>
-            <ImageSelectorDropdown
-              id="command-wait-reference"
-              label="Wait image ID"
-              value={pendingWaitReferenceImageId}
-              onChange={(id) => {
-                setPendingWaitReferenceImageId(id);
-                if (!id) setPendingWaitConfidence('');
-              }}
-              disabled={submitting || loading}
-            />
-          </div>
-          <div>
-            <label htmlFor="command-wait-confidence">Wait confidence (0-1)</label>
-            <input
-              id="command-wait-confidence"
-              type="number"
-              step="0.01"
-              min="0"
-              max="1"
-              value={pendingWaitConfidence}
-              onChange={(e) => setPendingWaitConfidence(e.target.value)}
-              disabled={submitting || loading || !pendingWaitReferenceImageId.trim()}
-            />
-          </div>
-          <div>
-            <label htmlFor="command-wait-timeout">Wait timeout (ms)</label>
-            <input
-              id="command-wait-timeout"
-              type="number"
-              min="0"
-              value={pendingWaitTimeoutMs}
-              onChange={(e) => setPendingWaitTimeoutMs(e.target.value)}
-              disabled={submitting || loading}
-            />
-          </div>
-        </div>
-        <div className="field">
-          <button
-            type="button"
-            onClick={() => {
-              const imageId = pendingWaitReferenceImageId.trim();
-              addStep({
+        {pendingActionType === 'WaitForImage' && (
+          <WaitForImagePanel
+            initialValue={
+              editingStep?.waitForImage
+                ? {
+                    timeoutMs: editingStep.waitForImage.timeoutMs,
+                    referenceImageId: editingStep.waitForImage.detectionTarget?.referenceImageId,
+                    confidence: editingStep.waitForImage.detectionTarget?.confidence,
+                  }
+                : undefined
+            }
+            onConfirm={(wfValue) =>
+              handlePanelConfirm({
                 type: 'WaitForImage',
                 waitForImage: {
-                  detectionTarget: imageId
-                    ? {
-                      referenceImageId: imageId,
-                      confidence: pendingWaitConfidence || undefined,
-                    }
+                  timeoutMs: wfValue.timeoutMs,
+                  detectionTarget: wfValue.referenceImageId?.trim()
+                    ? { referenceImageId: wfValue.referenceImageId, confidence: wfValue.confidence }
                     : undefined,
-                  timeoutMs: pendingWaitTimeoutMs || '1000',
-                }
-              });
-              setPendingWaitReferenceImageId('');
-              setPendingWaitConfidence('');
-              setPendingWaitTimeoutMs('1000');
-            }}
-            disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
-          >
-            Add wait for image step
-          </button>
-        </div>
+                },
+              })
+            }
+            onCancel={handlePanelCancel}
+            disabled={submitting}
+          />
+        )}
 
-        <div className="field">
-          <button
-            type="button"
-            onClick={() => addStep({ type: 'EnsureGameRunning' })}
-            disabled={submitting || loading}
-          >
-            Add ensure game running step
-          </button>
-        </div>
+        {pendingActionType === 'EnsureGameRunning' && (
+          <EnsureGameRunningPanel
+            onConfirm={() => handlePanelConfirm({ type: 'EnsureGameRunning' })}
+            onCancel={handlePanelCancel}
+            disabled={submitting}
+          />
+        )}
 
         <DndContext
           sensors={sensors}
@@ -359,8 +274,9 @@ export const CommandForm: React.FC<CommandFormProps> = ({
           <SortableSequenceStepList
             items={stepItems}
             onDelete={(item) => removeStep(item.id)}
+            onEdit={handleEditStep}
             disabled={submitting || loading}
-            emptyMessage="No steps yet. Add command, primitive tap, or wait-for-image steps."
+            emptyMessage="No steps yet. Select an action type above to add steps."
             activeId={activeStepId}
             overId={overId}
           />

--- a/src/web-ui/src/components/commands/EnsureGameRunningPanel.tsx
+++ b/src/web-ui/src/components/commands/EnsureGameRunningPanel.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export type EnsureGameRunningPanelProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+
+export const EnsureGameRunningPanel: React.FC<EnsureGameRunningPanelProps> = ({
+  onConfirm,
+  onCancel,
+  disabled,
+}) => {
+  return (
+    <div className="action-panel action-panel--ensure-game-running">
+      <p className="action-panel__description">
+        Checks that the game is in the foreground; starts it if not running.
+      </p>
+      <div className="action-panel__controls">
+        <button type="button" onClick={onConfirm} disabled={disabled}>
+          Add
+        </button>
+        <button type="button" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/commands/TapPanel.tsx
+++ b/src/web-ui/src/components/commands/TapPanel.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { ImageSelectorDropdown } from '../images/ImageSelectorDropdown';
+
+export type TapPanelValue = {
+  referenceImageId: string;
+  confidence?: string;
+  offsetX?: string;
+  offsetY?: string;
+};
+
+export type TapPanelProps = {
+  initialValue?: TapPanelValue;
+  onConfirm: (value: TapPanelValue) => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+
+const validateConfidence = (confidence: string): string | null => {
+  if (!confidence.trim()) return null;
+  const n = parseFloat(confidence);
+  if (isNaN(n) || n < 0 || n > 1) return 'Confidence must be a number between 0 and 1.';
+  return null;
+};
+
+export const TapPanel: React.FC<TapPanelProps> = ({ initialValue, onConfirm, onCancel, disabled }) => {
+  const [referenceImageId, setReferenceImageId] = useState(initialValue?.referenceImageId ?? '');
+  const [confidence, setConfidence] = useState(initialValue?.confidence ?? '');
+  const [offsetX, setOffsetX] = useState(initialValue?.offsetX ?? '0');
+  const [offsetY, setOffsetY] = useState(initialValue?.offsetY ?? '0');
+  const [stale, setStale] = useState(false);
+  const [attempted, setAttempted] = useState(false);
+
+  const imageError = !referenceImageId.trim() || stale ? 'Reference image is required.' : null;
+  const confidenceError = validateConfidence(confidence);
+  const hasErrors = Boolean(imageError || confidenceError);
+
+  const buttonLabel = initialValue !== undefined ? 'Save' : 'Add';
+
+  const handleConfirm = () => {
+    setAttempted(true);
+    if (hasErrors) return;
+    onConfirm({
+      referenceImageId: referenceImageId.trim(),
+      confidence: confidence.trim() || undefined,
+      offsetX: offsetX.trim() || undefined,
+      offsetY: offsetY.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="action-panel action-panel--tap">
+      <div className="field">
+        <ImageSelectorDropdown
+          id="tap-panel-image"
+          label="Reference image *"
+          value={referenceImageId}
+          onChange={(id) => { setReferenceImageId(id); setStale(false); }}
+          onStaleChange={setStale}
+          required
+          error={attempted && imageError ? imageError : undefined}
+          disabled={disabled}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="tap-panel-confidence">Confidence (0–1)</label>
+        <input
+          id="tap-panel-confidence"
+          type="number"
+          step="0.01"
+          min="0"
+          max="1"
+          value={confidence}
+          onChange={(e) => setConfidence(e.target.value)}
+          disabled={disabled}
+        />
+        {attempted && confidenceError && <div className="field-error" role="alert">{confidenceError}</div>}
+      </div>
+      <div className="field">
+        <label htmlFor="tap-panel-offset-x">Offset X</label>
+        <input
+          id="tap-panel-offset-x"
+          type="number"
+          value={offsetX}
+          onChange={(e) => setOffsetX(e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="tap-panel-offset-y">Offset Y</label>
+        <input
+          id="tap-panel-offset-y"
+          type="number"
+          value={offsetY}
+          onChange={(e) => setOffsetY(e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+      <div className="action-panel__controls">
+        <button type="button" onClick={handleConfirm} disabled={disabled}>
+          {buttonLabel}
+        </button>
+        <button type="button" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/commands/WaitForImagePanel.tsx
+++ b/src/web-ui/src/components/commands/WaitForImagePanel.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { ImageSelectorDropdown } from '../images/ImageSelectorDropdown';
+
+export type WaitForImagePanelValue = {
+  timeoutMs: string;
+  referenceImageId?: string;
+  confidence?: string;
+};
+
+export type WaitForImagePanelProps = {
+  initialValue?: {
+    timeoutMs?: string;
+    referenceImageId?: string;
+    confidence?: string;
+  };
+  onConfirm: (value: WaitForImagePanelValue) => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+
+const validateTimeoutMs = (value: string): string | null => {
+  if (!value.trim()) return 'Timeout must be a non-negative whole number (ms).';
+  if (!/^\d+$/.test(value.trim())) return 'Timeout must be a non-negative whole number (ms).';
+  return null;
+};
+
+const validateConfidence = (confidence: string): string | null => {
+  if (!confidence.trim()) return null;
+  const n = parseFloat(confidence);
+  if (isNaN(n) || n < 0 || n > 1) return 'Confidence must be a number between 0 and 1.';
+  return null;
+};
+
+export const WaitForImagePanel: React.FC<WaitForImagePanelProps> = ({
+  initialValue,
+  onConfirm,
+  onCancel,
+  disabled,
+}) => {
+  const [timeoutMs, setTimeoutMs] = useState(initialValue?.timeoutMs ?? '1000');
+  const [referenceImageId, setReferenceImageId] = useState(initialValue?.referenceImageId ?? '');
+  const [confidence, setConfidence] = useState(initialValue?.confidence ?? '');
+  const [attempted, setAttempted] = useState(false);
+
+  const timeoutError = validateTimeoutMs(timeoutMs);
+  const confidenceError = validateConfidence(confidence);
+  const hasErrors = Boolean(timeoutError || confidenceError);
+
+  const buttonLabel = initialValue !== undefined ? 'Save' : 'Add';
+
+  const handleConfirm = () => {
+    setAttempted(true);
+    if (hasErrors) return;
+    onConfirm({
+      timeoutMs: timeoutMs.trim(),
+      referenceImageId: referenceImageId.trim() || undefined,
+      confidence: confidence.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="action-panel action-panel--wait-for-image">
+      <div className="field">
+        <label htmlFor="wfi-panel-timeout">Timeout (ms) *</label>
+        <input
+          id="wfi-panel-timeout"
+          type="number"
+          min="0"
+          value={timeoutMs}
+          onChange={(e) => setTimeoutMs(e.target.value)}
+          disabled={disabled}
+        />
+        {attempted && timeoutError && <div className="field-error" role="alert">{timeoutError}</div>}
+      </div>
+      <div className="field">
+        <ImageSelectorDropdown
+          id="wfi-panel-image"
+          label="Reference image (optional)"
+          value={referenceImageId}
+          onChange={(id) => {
+            setReferenceImageId(id);
+            if (!id) setConfidence('');
+          }}
+          disabled={disabled}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="wfi-panel-confidence">Confidence (0–1)</label>
+        <input
+          id="wfi-panel-confidence"
+          type="number"
+          step="0.01"
+          min="0"
+          max="1"
+          value={confidence}
+          onChange={(e) => setConfidence(e.target.value)}
+          disabled={disabled}
+        />
+        {attempted && confidenceError && <div className="field-error" role="alert">{confidenceError}</div>}
+      </div>
+      <div className="action-panel__controls">
+        <button type="button" onClick={handleConfirm} disabled={disabled}>
+          {buttonLabel}
+        </button>
+        <button type="button" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/commands/__tests__/ActionTypeSelector.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/ActionTypeSelector.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ActionTypeSelector } from '../ActionTypeSelector';
+
+describe('ActionTypeSelector', () => {
+  it('renders a blank first option', () => {
+    render(<ActionTypeSelector value="" onChange={() => {}} />);
+    const select = screen.getByRole('combobox', { name: /action type/i });
+    expect(select).toHaveValue('');
+    const options = Array.from((select as HTMLSelectElement).options);
+    expect(options[0].value).toBe('');
+  });
+
+  it('renders exactly Tap, Wait for Image, Ensure Game Running options', () => {
+    render(<ActionTypeSelector value="" onChange={() => {}} />);
+    const select = screen.getByRole('combobox', { name: /action type/i });
+    const options = Array.from((select as HTMLSelectElement).options).map((o) => ({
+      value: o.value,
+      text: o.text,
+    }));
+    expect(options).toEqual([
+      { value: '', text: expect.any(String) },
+      { value: 'PrimitiveTap', text: 'Tap' },
+      { value: 'WaitForImage', text: 'Wait for Image' },
+      { value: 'EnsureGameRunning', text: 'Ensure Game Running' },
+    ]);
+    expect(options).toHaveLength(4);
+  });
+
+  it('onChange fires with PrimitiveTap when Tap is selected', () => {
+    const onChange = jest.fn();
+    render(<ActionTypeSelector value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), {
+      target: { value: 'PrimitiveTap' },
+    });
+    expect(onChange).toHaveBeenCalledWith('PrimitiveTap');
+  });
+
+  it('onChange fires with WaitForImage when Wait for Image is selected', () => {
+    const onChange = jest.fn();
+    render(<ActionTypeSelector value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), {
+      target: { value: 'WaitForImage' },
+    });
+    expect(onChange).toHaveBeenCalledWith('WaitForImage');
+  });
+
+  it('onChange fires with EnsureGameRunning when Ensure Game Running is selected', () => {
+    const onChange = jest.fn();
+    render(<ActionTypeSelector value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), {
+      target: { value: 'EnsureGameRunning' },
+    });
+    expect(onChange).toHaveBeenCalledWith('EnsureGameRunning');
+  });
+
+  it('onChange fires with empty string when blank option is selected', () => {
+    const onChange = jest.fn();
+    render(<ActionTypeSelector value="PrimitiveTap" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), {
+      target: { value: '' },
+    });
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('reflects current value in the select element', () => {
+    render(<ActionTypeSelector value="WaitForImage" onChange={() => {}} />);
+    expect(screen.getByRole('combobox', { name: /action type/i })).toHaveValue('WaitForImage');
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    render(<ActionTypeSelector value="" onChange={() => {}} disabled />);
+    expect(screen.getByRole('combobox', { name: /action type/i })).toBeDisabled();
+  });
+});

--- a/src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx
@@ -1,0 +1,355 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CommandForm, CommandFormValue, StepEntry } from '../CommandForm';
+
+// ── DnD mocks ─────────────────────────────────────────────────────────────────
+
+jest.mock('@dnd-kit/core', () => {
+  const React = jest.requireActual('react');
+  const MockDndContext = jest.fn(({ children }: any) =>
+    React.createElement(React.Fragment, null, children)
+  );
+  return {
+    DndContext: MockDndContext,
+    PointerSensor: class {},
+    useSensor: jest.fn(),
+    useSensors: jest.fn(() => []),
+  };
+});
+
+jest.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+  arrayMove: jest.fn((arr: unknown[], from: number, to: number) => {
+    const result = [...arr];
+    const [item] = result.splice(from, 1);
+    result.splice(to, 0, item);
+    return result;
+  }),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: { Translate: { toString: () => '' }, Transform: { toString: () => '' } },
+}));
+
+// ── ImageSelectorDropdown mock ────────────────────────────────────────────────
+
+jest.mock('../../images/ImageSelectorDropdown', () => ({
+  ImageSelectorDropdown: ({ value, onChange, onStaleChange, error, label, id }: any) => (
+    <div>
+      {label && <label htmlFor={id ?? 'mock-img'}>{label}</label>}
+      <input
+        id={id ?? 'mock-img'}
+        data-testid={`image-input-${id ?? 'default'}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {error && <div role="alert">{error}</div>}
+    </div>
+  ),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const tapStep: StepEntry = {
+  id: 'tap-1',
+  type: 'PrimitiveTap',
+  primitiveTap: { detectionTarget: { referenceImageId: 'img-a', offsetX: '0', offsetY: '0' } },
+};
+
+const waitStep: StepEntry = {
+  id: 'wait-1',
+  type: 'WaitForImage',
+  waitForImage: { timeoutMs: '2000', detectionTarget: { referenceImageId: 'img-b', confidence: '0.8' } },
+};
+
+const ensureStep: StepEntry = {
+  id: 'ensure-1',
+  type: 'EnsureGameRunning',
+};
+
+const commandStep: StepEntry = {
+  id: 'cmd-1',
+  type: 'Command',
+  targetId: 'other-cmd',
+};
+
+const emptyForm: CommandFormValue = { name: 'My Command', steps: [] };
+
+const getSelector = () => screen.getByRole('combobox', { name: /action type/i });
+
+// ── US1: Selector flow and scaffolding ────────────────────────────────────────
+
+describe('CommandForm — US1: selector and scaffolding', () => {
+  it('renders the action type selector', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    expect(getSelector()).toBeInTheDocument();
+  });
+
+  it('selector lists exactly Tap, Wait for Image, Ensure Game Running (no Command)', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    const options = Array.from((getSelector() as HTMLSelectElement).options).map((o) => o.text);
+    expect(options).toContain('Tap');
+    expect(options).toContain('Wait for Image');
+    expect(options).toContain('Ensure Game Running');
+    expect(options.some((t) => /command/i.test(t) && !/ensure/i.test(t))).toBe(false);
+  });
+
+  it('shows no "Add command" button (FR-001, SC-002)', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    expect(screen.queryByText(/add command step/i)).toBeNull();
+    expect(screen.queryByText(/add command/i)).toBeNull();
+  });
+
+  it('shows no panel when selector is blank', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    expect(screen.queryByText(/reference image \*/i)).toBeNull();
+    expect(screen.queryByText(/timeout/i)).toBeNull();
+    expect(screen.queryByText(/checks that the game/i)).toBeNull();
+  });
+
+  it('shows Tap panel when PrimitiveTap is selected', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    fireEvent.change(getSelector(), { target: { value: 'PrimitiveTap' } });
+    expect(screen.getByText(/reference image \*/i)).toBeInTheDocument();
+  });
+
+  it('shows Wait for Image panel when WaitForImage is selected', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    fireEvent.change(getSelector(), { target: { value: 'WaitForImage' } });
+    expect(screen.getByLabelText(/timeout \(ms\)/i)).toBeInTheDocument();
+  });
+
+  it('shows Ensure Game Running panel when EnsureGameRunning is selected', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    fireEvent.change(getSelector(), { target: { value: 'EnsureGameRunning' } });
+    expect(screen.getByText(/checks that the game is in the foreground/i)).toBeInTheDocument();
+  });
+
+  it('switching action type closes the previous panel (FR-006, SC-005)', () => {
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={() => {}} />);
+    fireEvent.change(getSelector(), { target: { value: 'PrimitiveTap' } });
+    expect(screen.getByText(/reference image \*/i)).toBeInTheDocument();
+    fireEvent.change(getSelector(), { target: { value: 'WaitForImage' } });
+    expect(screen.queryByText(/reference image \*/i)).toBeNull();
+    expect(screen.getByLabelText(/timeout \(ms\)/i)).toBeInTheDocument();
+  });
+
+  it('switching action type resets editingStepId so no old initialValue leaks', () => {
+    const onChange = jest.fn();
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [tapStep] }}
+        commandOptions={[]}
+        onChange={onChange}
+      />
+    );
+    // Open Tap panel in edit mode for tapStep
+    fireEvent.click(screen.getAllByText('Edit')[0]);
+    expect(getSelector()).toHaveValue('PrimitiveTap');
+
+    // Switch to WaitForImage → should show empty panel (no pre-filled timeout from tapStep)
+    fireEvent.change(getSelector(), { target: { value: 'WaitForImage' } });
+    const timeoutInput = screen.getByLabelText(/timeout \(ms\)/i);
+    // Default timeout is 1000 (fresh panel, not an old editingStep's value)
+    expect(timeoutInput).toHaveValue(1000);
+  });
+
+  it('existing Command-type step still renders in the step list (FR-010)', () => {
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [commandStep] }}
+        commandOptions={[{ value: 'other-cmd', label: 'Other Cmd' }]}
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByText(/Command: Other Cmd/)).toBeInTheDocument();
+  });
+
+  it('Delete button fires for Command-type step (FR-010)', () => {
+    const onChange = jest.fn();
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [commandStep] }}
+        commandOptions={[{ value: 'other-cmd', label: 'Other Cmd' }]}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onChange).toHaveBeenCalledWith({ ...emptyForm, steps: [] });
+  });
+
+  it('clicking Edit on a Command-type step does NOT open any panel (I2 guard)', () => {
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [commandStep] }}
+        commandOptions={[{ value: 'other-cmd', label: 'Other Cmd' }]}
+        onChange={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByText('Edit'));
+    expect(getSelector()).toHaveValue('');
+    expect(screen.queryByText(/reference image \*/i)).toBeNull();
+    expect(screen.queryByText(/timeout/i)).toBeNull();
+    expect(screen.queryByText(/checks that the game/i)).toBeNull();
+  });
+
+  it('step list labels read "Tap: …" not "Primitive tap: …" (plan C5)', () => {
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [tapStep] }}
+        commandOptions={[]}
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByText(/^Tap: img-a/)).toBeInTheDocument();
+    expect(screen.queryByText(/primitive tap/i)).toBeNull();
+  });
+});
+
+// ── US2: Tap panel — add and edit flow ────────────────────────────────────────
+
+describe('CommandForm — US2: Tap panel add and edit', () => {
+  it('adding a Tap step calls onChange with PrimitiveTap step and resets selector (FR-009, SC-006)', () => {
+    const onChange = jest.fn();
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={onChange} />);
+    fireEvent.change(getSelector(), { target: { value: 'PrimitiveTap' } });
+    fireEvent.change(screen.getByTestId('image-input-tap-panel-image'), { target: { value: 'img-x' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onChange).toHaveBeenCalled();
+    const updated: CommandFormValue = onChange.mock.calls[0][0];
+    expect(updated.steps).toHaveLength(1);
+    expect(updated.steps[0].type).toBe('PrimitiveTap');
+    expect(updated.steps[0].primitiveTap?.detectionTarget.referenceImageId).toBe('img-x');
+    // Selector should reset to blank
+    expect(getSelector()).toHaveValue('');
+  });
+
+  it('clicking Edit on a Tap step opens the panel pre-filled (FR-011, SC-007)', () => {
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [tapStep] }}
+        commandOptions={[]}
+        onChange={() => {}}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Edit')[0]);
+    expect(getSelector()).toHaveValue('PrimitiveTap');
+    const imageInput = screen.getByTestId('image-input-tap-panel-image');
+    expect(imageInput).toHaveValue('img-a');
+  });
+
+  it('saving an edited Tap step updates it in-place (SC-007)', () => {
+    const onChange = jest.fn();
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [tapStep] }}
+        commandOptions={[]}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Edit')[0]);
+    fireEvent.change(screen.getByTestId('image-input-tap-panel-image'), { target: { value: 'img-new' } });
+    // Panel Save button is type="button"; form Submit Save is type="submit" — take the first
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+    const updated: CommandFormValue = onChange.mock.calls[0][0];
+    expect(updated.steps).toHaveLength(1);
+    expect(updated.steps[0].id).toBe('tap-1');
+    expect(updated.steps[0].primitiveTap?.detectionTarget.referenceImageId).toBe('img-new');
+    expect(getSelector()).toHaveValue('');
+  });
+});
+
+// ── US3: Wait for Image panel — add and edit flow ─────────────────────────────
+
+describe('CommandForm — US3: Wait for Image panel add and edit', () => {
+  it('adding a WaitForImage step (timeout only) calls onChange and resets selector', () => {
+    const onChange = jest.fn();
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={onChange} />);
+    fireEvent.change(getSelector(), { target: { value: 'WaitForImage' } });
+    fireEvent.change(screen.getByLabelText(/timeout \(ms\)/i), { target: { value: '3000' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    const updated: CommandFormValue = onChange.mock.calls[0][0];
+    expect(updated.steps[0].type).toBe('WaitForImage');
+    expect(updated.steps[0].waitForImage?.timeoutMs).toBe('3000');
+    expect(updated.steps[0].waitForImage?.detectionTarget).toBeUndefined();
+    expect(getSelector()).toHaveValue('');
+  });
+
+  it('clicking Edit on a WaitForImage step opens the panel pre-filled', () => {
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [waitStep] }}
+        commandOptions={[]}
+        onChange={() => {}}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Edit')[0]);
+    expect(getSelector()).toHaveValue('WaitForImage');
+    expect(screen.getByLabelText(/timeout \(ms\)/i)).toHaveValue(2000);
+    expect(screen.getByTestId('image-input-wfi-panel-image')).toHaveValue('img-b');
+  });
+
+  it('saving an edited WaitForImage step updates it in-place', () => {
+    const onChange = jest.fn();
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [waitStep] }}
+        commandOptions={[]}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Edit')[0]);
+    fireEvent.change(screen.getByLabelText(/timeout \(ms\)/i), { target: { value: '9000' } });
+    // Panel Save button is type="button"; form Submit Save is type="submit" — take the first
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+    const updated: CommandFormValue = onChange.mock.calls[0][0];
+    expect(updated.steps[0].id).toBe('wait-1');
+    expect(updated.steps[0].waitForImage?.timeoutMs).toBe('9000');
+    expect(getSelector()).toHaveValue('');
+  });
+});
+
+// ── US4: Ensure Game Running panel — add flow ─────────────────────────────────
+
+describe('CommandForm — US4: Ensure Game Running panel add', () => {
+  it('adding EnsureGameRunning step calls onChange with correct type and resets selector', () => {
+    const onChange = jest.fn();
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={onChange} />);
+    fireEvent.change(getSelector(), { target: { value: 'EnsureGameRunning' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    const updated: CommandFormValue = onChange.mock.calls[0][0];
+    expect(updated.steps[0].type).toBe('EnsureGameRunning');
+    expect(getSelector()).toHaveValue('');
+  });
+
+  it('panel cancel resets selector to blank without adding a step', () => {
+    const onChange = jest.fn();
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={onChange} />);
+    fireEvent.change(getSelector(), { target: { value: 'EnsureGameRunning' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getSelector()).toHaveValue('');
+  });
+
+  it('clicking Edit on an EnsureGameRunning step opens the panel', () => {
+    render(
+      <CommandForm
+        value={{ ...emptyForm, steps: [ensureStep] }}
+        commandOptions={[]}
+        onChange={() => {}}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Edit')[0]);
+    expect(getSelector()).toHaveValue('EnsureGameRunning');
+    expect(screen.getByText(/checks that the game is in the foreground/i)).toBeInTheDocument();
+  });
+});

--- a/src/web-ui/src/components/commands/__tests__/EnsureGameRunningPanel.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/EnsureGameRunningPanel.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EnsureGameRunningPanel } from '../EnsureGameRunningPanel';
+
+describe('EnsureGameRunningPanel', () => {
+  describe('field rendering', () => {
+    it('renders a description of the action', () => {
+      render(<EnsureGameRunningPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(
+        screen.getByText(/checks that the game is in the foreground/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders Add and Cancel buttons', () => {
+      render(<EnsureGameRunningPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('does not render any input fields', () => {
+      render(<EnsureGameRunningPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.queryAllByRole('textbox')).toHaveLength(0);
+      expect(screen.queryAllByRole('spinbutton')).toHaveLength(0);
+      expect(screen.queryAllByRole('combobox')).toHaveLength(0);
+    });
+  });
+
+  describe('confirm', () => {
+    it('calls onConfirm when Add is clicked', () => {
+      const onConfirm = jest.fn();
+      render(<EnsureGameRunningPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cancel', () => {
+    it('calls onCancel and does not call onConfirm when Cancel is clicked', () => {
+      const onConfirm = jest.fn();
+      const onCancel = jest.fn();
+      render(<EnsureGameRunningPanel onConfirm={onConfirm} onCancel={onCancel} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables Add and Cancel buttons when disabled', () => {
+      render(<EnsureGameRunningPanel onConfirm={() => {}} onCancel={() => {}} disabled />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+  });
+});

--- a/src/web-ui/src/components/commands/__tests__/TapPanel.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/TapPanel.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TapPanel } from '../TapPanel';
+
+jest.mock('../../images/ImageSelectorDropdown', () => ({
+  ImageSelectorDropdown: ({ value, onChange, onStaleChange, error, label, required }: any) => (
+    <div>
+      {label && <label htmlFor="mock-image-input">{label}</label>}
+      <input
+        id="mock-image-input"
+        data-testid="image-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button
+        type="button"
+        data-testid="mark-stale"
+        onClick={() => onStaleChange?.(true)}
+      >
+        Mark Stale
+      </button>
+      <button
+        type="button"
+        data-testid="clear-stale"
+        onClick={() => onStaleChange?.(false)}
+      >
+        Clear Stale
+      </button>
+      {error && <div role="alert">{error}</div>}
+    </div>
+  ),
+}));
+
+describe('TapPanel', () => {
+  describe('field rendering', () => {
+    it('renders the reference image selector field', () => {
+      render(<TapPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.getByTestId('image-input')).toBeInTheDocument();
+    });
+
+    it('renders confidence, offsetX, and offsetY inputs', () => {
+      render(<TapPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.getByLabelText(/confidence/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/offset x/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/offset y/i)).toBeInTheDocument();
+    });
+
+    it('renders Add and Cancel buttons', () => {
+      render(<TapPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('renders Save button (not Add) when initialValue is provided', () => {
+      render(
+        <TapPanel
+          initialValue={{ referenceImageId: 'img-a' }}
+          onConfirm={() => {}}
+          onCancel={() => {}}
+        />
+      );
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Add' })).toBeNull();
+    });
+
+    it('does not render any fields beyond image, confidence, offsetX, offsetY', () => {
+      render(<TapPanel onConfirm={() => {}} onCancel={() => {}} />);
+      const inputs = screen.getAllByRole('textbox').concat(screen.queryAllByRole('spinbutton'));
+      // image-input (text), confidence (spinbutton), offsetX (spinbutton), offsetY (spinbutton)
+      expect(inputs.length).toBe(4);
+    });
+  });
+
+  describe('initialValue pre-fills fields', () => {
+    it('pre-fills referenceImageId from initialValue', () => {
+      render(
+        <TapPanel
+          initialValue={{ referenceImageId: 'img-x', confidence: '0.9', offsetX: '5', offsetY: '-3' }}
+          onConfirm={() => {}}
+          onCancel={() => {}}
+        />
+      );
+      expect(screen.getByTestId('image-input')).toHaveValue('img-x');
+      expect(screen.getByLabelText(/confidence/i)).toHaveValue(0.9);
+      expect(screen.getByLabelText(/offset x/i)).toHaveValue(5);
+      expect(screen.getByLabelText(/offset y/i)).toHaveValue(-3);
+    });
+  });
+
+  describe('validation — referenceImageId required', () => {
+    it('does not call onConfirm and shows error when referenceImageId is empty', () => {
+      const onConfirm = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent('Reference image is required.');
+    });
+
+    it('does not call onConfirm and shows error when referenceImageId is stale', () => {
+      const onConfirm = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByTestId('image-input'), { target: { value: 'deleted-img' } });
+      fireEvent.click(screen.getByTestId('mark-stale'));
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent('Reference image is required.');
+    });
+  });
+
+  describe('validation — confidence range', () => {
+    it('does not call onConfirm and shows error when confidence is above 1', () => {
+      const onConfirm = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByTestId('image-input'), { target: { value: 'img-a' } });
+      fireEvent.change(screen.getByLabelText(/confidence/i), { target: { value: '1.5' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent('Confidence must be a number between 0 and 1.');
+    });
+
+    it('does not call onConfirm and shows error when confidence is below 0', () => {
+      const onConfirm = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByTestId('image-input'), { target: { value: 'img-a' } });
+      fireEvent.change(screen.getByLabelText(/confidence/i), { target: { value: '-0.1' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent('Confidence must be a number between 0 and 1.');
+    });
+
+    it('allows empty confidence (optional field)', () => {
+      const onConfirm = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByTestId('image-input'), { target: { value: 'img-a' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalled();
+    });
+  });
+
+  describe('successful confirm', () => {
+    it('calls onConfirm with all four values when valid', () => {
+      const onConfirm = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByTestId('image-input'), { target: { value: 'img-a' } });
+      fireEvent.change(screen.getByLabelText(/confidence/i), { target: { value: '0.8' } });
+      fireEvent.change(screen.getByLabelText(/offset x/i), { target: { value: '10' } });
+      fireEvent.change(screen.getByLabelText(/offset y/i), { target: { value: '-5' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalledWith({
+        referenceImageId: 'img-a',
+        confidence: '0.8',
+        offsetX: '10',
+        offsetY: '-5',
+      });
+    });
+
+    it('calls onConfirm with undefined optional fields when left empty', () => {
+      const onConfirm = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByTestId('image-input'), { target: { value: 'img-a' } });
+      fireEvent.change(screen.getByLabelText(/offset x/i), { target: { value: '' } });
+      fireEvent.change(screen.getByLabelText(/offset y/i), { target: { value: '' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalledWith({
+        referenceImageId: 'img-a',
+        confidence: undefined,
+        offsetX: undefined,
+        offsetY: undefined,
+      });
+    });
+  });
+
+  describe('cancel', () => {
+    it('calls onCancel and does not call onConfirm when Cancel is clicked', () => {
+      const onConfirm = jest.fn();
+      const onCancel = jest.fn();
+      render(<TapPanel onConfirm={onConfirm} onCancel={onCancel} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onCancel).toHaveBeenCalled();
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables all buttons when disabled prop is true', () => {
+      render(<TapPanel onConfirm={() => {}} onCancel={() => {}} disabled />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+  });
+});

--- a/src/web-ui/src/components/commands/__tests__/WaitForImagePanel.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/WaitForImagePanel.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WaitForImagePanel } from '../WaitForImagePanel';
+
+jest.mock('../../images/ImageSelectorDropdown', () => ({
+  ImageSelectorDropdown: ({ value, onChange, label }: any) => (
+    <div>
+      {label && <label htmlFor="mock-wfi-image">{label}</label>}
+      <input
+        id="mock-wfi-image"
+        data-testid="wfi-image-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  ),
+}));
+
+describe('WaitForImagePanel', () => {
+  describe('field rendering', () => {
+    it('renders timeoutMs, image, and confidence inputs', () => {
+      render(<WaitForImagePanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.getByLabelText(/timeout/i)).toBeInTheDocument();
+      expect(screen.getByTestId('wfi-image-input')).toBeInTheDocument();
+      expect(screen.getByLabelText(/confidence/i)).toBeInTheDocument();
+    });
+
+    it('renders Add and Cancel buttons', () => {
+      render(<WaitForImagePanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('renders Save button when initialValue is provided', () => {
+      render(
+        <WaitForImagePanel
+          initialValue={{ timeoutMs: '2000' }}
+          onConfirm={() => {}}
+          onCancel={() => {}}
+        />
+      );
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Add' })).toBeNull();
+    });
+
+    it('does not render any fields beyond timeout, image, confidence', () => {
+      render(<WaitForImagePanel onConfirm={() => {}} onCancel={() => {}} />);
+      const spinbuttons = screen.getAllByRole('spinbutton');
+      // timeout (spinbutton) + confidence (spinbutton); image is text/testid
+      expect(spinbuttons.length).toBe(2);
+    });
+
+    it('does not have stale blocking — a stale-like image value does not block confirm', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      // Set a timeout to make form valid
+      fireEvent.change(screen.getByLabelText(/timeout/i), { target: { value: '1000' } });
+      // Even with a referenceImageId that could be stale, confirm should fire
+      fireEvent.change(screen.getByTestId('wfi-image-input'), { target: { value: 'some-img' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalled();
+    });
+  });
+
+  describe('initialValue pre-fills fields', () => {
+    it('pre-fills all fields from initialValue', () => {
+      render(
+        <WaitForImagePanel
+          initialValue={{ timeoutMs: '3000', referenceImageId: 'img-y', confidence: '0.7' }}
+          onConfirm={() => {}}
+          onCancel={() => {}}
+        />
+      );
+      expect(screen.getByLabelText(/timeout/i)).toHaveValue(3000);
+      expect(screen.getByTestId('wfi-image-input')).toHaveValue('img-y');
+      expect(screen.getByLabelText(/confidence/i)).toHaveValue(0.7);
+    });
+  });
+
+  describe('validation — timeout required', () => {
+    it('does not call onConfirm and shows error when timeout is empty', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByLabelText(/timeout/i), { target: { value: '' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent('Timeout must be a non-negative whole number (ms).');
+    });
+
+    it('does not call onConfirm and shows error when timeout is non-integer', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByLabelText(/timeout/i), { target: { value: '1.5' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent('Timeout must be a non-negative whole number (ms).');
+    });
+
+    it('does not call onConfirm and shows error when timeout is negative', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByLabelText(/timeout/i), { target: { value: '-1' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation — confidence range', () => {
+    it('does not call onConfirm and shows error when confidence is out of range', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByLabelText(/confidence/i), { target: { value: '2' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent('Confidence must be a number between 0 and 1.');
+    });
+
+    it('allows empty confidence (optional)', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalled();
+    });
+  });
+
+  describe('successful confirm', () => {
+    it('calls onConfirm with timeout only when image is empty', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByLabelText(/timeout/i), { target: { value: '2000' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalledWith({
+        timeoutMs: '2000',
+        referenceImageId: undefined,
+        confidence: undefined,
+      });
+    });
+
+    it('calls onConfirm with all three values when all are filled', () => {
+      const onConfirm = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.change(screen.getByLabelText(/timeout/i), { target: { value: '5000' } });
+      fireEvent.change(screen.getByTestId('wfi-image-input'), { target: { value: 'img-z' } });
+      fireEvent.change(screen.getByLabelText(/confidence/i), { target: { value: '0.6' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalledWith({
+        timeoutMs: '5000',
+        referenceImageId: 'img-z',
+        confidence: '0.6',
+      });
+    });
+  });
+
+  describe('cancel', () => {
+    it('calls onCancel and does not call onConfirm', () => {
+      const onConfirm = jest.fn();
+      const onCancel = jest.fn();
+      render(<WaitForImagePanel onConfirm={onConfirm} onCancel={onCancel} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onCancel).toHaveBeenCalled();
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables Add and Cancel buttons when disabled', () => {
+      render(<WaitForImagePanel onConfirm={() => {}} onCancel={() => {}} disabled />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+  });
+});

--- a/src/web-ui/src/features/authoring/__tests__/CommandForm.zoom.test.tsx
+++ b/src/web-ui/src/features/authoring/__tests__/CommandForm.zoom.test.tsx
@@ -36,6 +36,20 @@ jest.mock('@dnd-kit/utilities', () => ({
   CSS: { Translate: { toString: () => '' }, Transform: { toString: () => '' } },
 }));
 
+jest.mock('../../../components/images/ImageSelectorDropdown', () => ({
+  ImageSelectorDropdown: ({ value, onChange, label, id }: any) => (
+    <div>
+      {label && <label htmlFor={id}>{label}</label>}
+      <input
+        id={id}
+        data-testid={`image-input-${id ?? 'default'}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  ),
+}));
+
 import { DndContext } from '@dnd-kit/core';
 
 const getDndHandlers = () => {
@@ -92,9 +106,18 @@ describe('CommandForm zoom layout', () => {
     expect(screen.getByLabelText(/Offset X/i, { selector: '#command-detection-offset-x' })).toBeInTheDocument();
     expect(screen.getByLabelText(/Offset Y/i, { selector: '#command-detection-offset-y' })).toBeInTheDocument();
   });
+
+  it('action type selector is visible at 125% zoom', () => {
+    render(
+      <div style={{ width: '1280px', zoom: 1.25 }}>
+        <CommandForm value={baseValue} commandOptions={[]} onChange={() => undefined} />
+      </div>
+    );
+    expect(screen.getByRole('combobox', { name: /action type/i })).toBeInTheDocument();
+  });
 });
 
-// ── US1: Drag to reorder (T007-T012) ─────────────────────────────────────────
+// ── US1: Drag to reorder ──────────────────────────────────────────────────────
 
 describe('CommandForm drag-and-drop reordering', () => {
   beforeEach(() => {
@@ -186,7 +209,6 @@ describe('CommandForm drag-and-drop reordering', () => {
       onDragOver({ over: { id: 'step-2' } });
     });
 
-    // Re-read handlers after re-render caused by state update
     const { onDragStart: _s, onDragOver: _o, ..._ } = getDndHandlers();
     expect(document.querySelector('.drop-indicator')).toBeInTheDocument();
   });
@@ -229,7 +251,7 @@ describe('CommandForm drag-and-drop reordering', () => {
   });
 });
 
-// ── US2: Visual consistency (T013) ───────────────────────────────────────────
+// ── US2: Visual consistency ───────────────────────────────────────────────────
 
 describe('CommandForm drag handle visibility', () => {
   beforeEach(() => {

--- a/src/web-ui/src/pages/CommandsPage.tsx
+++ b/src/web-ui/src/pages/CommandsPage.tsx
@@ -246,12 +246,12 @@ export const CommandsPage: React.FC<CommandsPageProps> = ({ initialCreate, initi
     const next: Record<string, string> = {};
     if (!v.name.trim()) next.name = 'Name is required';
     if (v.steps.length === 0) {
-      next.steps = 'Add at least one step before saving (for example, a Primitive tap step).';
+      next.steps = 'Add at least one step before saving (for example, a Tap step).';
     }
     for (const step of v.steps) {
       if (step.type === 'PrimitiveTap') {
         if (!step.primitiveTap?.detectionTarget.referenceImageId?.trim()) {
-          next.steps = 'Primitive tap steps require a detection target reference image ID';
+          next.steps = 'Tap steps require a detection target reference image ID';
           break;
         }
       } else if (step.type === 'WaitForImage') {

--- a/src/web-ui/src/pages/__tests__/CommandsAndSequencesPrimitiveAuthoring.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/CommandsAndSequencesPrimitiveAuthoring.spec.tsx
@@ -24,6 +24,39 @@ jest.mock('../../components/images/ImageSelectorDropdown', () => ({
   ),
 }));
 
+jest.mock('@dnd-kit/core', () => {
+  const React = jest.requireActual('react');
+  return {
+    DndContext: jest.fn(({ children }: any) => React.createElement(React.Fragment, null, children)),
+    PointerSensor: class {},
+    useSensor: jest.fn(),
+    useSensors: jest.fn(() => []),
+  };
+});
+
+jest.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+  arrayMove: jest.fn((arr: unknown[], from: number, to: number) => {
+    const result = [...arr];
+    const [item] = result.splice(from, 1);
+    result.splice(to, 0, item);
+    return result;
+  }),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: { Translate: { toString: () => '' }, Transform: { toString: () => '' } },
+}));
+
 const listCommandsMock = listCommands as jest.MockedFunction<typeof listCommands>;
 const createCommandMock = createCommand as jest.MockedFunction<typeof createCommand>;
 const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
@@ -50,9 +83,10 @@ describe('Commands and sequences primitive authoring', () => {
     await waitFor(() => expect(listCommandsMock).toHaveBeenCalled());
     fireEvent.click(screen.getByText('Create Command'));
     fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Primitive Command' } });
-    fireEvent.change(screen.getByLabelText('Primitive tap image ID'), { target: { value: tapImageId } });
-    fireEvent.change(screen.getByLabelText('Primitive confidence (0-1)'), { target: { value: `${tapConfidence}` } });
-    fireEvent.click(screen.getByText('Add primitive tap step'));
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), { target: { value: 'PrimitiveTap' } });
+    fireEvent.change(screen.getByLabelText('Reference image *'), { target: { value: tapImageId } });
+    fireEvent.change(screen.getByLabelText('Confidence (0–1)'), { target: { value: `${tapConfidence}` } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
     fireEvent.click(screen.getByText('Save'));
 
     await waitFor(() => expect(createCommandMock).toHaveBeenCalled());

--- a/src/web-ui/src/pages/__tests__/CommandsPage.detection.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/CommandsPage.detection.spec.tsx
@@ -43,11 +43,12 @@ describe('CommandsPage detection persistence', () => {
     fireEvent.change(screen.getByLabelText('Confidence (0-1)'), { target: { value: '0.77' } });
     fireEvent.change(screen.getByLabelText('Offset X'), { target: { value: '5' } });
     fireEvent.change(screen.getByLabelText('Offset Y'), { target: { value: '-3' } });
-    fireEvent.change(screen.getByLabelText('Primitive tap image ID'), { target: { value: 'template_a' } });
-    fireEvent.change(screen.getByLabelText('Primitive confidence (0-1)'), { target: { value: '0.77' } });
-    fireEvent.change(screen.getByLabelText('Primitive offset X'), { target: { value: '5' } });
-    fireEvent.change(screen.getByLabelText('Primitive offset Y'), { target: { value: '-3' } });
-    fireEvent.click(screen.getByText('Add primitive tap step'));
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), { target: { value: 'PrimitiveTap' } });
+    fireEvent.change(screen.getByLabelText('Reference image *'), { target: { value: 'template_a' } });
+    fireEvent.change(screen.getByLabelText('Confidence (0–1)'), { target: { value: '0.77' } });
+    fireEvent.change(screen.getByLabelText('Offset X', { selector: '#tap-panel-offset-x' }), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText('Offset Y', { selector: '#tap-panel-offset-y' }), { target: { value: '-3' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     createCommandMock.mockResolvedValue({} as any);
 
@@ -112,7 +113,7 @@ describe('CommandsPage detection persistence', () => {
     await screen.findByText('Edit Command');
     fireEvent.click(screen.getAllByText('Save')[0]);
 
-    expect(await screen.findByText('Primitive tap steps require a detection target reference image ID')).toBeInTheDocument();
+    expect(await screen.findByText('Tap steps require a detection target reference image ID')).toBeInTheDocument();
     expect(updateCommandMock).not.toHaveBeenCalled();
   });
 
@@ -135,6 +136,6 @@ describe('CommandsPage detection persistence', () => {
     fireEvent.click(screen.getByText('FallbackPrimitive'));
 
     await screen.findByText('Edit Command');
-    expect(screen.getByText('Primitive tap: tpl-fallback')).toBeInTheDocument();
+    expect(screen.getByText('Tap: tpl-fallback')).toBeInTheDocument();
   });
 });

--- a/src/web-ui/src/pages/__tests__/CommandsPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/CommandsPage.spec.tsx
@@ -101,8 +101,9 @@ describe('CommandsPage', () => {
     expect(await screen.findByText('Name is required')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Test Cmd' } });
-    fireEvent.change(screen.getByLabelText('Primitive tap image ID'), { target: { value: 'alliance_button' } });
-    fireEvent.click(screen.getByText('Add primitive tap step'));
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), { target: { value: 'PrimitiveTap' } });
+    fireEvent.change(screen.getByLabelText('Reference image *'), { target: { value: 'alliance_button' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     createCommandMock.mockResolvedValue({} as any);
 
@@ -209,12 +210,13 @@ describe('CommandsPage', () => {
 
     fireEvent.click(screen.getByText('Create Command'));
     fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Primitive Command' } });
-    fireEvent.change(screen.getByLabelText('Primitive tap image ID'), { target: { value: 'home_button' } });
-    fireEvent.change(screen.getByLabelText('Primitive confidence (0-1)'), { target: { value: '0.95' } });
-    fireEvent.change(screen.getByLabelText('Primitive offset X'), { target: { value: '2' } });
-    fireEvent.change(screen.getByLabelText('Primitive offset Y'), { target: { value: '-1' } });
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), { target: { value: 'PrimitiveTap' } });
+    fireEvent.change(screen.getByLabelText('Reference image *'), { target: { value: 'home_button' } });
+    fireEvent.change(screen.getByLabelText('Confidence (0–1)'), { target: { value: '0.95' } });
+    fireEvent.change(screen.getByLabelText('Offset X', { selector: '#tap-panel-offset-x' }), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText('Offset Y', { selector: '#tap-panel-offset-y' }), { target: { value: '-1' } });
 
-    fireEvent.click(screen.getByText('Add primitive tap step'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     createCommandMock.mockResolvedValue({} as any);
     fireEvent.click(screen.getByText('Save'));
@@ -237,25 +239,21 @@ describe('CommandsPage', () => {
     }));
   });
 
-  it('creates a command with a command step', async () => {
+  it('does not show Add command UI (Command step addition is removed, FR-001)', async () => {
     listCommandsMock.mockResolvedValue([{ id: 'existing-cmd', name: 'Existing Command', steps: [] } as any]);
 
     render(<CommandsPage />);
     await waitFor(() => expect(listCommandsMock).toHaveBeenCalled());
 
     fireEvent.click(screen.getByText('Create Command'));
-    fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Composite Command' } });
-    fireEvent.change(screen.getByLabelText('Add command'), { target: { value: 'existing-cmd' } });
-    fireEvent.click(screen.getByText('Add command step'));
+    expect(screen.queryByText('Add command step')).toBeNull();
+    expect(screen.queryByText('Add command')).toBeNull();
 
-    createCommandMock.mockResolvedValue({} as any);
-    fireEvent.click(screen.getByText('Save'));
-
-    await waitFor(() => expect(createCommandMock).toHaveBeenCalledWith({
-      name: 'Composite Command',
-      steps: [{ type: 'Command', targetId: 'existing-cmd', order: 0 }],
-      detection: undefined,
-    }));
+    // Action type selector lists only the three primitive actions — no Command option
+    const options = Array.from(
+      (screen.getByRole('combobox', { name: /action type/i }) as HTMLSelectElement).options
+    ).map((o) => o.value);
+    expect(options).not.toContain('Command');
   });
 
   it('creates a command with a wait for image step', async () => {
@@ -264,10 +262,11 @@ describe('CommandsPage', () => {
 
     fireEvent.click(screen.getByText('Create Command'));
     fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Wait Command' } });
-    fireEvent.change(screen.getByLabelText('Wait image ID'), { target: { value: 'home_button' } });
-    fireEvent.change(screen.getByLabelText('Wait confidence (0-1)'), { target: { value: '0.91' } });
-    fireEvent.change(screen.getByLabelText('Wait timeout (ms)'), { target: { value: '2500' } });
-    fireEvent.click(screen.getByText('Add wait for image step'));
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), { target: { value: 'WaitForImage' } });
+    fireEvent.change(screen.getByLabelText('Timeout (ms) *'), { target: { value: '2500' } });
+    fireEvent.change(screen.getByLabelText('Reference image (optional)'), { target: { value: 'home_button' } });
+    fireEvent.change(screen.getByLabelText('Confidence (0–1)'), { target: { value: '0.91' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     createCommandMock.mockResolvedValue({} as any);
     fireEvent.click(screen.getByText('Save'));


### PR DESCRIPTION
## Summary

- Replaces the flat always-visible step controls in `CommandForm` with an `ActionTypeSelector` that reveals a dedicated attribute panel per primitive action (Tap, Wait for Image, Ensure Game Running)
- Adds in-place step editing — clicking an existing step opens its panel pre-filled; saving updates it at the same position
- Removes the "Add command" step-addition UI; existing Command steps remain renderable and deletable
- Renames "Primitive tap" → "Tap" in step list labels and validation messages
- Adds `onEdit` callback prop to `SortableSequenceStepList`
- Fixes Edit/Delete buttons stacking vertically for some step types (controls now has `flex-shrink: 0`)

## New files

- `ActionTypeSelector.tsx` + test
- `TapPanel.tsx` + test (required image, optional confidence/offsetX/offsetY, validation with error strings)
- `WaitForImagePanel.tsx` + test (required timeout, optional image/confidence, validation with error strings)
- `EnsureGameRunningPanel.tsx` + test (description + confirm, no inputs)
- `CommandForm.steps.test.tsx` — integration tests covering all four user stories

## Test plan

- [ ] `vite build` passes (green)
- [ ] `jest` passes — 414 tests, 0 failures
- [ ] Select each action type in the command editor; verify only that action's panel appears
- [ ] Confirm a Tap step; verify selector resets to blank and step appears as "Tap: …"
- [ ] Click an existing step; verify panel opens pre-filled and Save updates in place
- [ ] Click Edit on an existing Command-type step; verify no panel opens
- [ ] Verify Edit and Delete buttons appear side by side for all step types

🤖 Generated with [Claude Code](https://claude.com/claude-code)