### PR TITLE
Add KeyInput and Swipe primitive action steps (#054)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,4 +1,3 @@
 {
-  "feature_directory": "specs/053-command-editor-rework"
-  "feature_directory": "specs/053-schedulable-sequences"
+  "feature_directory": "specs/054-key-swipe-actions"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,5 @@ For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
 at specs/053-command-editor-rework/plan.md
 at specs/053-schedulable-sequences/plan.md
+at specs/054-key-swipe-actions/plan.md
 <!-- SPECKIT END -->

--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "0",
   "minor": "8",
-  "patch": "0",
+  "patch": "1",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-06-03T19:07:40Z"
+  "updatedAtUtc": "2026-06-05T00:00:00Z"
 }

--- a/specs/054-key-swipe-actions/checklists/requirements.md
+++ b/specs/054-key-swipe-actions/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Key Input and Swipe Primitive Actions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit-plan`.
+- Assumptions section documents key scope decisions: direct coordinates for swipe, free-text key identifier, no modifier key support.

--- a/specs/054-key-swipe-actions/contracts/command-step-types.md
+++ b/specs/054-key-swipe-actions/contracts/command-step-types.md
@@ -1,0 +1,83 @@
+# Contract: Command Step Types Extension
+
+**Feature**: 054-key-swipe-actions
+**Date**: 2026-06-04
+**Endpoint**: `/api/commands` (POST, PATCH, GET)
+
+## Overview
+
+Two new step type values are added to the `type` discriminator field accepted and returned by the Commands API. All existing step types and shapes are unchanged.
+
+## New Step Type: KeyInput
+
+### Request (POST /api/commands or PATCH /api/commands/{id})
+
+```json
+{
+  "steps": [
+    {
+      "type": "KeyInput",
+      "order": 0,
+      "keyInput": {
+        "key": "Enter"
+      }
+    }
+  ]
+}
+```
+
+### Response (GET /api/commands/{id})
+
+Same shape as the request step object. The `keyInput` property is present when `type` is `"KeyInput"`.
+
+### Validation
+
+| Field | Rule |
+|-------|------|
+| `keyInput.key` | Required. Non-empty string. |
+
+The API does not validate that `key` maps to a supported key name; that is enforced at runtime execution.
+
+## New Step Type: Swipe
+
+### Request
+
+```json
+{
+  "steps": [
+    {
+      "type": "Swipe",
+      "order": 1,
+      "swipe": {
+        "startX": 100,
+        "startY": 800,
+        "endX": 100,
+        "endY": 200,
+        "durationMs": 300
+      }
+    }
+  ]
+}
+```
+
+### Response
+
+Same shape as the request step object. The `swipe` property is present when `type` is `"Swipe"`.
+
+### Validation
+
+| Field | Rule |
+|-------|------|
+| `swipe.startX` | Required integer. |
+| `swipe.startY` | Required integer. |
+| `swipe.endX` | Required integer. |
+| `swipe.endY` | Required integer. |
+| `swipe.durationMs` | Optional integer ≥ 0. Omit or null for runtime default. |
+
+Coordinates are absolute screen pixels. No range restriction is enforced by the API.
+
+## Backward Compatibility
+
+- Existing step types (`Command`, `PrimitiveTap`, `WaitForImage`, `EnsureGameRunning`) are unchanged.
+- No migration of persisted command files is required.
+- The `CommandStepTypeDto` enum values are additive; existing serialized values remain valid.

--- a/specs/054-key-swipe-actions/data-model.md
+++ b/specs/054-key-swipe-actions/data-model.md
@@ -1,0 +1,203 @@
+# Data Model: Key Input and Swipe Steps
+
+**Feature**: 054-key-swipe-actions
+**Date**: 2026-06-04
+
+## Domain Layer
+
+### KeyInputConfig (new)
+
+```csharp
+public sealed class KeyInputConfig {
+  public required string Key { get; init; }
+}
+```
+
+- `Key`: the key identifier string (e.g., `"Enter"`, `"Escape"`, `"F5"`, `"a"`). Required, non-empty. Runtime validates that it names a supported key.
+
+### SwipeConfig (new)
+
+```csharp
+public sealed class SwipeConfig {
+  public required int StartX { get; init; }
+  public required int StartY { get; init; }
+  public required int EndX { get; init; }
+  public required int EndY { get; init; }
+  public int? DurationMs { get; init; }
+}
+```
+
+- `StartX`, `StartY`: absolute screen pixel coordinates of the swipe origin. Required integers.
+- `EndX`, `EndY`: absolute screen pixel coordinates of the swipe destination. Required integers.
+- `DurationMs`: swipe duration in milliseconds. Optional; null means use the runtime default. When present must be ≥ 0.
+
+### CommandStepType enum (updated)
+
+```csharp
+public enum CommandStepType {
+  Command,
+  PrimitiveTap,
+  WaitForImage,
+  EnsureGameRunning,
+  KeyInput,    // NEW
+  Swipe        // NEW
+}
+```
+
+### CommandStep class (updated)
+
+```csharp
+public sealed class CommandStep {
+  public required CommandStepType Type { get; init; }
+  public string TargetId { get; init; } = string.Empty;
+  public PrimitiveTapConfig? PrimitiveTap { get; init; }
+  public WaitForImageConfig? WaitForImage { get; init; }
+  public KeyInputConfig? KeyInput { get; init; }   // NEW
+  public SwipeConfig? Swipe { get; init; }         // NEW
+  public int Order { get; init; }
+}
+```
+
+## Service (DTO) Layer
+
+### KeyInputConfigDto (new)
+
+```csharp
+internal sealed class KeyInputConfigDto {
+  public required string Key { get; init; }
+}
+```
+
+### SwipeConfigDto (new)
+
+```csharp
+internal sealed class SwipeConfigDto {
+  public required int StartX { get; init; }
+  public required int StartY { get; init; }
+  public required int EndX { get; init; }
+  public required int EndY { get; init; }
+  public int? DurationMs { get; init; }
+}
+```
+
+### CommandStepTypeDto enum (updated)
+
+```csharp
+internal enum CommandStepTypeDto {
+  Command,
+  PrimitiveTap,
+  WaitForImage,
+  EnsureGameRunning,
+  KeyInput,    // NEW
+  Swipe        // NEW
+}
+```
+
+### CommandStepDto class (updated)
+
+```csharp
+internal sealed class CommandStepDto {
+  public required CommandStepTypeDto Type { get; init; }
+  public string? TargetId { get; init; }
+  public PrimitiveTapConfigDto? PrimitiveTap { get; init; }
+  public WaitForImageConfigDto? WaitForImage { get; init; }
+  public KeyInputConfigDto? KeyInput { get; init; }   // NEW
+  public SwipeConfigDto? Swipe { get; init; }         // NEW
+  public int Order { get; init; }
+}
+```
+
+## Frontend Layer
+
+### StepEntry (updated in CommandForm.tsx)
+
+```typescript
+export type StepEntry = {
+  id: string;
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
+  targetId?: string;
+  primitiveTap?: { detectionTarget: DetectionTargetForm };
+  waitForImage?: { detectionTarget?: DetectionTargetForm; timeoutMs?: string };
+  keyInput?: { key: string };
+  swipe?: { startX: string; startY: string; endX: string; endY: string; durationMs?: string };
+};
+```
+
+### CommandStepDto (updated in commands.ts)
+
+```typescript
+export type CommandStepDto = {
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
+  targetId?: string;
+  order: number;
+  primitiveTap?: PrimitiveTapConfigDto;
+  waitForImage?: WaitForImageConfigDto;
+  keyInput?: KeyInputConfigDto;    // NEW
+  swipe?: SwipeConfigDto;          // NEW
+};
+
+export type KeyInputConfigDto = {
+  key: string;
+};
+
+export type SwipeConfigDto = {
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  durationMs?: number;
+};
+```
+
+### KeyInputPanelValue
+
+```typescript
+type KeyInputPanelValue = {
+  key: string;
+};
+```
+
+### SwipePanelValue
+
+```typescript
+type SwipePanelValue = {
+  startX: string;
+  startY: string;
+  endX: string;
+  endY: string;
+  durationMs?: string;
+};
+```
+
+## Persistence (JSON)
+
+Key Input step in a saved command:
+```json
+{
+  "type": "KeyInput",
+  "order": 1,
+  "keyInput": { "key": "Enter" }
+}
+```
+
+Swipe step in a saved command:
+```json
+{
+  "type": "Swipe",
+  "order": 2,
+  "swipe": {
+    "startX": 100,
+    "startY": 800,
+    "endX": 100,
+    "endY": 200,
+    "durationMs": 300
+  }
+}
+```
+
+## Step List Display
+
+| Step type | Label | Description |
+|-----------|-------|-------------|
+| KeyInput | `Key: <key>` (truncated with ellipsis) | (empty) |
+| Swipe | `Swipe` | `(startX,startY) → (endX,endY)` optionally appended with `, Nms` when duration is set |

--- a/specs/054-key-swipe-actions/plan.md
+++ b/specs/054-key-swipe-actions/plan.md
@@ -1,0 +1,73 @@
+# Implementation Plan: Key Input and Swipe Primitive Actions
+
+**Branch**: `054-key-swipe-actions` | **Date**: 2026-06-04 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/054-key-swipe-actions/spec.md`
+
+## Summary
+
+Add `KeyInput` and `Swipe` as selectable step types in the command editor UI, following the existing patterns for `Tap`, `WaitForImage`, and `EnsureGameRunning`. The domain-layer action variant classes (`PrimitiveKeyAction`, `PrimitiveSwipeAction`) and their validation logic already exist; the work is exposing them through the `CommandStep` type system (domain + service layers) and implementing two new React panel components on the frontend.
+
+## Technical Context
+
+**Language/Version**: C# (.NET 8) — backend; TypeScript 5 + React 18 — frontend
+**Primary Dependencies**: ASP.NET Core (service layer), React + dnd-kit (UI drag-and-drop), System.Text.Json (serialization)
+**Storage**: JSON files on disk (command persistence via existing file-based store)
+**Testing**: xUnit — backend unit + integration tests; Jest + React Testing Library — frontend
+**Target Platform**: Windows desktop application (single-user, web UI served locally)
+**Project Type**: Desktop application with embedded web UI
+**Performance Goals**: UI panel interactions feel immediate (<100 ms response to user input); no throughput requirements for a UI form feature
+**Constraints**: New step types must serialize/deserialize cleanly alongside existing `CommandStep` JSON; `CommandStepType` enum must remain backward-compatible
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Build passing | ✅ Assumed green (clean branch) | Must remain green throughout |
+| Tests passing | ✅ Assumed green | New tests required per Testing Standards |
+| Lint/format clean | ✅ | No new high/critical issues permitted; method names use CamelCase |
+| UX consistency | ✅ | Panels follow established `TapPanel` / `EnsureGameRunningPanel` patterns |
+| Performance goals documented | ✅ | Declared above |
+| Security scan | ✅ | No secrets; no user-facing security surface |
+
+*No violations. No Complexity Tracking entry required.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/054-key-swipe-actions/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── contracts/
+│   └── command-step-types.md   # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit-tasks — not created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   └── Commands/
+│       └── CommandStep.cs              # Add KeyInput + Swipe variants to enum + new config classes
+├── GameBot.Service/
+│   ├── Models/
+│   │   └── Commands.cs                 # Add DTO enum variants + config DTO classes + CommandStepDto props
+│   └── Services/
+│       └── CommandExecutor.cs          # Add execution handlers for KeyInput + Swipe steps
+└── web-ui/src/
+    ├── components/commands/
+    │   ├── ActionTypeSelector.tsx       # Add 'KeyInput' | 'Swipe' to type union + dropdown options
+    │   ├── CommandForm.tsx              # Add StepEntry variants, panel rendering, toStepItems branches
+    │   ├── KeyInputPanel.tsx            # New component (mirrors TapPanel pattern, single text field)
+    │   ├── SwipePanel.tsx               # New component (four integer fields + optional duration)
+    │   └── CommandForm.css              # Add .action-panel--key-input and .action-panel--swipe classes
+    └── services/
+        └── commands.ts                 # Add 'KeyInput' | 'Swipe' to CommandStepDto type + config types
+```
+
+**Structure Decision**: Web application layout — backend under `src/GameBot.*`, frontend under `src/web-ui/src`.

--- a/specs/054-key-swipe-actions/research.md
+++ b/specs/054-key-swipe-actions/research.md
@@ -1,0 +1,54 @@
+# Research: Key Input and Swipe Primitive Actions
+
+**Feature**: 054-key-swipe-actions
+**Date**: 2026-06-04
+
+## Finding 1: Domain Layer Already Has Action Classes
+
+**Decision**: Reuse existing `PrimitiveKeyAction` and `PrimitiveSwipeAction` domain classes; no new domain model additions needed.
+
+**Rationale**: Both classes are defined in `GameBot.Domain/Actions/PrimitiveActionVariants.cs`, have complete validation rules in `PrimitiveActionValidationService.cs`, and are registered in `PrimitiveActionTypes.All`. The type string constants `"key"` and `"swipe"` are also present in `ActionTypes.cs`.
+
+**Alternatives considered**: Defining new command-specific config classes that re-declare fields — rejected because `PrimitiveKeyAction` and `PrimitiveSwipeAction` already have the right shape and are used by the sequence runner.
+
+Key details:
+- `PrimitiveKeyAction` (`PrimitiveActionVariants.cs:22-27`): fields `Key` (string), `KeyCode` (int?); validation requires `Key` OR `KeyCode`
+- `PrimitiveSwipeAction` (`PrimitiveActionVariants.cs:12-20`): fields `X1`, `Y1`, `X2`, `Y2` (int), `DurationMs` (int?)
+- Type strings: `"key"` (`ActionTypes.cs:10`), `"swipe"` (`ActionTypes.cs:9`)
+
+## Finding 2: CommandStep Type System Is the Primary Gap
+
+**Decision**: Add `KeyInput` and `Swipe` to `CommandStepType` enum and the parallel DTO types; add dedicated config classes at both domain and DTO layers.
+
+**Rationale**: `CommandStepType` in `CommandStep.cs:3-8` is the authoritative discriminator for command-level steps. The service-layer `CommandStepTypeDto` in `Commands.cs:40-45` mirrors it. Both need new variants and corresponding typed config properties to maintain the type-safe pattern established by `PrimitiveTapConfig` / `WaitForImageConfig`.
+
+**Alternatives considered**: Using a generic string type or embedding the step config in a dictionary — rejected to stay consistent with the existing enum + typed-config pattern.
+
+Files to change:
+- `src/GameBot.Domain/Commands/CommandStep.cs` — enum + `KeyInputConfig` + `SwipeConfig` classes + `CommandStep` properties
+- `src/GameBot.Service/Models/Commands.cs` — `CommandStepTypeDto` enum + `KeyInputConfigDto` + `SwipeConfigDto` + `CommandStepDto` properties
+
+## Finding 3: Sequences Need No Backend Changes
+
+**Decision**: No sequence-layer backend changes required.
+
+**Rationale**: `SequenceActionPayload` uses a generic `Type` (string) + `Parameters` (dictionary) model (`SequenceStep.cs:15-20`). Both `"key"` and `"swipe"` are already in `PrimitiveActionTypes.All`, so the sequence runner can already execute them. The sequence UI (if any) is also out of scope for this feature.
+
+## Finding 4: Frontend Panel Pattern Is Well-Established
+
+**Decision**: Follow `TapPanel.tsx` exactly for both new components.
+
+**Rationale**: `TapPanel.tsx` establishes the canonical frontend pattern: per-field local state, `attempted` boolean for deferred validation, `action-panel` + BEM modifier CSS class, `action-panel__controls` button container, `initialValue` prop for edit repopulation, `onConfirm` / `onCancel` callbacks. `EnsureGameRunningPanel.tsx` shows the minimal variant (no fields).
+
+`KeyInputPanel` is simpler than TapPanel — one required text field, no image selector needed.
+`SwipePanel` mirrors the numeric field pattern from TapPanel — four required integer fields (StartX, StartY, EndX, EndY) plus one optional integer field (DurationMs).
+
+## Finding 5: CommandExecutor Needs Two New Execution Handlers
+
+**Decision**: Add `KeyInput` and `Swipe` branches to the existing if-then chain in `CommandExecutor.cs`.
+
+**Rationale**: The executor switches on `CommandStepType` (lines 154-270). New types need branches that map step config to `InputActionDto`. The `InputActionDto` model in `Sessions.cs:25-30` already accepts any `Type` string + `Args` dictionary, so no session-layer changes are needed.
+
+Execution payload shapes to produce:
+- Key: `type = "key"`, `args = { ["key"] = config.Key }`
+- Swipe: `type = "swipe"`, `args = { ["x1"] = config.StartX, ["y1"] = config.StartY, ["x2"] = config.EndX, ["y2"] = config.EndY, ["durationMs"] = config.DurationMs }`

--- a/specs/054-key-swipe-actions/spec.md
+++ b/specs/054-key-swipe-actions/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Key Input and Swipe Primitive Actions
+
+**Feature Branch**: `054-key-swipe-actions`  
+**Created**: 2026-06-04  
+**Status**: Draft  
+**Input**: User description: "i want to be able to add key input and swipe as primitive actions as steps of a command via UI. it should be done in the same style and reusing all possible components that are available for the tap, wait for image and connect to game."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Add Key Input Step (Priority: P1)
+
+A user building a command wants to press a keyboard key as part of an automation sequence. They select "Key Input" from the action type selector, enter the key identifier (e.g., "Enter", "Escape", "F5"), and add it as a step. The step appears in the step list labeled with the key name, and the user can reorder, edit, or delete it like any other step.
+
+**Why this priority**: Key presses are fundamental automation actions used to dismiss dialogs, confirm prompts, or trigger shortcuts in games. This is immediately useful on its own.
+
+**Independent Test**: Can be fully tested by opening a command, selecting "Key Input", entering a key name, adding the step, and verifying it appears correctly in the step list with the key name displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command editor is open with no pending step, **When** the user selects "Key Input" from the action type selector, **Then** a Key Input panel appears with a key identifier input field and Add/Cancel buttons.
+2. **Given** the Key Input panel is shown, **When** the user enters a key identifier and clicks Add, **Then** the step is added to the step list showing the key name, and the panel resets.
+3. **Given** the Key Input panel is shown, **When** the user clicks Add without entering a key identifier, **Then** a validation error is shown and the step is not added.
+4. **Given** a Key Input step is in the step list, **When** the user clicks Edit, **Then** the Key Input panel repopulates with the current key identifier.
+5. **Given** the Key Input panel is shown, **When** the user clicks Cancel, **Then** the panel closes without adding a step and any entered text is discarded.
+
+---
+
+### User Story 2 - Add Swipe Step (Priority: P2)
+
+A user building a command wants to perform a swipe gesture as part of an automation sequence (e.g., scrolling a list, swiping between screens). They select "Swipe" from the action type selector, specify the start position, end position, and optionally the swipe duration, then add it as a step. The step appears in the step list with a summary of the swipe parameters.
+
+**Why this priority**: Swipe is a common game interaction. It depends on the same infrastructure as Key Input so both are natural to deliver together.
+
+**Independent Test**: Can be fully tested by opening a command, selecting "Swipe", filling in start and end coordinates, adding the step, and verifying the step list shows the swipe summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command editor is open with no pending step, **When** the user selects "Swipe" from the action type selector, **Then** a Swipe panel appears with start position fields, end position fields, an optional duration field, and Add/Cancel buttons.
+2. **Given** the Swipe panel is shown with start and end positions filled in, **When** the user clicks Add, **Then** the step is added to the step list with a readable summary (e.g., "(0,0) → (100,200)"), and the panel resets.
+3. **Given** the Swipe panel is shown, **When** the user clicks Add with any required position field left empty, **Then** a validation error is shown on the empty field and the step is not added.
+4. **Given** the Swipe panel is shown, **When** the user enters an optional duration and clicks Add, **Then** the step list description includes the duration.
+5. **Given** a Swipe step is in the step list, **When** the user clicks Edit, **Then** the Swipe panel repopulates with all previously entered values.
+6. **Given** the Swipe panel is shown, **When** the user clicks Cancel, **Then** the panel closes without adding a step.
+
+---
+
+### User Story 3 - Both actions consistent with existing action style (Priority: P3)
+
+The Key Input and Swipe panels look, behave, and validate consistently with the existing Tap, Wait for Image, and Ensure Game Running panels. The same shared controls (field layout, buttons, error display) are used so the overall command editor feels cohesive.
+
+**Why this priority**: Visual and behavioral consistency makes the product feel polished and reduces the user's cognitive load when working across action types.
+
+**Independent Test**: Can be verified by inspecting both new panels side-by-side with existing panels to confirm matching field layout, button placement, error styling, and form behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user switches between Key Input, Swipe, Tap, Wait for Image, and Ensure Game Running, **Then** all panels use the same layout structure, button styles, and error formatting.
+2. **Given** a user has partially filled a Key Input or Swipe panel and switches to a different action type, **Then** switching back resets the panel to its empty state (consistent with existing action switching behavior).
+
+---
+
+### Edge Cases
+
+- A swipe duration of zero is valid; the runtime determines the behavior of a zero-duration swipe.
+- Long key identifiers in the step list label are truncated with an ellipsis to fit the list item width.
+- What happens if start and end positions for a swipe are identical (zero-distance swipe)?
+- What happens when the user edits a Key Input step and clears the key identifier before saving?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The action type selector MUST include "Key Input" and "Swipe" as selectable action types alongside the existing options.
+- **FR-002**: Selecting "Key Input" MUST display a Key Input configuration panel with a required key identifier field and Add/Cancel buttons.
+- **FR-003**: The key identifier field MUST accept free-text input representing a key name or code (e.g., "Enter", "Escape", "F5", "a").
+- **FR-004**: The key identifier field MUST be required; attempting to add a step without a value MUST show a validation error.
+- **FR-005**: Selecting "Swipe" MUST display a Swipe configuration panel with start position (X, Y), end position (X, Y), optional duration, and Add/Cancel buttons.
+- **FR-006**: Start X, Start Y, End X, and End Y MUST be required integer fields representing absolute screen pixel coordinates; leaving any empty MUST show a validation error.
+- **FR-007**: Duration MUST be an optional non-negative integer field representing the swipe duration in milliseconds.
+- **FR-008**: A confirmed Key Input step MUST appear in the step list with the key identifier displayed as the step label; long identifiers MUST be truncated with an ellipsis to fit the list item width.
+- **FR-009**: A confirmed Swipe step MUST appear in the step list with a readable summary of start position, end position, and duration (if set).
+- **FR-010**: Clicking Edit on a Key Input step MUST repopulate the Key Input panel with the existing key identifier.
+- **FR-011**: Clicking Edit on a Swipe step MUST repopulate the Swipe panel with all existing values.
+- **FR-012**: Both panels MUST use the same shared layout components (field containers, button bar, error display) used by existing action panels.
+- **FR-013**: Both panels MUST apply the same validation timing behavior as existing panels (deferred until Add/Save is clicked).
+- **FR-014**: Switching the action type selector away from Key Input or Swipe and back MUST reset the panel to its empty state.
+- **FR-015**: Key Input and Swipe steps MUST support deletion and drag-to-reorder in the step list, consistent with other step types.
+
+### Key Entities
+
+- **Key Input Step**: A command step that performs a single key press (not a hold); has exactly one attribute — the key identifier. No hold duration or repeat count.
+- **Swipe Step**: A command step that performs a swipe gesture; has start position (X, Y), end position (X, Y), and optional duration (ms).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can add a Key Input step with a valid key identifier in under 30 seconds from opening the action selector.
+- **SC-002**: A user can add a Swipe step with start/end positions in under 45 seconds from opening the action selector.
+- **SC-003**: All validation errors for Key Input and Swipe panels are visible and clearly describe the issue within the panel bounds, without page navigation.
+- **SC-004**: Switching among all five action types (Tap, Wait for Image, Ensure Game Running, Key Input, Swipe) produces no visible layout shifts or style inconsistencies.
+- **SC-005**: Editing and re-saving an existing Key Input or Swipe step preserves all previously entered values and updates the step list correctly.
+
+## Clarifications
+
+### Session 2026-06-04
+
+- Q: Are swipe coordinates absolute screen pixels or normalized (0–1 relative to screen size)? → A: Absolute pixel coordinates (integers, e.g., x=540, y=960)
+- Q: Is the key identifier a free-text field or a predefined dropdown of supported keys? → A: Free-text input; runtime is responsible for validating the key name
+- Q: Should Key Input support an optional hold duration (how long to hold the key down)? → A: No — key press only; single key identifier field, no hold duration
+- Q: How should the step list label render when a key identifier is very long? → A: Truncate with ellipsis to fit the list item width
+
+## Assumptions
+
+- Swipe positions are defined by absolute screen pixel coordinates (integers), consistent with how offsets work in existing actions. No image-based start/end point targeting is required for this feature.
+- The key identifier is a free-text string; validation of whether it corresponds to a real key is left to the runtime, not the UI.
+- A swipe duration of zero is treated as valid input (instantaneous swipe); the runtime determines behavior.
+- No modifier key support (Ctrl, Alt, Shift combinations) is required in this iteration.
+- Key Input is a single instantaneous key press with no configurable hold duration or repeat count.

--- a/specs/054-key-swipe-actions/tasks.md
+++ b/specs/054-key-swipe-actions/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: Key Input and Swipe Primitive Actions
+
+**Input**: Design documents from `specs/054-key-swipe-actions/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on each other)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify baseline before changes begin.
+
+- [X] T001 Confirm `dotnet build` and `npm run build` (in `src/web-ui`) both pass with no new errors before any changes
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Extend the `CommandStep` type system across backend and frontend. Both US1 and US2 depend on this phase being complete.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Extend `CommandStepType` enum with `KeyInput` and `Swipe`; add `KeyInputConfig` (`Key` string required) and `SwipeConfig` (`StartX`, `StartY`, `EndX`, `EndY` int required; `DurationMs` int optional) classes; add `KeyInput?` and `Swipe?` properties to `CommandStep` class in `src/GameBot.Domain/Commands/CommandStep.cs`
+- [X] T003 [P] Extend `CommandStepTypeDto` enum with `KeyInput` and `Swipe`; add `KeyInputConfigDto` and `SwipeConfigDto` mirroring the domain config shapes; add `KeyInput?` and `Swipe?` properties to `CommandStepDto` in `src/GameBot.Service/Models/Commands.cs`
+- [X] T004 Update the command step mapper in `src/GameBot.Service/Endpoints/CommandsEndpoints.cs` (or the equivalent command service/mapper class) to handle the two new `CommandStepTypeDto` variants in both directions: incoming (`CommandStepTypeDto.KeyInput` → `CommandStepType.KeyInput` + `KeyInputConfig`; `CommandStepTypeDto.Swipe` → `CommandStepType.Swipe` + `SwipeConfig`) and outgoing (reverse mapping for GET responses) (depends on T002 and T003)
+- [X] T005 Add unit tests for the two new `CommandExecutor` execution branches in `tests/unit/Commands/CommandExecutorKeyInputTests.cs` and `tests/unit/Commands/CommandExecutorSwipeTests.cs`: verify a `CommandStep` with `Type=KeyInput` dispatches `InputAction(type="key", args={["key"]=config.Key})` and a step with `Type=Swipe` dispatches `InputAction(type="swipe", args={["x1"]=StartX, ["y1"]=StartY, ["x2"]=EndX, ["y2"]=EndY, ["durationMs"]=DurationMs})` (depends on T002)
+- [X] T006 Add `KeyInput` and `Swipe` execution handler branches to the step dispatch chain in `src/GameBot.Service/Services/CommandExecutor.cs`: for KeyInput map `config.Key` → `InputAction(type="key", args={["key"]=config.Key})`; for Swipe map `config.StartX → args["x1"]`, `config.StartY → args["y1"]`, `config.EndX → args["x2"]`, `config.EndY → args["y2"]`, `config.DurationMs → args["durationMs"]` (depends on T002, T003, T004)
+- [X] T007 [P] Add `'KeyInput' | 'Swipe'` to the `CommandStepDto.type` union; add `KeyInputConfigDto` and `SwipeConfigDto` TypeScript types in `src/web-ui/src/services/commands.ts`
+- [X] T008 [P] Add `'KeyInput' | 'Swipe'` to the `PrimitiveActionType` union; add `<option value="KeyInput">Key Input</option>` and `<option value="Swipe">Swipe</option>` to the dropdown in `src/web-ui/src/components/commands/ActionTypeSelector.tsx`
+- [X] T009 Update `StepEntry` type to include `'KeyInput' | 'Swipe'` in the `type` discriminant and add `keyInput?: { key: string }` and `swipe?: { startX: string; startY: string; endX: string; endY: string; durationMs?: string }` properties; add `'KeyInput'` and `'Swipe'` to the `EDITABLE_TYPES` set in `src/web-ui/src/components/commands/CommandForm.tsx` (depends on T008)
+
+**Checkpoint**: Type system, mapper, executor, and tests are complete — both backend and frontend know about `KeyInput` and `Swipe`. The action type selector now shows both options. Panel implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Add Key Input Step (Priority: P1) 🎯 MVP
+
+**Goal**: User can select "Key Input", enter a key identifier, add it as a step, and edit or delete it.
+
+**Independent Test**: Open the command editor, select "Key Input" from the action type selector, type "Enter" in the key field, click Add — step appears in the step list as `Key: Enter`. Click Edit — panel repopulates with "Enter". Click the step's delete button — step is removed. Confirm the step also supports drag-to-reorder in the list.
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Create `KeyInputPanel.tsx` in `src/web-ui/src/components/commands/KeyInputPanel.tsx`: single required text field for key identifier (`<input type="text">`), `attempted` state for deferred validation (error shown only after Add is clicked), `initialValue` prop for edit repopulation, `onConfirm(value: { key: string })` / `onCancel` callbacks, `action-panel action-panel--key-input` CSS classes on root div, `action-panel__controls` div with Add/Save (label switches on `initialValue !== undefined`) and Cancel buttons
+- [X] T011 [US1] Add `KeyInput` case to `toStepItems` returning `{ label: 'Key: <key>', description: undefined }` (label relies on CSS truncation from `.reorderable-list__label`); add `{pendingActionType === 'KeyInput' && <KeyInputPanel ... />}` rendering block with `handlePanelConfirm` mapping `{ type: 'KeyInput', keyInput: { key } }`; import `KeyInputPanel`; verify the new step appears in `SortableSequenceStepList` with functional edit and delete controls (FR-015) in `src/web-ui/src/components/commands/CommandForm.tsx` (depends on T009, T010)
+- [X] T012 [P] [US1] Add `.action-panel--key-input` CSS modifier class rules (base sizing, field spacing consistent with `.action-panel--tap`) to `src/web-ui/src/components/commands/CommandForm.css`
+
+**Checkpoint**: User Story 1 complete — Key Input step can be added, displayed (with truncated label), edited, deleted, and reordered independently of Swipe.
+
+---
+
+## Phase 4: User Story 2 — Add Swipe Step (Priority: P2)
+
+**Goal**: User can select "Swipe", enter start/end coordinates and optional duration, add it as a step, and edit or delete it.
+
+**Independent Test**: Open the command editor, select "Swipe", fill StartX=0, StartY=0, EndX=100, EndY=200, DurationMs=300, click Add — step appears with description `(0,0) → (100,200), 300ms`. Click Add with StartX empty — validation error shown on that field, step not added. Click Edit on the step — panel repopulates all five fields. Confirm the step supports drag-to-reorder in the list.
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Create `SwipePanel.tsx` in `src/web-ui/src/components/commands/SwipePanel.tsx`: four required integer fields (`StartX`, `StartY`, `EndX`, `EndY` as `<input type="number">`) and one optional integer field (`DurationMs`); `attempted` state for deferred validation (each empty required field shows individual error after Add is clicked); `initialValue` prop for edit repopulation; `onConfirm(value: SwipePanelValue)` / `onCancel` callbacks; `action-panel action-panel--swipe` CSS classes; `action-panel__controls` with Add/Save and Cancel buttons
+- [X] T014 [US2] Add `Swipe` case to `toStepItems` returning `{ label: 'Swipe', description: '(startX,startY) → (endX,endY)' }` with optional `, Nms` appended when `durationMs` is set; add `{pendingActionType === 'Swipe' && <SwipePanel ... />}` rendering block with `handlePanelConfirm` mapping `{ type: 'Swipe', swipe: { startX, startY, endX, endY, durationMs } }`; import `SwipePanel`; verify the new step appears in `SortableSequenceStepList` with functional edit and delete controls (FR-015) in `src/web-ui/src/components/commands/CommandForm.tsx` (depends on T011, T013)
+- [X] T015 [P] [US2] Add `.action-panel--swipe` CSS modifier class rules to `src/web-ui/src/components/commands/CommandForm.css`
+
+**Checkpoint**: User Story 2 complete — Swipe step can be added, displayed, edited, deleted, and reordered. Both US1 and US2 are independently functional.
+
+---
+
+## Phase 5: User Story 3 — Consistency (Priority: P3)
+
+**Goal**: Key Input and Swipe panels are visually and behaviorally indistinguishable in style from Tap, Wait for Image, and Ensure Game Running.
+
+**Independent Test**: Open the command editor and cycle through all five action types — Tap, Wait for Image, Ensure Game Running, Key Input, Swipe. All panels share the same field layout, button placement, error styling, and font. Switching action type away from Key Input and back resets the panel. Switching away from Swipe and back resets all five fields.
+
+### Implementation for User Story 3
+
+- [X] T016 [US3] Verify `.reorderable-list__label` in `src/web-ui/src/components/commands/CommandForm.css` applies `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`; if not, add those properties so long Key Input key names truncate with an ellipsis to fit the list item width
+- [X] T017 [US3] Review `KeyInputPanel.tsx` and `SwipePanel.tsx` against `TapPanel.tsx` for structural consistency: confirm field `<div className="field">` wrappers match, button element ordering in `action-panel__controls` matches (primary action first, Cancel second), error `<div className="field-error" role="alert">` elements are used for validation messages, `disabled` prop is forwarded to all interactive elements, and error messages use actionable text (e.g., "Key identifier is required." not just a red border)
+
+**Checkpoint**: All three user stories complete. All five action types are consistent in appearance and behavior.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T018 [P] Run `dotnet build` and `dotnet format --verify-no-changes` in `src/GameBot.Domain` and `src/GameBot.Service`; confirm no new compiler warnings, errors, or formatting violations from T002–T006 changes
+- [X] T019 [P] Run `npm run build` and the project's lint command (e.g., `npm run lint`) in `src/web-ui`; confirm no TypeScript errors or lint violations from T007–T017 changes
+- [X] T020 Add automated integration test cases to `tests/integration/PrimitiveAuthoringFlowTests.cs` covering: (1) POST a command with a KeyInput step, GET it back — `type`, `keyInput.key` round-trip correctly; (2) POST a command with a Swipe step, GET it back — `type`, `swipe.startX/Y`, `swipe.endX/Y`, `swipe.durationMs` round-trip correctly (follows existing authoring flow test pattern; validates T004 mapper)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — **blocks all user stories**
+- **Phase 3 (US1)**: Depends on Phase 2 — can start once foundational is done
+- **Phase 4 (US2)**: Depends on Phase 3 — sequentially after US1 (same file: `CommandForm.tsx`)
+- **Phase 5 (US3)**: Depends on Phases 3 and 4
+- **Phase 6 (Polish)**: Depends on all prior phases
+
+### Within Phase 2 (Foundational)
+
+```
+T002 ──┬──► T004 ──► T006
+T003 ──┘
+T002 ──────► T005
+T007  (independent)
+T008 ──────► T009
+```
+
+T002 and T003 can run in parallel (different files).
+T004 waits for T002 + T003; T006 waits for T002, T003, T004.
+T005 (tests) waits for T002.
+T007 and T008 are independent of the backend tasks and of each other.
+T009 waits for T008.
+
+### Within Phase 3 (US1)
+
+```
+T010 ──► T011
+T012  (parallel — different file)
+```
+
+### Within Phase 4 (US2)
+
+```
+T013 ──► T014
+T015  (parallel — different file)
+```
+
+---
+
+## Parallel Execution Example: Phase 2 (Foundational)
+
+```
+Parallel batch 1 — all different files, no dependencies:
+  T002  src/GameBot.Domain/Commands/CommandStep.cs
+  T003  src/GameBot.Service/Models/Commands.cs
+  T007  src/web-ui/src/services/commands.ts
+  T008  src/web-ui/src/components/commands/ActionTypeSelector.tsx
+
+Sequential after batch 1:
+  T004  src/GameBot.Service/Endpoints/CommandsEndpoints.cs  (needs T002 + T003)
+  T005  tests/unit/Commands/CommandExecutor*Tests.cs         (needs T002)
+  T006  src/GameBot.Service/Services/CommandExecutor.cs      (needs T002, T003, T004)
+  T009  src/web-ui/src/components/commands/CommandForm.tsx   (needs T008)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (including mapper T004 and tests T005)
+3. Complete Phase 3: User Story 1 (Key Input)
+4. **STOP and VALIDATE**: Add a Key Input step end-to-end — type selector shows "Key Input", panel appears, step saves, reloads, edit/delete/reorder all work
+5. Demo if ready before proceeding
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → Type system, mapper, and tests ready
+2. Phase 3 → Key Input working (MVP)
+3. Phase 4 → Swipe working
+4. Phase 5 + Phase 6 → Consistency verified, build clean
+
+---
+
+## Notes
+
+- [P] tasks touch different files and have no blocking dependencies on each other within their phase
+- `CommandForm.tsx` is modified in T009 (foundational), T011 (US1), and T014 (US2) — do these sequentially to avoid conflicts
+- The backend executor (T006) only needs the `InputAction` model, which already accepts any `type` string + `args` dict — no session-layer changes are needed beyond the mapper (T004) and executor (T006)
+- The `args` key names in T006 (`x1`, `y1`, `x2`, `y2`) intentionally differ from the `SwipeConfig` property names (`StartX`, `StartY`, `EndX`, `EndY`) to match the existing `PrimitiveSwipeAction` domain convention — the mapping is explicit in T006
+- Swipe and Key domain classes (`PrimitiveKeyAction`, `PrimitiveSwipeAction`) already exist — T002 adds the `CommandStep`-level config classes which are shaped after but distinct from those domain action classes

--- a/src/GameBot.Domain/Commands/CommandStep.cs
+++ b/src/GameBot.Domain/Commands/CommandStep.cs
@@ -4,11 +4,25 @@ public enum CommandStepType {
   Command,
   PrimitiveTap,
   WaitForImage,
-  EnsureGameRunning
+  EnsureGameRunning,
+  KeyInput,
+  Swipe
 }
 
 public sealed class PrimitiveTapConfig {
   public required DetectionTarget DetectionTarget { get; init; }
+}
+
+public sealed class KeyInputConfig {
+  public required string Key { get; init; }
+}
+
+public sealed class SwipeConfig {
+  public required int StartX { get; init; }
+  public required int StartY { get; init; }
+  public required int EndX { get; init; }
+  public required int EndY { get; init; }
+  public int? DurationMs { get; init; }
 }
 
 public sealed class CommandStep {
@@ -16,5 +30,7 @@ public sealed class CommandStep {
   public string TargetId { get; init; } = string.Empty;
   public PrimitiveTapConfig? PrimitiveTap { get; init; }
   public WaitForImageConfig? WaitForImage { get; init; }
+  public KeyInputConfig? KeyInput { get; init; }
+  public SwipeConfig? Swipe { get; init; }
   public int Order { get; init; }
 }

--- a/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
@@ -26,6 +26,8 @@ internal static class CommandsEndpoints {
     CommandStepTypeDto.Command => CommandStepType.Command,
     CommandStepTypeDto.WaitForImage => CommandStepType.WaitForImage,
     CommandStepTypeDto.EnsureGameRunning => CommandStepType.EnsureGameRunning,
+    CommandStepTypeDto.KeyInput => CommandStepType.KeyInput,
+    CommandStepTypeDto.Swipe => CommandStepType.Swipe,
     _ => CommandStepType.PrimitiveTap
   };
 
@@ -33,6 +35,8 @@ internal static class CommandsEndpoints {
     CommandStepType.Command => CommandStepTypeDto.Command,
     CommandStepType.WaitForImage => CommandStepTypeDto.WaitForImage,
     CommandStepType.EnsureGameRunning => CommandStepTypeDto.EnsureGameRunning,
+    CommandStepType.KeyInput => CommandStepTypeDto.KeyInput,
+    CommandStepType.Swipe => CommandStepTypeDto.Swipe,
     _ => CommandStepTypeDto.PrimitiveTap
   };
 
@@ -59,6 +63,26 @@ internal static class CommandsEndpoints {
       DetectionTarget = ToDomainDetection(dto.DetectionTarget),
       TimeoutMs = timeoutMs
     };
+  }
+
+  private static KeyInputConfig? ToDomainKeyInput(KeyInputConfigDto? dto) {
+    if (dto is null || string.IsNullOrWhiteSpace(dto.Key)) return null;
+    return new KeyInputConfig { Key = dto.Key };
+  }
+
+  private static KeyInputConfigDto? ToResponseKeyInput(KeyInputConfig? cfg) {
+    if (cfg is null) return null;
+    return new KeyInputConfigDto { Key = cfg.Key };
+  }
+
+  private static SwipeConfig? ToDomainSwipe(SwipeConfigDto? dto) {
+    if (dto is null) return null;
+    return new SwipeConfig { StartX = dto.StartX, StartY = dto.StartY, EndX = dto.EndX, EndY = dto.EndY, DurationMs = dto.DurationMs };
+  }
+
+  private static SwipeConfigDto? ToResponseSwipe(SwipeConfig? cfg) {
+    if (cfg is null) return null;
+    return new SwipeConfigDto { StartX = cfg.StartX, StartY = cfg.StartY, EndX = cfg.EndX, EndY = cfg.EndY, DurationMs = cfg.DurationMs };
   }
 
   private static WaitForImageConfigDto? ToResponseWaitForImage(WaitForImageConfig? cfg) {
@@ -98,6 +122,23 @@ internal static class CommandsEndpoints {
       return null;
     }
 
+    if (step.Type == CommandStepTypeDto.KeyInput) {
+      if (step.KeyInput is null || string.IsNullOrWhiteSpace(step.KeyInput.Key)) {
+        return "keyInput.key is required for KeyInput steps";
+      }
+      return null;
+    }
+
+    if (step.Type == CommandStepTypeDto.Swipe) {
+      if (step.Swipe is null) {
+        return "swipe is required for Swipe steps";
+      }
+      if (step.Swipe.DurationMs is < 0) {
+        return "swipe.durationMs must be greater than or equal to zero";
+      }
+      return null;
+    }
+
     if (string.IsNullOrWhiteSpace(step.TargetId)) {
       return "targetId is required for Command steps";
     }
@@ -109,6 +150,8 @@ internal static class CommandsEndpoints {
     TargetId = s.TargetId ?? string.Empty,
     PrimitiveTap = s.Type == CommandStepTypeDto.PrimitiveTap ? ToDomainPrimitiveTap(s.PrimitiveTap) : null,
     WaitForImage = s.Type == CommandStepTypeDto.WaitForImage ? ToDomainWaitForImage(s.WaitForImage) : null,
+    KeyInput = s.Type == CommandStepTypeDto.KeyInput ? ToDomainKeyInput(s.KeyInput) : null,
+    Swipe = s.Type == CommandStepTypeDto.Swipe ? ToDomainSwipe(s.Swipe) : null,
     Order = s.Order
   };
 
@@ -117,6 +160,8 @@ internal static class CommandsEndpoints {
     TargetId = s.Type == CommandStepType.Command ? s.TargetId : null,
     PrimitiveTap = s.Type == CommandStepType.PrimitiveTap ? ToResponsePrimitiveTap(s.PrimitiveTap) : null,
     WaitForImage = s.Type == CommandStepType.WaitForImage ? ToResponseWaitForImage(s.WaitForImage) : null,
+    KeyInput = s.Type == CommandStepType.KeyInput ? ToResponseKeyInput(s.KeyInput) : null,
+    Swipe = s.Type == CommandStepType.Swipe ? ToResponseSwipe(s.Swipe) : null,
     Order = s.Order
   };
 

--- a/src/GameBot.Service/Models/Commands.cs
+++ b/src/GameBot.Service/Models/Commands.cs
@@ -41,7 +41,21 @@ internal enum CommandStepTypeDto {
   Command,
   PrimitiveTap,
   WaitForImage,
-  EnsureGameRunning
+  EnsureGameRunning,
+  KeyInput,
+  Swipe
+}
+
+internal sealed class KeyInputConfigDto {
+  public required string Key { get; init; }
+}
+
+internal sealed class SwipeConfigDto {
+  public required int StartX { get; init; }
+  public required int StartY { get; init; }
+  public required int EndX { get; init; }
+  public required int EndY { get; init; }
+  public int? DurationMs { get; init; }
 }
 
 internal sealed class PrimitiveTapConfigDto {
@@ -58,6 +72,8 @@ internal sealed class CommandStepDto {
   public string? TargetId { get; init; }
   public PrimitiveTapConfigDto? PrimitiveTap { get; init; }
   public WaitForImageConfigDto? WaitForImage { get; init; }
+  public KeyInputConfigDto? KeyInput { get; init; }
+  public SwipeConfigDto? Swipe { get; init; }
   public int Order { get; init; }
 }
 

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -182,6 +182,38 @@ internal sealed class CommandExecutor : ICommandExecutor {
         continue;
       }
 
+      if (step.Type == CommandStepType.KeyInput) {
+        if (step.KeyInput is null) {
+          stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_invalid_config", "key_input_missing_config", null, null, StepType: "key"));
+          continue;
+        }
+        var keyArgs = new Dictionary<string, object> { ["key"] = step.KeyInput.Key };
+        var keyAction = new GameBot.Emulator.Session.InputAction("key", keyArgs, null, null);
+        totalAccepted += await _sessions.SendInputsAsync(sessionId, new[] { keyAction }, ct).ConfigureAwait(false);
+        stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", null, null, null, StepType: "key"));
+        continue;
+      }
+
+      if (step.Type == CommandStepType.Swipe) {
+        if (step.Swipe is null) {
+          stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "skipped_invalid_config", "swipe_missing_config", null, null, StepType: "swipe"));
+          continue;
+        }
+        var swipeArgs = new Dictionary<string, object> {
+          ["x1"] = step.Swipe.StartX,
+          ["y1"] = step.Swipe.StartY,
+          ["x2"] = step.Swipe.EndX,
+          ["y2"] = step.Swipe.EndY
+        };
+        if (step.Swipe.DurationMs.HasValue) {
+          swipeArgs["durationMs"] = step.Swipe.DurationMs.Value;
+        }
+        var swipeAction = new GameBot.Emulator.Session.InputAction("swipe", swipeArgs, null, null);
+        totalAccepted += await _sessions.SendInputsAsync(sessionId, new[] { swipeAction }, ct).ConfigureAwait(false);
+        stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", null, null, null, StepType: "swipe"));
+        continue;
+      }
+
       if (step.Type == CommandStepType.PrimitiveTap) {
         // Backward-compatible fallback: older commands may keep detection at command level.
         var primitiveDetection = step.PrimitiveTap?.DetectionTarget ?? cmd.Detection;

--- a/src/web-ui/src/components/commands/ActionTypeSelector.tsx
+++ b/src/web-ui/src/components/commands/ActionTypeSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type PrimitiveActionType = 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning';
+export type PrimitiveActionType = 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
 
 export type ActionTypeSelectorProps = {
   value: PrimitiveActionType | '';
@@ -22,6 +22,8 @@ export const ActionTypeSelector: React.FC<ActionTypeSelectorProps> = ({ value, o
         <option value="PrimitiveTap">Tap</option>
         <option value="WaitForImage">Wait for Image</option>
         <option value="EnsureGameRunning">Ensure Game Running</option>
+        <option value="KeyInput">Key Input</option>
+        <option value="Swipe">Swipe</option>
       </select>
     </div>
   );

--- a/src/web-ui/src/components/commands/CommandForm.css
+++ b/src/web-ui/src/components/commands/CommandForm.css
@@ -191,6 +191,14 @@
   margin-top: 2px;
 }
 
+.command-form .action-panel--key-input {
+  max-width: 420px;
+}
+
+.command-form .action-panel--swipe {
+  max-width: 480px;
+}
+
 @media (min-width: 1280px) {
   .command-form {
     padding: 20px 24px;

--- a/src/web-ui/src/components/commands/CommandForm.tsx
+++ b/src/web-ui/src/components/commands/CommandForm.tsx
@@ -10,11 +10,13 @@ import { ActionTypeSelector, PrimitiveActionType } from './ActionTypeSelector';
 import { TapPanel } from './TapPanel';
 import { WaitForImagePanel } from './WaitForImagePanel';
 import { EnsureGameRunningPanel } from './EnsureGameRunningPanel';
+import { KeyInputPanel } from './KeyInputPanel';
+import { SwipePanel } from './SwipePanel';
 import './CommandForm.css';
 
 export type StepEntry = {
   id: string;
-  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning';
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
   targetId?: string;
   primitiveTap?: {
     detectionTarget: DetectionTargetForm;
@@ -23,6 +25,8 @@ export type StepEntry = {
     detectionTarget?: DetectionTargetForm;
     timeoutMs?: string;
   };
+  keyInput?: { key: string };
+  swipe?: { startX: string; startY: string; endX: string; endY: string; durationMs?: string };
 };
 
 export type DetectionTargetForm = {
@@ -84,6 +88,22 @@ const toStepItems = (steps: StepEntry[], commandOpts: SearchableOption[]): Reord
       };
     }
 
+    if (step.type === 'KeyInput') {
+      return {
+        id: step.id,
+        label: `Key: ${step.keyInput?.key ?? ''}`,
+        description: undefined,
+      };
+    }
+
+    if (step.type === 'Swipe') {
+      const { startX = '0', startY = '0', endX = '0', endY = '0', durationMs } = step.swipe ?? {};
+      const desc = durationMs?.trim()
+        ? `(${startX},${startY}) → (${endX},${endY}), ${durationMs}ms`
+        : `(${startX},${startY}) → (${endX},${endY})`;
+      return { id: step.id, label: 'Swipe', description: desc };
+    }
+
     const targetId = step.targetId ?? '';
     const match = commandMap.get(targetId);
     return {
@@ -94,7 +114,7 @@ const toStepItems = (steps: StepEntry[], commandOpts: SearchableOption[]): Reord
   });
 };
 
-const EDITABLE_TYPES = new Set<string>(['PrimitiveTap', 'WaitForImage', 'EnsureGameRunning']);
+const EDITABLE_TYPES = new Set<string>(['PrimitiveTap', 'WaitForImage', 'EnsureGameRunning', 'KeyInput', 'Swipe']);
 
 export const CommandForm: React.FC<CommandFormProps> = ({
   value,
@@ -259,6 +279,29 @@ export const CommandForm: React.FC<CommandFormProps> = ({
         {pendingActionType === 'EnsureGameRunning' && (
           <EnsureGameRunningPanel
             onConfirm={() => handlePanelConfirm({ type: 'EnsureGameRunning' })}
+            onCancel={handlePanelCancel}
+            disabled={submitting}
+          />
+        )}
+
+        {pendingActionType === 'KeyInput' && (
+          <KeyInputPanel
+            initialValue={editingStep?.keyInput}
+            onConfirm={(v) => handlePanelConfirm({ type: 'KeyInput', keyInput: { key: v.key } })}
+            onCancel={handlePanelCancel}
+            disabled={submitting}
+          />
+        )}
+
+        {pendingActionType === 'Swipe' && (
+          <SwipePanel
+            initialValue={editingStep?.swipe}
+            onConfirm={(v) =>
+              handlePanelConfirm({
+                type: 'Swipe',
+                swipe: { startX: v.startX, startY: v.startY, endX: v.endX, endY: v.endY, durationMs: v.durationMs },
+              })
+            }
             onCancel={handlePanelCancel}
             disabled={submitting}
           />

--- a/src/web-ui/src/components/commands/KeyInputPanel.tsx
+++ b/src/web-ui/src/components/commands/KeyInputPanel.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+export type KeyInputPanelValue = {
+  key: string;
+};
+
+export type KeyInputPanelProps = {
+  initialValue?: KeyInputPanelValue;
+  onConfirm: (value: KeyInputPanelValue) => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+
+export const KeyInputPanel: React.FC<KeyInputPanelProps> = ({ initialValue, onConfirm, onCancel, disabled }) => {
+  const [key, setKey] = useState(initialValue?.key ?? '');
+  const [attempted, setAttempted] = useState(false);
+
+  const keyError = !key.trim() ? 'Key identifier is required.' : null;
+  const buttonLabel = initialValue !== undefined ? 'Save' : 'Add';
+
+  const handleConfirm = () => {
+    setAttempted(true);
+    if (keyError) return;
+    onConfirm({ key: key.trim() });
+  };
+
+  return (
+    <div className="action-panel action-panel--key-input">
+      <div className="field">
+        <label htmlFor="key-input-panel-key">Key identifier *</label>
+        <input
+          id="key-input-panel-key"
+          type="text"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="e.g. Enter, Escape, F5, a"
+          disabled={disabled}
+          aria-invalid={attempted && Boolean(keyError)}
+          aria-describedby={attempted && keyError ? 'key-input-panel-key-error' : undefined}
+        />
+        {attempted && keyError && (
+          <div id="key-input-panel-key-error" className="field-error" role="alert">{keyError}</div>
+        )}
+      </div>
+      <div className="action-panel__controls">
+        <button type="button" onClick={handleConfirm} disabled={disabled}>
+          {buttonLabel}
+        </button>
+        <button type="button" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/commands/SwipePanel.tsx
+++ b/src/web-ui/src/components/commands/SwipePanel.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+
+export type SwipePanelValue = {
+  startX: string;
+  startY: string;
+  endX: string;
+  endY: string;
+  durationMs?: string;
+};
+
+export type SwipePanelProps = {
+  initialValue?: SwipePanelValue;
+  onConfirm: (value: SwipePanelValue) => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+
+const validateInteger = (value: string, label: string): string | null => {
+  if (!value.trim()) return `${label} is required.`;
+  if (!Number.isInteger(Number(value)) || isNaN(Number(value))) return `${label} must be an integer.`;
+  return null;
+};
+
+const validateDuration = (value: string): string | null => {
+  if (!value.trim()) return null;
+  const n = parseInt(value, 10);
+  if (isNaN(n) || n < 0) return 'Duration must be a non-negative integer.';
+  return null;
+};
+
+export const SwipePanel: React.FC<SwipePanelProps> = ({ initialValue, onConfirm, onCancel, disabled }) => {
+  const [startX, setStartX] = useState(initialValue?.startX ?? '');
+  const [startY, setStartY] = useState(initialValue?.startY ?? '');
+  const [endX, setEndX] = useState(initialValue?.endX ?? '');
+  const [endY, setEndY] = useState(initialValue?.endY ?? '');
+  const [durationMs, setDurationMs] = useState(initialValue?.durationMs ?? '');
+  const [attempted, setAttempted] = useState(false);
+
+  const startXError = validateInteger(startX, 'Start X');
+  const startYError = validateInteger(startY, 'Start Y');
+  const endXError = validateInteger(endX, 'End X');
+  const endYError = validateInteger(endY, 'End Y');
+  const durationError = validateDuration(durationMs);
+  const hasErrors = Boolean(startXError || startYError || endXError || endYError || durationError);
+
+  const buttonLabel = initialValue !== undefined ? 'Save' : 'Add';
+
+  const handleConfirm = () => {
+    setAttempted(true);
+    if (hasErrors) return;
+    onConfirm({
+      startX: startX.trim(),
+      startY: startY.trim(),
+      endX: endX.trim(),
+      endY: endY.trim(),
+      durationMs: durationMs.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="action-panel action-panel--swipe">
+      <div className="field">
+        <label htmlFor="swipe-panel-start-x">Start X *</label>
+        <input
+          id="swipe-panel-start-x"
+          type="number"
+          value={startX}
+          onChange={(e) => setStartX(e.target.value)}
+          disabled={disabled}
+          aria-invalid={attempted && Boolean(startXError)}
+          aria-describedby={attempted && startXError ? 'swipe-panel-start-x-error' : undefined}
+        />
+        {attempted && startXError && (
+          <div id="swipe-panel-start-x-error" className="field-error" role="alert">{startXError}</div>
+        )}
+      </div>
+      <div className="field">
+        <label htmlFor="swipe-panel-start-y">Start Y *</label>
+        <input
+          id="swipe-panel-start-y"
+          type="number"
+          value={startY}
+          onChange={(e) => setStartY(e.target.value)}
+          disabled={disabled}
+          aria-invalid={attempted && Boolean(startYError)}
+          aria-describedby={attempted && startYError ? 'swipe-panel-start-y-error' : undefined}
+        />
+        {attempted && startYError && (
+          <div id="swipe-panel-start-y-error" className="field-error" role="alert">{startYError}</div>
+        )}
+      </div>
+      <div className="field">
+        <label htmlFor="swipe-panel-end-x">End X *</label>
+        <input
+          id="swipe-panel-end-x"
+          type="number"
+          value={endX}
+          onChange={(e) => setEndX(e.target.value)}
+          disabled={disabled}
+          aria-invalid={attempted && Boolean(endXError)}
+          aria-describedby={attempted && endXError ? 'swipe-panel-end-x-error' : undefined}
+        />
+        {attempted && endXError && (
+          <div id="swipe-panel-end-x-error" className="field-error" role="alert">{endXError}</div>
+        )}
+      </div>
+      <div className="field">
+        <label htmlFor="swipe-panel-end-y">End Y *</label>
+        <input
+          id="swipe-panel-end-y"
+          type="number"
+          value={endY}
+          onChange={(e) => setEndY(e.target.value)}
+          disabled={disabled}
+          aria-invalid={attempted && Boolean(endYError)}
+          aria-describedby={attempted && endYError ? 'swipe-panel-end-y-error' : undefined}
+        />
+        {attempted && endYError && (
+          <div id="swipe-panel-end-y-error" className="field-error" role="alert">{endYError}</div>
+        )}
+      </div>
+      <div className="field">
+        <label htmlFor="swipe-panel-duration">Duration (ms)</label>
+        <input
+          id="swipe-panel-duration"
+          type="number"
+          min="0"
+          value={durationMs}
+          onChange={(e) => setDurationMs(e.target.value)}
+          disabled={disabled}
+        />
+        {attempted && durationError && (
+          <div className="field-error" role="alert">{durationError}</div>
+        )}
+      </div>
+      <div className="action-panel__controls">
+        <button type="button" onClick={handleConfirm} disabled={disabled}>
+          {buttonLabel}
+        </button>
+        <button type="button" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/commands/__tests__/ActionTypeSelector.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/ActionTypeSelector.test.tsx
@@ -11,7 +11,7 @@ describe('ActionTypeSelector', () => {
     expect(options[0].value).toBe('');
   });
 
-  it('renders exactly Tap, Wait for Image, Ensure Game Running options', () => {
+  it('renders exactly Tap, Wait for Image, Ensure Game Running, Key Input, Swipe options', () => {
     render(<ActionTypeSelector value="" onChange={() => {}} />);
     const select = screen.getByRole('combobox', { name: /action type/i });
     const options = Array.from((select as HTMLSelectElement).options).map((o) => ({
@@ -23,8 +23,10 @@ describe('ActionTypeSelector', () => {
       { value: 'PrimitiveTap', text: 'Tap' },
       { value: 'WaitForImage', text: 'Wait for Image' },
       { value: 'EnsureGameRunning', text: 'Ensure Game Running' },
+      { value: 'KeyInput', text: 'Key Input' },
+      { value: 'Swipe', text: 'Swipe' },
     ]);
-    expect(options).toHaveLength(4);
+    expect(options).toHaveLength(6);
   });
 
   it('onChange fires with PrimitiveTap when Tap is selected', () => {

--- a/src/web-ui/src/services/commands.ts
+++ b/src/web-ui/src/services/commands.ts
@@ -18,11 +18,25 @@ export type CommandCreate = {
 export type CommandUpdate = CommandCreate;
 
 export type CommandStepDto = {
-  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning';
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
   targetId?: string;
   order: number;
   primitiveTap?: PrimitiveTapConfigDto;
   waitForImage?: WaitForImageConfigDto;
+  keyInput?: KeyInputConfigDto;
+  swipe?: SwipeConfigDto;
+};
+
+export type KeyInputConfigDto = {
+  key: string;
+};
+
+export type SwipeConfigDto = {
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  durationMs?: number;
 };
 
 export type PrimitiveTapConfigDto = {

--- a/tests/integration/PrimitiveAuthoringFlowTests.cs
+++ b/tests/integration/PrimitiveAuthoringFlowTests.cs
@@ -99,6 +99,77 @@ public sealed class PrimitiveAuthoringFlowTests : IDisposable {
   }
 
   [Fact]
+  public async Task CommandCreateReadSupportsKeyInputStep() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+
+    var createPayload = new {
+      name = "key-input-command",
+      steps = new[] {
+        new {
+          type = "KeyInput",
+          order = 0,
+          keyInput = new { key = "Enter" }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync(new Uri("/api/commands", UriKind.Relative), createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var commandId = created.GetProperty("id").GetString();
+    commandId.Should().NotBeNullOrWhiteSpace();
+
+    var getResponse = await client.GetAsync(new Uri($"/api/commands/{commandId}", UriKind.Relative)).ConfigureAwait(false);
+    getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var retrieved = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var step = retrieved.GetProperty("steps")[0];
+    step.GetProperty("type").GetString().Should().Be("KeyInput");
+    step.GetProperty("keyInput").GetProperty("key").GetString().Should().Be("Enter");
+  }
+
+  [Fact]
+  public async Task CommandCreateReadSupportsSwipeStep() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+
+    var createPayload = new {
+      name = "swipe-command",
+      steps = new[] {
+        new {
+          type = "Swipe",
+          order = 0,
+          swipe = new { startX = 100, startY = 800, endX = 100, endY = 200, durationMs = 300 }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync(new Uri("/api/commands", UriKind.Relative), createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var commandId = created.GetProperty("id").GetString();
+    commandId.Should().NotBeNullOrWhiteSpace();
+
+    var getResponse = await client.GetAsync(new Uri($"/api/commands/{commandId}", UriKind.Relative)).ConfigureAwait(false);
+    getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var retrieved = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var step = retrieved.GetProperty("steps")[0];
+    step.GetProperty("type").GetString().Should().Be("Swipe");
+    var swipe = step.GetProperty("swipe");
+    swipe.GetProperty("startX").GetInt32().Should().Be(100);
+    swipe.GetProperty("startY").GetInt32().Should().Be(800);
+    swipe.GetProperty("endX").GetInt32().Should().Be(100);
+    swipe.GetProperty("endY").GetInt32().Should().Be(200);
+    swipe.GetProperty("durationMs").GetInt32().Should().Be(300);
+  }
+
+  [Fact]
   public async Task SequenceCreateReadUpdateSupportsInlinePrimitiveActions() {
     using var app = new WebApplicationFactory<Program>();
     var client = app.CreateClient();

--- a/tests/unit/Commands/CommandExecutorKeyInputTests.cs
+++ b/tests/unit/Commands/CommandExecutorKeyInputTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Sessions;
+using GameBot.Domain.Triggers;
+using GameBot.Domain.Triggers.Evaluators;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+// Test-code analyzer relaxations permitted by the constitution:
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Commands;
+
+public sealed class CommandExecutorKeyInputTests {
+  // ── Fakes ─────────────────────────────────────────────────────────────────
+
+  private sealed class FakeCommandRepository : ICommandRepository {
+    private readonly Dictionary<string, Command> _cmds = new(StringComparer.Ordinal);
+    public void Seed(Command c) => _cmds[c.Id] = c;
+    public Task<Command> AddAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult(c); }
+    public Task<Command?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.TryGetValue(id, out var c) ? c : null);
+    public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Command>)_cmds.Values.ToList());
+    public Task<Command?> UpdateAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult<Command?>(c); }
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.Remove(id));
+  }
+
+  private sealed class RecordingSessionManager : ISessionManager {
+    private readonly EmulatorSession _session;
+    public List<InputAction> ReceivedInputs { get; } = new();
+    public int SendResult { get; set; } = 1;
+    public RecordingSessionManager(EmulatorSession session) => _session = session;
+    public int ActiveCount => 1;
+    public bool CanCreateSession => false;
+    public EmulatorSession? GetSession(string id) => id == _session.Id ? _session : null;
+    public EmulatorSession CreateSession(string g, string? s = null) => throw new NotSupportedException();
+    public IReadOnlyCollection<EmulatorSession> ListSessions() => new[] { _session };
+    public bool StopSession(string id) => false;
+    public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) {
+      ReceivedInputs.AddRange(actions);
+      return Task.FromResult(SendResult);
+    }
+    public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+  }
+
+  private sealed class FakeTriggerRepository : ITriggerRepository {
+    public Task<Trigger?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<Trigger?>(null);
+    public Task<IReadOnlyList<Trigger>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Trigger>)Array.Empty<Trigger>());
+    public Task UpsertAsync(Trigger t, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+  }
+
+  private sealed class FakeSessionContextCache : ISessionContextCache {
+    public void SetSessionId(string g, string a, string s) { }
+    public string? GetSessionId(string g, string a) => null;
+    public void ClearSession(string g, string a) { }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private static EmulatorSession RunningSession(string id = "session1") =>
+    new() { Id = id, GameId = "queue:q1", Status = SessionStatus.Running, DeviceSerial = "emulator-5554" };
+
+  private static Command KeyInputCommand(string key, string id = "cmd1") => new() {
+    Id = id,
+    Name = "KeyInput",
+    TriggerId = null,
+    Steps = new Collection<CommandStep> {
+      new() { Type = CommandStepType.KeyInput, KeyInput = new KeyInputConfig { Key = key }, Order = 1 }
+    }
+  };
+
+  private static CommandExecutor BuildExecutor(FakeCommandRepository cmds, RecordingSessionManager sessions) =>
+    new(cmds, sessions, new FakeTriggerRepository(),
+        new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+        NullLogger<CommandExecutor>.Instance,
+        new FakeSessionContextCache());
+
+  // ── Tests ─────────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task KeyInputStepDispatchesInputActionWithCorrectTypeAndKey() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(KeyInputCommand("Enter"));
+    var executor = BuildExecutor(cmds, sessions);
+
+    await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    sessions.ReceivedInputs.Should().ContainSingle();
+    sessions.ReceivedInputs[0].Type.Should().Be("key");
+    sessions.ReceivedInputs[0].Args.Should().ContainKey("key").WhoseValue.Should().Be("Enter");
+  }
+
+  [Fact]
+  public async Task KeyInputStepCountsAsOneAccepted() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession()) { SendResult = 1 };
+    cmds.Seed(KeyInputCommand("Escape"));
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(1);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("executed");
+  }
+
+  [Fact]
+  public async Task KeyInputStepWithNullConfigRecordsSkippedInvalidConfig() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(new Command {
+      Id = "cmd1",
+      Name = "BadKeyInput",
+      TriggerId = null,
+      Steps = new Collection<CommandStep> {
+        new() { Type = CommandStepType.KeyInput, KeyInput = null, Order = 1 }
+      }
+    });
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(0);
+    sessions.ReceivedInputs.Should().BeEmpty();
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("skipped_invalid_config");
+  }
+
+  [Fact]
+  public async Task KeyInputStepRecordsKeyStepType() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(KeyInputCommand("F5"));
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.StepOutcomes.Should().ContainSingle().Which.StepType.Should().Be("key");
+  }
+}

--- a/tests/unit/Commands/CommandExecutorKeyInputTests.cs
+++ b/tests/unit/Commands/CommandExecutorKeyInputTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using GameBot.Domain.Commands;
 using GameBot.Domain.Sessions;
+using GameBot.Domain.Services;
 using GameBot.Domain.Triggers;
 using GameBot.Domain.Triggers.Evaluators;
 using GameBot.Emulator.Session;

--- a/tests/unit/Commands/CommandExecutorSwipeTests.cs
+++ b/tests/unit/Commands/CommandExecutorSwipeTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using GameBot.Domain.Commands;
 using GameBot.Domain.Sessions;
+using GameBot.Domain.Services;
 using GameBot.Domain.Triggers;
 using GameBot.Domain.Triggers.Evaluators;
 using GameBot.Emulator.Session;

--- a/tests/unit/Commands/CommandExecutorSwipeTests.cs
+++ b/tests/unit/Commands/CommandExecutorSwipeTests.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Sessions;
+using GameBot.Domain.Triggers;
+using GameBot.Domain.Triggers.Evaluators;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+// Test-code analyzer relaxations permitted by the constitution:
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Commands;
+
+public sealed class CommandExecutorSwipeTests {
+  // ── Fakes ─────────────────────────────────────────────────────────────────
+
+  private sealed class FakeCommandRepository : ICommandRepository {
+    private readonly Dictionary<string, Command> _cmds = new(StringComparer.Ordinal);
+    public void Seed(Command c) => _cmds[c.Id] = c;
+    public Task<Command> AddAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult(c); }
+    public Task<Command?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.TryGetValue(id, out var c) ? c : null);
+    public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Command>)_cmds.Values.ToList());
+    public Task<Command?> UpdateAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult<Command?>(c); }
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.Remove(id));
+  }
+
+  private sealed class RecordingSessionManager : ISessionManager {
+    private readonly EmulatorSession _session;
+    public List<InputAction> ReceivedInputs { get; } = new();
+    public int SendResult { get; set; } = 1;
+    public RecordingSessionManager(EmulatorSession session) => _session = session;
+    public int ActiveCount => 1;
+    public bool CanCreateSession => false;
+    public EmulatorSession? GetSession(string id) => id == _session.Id ? _session : null;
+    public EmulatorSession CreateSession(string g, string? s = null) => throw new NotSupportedException();
+    public IReadOnlyCollection<EmulatorSession> ListSessions() => new[] { _session };
+    public bool StopSession(string id) => false;
+    public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) {
+      ReceivedInputs.AddRange(actions);
+      return Task.FromResult(SendResult);
+    }
+    public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+  }
+
+  private sealed class FakeTriggerRepository : ITriggerRepository {
+    public Task<Trigger?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<Trigger?>(null);
+    public Task<IReadOnlyList<Trigger>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Trigger>)Array.Empty<Trigger>());
+    public Task UpsertAsync(Trigger t, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+  }
+
+  private sealed class FakeSessionContextCache : ISessionContextCache {
+    public void SetSessionId(string g, string a, string s) { }
+    public string? GetSessionId(string g, string a) => null;
+    public void ClearSession(string g, string a) { }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private static EmulatorSession RunningSession(string id = "session1") =>
+    new() { Id = id, GameId = "queue:q1", Status = SessionStatus.Running, DeviceSerial = "emulator-5554" };
+
+  private static Command SwipeCommand(int startX, int startY, int endX, int endY, int? durationMs, string id = "cmd1") => new() {
+    Id = id,
+    Name = "Swipe",
+    TriggerId = null,
+    Steps = new Collection<CommandStep> {
+      new() {
+        Type = CommandStepType.Swipe,
+        Swipe = new SwipeConfig { StartX = startX, StartY = startY, EndX = endX, EndY = endY, DurationMs = durationMs },
+        Order = 1
+      }
+    }
+  };
+
+  private static CommandExecutor BuildExecutor(FakeCommandRepository cmds, RecordingSessionManager sessions) =>
+    new(cmds, sessions, new FakeTriggerRepository(),
+        new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+        NullLogger<CommandExecutor>.Instance,
+        new FakeSessionContextCache());
+
+  // ── Tests ─────────────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task SwipeStepDispatchesInputActionWithCorrectCoordinateArgs() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(SwipeCommand(100, 200, 300, 400, null));
+    var executor = BuildExecutor(cmds, sessions);
+
+    await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    sessions.ReceivedInputs.Should().ContainSingle();
+    var sent = sessions.ReceivedInputs[0];
+    sent.Type.Should().Be("swipe");
+    sent.Args.Should().ContainKey("x1").WhoseValue.Should().Be(100);
+    sent.Args.Should().ContainKey("y1").WhoseValue.Should().Be(200);
+    sent.Args.Should().ContainKey("x2").WhoseValue.Should().Be(300);
+    sent.Args.Should().ContainKey("y2").WhoseValue.Should().Be(400);
+  }
+
+  [Fact]
+  public async Task SwipeStepWithDurationIncludesDurationMsInArgs() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(SwipeCommand(0, 0, 100, 100, 300));
+    var executor = BuildExecutor(cmds, sessions);
+
+    await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    sessions.ReceivedInputs[0].Args.Should().ContainKey("durationMs").WhoseValue.Should().Be(300);
+  }
+
+  [Fact]
+  public async Task SwipeStepWithoutDurationOmitsDurationMsFromArgs() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(SwipeCommand(0, 0, 100, 100, null));
+    var executor = BuildExecutor(cmds, sessions);
+
+    await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    sessions.ReceivedInputs[0].Args.Should().NotContainKey("durationMs");
+  }
+
+  [Fact]
+  public async Task SwipeStepCountsAsOneAccepted() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession()) { SendResult = 1 };
+    cmds.Seed(SwipeCommand(0, 0, 100, 200, null));
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(1);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("executed");
+  }
+
+  [Fact]
+  public async Task SwipeStepWithNullConfigRecordsSkippedInvalidConfig() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(new Command {
+      Id = "cmd1",
+      Name = "BadSwipe",
+      TriggerId = null,
+      Steps = new Collection<CommandStep> {
+        new() { Type = CommandStepType.Swipe, Swipe = null, Order = 1 }
+      }
+    });
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(0);
+    sessions.ReceivedInputs.Should().BeEmpty();
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("skipped_invalid_config");
+  }
+
+  [Fact]
+  public async Task SwipeStepRecordsSwipeStepType() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(SwipeCommand(10, 20, 30, 40, null));
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.StepOutcomes.Should().ContainSingle().Which.StepType.Should().Be("swipe");
+  }
+}


### PR DESCRIPTION
## Summary

- **Key Input**: new command step type that sends a single key press (free-text identifier e.g. `Enter`, `Escape`, `F5`). Dispatches `InputAction(type="key", args={key=...})` at runtime.
- **Swipe**: new command step type that performs a swipe gesture defined by absolute pixel coordinates (StartX, StartY → EndX, EndY) with optional duration. Dispatches `InputAction(type="swipe", args={x1,y1,x2,y2,durationMs})` at runtime.
- Both panels follow the existing Tap/WaitForImage/EnsureGameRunning style: `action-panel` CSS pattern, deferred validation, `initialValue` for edit repopulation, Add/Save/Cancel buttons.

## Changes

**Backend**
- `CommandStepType` enum + `CommandStep` class: added `KeyInput`/`Swipe` variants with `KeyInputConfig`/`SwipeConfig`
- `Commands.cs`: matching DTO types (`KeyInputConfigDto`, `SwipeConfigDto`, enum variants)
- `CommandsEndpoints.cs`: mapper extended in both directions + step validation for new types
- `CommandExecutor.cs`: execution handler branches for `KeyInput` and `Swipe`

**Frontend**
- `KeyInputPanel.tsx`: new panel — single required text field
- `SwipePanel.tsx`: new panel — four required integer coordinate fields + optional duration
- `ActionTypeSelector.tsx`, `CommandForm.tsx`, `commands.ts`: extended for new types

**Tests**
- `CommandExecutorKeyInputTests.cs` (4 unit tests)
- `CommandExecutorSwipeTests.cs` (6 unit tests)
- `PrimitiveAuthoringFlowTests.cs`: 2 new integration tests for API round-trip

## Test plan

- [ ] Run `dotnet test` — new unit tests pass (10 new tests)
- [ ] Run `dotnet test` integration — KeyInput and Swipe round-trip tests pass
- [ ] Open command editor → action type selector shows "Key Input" and "Swipe"
- [ ] Add Key Input step with key="Enter" → step list shows `Key: Enter`; edit repopulates; delete works
- [ ] Add Swipe step with coords → step list shows `(x,y) → (x,y)`; duration shown when set; edit repopulates all 5 fields
- [ ] Add Key Input step with empty key → validation error shown, step not added
- [ ] Add Swipe step with empty coordinate → per-field validation error, step not added

🤖 Generated with [Claude Code](https://claude.com/claude-code)