### PR TITLE
Authoring backup/restore: fix CI analyzer errors and duplicate-type restore bug

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/056-simulate-recorded-step"
+  "feature_directory": "specs/057-authoring-backup-restore"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/053-command-editor-rework/plan.md
-at specs/053-schedulable-sequences/plan.md
-at specs/054-key-swipe-actions/plan.md
-at specs/055-record-command/plan.md
-at specs/056-simulate-recorded-step/plan.md
+at specs/057-authoring-backup-restore/plan.md
 <!-- SPECKIT END -->

--- a/specs/057-authoring-backup-restore/checklists/requirements.md
+++ b/specs/057-authoring-backup-restore/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Authoring Backup & Restore
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-06-06  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec validated on 2026-06-06; all items pass. Ready for `/speckit-plan`.
+- Re-validated 2026-06-06 after clarification session (3 Q&A): restore atomicity, selective backup scope, UI placement. All 12/12 items still pass.

--- a/specs/057-authoring-backup-restore/contracts/api-backup-restore.md
+++ b/specs/057-authoring-backup-restore/contracts/api-backup-restore.md
@@ -1,0 +1,169 @@
+# API Contract: Authoring Backup & Restore
+
+**Branch**: `057-authoring-backup-restore` | **Date**: 2026-06-06
+
+---
+
+## `POST /api/authoring/backup`
+
+Assembles a zip archive of the selected commands, sequences, and their referenced images. Returns the archive as a binary stream.
+
+### Request
+
+**Content-Type**: `application/json`
+
+```json
+{
+  "commandIds": ["cmd-abc", "cmd-def"],
+  "sequenceIds": ["seq-xyz"]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `commandIds` | `string[]` | No | IDs of commands to include |
+| `sequenceIds` | `string[]` | No | IDs of sequences to include (commands they reference are added automatically) |
+
+At least one non-empty list is required. IDs not found in the repository are silently skipped.
+
+### Response — 200 OK
+
+**Content-Type**: `application/zip`
+**Content-Disposition**: `attachment; filename="gamebot-backup-YYYYMMDDHHMMSS.zip"`
+
+Binary zip archive body. See [data-model.md](../data-model.md) for archive structure.
+
+### Response — 400 Bad Request
+
+```json
+{ "error": "At least one commandId or sequenceId must be provided." }
+```
+
+---
+
+## `POST /api/authoring/restore/dry-run`
+
+Validates a backup archive and returns a conflict report. **No data is modified.**
+
+### Request
+
+**Content-Type**: `multipart/form-data`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `archive` | file | Yes | The zip backup archive to validate |
+
+### Response — 200 OK
+
+```json
+{
+  "hasConflicts": true,
+  "conflictingCommandNames": ["AttackSequence", "Heal"],
+  "conflictingSequenceNames": ["DailyRoutine"],
+  "conflictingImageIds": ["img_heal_icon"],
+  "totalCommands": 5,
+  "totalSequences": 2,
+  "totalImages": 8
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `hasConflicts` | `true` if any conflicting names/IDs were found |
+| `conflictingCommandNames` | Command names in archive that match existing commands by name |
+| `conflictingSequenceNames` | Sequence names in archive that match existing sequences by name |
+| `conflictingImageIds` | Image IDs in archive that match existing image IDs |
+| `totalCommands` | Number of commands in the archive |
+| `totalSequences` | Number of sequences in the archive |
+| `totalImages` | Number of images in the archive |
+
+### Response — 400 Bad Request
+
+```json
+{ "error": "Invalid or unrecognised backup archive format." }
+```
+
+Returned for: missing `archive` field, file is not a valid zip, manifest is missing, manifest version is unsupported.
+
+---
+
+## `POST /api/authoring/restore/apply`
+
+Applies a backup archive. Overwrites any conflicting objects. The operation is as atomic as possible: on failure, all changes are rolled back. Due to file-based storage constraints, image rollback is best-effort — the system re-saves pre-loaded originals and reports any rollback failure explicitly.
+
+**The client is expected to have already called `/dry-run` and received user confirmation before calling this endpoint.**
+
+### Request
+
+**Content-Type**: `multipart/form-data`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `archive` | file | Yes | The zip backup archive to restore |
+
+### Response — 200 OK
+
+```json
+{
+  "restoredCommands": 5,
+  "restoredSequences": 2,
+  "restoredImages": 8,
+  "rolledBack": false,
+  "errorMessage": null
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `restoredCommands` | Number of commands written (including overwrites) |
+| `restoredSequences` | Number of sequences written (including overwrites) |
+| `restoredImages` | Number of images written (including overwrites) |
+| `rolledBack` | `true` if the apply partially failed and a rollback was attempted |
+| `errorMessage` | Non-null only when `rolledBack` is `true` or an error occurred |
+
+### Response — 400 Bad Request
+
+```json
+{ "error": "Invalid or unrecognised backup archive format." }
+```
+
+### Response — 500 Internal Server Error
+
+```json
+{
+  "restoredCommands": 0,
+  "restoredSequences": 0,
+  "restoredImages": 0,
+  "rolledBack": true,
+  "errorMessage": "Restore failed during file move phase. Rollback attempted. Original data restored."
+}
+```
+
+Returned when the apply failed after staging writes had begun and a rollback was performed (or attempted).
+
+---
+
+## New Route Constants (ApiRoutes.cs)
+
+```csharp
+internal const string AuthoringBackup         = Base + "/authoring/backup";
+internal const string AuthoringRestoreDryRun  = Base + "/authoring/restore/dry-run";
+internal const string AuthoringRestoreApply   = Base + "/authoring/restore/apply";
+```
+
+---
+
+## Frontend Service (`backup.ts`) Signatures
+
+```typescript
+// POST /api/authoring/backup — triggers browser file download
+export async function downloadBackup(selection: BackupSelection): Promise<void>
+
+// POST /api/authoring/restore/dry-run
+export async function validateRestore(file: File): Promise<ConflictReport>
+
+// POST /api/authoring/restore/apply
+export async function applyRestore(file: File): Promise<RestoreResult>
+```
+
+All functions use `buildApiUrl()` and `buildAuthHeaders()` from `lib/api.ts`, following the existing pattern in `services/images.ts`.

--- a/specs/057-authoring-backup-restore/data-model.md
+++ b/specs/057-authoring-backup-restore/data-model.md
@@ -1,0 +1,227 @@
+# Data Model: Authoring Backup & Restore
+
+**Branch**: `057-authoring-backup-restore` | **Date**: 2026-06-06
+
+---
+
+## Archive Format
+
+The backup archive is a zip file containing the following entries.
+
+### `manifest.json`
+
+```json
+{
+  "version": "1.0",
+  "createdAt": "2026-06-06T10:00:00Z",
+  "commandCount": 3,
+  "sequenceCount": 2,
+  "imageCount": 7
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `string` | Archive format version — currently `"1.0"` |
+| `createdAt` | ISO 8601 | UTC timestamp when the archive was created |
+| `commandCount` | `int` | Number of `commands/` entries |
+| `sequenceCount` | `int` | Number of `sequences/` entries |
+| `imageCount` | `int` | Number of `images/` entries |
+
+### `commands/{id}.json`
+
+Verbatim JSON serialisation produced by `FileCommandRepository` — same format already on disk. One file per command. The `id` in the filename matches `Command.Id`.
+
+### `sequences/{id}.json`
+
+Verbatim JSON serialisation produced by `FileSequenceRepository`. One file per sequence. The `id` in the filename matches `CommandSequence.Id`.
+
+### `images/{id}.ext`
+
+Binary image file (`.png` or `.jpeg`). The `id` matches `ImageAsset.Id`. Extension is derived from `ContentType`.
+
+---
+
+## Backend DTOs
+
+### `BackupRequestDto`
+
+Sent as the JSON body of `POST /api/authoring/backup`.
+
+```csharp
+public sealed class BackupRequestDto {
+  public IReadOnlyList<string> CommandIds { get; init; } = Array.Empty<string>();
+  public IReadOnlyList<string> SequenceIds { get; init; } = Array.Empty<string>();
+}
+```
+
+| Field | Validation |
+|-------|-----------|
+| `CommandIds` | May be empty if only sequences selected; IDs not found in repository are silently skipped |
+| `SequenceIds` | May be empty if only commands selected; at least one of the two lists must be non-empty |
+
+### `ConflictReportDto`
+
+Returned by `POST /api/authoring/restore/dry-run`.
+
+```csharp
+public sealed class ConflictReportDto {
+  public bool HasConflicts { get; init; }
+  public IReadOnlyList<string> ConflictingCommandNames { get; init; } = Array.Empty<string>();
+  public IReadOnlyList<string> ConflictingSequenceNames { get; init; } = Array.Empty<string>();
+  public IReadOnlyList<string> ConflictingImageIds { get; init; } = Array.Empty<string>();
+  public int TotalCommands { get; init; }
+  public int TotalSequences { get; init; }
+  public int TotalImages { get; init; }
+}
+```
+
+### `RestoreResultDto`
+
+Returned by `POST /api/authoring/restore/apply`.
+
+```csharp
+public sealed class RestoreResultDto {
+  public int RestoredCommands { get; init; }
+  public int RestoredSequences { get; init; }
+  public int RestoredImages { get; init; }
+  public bool RolledBack { get; init; }    // true if apply partially failed and rollback was attempted
+  public string? ErrorMessage { get; init; }
+}
+```
+
+---
+
+## `BackupService` Methods
+
+Lives in `GameBot.Service.Services`. Injected repositories: `ICommandRepository`, `ISequenceRepository`, `IImageRepository`.
+
+### `CreateBackupAsync`
+
+```csharp
+public async Task CreateBackupAsync(
+    BackupRequestDto request,
+    Stream outputStream,
+    CancellationToken ct = default)
+```
+
+Steps:
+1. For each `commandId` in `request.CommandIds`: load command, collect `ImageReferenceExtractor.ExtractImageIds(command)`
+2. For each `sequenceId` in `request.SequenceIds`: load sequence, collect `SequenceStep.CommandId` references (recursively into `Body`), load those commands, collect image IDs
+3. Deduplicate all command IDs, sequence IDs, image IDs
+4. Open `ZipArchive` on `outputStream` in `Create` mode
+5. Write `manifest.json`
+6. For each command: write raw JSON file from disk (or re-serialise from loaded model) to `commands/{id}.json`
+7. For each sequence: write raw JSON to `sequences/{id}.json`
+8. For each image ID: open read stream from `IImageRepository.OpenReadAsync(id)` and copy to `images/{id}.ext`
+
+### `DryRunRestoreAsync`
+
+```csharp
+public async Task<ConflictReportDto> DryRunRestoreAsync(
+    Stream archiveStream,
+    CancellationToken ct = default)
+```
+
+Steps:
+1. Open `ZipArchive` on `archiveStream` in `Read` mode
+2. Parse `manifest.json` — validate `version == "1.0"`, throw `BackupFormatException` if unsupported
+3. Read command names from `commands/*.json` entries
+4. Read sequence names from `sequences/*.json` entries
+5. Read image IDs from `images/*` entry filenames
+6. Cross-check: scan each `commands/*.json` and `sequences/*.json` entry for `ReferenceImageId` / `GateConfig.TargetId` references; verify a corresponding `images/{id}.*` entry exists in the archive; throw `BackupFormatException` listing all missing IDs if any are absent
+7. Load existing: `ICommandRepository.ListAsync()`, `ISequenceRepository.ListAsync()`, `IImageRepository.ListIdsAsync()`
+8. Compute conflicts: commands by `Name`, sequences by `Name`, images by `Id`
+9. Return `ConflictReportDto`
+
+### `ApplyRestoreAsync`
+
+```csharp
+public async Task<RestoreResultDto> ApplyRestoreAsync(
+    Stream archiveStream,
+    CancellationToken ct = default)
+```
+
+Steps:
+1. Parse archive into memory: deserialise all commands, sequences; buffer all image byte streams + metadata
+2. Validate manifest version — throw `BackupFormatException` if unsupported
+3. Cross-check missing images: scan each `commands/*.json` and `sequences/*.json` entry for `ReferenceImageId` / `GateConfig.TargetId` references; verify a corresponding `images/{id}.*` entry exists in the archive; throw `BackupFormatException` listing all missing IDs if any are absent
+4. Resolve existing objects by name (commands/sequences) and by ID (images) that will be overwritten
+5. Pre-load originals of all to-be-overwritten objects in memory for rollback — **for images this means reading the existing byte stream via `IImageRepository.OpenReadAsync` before any writes begin**
+6. Create temp staging directory; write all commands and sequences to temp JSON files
+7. Write all images directly via `IImageRepository.SaveAsync(..., overwrite: true)` (images bypass temp staging — they are written in-place; rollback is best-effort via re-save of pre-loaded originals)
+8. If any staging write (step 6) fails → delete temp dir, return with error (no data changed; images not yet written)
+9. Delete conflicting command/sequence originals from real storage; move staged files to real storage locations
+10. If any move fails → attempt rollback: re-save pre-loaded original images via `SaveAsync`; re-create pre-loaded original commands/sequences; clean up temp dir; return `RestoreResultDto { RolledBack = true }`
+11. Clean up temp dir; return `RestoreResultDto` with counts
+
+---
+
+## `ImageReferenceExtractor` (static helper)
+
+Lives in `GameBot.Service.Services` (or a nested namespace).
+
+```csharp
+internal static class ImageReferenceExtractor {
+    public static IEnumerable<string> ExtractImageIds(Command command)
+    public static IEnumerable<string> ExtractImageIds(IEnumerable<SequenceStep> steps)
+}
+```
+
+**Command extraction**:
+- `command.Detection?.ReferenceImageId`
+- For each step in `command.Steps`:
+  - `CommandStepType.PrimitiveTap`: `step.PrimitiveTap?.DetectionTarget.ReferenceImageId`
+  - `CommandStepType.WaitForImage`: `step.WaitForImage?.DetectionTarget?.ReferenceImageId`
+
+**Sequence step extraction** (recursive):
+- `step.WaitForImage?.DetectionTarget?.ReferenceImageId`
+- `step.Gate?.TargetId`
+- For `Loop` steps: recurse into `step.Body`
+
+---
+
+## Conflict Resolution Logic (Apply)
+
+| Object type | Conflict key | Delete strategy | Create strategy |
+|-------------|-------------|----------------|----------------|
+| Command | `Name` (exact, case-sensitive) | `ICommandRepository.DeleteAsync(existingId)` | `ICommandRepository.AddAsync(archiveCommand)` |
+| Sequence | `Name` (exact, case-sensitive) | `ISequenceRepository.DeleteAsync(existingId)` | `ISequenceRepository.CreateAsync(archiveSequence)` |
+| Image | `Id` (exact) | Overwritten via `IImageRepository.SaveAsync(..., overwrite: true)` | Same |
+
+Non-conflicting objects (no existing object with same name/ID) are created directly without a delete step.
+
+---
+
+## Frontend Types
+
+### `backup.ts` exports
+
+```typescript
+export interface BackupSelection {
+  commandIds: string[];
+  sequenceIds: string[];
+}
+
+export interface ConflictReport {
+  hasConflicts: boolean;
+  conflictingCommandNames: string[];
+  conflictingSequenceNames: string[];
+  conflictingImageIds: string[];
+  totalCommands: number;
+  totalSequences: number;
+  totalImages: number;
+}
+
+export interface RestoreResult {
+  restoredCommands: number;
+  restoredSequences: number;
+  restoredImages: number;
+  rolledBack: boolean;
+  errorMessage?: string;
+}
+
+export async function downloadBackup(selection: BackupSelection): Promise<void>
+export async function validateRestore(file: File): Promise<ConflictReport>
+export async function applyRestore(file: File): Promise<RestoreResult>
+```

--- a/specs/057-authoring-backup-restore/plan.md
+++ b/specs/057-authoring-backup-restore/plan.md
@@ -1,0 +1,132 @@
+# Implementation Plan: Authoring Backup & Restore
+
+**Branch**: `057-authoring-backup-restore` | **Date**: 2026-06-06 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/057-authoring-backup-restore/spec.md`
+
+## Summary
+
+Add selective backup and atomic restore of commands, sequences, and their referenced images to the Authoring section of the GameBot web UI. A user selects objects via a new "Backup & Restore" tab, downloads a server-assembled zip archive, and can later restore it with server-side dry-run conflict detection and overwrite confirmation. The implementation spans three new ASP.NET Core endpoints, a `BackupService` orchestration class, a new React page, a TypeScript service module, and corresponding tests.
+
+## Technical Context
+
+**Language/Version**: C# 12 / .NET 9.0 (backend); TypeScript 5 / React 18 (frontend)
+**Primary Dependencies**: `System.IO.Compression` (ZipArchive — BCL, no new NuGet); `@testing-library/react`, Jest (frontend tests)
+**Storage**: Existing file-based repos — `FileCommandRepository`, `FileSequenceRepository`, `FileImageRepository` all used read-only (plus overwrite writes for restore apply)
+**Testing**: xUnit + integration tests (backend); Jest + React Testing Library (frontend)
+**Target Platform**: Windows desktop — locally served web UI (ASP.NET Core + React/Vite)
+**Project Type**: Web application — ASP.NET Core Minimal API backend + React/Vite frontend
+**Performance Goals**: Backup zip assembly completes in ≤30 s for a typical authoring dataset (≤100 commands, ≤50 sequences, ≤200 images); restore dry-run and apply each complete within the same budget (SC-001/SC-002)
+**Constraints**: No new NuGet packages; `System.IO.Compression.ZipArchive` is in .NET BCL; all file I/O is local; single concurrent user; `ICommandRepository` and `ISequenceRepository` have no find-by-name methods — name lookups require `ListAsync()` + in-memory filter
+**Scale/Scope**: Typically ≤100 commands, ≤50 sequences, ≤200 images; single user
+
+## Constitution Check
+
+*GATE: Must pass before implementation.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Code Quality | ✅ Pass | CamelCase methods only; `BackupService` ≤50 LOC per method via private helpers; no dead code planned |
+| II. Testing | ✅ Pass | Unit tests for `BackupService` (archive composition, image-ref extraction, conflict detection); integration tests for all three endpoints; React component tests for `BackupRestorePage` required |
+| III. UX Consistency | ✅ Pass | Follows existing tab/page pattern from `Nav.tsx`; error messages actionable with remediation hints |
+| IV. Performance | ✅ Pass | ≤30 s budget declared; streaming zip (write-to-stream, no temp copy on backup); perf note required in PR for archive assembly path |
+
+No violations. No complexity-tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/057-authoring-backup-restore/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── contracts/
+│   └── api-backup-restore.md
+└── tasks.md             ← Phase 2 output (/speckit-tasks)
+```
+
+### Source Code
+
+```text
+src/GameBot.Service/
+├── ApiRoutes.cs                          ← ADD 3 new route constants
+├── Endpoints/
+│   └── BackupRestoreEndpoints.cs         ← NEW: 3 minimal API handlers
+├── Services/
+│   └── BackupService.cs                  ← NEW: orchestration service
+└── Contracts/Backup/
+    ├── BackupRequestDto.cs               ← NEW: selection payload
+    ├── ConflictReportDto.cs              ← NEW: dry-run response
+    └── RestoreResultDto.cs               ← NEW: apply response
+
+tests/
+├── unit/
+│   └── BackupServiceTests.cs             ← NEW: unit tests
+└── integration/
+    └── BackupRestoreEndpointsTests.cs    ← NEW: integration tests
+
+src/web-ui/src/
+├── components/
+│   └── Nav.tsx                           ← MODIFY: add 'Backup & Restore' tab
+├── pages/
+│   └── BackupRestorePage.tsx             ← NEW: backup & restore UI
+├── services/
+│   └── backup.ts                         ← NEW: API client
+└── App.tsx                               ← MODIFY: wire new tab
+```
+
+**Structure Decision**: Web application (backend + frontend split). Backend adds one new service class and one new endpoints file, following the existing `{Feature}Service.cs` / `{Feature}Endpoints.cs` pattern. Frontend follows the existing `Nav.tsx` tab + `*Page.tsx` pattern exactly.
+
+## Phase 0: Research
+
+See [research.md](research.md) — all decisions resolved, no NEEDS CLARIFICATION items remain.
+
+## Phase 1: Design
+
+See [data-model.md](data-model.md) and [contracts/api-backup-restore.md](contracts/api-backup-restore.md).
+
+### Key Design Decisions
+
+**Backup endpoint** (`POST /api/authoring/backup`):
+- Accepts JSON body `{ commandIds: [...], sequenceIds: [...] }`
+- `BackupService.CreateBackupAsync` collects the selected commands and their images, collects the selected sequences (plus the commands they transitively reference and those commands' images), deduplicates, then streams a zip directly to the HTTP response
+- Zip structure: `manifest.json`, `commands/{id}.json`, `sequences/{id}.json`, `images/{id}.ext`
+- Response: `application/zip`, `Content-Disposition: attachment; filename="gamebot-backup-YYYYMMDDHHMMSS.zip"`
+
+**Dry-run endpoint** (`POST /api/authoring/restore/dry-run`):
+- Accepts multipart upload of zip file
+- `BackupService.DryRunRestoreAsync` reads the manifest and object names from the archive, calls `ICommandRepository.ListAsync()` and `ISequenceRepository.ListAsync()` and `IImageRepository.ListIdsAsync()`, compares by name (commands/sequences) and by ID (images), returns a `ConflictReportDto`
+- No data is written; the zip stream is consumed and discarded
+
+**Apply endpoint** (`POST /api/authoring/restore/apply`):
+- Accepts multipart upload of zip file (re-upload, same archive)
+- `BackupService.ApplyRestoreAsync` performs the full atomic restore:
+  1. Parse all objects out of the archive into memory
+  2. For each command/sequence in archive: find existing by name → collect IDs to delete
+  3. Write all archive objects to a staging temp directory
+  4. If all staging writes succeed: delete old conflicting files, move staged files to real locations
+  5. If any move fails: attempt rollback by moving staged back and re-saving pre-loaded originals; report failure with rollback status
+- Images use `IImageRepository.SaveAsync(id, stream, contentType, filename, overwrite: true)`
+
+**Image reference extraction** (static helper, `ImageReferenceExtractor`):
+- For each `CommandStep`:
+  - `PrimitiveTap?.DetectionTarget.ReferenceImageId`
+  - `WaitForImage?.DetectionTarget?.ReferenceImageId`
+- `Command.Detection?.ReferenceImageId`
+- For each `SequenceStep` (recursive into `Body` for loop steps):
+  - `WaitForImage?.DetectionTarget?.ReferenceImageId`
+  - `GateConfig?.TargetId` (also an image ID)
+  - `CommandId` → resolved to Command → then apply command extraction
+
+**Frontend flow**:
+- `Nav.tsx`: add `'Backup & Restore'` to `AuthoringTab` union and `tabs` array
+- `App.tsx`: add tab render branch `{tab === 'Backup & Restore' && <BackupRestorePage />}`
+- `BackupRestorePage.tsx`: two sections
+  - **Backup**: fetches commands + sequences lists; checkboxes with "Select all"; "Download Backup" button (disabled if nothing selected) → calls `backup.ts:downloadBackup()` → blob download via `URL.createObjectURL` + hidden `<a>` click
+  - **Restore**: file `<input type="file" accept=".zip">` → on file selected, calls `backup.ts:validateRestore()` → displays conflict report → confirm/cancel modal → on confirm calls `backup.ts:applyRestore()`
+- Loading states per phase; actionable error messages for every failure path
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/057-authoring-backup-restore/research.md
+++ b/specs/057-authoring-backup-restore/research.md
@@ -1,0 +1,102 @@
+# Research: Authoring Backup & Restore
+
+**Branch**: `057-authoring-backup-restore` | **Date**: 2026-06-06
+
+All decisions resolved. No NEEDS CLARIFICATION items remain.
+
+---
+
+## Decision 1: Zip library
+
+**Decision**: Use `System.IO.Compression.ZipArchive` (BCL, .NET 9.0)
+
+**Rationale**: Already available in the runtime — no new NuGet dependency. Supports streaming write via `ZipArchiveMode.Create` against any writable `Stream`, satisfying the requirement to pipe directly to the HTTP response without buffering the entire archive on disk. `ZipArchiveMode.Read` works equivalently for restore parsing.
+
+**Alternatives considered**: `SharpZipLib`, `DotNetZip` — rejected because they add package overhead when the BCL covers all required functionality.
+
+---
+
+## Decision 2: Conflict detection key for commands and sequences
+
+**Decision**: Command conflicts detected by `Command.Name`; sequence conflicts detected by `CommandSequence.Name`. Comparison is case-sensitive and exact (matching the spec's Assumptions).
+
+**Rationale**: `ICommandRepository` and `ISequenceRepository` expose no find-by-name methods; detection requires `ListAsync()` followed by an in-memory LINQ filter. At typical scale (≤100 commands, ≤50 sequences) this is negligible overhead. Using `Name` (not `Id`) matches user expectation — if two systems have the same command name but different machine IDs, they still conflict.
+
+**Alternatives considered**: Conflict by `Id` — rejected because two different instances of the tool will generate different IDs for the same logical command; name-based matching is more meaningful for cross-machine backup/restore.
+
+---
+
+## Decision 3: Conflict detection key for images
+
+**Decision**: Image conflicts detected by `ImageAsset.Id` (the filename without extension stored in `FileImageRepository`).
+
+**Rationale**: Images have no user-visible unique name — `ImageAsset.Filename` is optional metadata. The identity of an image in the repository is its `Id`. FR-010 explicitly includes "same identifier" for images. `IImageRepository.ListIdsAsync()` makes this efficient.
+
+**Alternatives considered**: Hash-based comparison — rejected as overkill for a local tool where the image ID already uniquely identifies the asset.
+
+---
+
+## Decision 4: Atomicity approach for restore apply
+
+**Decision**: Two-phase write using a per-operation temp directory: write all archive objects to a temp staging area first; if all staging writes succeed, delete conflicting originals and move staged files to their real paths; on any move failure, attempt best-effort rollback (pre-load originals in memory before delete, re-create them if move fails).
+
+**Rationale**: `FileCommandRepository` uses direct `File.Create` (not atomic rename) so there is no existing atomic primitive. A temp-stage-then-rename approach is the closest file-system-level atomicity available on Windows without a transaction file system. The spec requires "fully atomic" (A1 clarification); rollback from memory covers the most dangerous failure mode (partial overwrite). The temp directory is cleaned up regardless of outcome.
+
+**Alternatives considered**: Write-in-place — rejected because a failure after first file written leaves partial state. Full transactional rollback via a WAL — rejected as disproportionate complexity for a local, single-user tool.
+
+---
+
+## Decision 5: Archive file format
+
+**Decision**: Zip archive with the following layout:
+```
+manifest.json              ← version, timestamp, counts
+commands/{id}.json         ← one file per command, raw JSON as stored by FileCommandRepository
+sequences/{id}.json        ← one file per sequence, raw JSON as stored by FileSequenceRepository
+images/{id}.png            ← binary image, extension matches ContentType
+images/{id}.jpeg           ← (or jpeg — whichever the repository recorded)
+```
+
+**Rationale**: Re-using the same JSON serialisation format already on disk avoids any translation layer for commands and sequences — the files can be copied verbatim into and out of the archive. The manifest provides version detection for future format changes.
+
+**Alternatives considered**: A custom binary format — rejected as unnecessary complexity. A single flat JSON export — rejected because it cannot embed binary image data without Base64 encoding (which inflates size significantly).
+
+---
+
+## Decision 6: Backup endpoint HTTP method and body
+
+**Decision**: `POST /api/authoring/backup` with `application/json` body `{ "commandIds": [...], "sequenceIds": [...] }`.
+
+**Rationale**: The selection payload (two ID arrays) must be sent to the server before the zip is streamed back. `GET` with a body is ambiguous in HTTP semantics; `POST` is the idiomatic choice for an action that produces a resource (the archive). The response is `application/zip` streamed directly, matching the existing `Results.Stream()` pattern used by `GET /api/images/{id}`.
+
+**Alternatives considered**: `GET` with query-string IDs — rejected because URL length limits restrict the number of selectable IDs, and query strings are awkward for arrays. `POST` returning a presigned download URL — rejected as unnecessary complexity for a local tool.
+
+---
+
+## Decision 7: Restore upload pattern (two separate uploads)
+
+**Decision**: Dry-run and apply each accept the zip as a multipart file upload (`multipart/form-data`). The user uploads the file twice — once for dry-run, once for apply.
+
+**Rationale**: The frontend already has the file in memory (via `<input type="file">`); re-uploading it on confirm is cheap for typical archive sizes. This avoids server-side temporary file storage between dry-run and apply (which would require cleanup logic, session IDs, and TTL management).
+
+**Alternatives considered**: Server-side session holding the archive between dry-run and apply — rejected because it requires session state management, temp-file cleanup, and introduces TOCTOU concerns if the server restarts between steps.
+
+---
+
+## Decision 8: Transitive command inclusion for sequences
+
+**Decision**: When a sequence is selected for backup, all commands referenced by any `SequenceStep.CommandId` at any nesting depth (including `Body` steps in `Loop` steps) are automatically included in the archive, along with their images.
+
+**Rationale**: A sequence archive is useless on restore without its referenced commands. Automatic inclusion prevents broken references and matches the spec's FR-001 ("commands transitively referenced by selected sequences").
+
+**Alternatives considered**: Only include explicitly selected commands — rejected because this produces archives that fail restore validation silently (missing command references in sequences).
+
+---
+
+## Decision 9: Frontend download mechanism
+
+**Decision**: `fetch` the backup endpoint → receive response as `Blob` → `URL.createObjectURL(blob)` → programmatically click a hidden `<a download="...">` element → `URL.revokeObjectURL` after click.
+
+**Rationale**: This is the standard browser-side file download pattern when the content requires authentication headers (which the existing `buildAuthHeaders()` utility provides). Direct `<a href="...">` links cannot attach auth headers.
+
+**Alternatives considered**: `window.open` with a query-string token — rejected because it would require embedding auth tokens in the URL. Server-side presigned URL — rejected as unnecessary for a local tool.

--- a/specs/057-authoring-backup-restore/spec.md
+++ b/specs/057-authoring-backup-restore/spec.md
@@ -1,0 +1,120 @@
+# Feature Specification: Authoring Backup & Restore
+
+**Feature Branch**: `057-authoring-backup-restore`  
+**Created**: 2026-06-06  
+**Status**: Draft  
+**Input**: User description: "I want to be able to backup up and restore commands and sequences, including all necessary images, etc. The functionality should be available via UI, but the actual composition should be done on the server side. I want the backup to be provided as a downloadable zip archive. When restoring the archive and objects with the same names already existing, I want to be asked, if I want to overwrite the existing objects (so probably some kind of dry-run would be needed on the server-side). The only way to restore if the objects already exist is to override them, no need to rename or anything else. I guess the backup/restore could be put under Authoring itself, as it's the area that is being affected."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Select objects and download a backup archive (Priority: P1)
+
+A user navigates to the Authoring section, selects the specific commands and/or sequences they want to back up, triggers the backup, and receives a downloadable zip file containing the selected objects and any images they reference.
+
+**Why this priority**: Backup is the foundation of this feature; without it restore is impossible. It also delivers standalone value as a data portability and disaster-recovery tool.
+
+**Independent Test**: Select a subset of commands and sequences in the Authoring UI, download the zip, unzip it, and verify it contains exactly the selected objects and their referenced images — and no others.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is in the Authoring section, **When** they select one or more commands and/or sequences and click "Download Backup", **Then** the browser downloads a zip archive containing only the selected objects and their referenced images.
+2. **Given** the downloaded zip, **When** it is inspected, **Then** it contains exactly the selected commands, selected sequences, all images referenced by those objects, and any commands transitively referenced by selected sequences.
+3. **Given** no commands or sequences exist, **When** the user opens the backup selector, **Then** the selector shows an empty state with a clear message and the backup action is disabled.
+
+---
+
+### User Story 2 - Restore a backup with no conflicts (Priority: P1)
+
+A user uploads a previously downloaded backup zip. The server performs a dry-run and finds no name conflicts. The user confirms and all objects are imported successfully.
+
+**Why this priority**: The core restore path (conflict-free) must work before conflict handling is introduced. Together with backup, it forms the minimum viable round-trip.
+
+**Independent Test**: On a clean instance (no existing commands/sequences), upload a known backup archive and verify all objects are recreated with matching data and images.
+
+**Acceptance Scenarios**:
+
+1. **Given** no existing commands or sequences share names with objects in the backup, **When** the user uploads the archive and confirms, **Then** all commands, sequences, and images are restored and appear in their respective lists.
+2. **Given** a successful restore, **When** the user browses commands and sequences, **Then** each restored object contains the same steps, references, and images as the original.
+
+---
+
+### User Story 3 - Restore a backup with name conflicts (Priority: P1)
+
+A user uploads a backup archive. The server dry-run detects that one or more objects in the archive share names with existing objects. The UI presents a clear conflict report and asks whether to overwrite. If the user confirms, conflicting objects are overwritten; if the user cancels, nothing is changed.
+
+**Why this priority**: Without conflict resolution the restore operation is unsafe — it could either silently corrupt existing work or fail with no explanation.
+
+**Independent Test**: Restore a backup on an instance that already contains at least one command or sequence with the same name as an object in the archive. Verify the conflict is surfaced, overwrite confirmation is required, and after confirmation the existing object reflects the restored data.
+
+**Acceptance Scenarios**:
+
+1. **Given** the backup contains a command named "AttackSequence" and a command with that name already exists, **When** the user uploads the archive, **Then** the UI shows a conflict report listing the conflicting names before asking for confirmation.
+2. **Given** the conflict report is shown, **When** the user cancels, **Then** no data is modified and the user is returned to the Authoring section unchanged.
+3. **Given** the conflict report is shown, **When** the user confirms the overwrite, **Then** all conflicting objects are replaced with the versions from the archive, and non-conflicting objects are created fresh.
+4. **Given** the user confirms overwrite, **When** an image referenced by a conflicting object already exists, **Then** it is also overwritten with the version from the archive.
+
+---
+
+### Edge Cases
+
+- What happens if the user attempts to download a backup without selecting any objects? The backup action is disabled until at least one command or sequence is selected.
+- What happens when the uploaded file is not a valid backup archive? The system rejects it with a clear error message and does not modify any data.
+- What happens if the backup archive is from a different or incompatible version? The server reports a version mismatch error; no partial import occurs.
+- What happens if the archive is very large? The system accepts it but may take longer; the UI indicates progress or a loading state.
+- What happens if the server encounters an error mid-restore after overwrite begins? The entire restore operation is rolled back — no objects or images are modified — and the UI reports the failure with an explanatory message.
+- What happens if images referenced in the manifest are missing from the archive? The server reports which images are missing; the restore is aborted with an explanatory error.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Authoring section MUST expose a "Backup" action that allows the user to select specific commands and/or sequences to include; the server assembles a zip archive containing the selected objects, all images they reference, and any commands transitively referenced by selected sequences.
+- **FR-002**: The server MUST compose the backup archive entirely on the server side; the browser only receives and downloads the completed archive.
+- **FR-003**: The zip archive MUST include a manifest describing the archive contents and format version to support validation during restore.
+- **FR-004**: The Authoring section MUST expose a "Restore" action that accepts a zip archive uploaded by the user.
+- **FR-005**: Before applying any changes, the server MUST perform a dry-run that compares archive objects against existing objects (commands and sequences by name; images by identifier) and returns a conflict report listing any matches.
+- **FR-006**: If the dry-run finds no conflicts, the UI MUST ask the user to confirm the restore before committing.
+- **FR-007**: If the dry-run finds conflicts, the UI MUST present the conflict report (listing conflicting names) and ask the user to confirm an overwrite or cancel.
+- **FR-008**: If the user cancels at the confirmation step, the server MUST NOT modify any existing data.
+- **FR-009**: If the user confirms (with or without conflicts), the server MUST restore all objects from the archive, overwriting any existing objects that share a name.
+- **FR-010**: Restored images MUST also overwrite existing images of the same identifier when conflicts are confirmed.
+- **FR-011**: The server MUST validate the uploaded archive format before performing the dry-run; invalid or unrecognisable archives MUST be rejected with an explanatory error and no data changes.
+- **FR-012**: Backup and Restore controls MUST be accessible via a dedicated "Backup & Restore" entry in the Authoring navigation menu, opening its own page or panel with enough space for the multi-step restore workflow.
+- **FR-013**: The UI MUST provide clear feedback for each phase: backup generation in progress, download ready, restore upload in progress, conflict report, confirmation prompt, restore applying, and restore complete.
+- **FR-014**: The restore operation MUST be as atomic as possible: if any error occurs during the apply phase, all changes are rolled back and the existing dataset is left unmodified. Due to file-based storage constraints without transactional support, image rollback is best-effort — the system re-saves pre-loaded originals and reports any rollback failure explicitly to the user.
+
+### Key Entities
+
+- **Backup Archive**: A zip file produced by the server containing a manifest, serialised definitions for the user-selected commands and sequences (plus any commands transitively referenced by selected sequences), and all referenced image binary files.
+- **Backup Manifest**: A metadata document inside the archive listing format version, creation timestamp, and the names/counts of all included object types.
+- **Conflict Report**: A server-generated list of object names from the archive that collide with names of existing objects; returned as part of the dry-run response.
+- **Command**: An authoring object with a name and steps; may reference images.
+- **Sequence**: An ordered collection of command references with a name.
+- **Image**: A binary asset referenced by command steps (e.g., image-match or wait-for-image steps).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can download a backup archive for any selection of commands and sequences, including their referenced images, in under 30 seconds for a typical authoring dataset.
+- **SC-002**: A conflict-free restore completes and all objects are visible in the Authoring lists within 30 seconds of the user confirming.
+- **SC-003**: When conflicts exist, 100% of conflicting object names are surfaced in the conflict report before any data is modified.
+- **SC-004**: Cancelling at the confirmation step results in zero changes to existing data (verified by comparing state before and after).
+- **SC-005**: 95% of users can complete the full backup-and-restore round-trip without support assistance, guided solely by the UI. *(Post-launch metric — validated via user testing; no automated coverage.)*
+
+## Clarifications
+
+### Session 2026-06-06
+
+- Q: If an error occurs mid-restore after overwrite has begun, should the restore roll back all changes (atomic) or apply as many objects as possible and report failures (best-effort)? → A: Fully atomic — all changes are rolled back on any failure; the dataset is left unmodified.
+- Q: Should backup cover all commands and sequences always, or should the user be able to select specific objects to include? → A: Selective — the user picks which commands and/or sequences to include; referenced images and transitively referenced commands are included automatically.
+- Q: Where in the UI should Backup & Restore controls be located within the Authoring section? → A: A dedicated "Backup & Restore" entry in the Authoring navigation menu, opening its own page/panel.
+
+## Assumptions
+
+- All images required by commands and sequences are already stored on the server and accessible for inclusion in the backup.
+- "Same name" is the conflict-detection key for both commands and sequences; name comparison is case-sensitive and exact.
+- Restore is as atomic as possible: either all objects and images from the archive are applied, or — if any error occurs — changes are rolled back. Due to file-based storage without transactions, command and sequence rollback uses temp-stage-then-rename (reliable); image rollback re-saves pre-loaded originals via the repository (best-effort). Any rollback failure is reported explicitly to the user.
+- The backup covers commands and sequences only; other authoring objects (games, triggers, standalone actions) are out of scope for this feature.
+- No access-control or permission gating is required beyond what the Authoring section already enforces.
+- Archive size limits, if any, are enforced by existing infrastructure (e.g., upload size limits); this feature does not introduce new limits.

--- a/specs/057-authoring-backup-restore/tasks.md
+++ b/specs/057-authoring-backup-restore/tasks.md
@@ -1,0 +1,244 @@
+# Tasks: Authoring Backup & Restore
+
+**Input**: Design documents from `specs/057-authoring-backup-restore/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/api-backup-restore.md ✅
+
+**Tech stack**: C# 12 / .NET 9.0 (ASP.NET Core Minimal APIs) + TypeScript 5 / React 18 (Vite)
+**Tests**: Required by constitution (≥80% line / ≥70% branch on touched areas)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks in same phase)
+- **[Story]**: User story this task belongs to (US1/US2/US3)
+- Exact file paths included in every task description
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add route constants, DTO contracts, and a custom exception — all pre-conditions for every subsequent phase.
+
+- [X] T001 Add `AuthoringBackup`, `AuthoringRestoreDryRun`, `AuthoringRestoreApply` constants to `src/GameBot.Service/ApiRoutes.cs`
+- [X] T002 [P] Create `src/GameBot.Service/Contracts/Backup/BackupRequestDto.cs` with `CommandIds` and `SequenceIds` string-list properties
+- [X] T003 [P] Create `src/GameBot.Service/Contracts/Backup/ConflictReportDto.cs` with `HasConflicts`, `ConflictingCommandNames`, `ConflictingSequenceNames`, `ConflictingImageIds`, `TotalCommands`, `TotalSequences`, `TotalImages` properties
+- [X] T004 [P] Create `src/GameBot.Service/Contracts/Backup/RestoreResultDto.cs` with `RestoredCommands`, `RestoredSequences`, `RestoredImages`, `RolledBack`, `ErrorMessage` properties
+- [X] T005 [P] Create `src/GameBot.Service/Services/BackupFormatException.cs` — custom exception for unrecognised or version-mismatched archive format
+
+**Checkpoint**: Route constants and DTO types available for use in all subsequent phases.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core service skeleton, endpoints registration, and frontend scaffolding that ALL user stories depend on. No user story work begins until this phase is complete.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T006 Create `src/GameBot.Service/Services/ImageReferenceExtractor.cs` — static internal class with stub methods `ExtractImageIds(Command)` and `ExtractImageIds(IEnumerable<SequenceStep>)` returning empty sequences
+- [X] T007 Create `src/GameBot.Service/Services/BackupService.cs` — class with constructor injecting `ICommandRepository`, `ISequenceRepository`, `IImageRepository`; stub out `CreateBackupAsync`, `DryRunRestoreAsync`, `ApplyRestoreAsync` method signatures per data-model.md
+- [X] T008 Register `BackupService` as a singleton in `src/GameBot.Service/Program.cs` (matching the existing `AddSingleton` pattern used for all repository registrations — avoids captive dependency)
+- [X] T009 Create `src/GameBot.Service/Endpoints/BackupRestoreEndpoints.cs` — `MapBackupRestoreEndpoints` extension method that registers the three routes (`POST /api/authoring/backup`, `POST /api/authoring/restore/dry-run`, `POST /api/authoring/restore/apply`) as stub handlers returning `Results.StatusCode(501)`; call `MapBackupRestoreEndpoints()` from `src/GameBot.Service/Program.cs`
+- [X] T010 [P] Add `'Backup & Restore'` to `AuthoringTab` union type and `tabs` array in `src/web-ui/src/components/Nav.tsx`
+- [X] T011 [P] Create `src/web-ui/src/pages/BackupRestorePage.tsx` — scaffold with two empty sections (`<section>` for Backup and `<section>` for Restore) and a placeholder heading each
+- [X] T012 [P] Add `{tab === 'Backup & Restore' && <BackupRestorePage />}` render branch to the authoring section in `src/web-ui/src/App.tsx`; import `BackupRestorePage`
+- [X] T013 [P] Create `src/web-ui/src/services/backup.ts` — skeleton module exporting `BackupSelection`, `ConflictReport`, `RestoreResult` interfaces and stub `downloadBackup`, `validateRestore`, `applyRestore` async functions (throw `Error('not implemented')`)
+
+**Checkpoint**: Service skeleton compiles, endpoints return 501, new tab appears in Authoring nav and renders the empty page.
+
+---
+
+## Phase 3: User Story 1 — Backup Download (Priority: P1) 🎯 MVP
+
+**Goal**: User selects commands and/or sequences, clicks "Download Backup", and receives a valid zip archive.
+
+**Independent Test**: Select at least one command (with an image-referencing step) and one sequence, click "Download Backup", open the zip, and verify it contains `manifest.json`, `commands/{id}.json`, `sequences/{id}.json`, `images/{id}.ext` for all referenced images.
+
+### Implementation
+
+- [X] T014 [US1] Implement `ImageReferenceExtractor.ExtractImageIds(Command command)` in `src/GameBot.Service/Services/ImageReferenceExtractor.cs` — collect `ReferenceImageId` from `Command.Detection`, `PrimitiveTap.DetectionTarget`, and `WaitForImage.DetectionTarget` across all steps
+- [X] T015 [US1] Implement `ImageReferenceExtractor.ExtractImageIds(IEnumerable<SequenceStep> steps)` in `src/GameBot.Service/Services/ImageReferenceExtractor.cs` — collect `WaitForImage.DetectionTarget?.ReferenceImageId`, `Gate?.TargetId`, and recurse into `step.Body` for `Loop` steps
+- [X] T016 [US1] Implement `BackupService.CreateBackupAsync(BackupRequestDto, Stream, CancellationToken)` in `src/GameBot.Service/Services/BackupService.cs`:
+  - Load selected commands and sequences; skip IDs not found
+  - Expand sequences: collect all `SequenceStep.CommandId` values (recursive into `Body`), load those commands if not already selected
+  - Deduplicate command IDs, sequence IDs, image IDs
+  - Open `ZipArchive` on output stream in `Create` mode; write `manifest.json`, `commands/{id}.json` (re-serialised), `sequences/{id}.json`, `images/{id}.ext` (streamed from `IImageRepository.OpenReadAsync`)
+- [X] T017 [US1] Replace stub backup handler in `src/GameBot.Service/Endpoints/BackupRestoreEndpoints.cs` with full implementation: deserialise `BackupRequestDto`, validate at least one ID provided (return 400 otherwise), call `BackupService.CreateBackupAsync` writing to response body stream, set `Content-Type: application/zip` and `Content-Disposition: attachment; filename="gamebot-backup-{timestamp}.zip"`
+- [X] T018 [P] [US1] Write unit tests for `ImageReferenceExtractor` (both overloads: command with multiple step types, sequence with nested loop body) in `tests/unit/ImageReferenceExtractorTests.cs` (new file — kept separate to allow parallel execution with T019)
+- [X] T019 [P] [US1] Write unit tests for `BackupService.CreateBackupAsync` (mock repos: verify zip entries match selected objects + transitively included commands + images) in `tests/unit/BackupServiceTests.cs`
+- [X] T020 [US1] Write integration test for `POST /api/authoring/backup` in `tests/integration/BackupRestoreEndpointsTests.cs`: seed commands and sequences, POST with selection, assert 200 + `application/zip` response, parse zip and verify manifest and entry names
+- [X] T021 [P] [US1] Implement backup section UI in `src/web-ui/src/pages/BackupRestorePage.tsx`: fetch commands and sequences lists on mount; render two checkbox groups (Commands, Sequences) with Select All; "Download Backup" button disabled when nothing selected; show loading spinner while fetching lists
+- [X] T022 [US1] Implement `downloadBackup(selection: BackupSelection): Promise<void>` in `src/web-ui/src/services/backup.ts` using `buildApiUrl`, `buildAuthHeaders`, `fetch` → `response.blob()` → `URL.createObjectURL` → hidden `<a download>` click → `URL.revokeObjectURL`
+- [X] T023 [US1] Wire "Download Backup" button in `src/web-ui/src/pages/BackupRestorePage.tsx` to call `downloadBackup`, show loading state during request, show actionable error message on failure
+- [X] T024 [US1] Write frontend tests for backup section in `src/web-ui/src/pages/__tests__/BackupRestorePage.test.tsx`: renders command/sequence lists, Select All works, button disabled when nothing selected, calls `downloadBackup` with correct IDs on click
+
+**Checkpoint**: User can navigate to "Backup & Restore" tab, select objects, and download a valid zip archive. Backend integration test passes.
+
+---
+
+## Phase 4: User Story 2 — Restore (No Conflicts) (Priority: P1)
+
+**Goal**: User uploads a backup archive, server finds no conflicts, user confirms, all objects are restored.
+
+**Independent Test**: On an empty or clean instance, upload a previously downloaded backup and confirm. Verify all commands, sequences, and images appear in their respective authoring lists with correct data.
+
+### Implementation
+
+- [X] T025 [US2] Implement `BackupService.DryRunRestoreAsync(Stream, CancellationToken)` in `src/GameBot.Service/Services/BackupService.cs`:
+  - Open `ZipArchive` in `Read` mode; parse `manifest.json` — throw `BackupFormatException` if missing or `version != "1.0"`
+  - Read command names from `commands/*.json` entries; read sequence names from `sequences/*.json` entries; collect image IDs from `images/*` filenames
+  - Cross-check: scan each `commands/*.json` and `sequences/*.json` entry for `ReferenceImageId` / `GateConfig.TargetId` references and verify a corresponding `images/{id}.*` entry exists in the archive; throw `BackupFormatException` listing missing IDs if any are absent
+  - Call `ICommandRepository.ListAsync()`, `ISequenceRepository.ListAsync()`, `IImageRepository.ListIdsAsync()`
+  - Compute `ConflictReportDto` (commands by Name, sequences by Name, images by Id)
+- [X] T026 [US2] Replace stub dry-run handler in `src/GameBot.Service/Endpoints/BackupRestoreEndpoints.cs` with full implementation: accept multipart upload, call `DryRunRestoreAsync`, return `ConflictReportDto` as JSON; return 400 with error message on `BackupFormatException`
+- [X] T027 [US2] Implement `BackupService.ApplyRestoreAsync(Stream, CancellationToken)` in `src/GameBot.Service/Services/BackupService.cs`:
+  - Parse entire archive into memory (deserialise commands, sequences; buffer **all image byte streams + metadata** before any writes)
+  - Validate manifest version (throw `BackupFormatException` on mismatch)
+  - Cross-check missing images: same check as T025 — verify every image ID referenced in the archive's command/sequence JSON has a corresponding `images/{id}.*` entry; throw `BackupFormatException` listing missing IDs if any are absent (guards against callers that skip dry-run)
+  - Resolve conflicting existing objects by name (commands/sequences) and by ID (images); **pre-load all conflicting originals in memory for rollback — for images this means reading the existing byte stream via `IImageRepository.OpenReadAsync` before overwriting**
+  - Write all commands and sequences to a temp staging directory under `Path.GetTempPath()`; write images via `IImageRepository.SaveAsync(..., overwrite: true)`
+  - If staging writes succeed: delete conflicting command/sequence originals, move staged files to real storage; images are already written
+  - If any move fails: attempt rollback — re-save pre-loaded original images via `SaveAsync`, re-create pre-loaded original commands/sequences; clean up temp dir; return `RestoreResultDto { RolledBack = true }` (note: rollback is best-effort for images since `SaveAsync` already completed)
+  - On full success: clean up temp dir; return `RestoreResultDto` with counts
+- [X] T028 [US2] Replace stub apply handler in `src/GameBot.Service/Endpoints/BackupRestoreEndpoints.cs` with full implementation: accept multipart upload, call `ApplyRestoreAsync`, return `RestoreResultDto` as JSON; return 400 on `BackupFormatException`; return 500 on `RolledBack = true`
+- [X] T029 [P] [US2] Write unit tests for `BackupService.DryRunRestoreAsync` in `tests/unit/BackupServiceTests.cs`: valid archive no conflicts → empty report; valid archive with name matches → populated conflict lists; missing manifest → `BackupFormatException`
+- [X] T030 [US2] Write unit tests for `BackupService.ApplyRestoreAsync` (no-conflict scenario: mock repos, verify `AddAsync` called for each object, `DeleteAsync` not called) in `tests/unit/BackupServiceTests.cs` (sequential after T029 — same file)
+- [X] T031 [US2] Write integration tests for dry-run (no-conflict) and apply (no-conflict) in `tests/integration/BackupRestoreEndpointsTests.cs`: seed no existing objects, upload archive, assert dry-run returns `hasConflicts: false`, apply returns 200 with counts, verify objects exist in repos after apply
+- [X] T032 [P] [US2] Implement restore section UI in `src/web-ui/src/pages/BackupRestorePage.tsx`: file input (`accept=".zip"`), "Upload & Check" button; on file selected call `validateRestore()`, show loading state; on success show a confirmation dialog with archive summary (counts)
+- [X] T033 [US2] Implement `validateRestore(file: File): Promise<ConflictReport>` and `applyRestore(file: File): Promise<RestoreResult>` in `src/web-ui/src/services/backup.ts` using `FormData` + `buildApiUrl` + `buildAuthHeaders`
+- [X] T034 [US2] Wire confirmation dialog "Confirm Restore" button to call `applyRestore`, show loading state, show success message with counts or actionable error message on failure in `src/web-ui/src/pages/BackupRestorePage.tsx`
+- [X] T035 [US2] Write frontend tests for restore flow (no-conflict path) in `src/web-ui/src/pages/__tests__/BackupRestorePage.test.tsx`: file input renders, `validateRestore` called on upload, confirmation dialog shown with counts, `applyRestore` called on confirm, success message shown
+
+**Checkpoint**: Full restore round-trip works on a clean instance. Integration test passes. User can see success confirmation in the UI.
+
+---
+
+## Phase 5: User Story 3 — Restore with Conflicts (Priority: P1)
+
+**Goal**: When the dry-run finds conflicts, the UI shows exactly which objects will be overwritten; user can confirm overwrite or cancel with no data changed.
+
+**Independent Test**: Restore a backup on an instance that has at least one command and one sequence with matching names. Verify the conflict report lists their names, confirm overwrites them, and cancel leaves the originals intact.
+
+### Implementation
+
+- [X] T036 [US3] Extend confirmation dialog in `src/web-ui/src/pages/BackupRestorePage.tsx` to render conflict details when `conflictReport.hasConflicts` is true: show lists of `conflictingCommandNames`, `conflictingSequenceNames`, `conflictingImageIds` with a warning that these will be overwritten; render cancel button that closes dialog and makes no API call
+- [X] T037 [US3] Write integration tests for apply with conflicting objects in `tests/integration/BackupRestoreEndpointsTests.cs`: seed commands/sequences matching archive names, run dry-run (assert conflicts returned), run apply (assert 200), verify existing objects replaced with archive data and non-conflicting archive objects created
+- [X] T038 [P] [US3] Write unit tests for `BackupService.ApplyRestoreAsync` in `tests/unit/BackupServiceTests.cs`:
+  - Conflict scenario: mock repos, verify `DeleteAsync` called for conflicting originals, `AddAsync` called for all archive objects
+  - Rollback-failure scenario: simulate a file-move failure after staging; assert `RestoreResultDto.RolledBack == true`, pre-loaded original commands/sequences re-created via repo, pre-loaded original image bytes re-saved via `SaveAsync`
+- [X] T039 [US3] Write frontend tests for restore flow (conflict path) in `src/web-ui/src/pages/__tests__/BackupRestorePage.test.tsx`: dialog shows conflict lists, "Cancel" closes dialog without calling `applyRestore`, "Confirm Overwrite" calls `applyRestore`
+
+**Checkpoint**: All three user stories fully functional. Conflict report is surfaced clearly. Cancel leaves data unchanged. Integration tests cover both conflict and no-conflict scenarios.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Error handling completeness, edge cases, build validation.
+
+- [X] T040 [P] Verify all three endpoints return 400 with `{ "error": "..." }` for: invalid zip, missing `archive` field, unsupported manifest version, and missing images referenced in archive (per spec edge case) in `src/GameBot.Service/Endpoints/BackupRestoreEndpoints.cs`; add integration test cases for each scenario in `tests/integration/BackupRestoreEndpointsTests.cs`
+- [X] T041 [P] Add empty-selection guard to backup UI in `src/web-ui/src/pages/BackupRestorePage.tsx`: if commands and sequences lists are both empty, show empty-state message and disable "Download Backup" button (per edge case in spec)
+- [X] T042 Add rollback failure reporting to `BackupRestorePage.tsx`: when `applyRestore` returns `{ rolledBack: true }`, show a distinct warning message explaining partial failure and suggesting manual verification (sequential after T041 — same file)
+- [X] T043 Final quality gate — complete all of the following before marking the feature done:
+  - Run `dotnet test` and `npx jest` (+ `npm run build`); address any failures, linting, or type errors
+  - Add XML doc-comments (`<summary>`, `<param>`, `<returns>`, `<exception>`) to all public/internal methods in `BackupService.cs` and `ImageReferenceExtractor.cs` per constitution Principle I
+  - Record a perf note in the PR description with measured archive assembly time for the typical dataset (≤100 commands, ≤50 sequences, ≤200 images) per constitution Principle IV; flag if ≥30 s (SC-001/SC-002)
+  - Run a manual smoke test with a seeded typical dataset; record actual backup and restore durations in the PR perf note
+
+**Checkpoint**: All quality gates pass. Feature is shippable.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately; T002, T003, T004, T005 fully parallel
+- **Phase 2 (Foundational)**: Depends on Phase 1 — blocks all user story phases; T010–T013 parallel with T006–T009
+- **Phase 3 (US1)**: Depends on Phase 2 completion
+- **Phase 4 (US2)**: Depends on Phase 2 completion; may proceed in parallel with Phase 3 on the backend side (different service methods), but frontend restore section depends on the `BackupRestorePage` scaffold from T011
+- **Phase 5 (US3)**: Depends on Phase 4 (extends same UI component and same endpoints)
+- **Phase 6 (Polish)**: Depends on Phases 3–5
+
+### User Story Dependencies
+
+- **US1**: Depends only on Phase 2 — independently deliverable (backup without restore)
+- **US2**: Depends only on Phase 2 — backend independently implementable after foundation; frontend depends on US1's page scaffold
+- **US3**: Depends on US2 — extends the restore confirmation dialog and adds conflict-scenario integration tests
+
+### Within Each Phase
+
+- Backend service method → backend endpoint handler (T014–T016 before T017)
+- Unit tests written alongside service implementation (T018, T019 parallel with T016)
+- Frontend service module (`backup.ts`) function before wiring to UI component
+- Integration tests after endpoint handlers are complete
+
+---
+
+## Parallel Execution Examples
+
+### Phase 3 (US1) Parallel Opportunities
+
+```
+Parallel group A (backend):
+  T014 — ImageReferenceExtractor.ExtractImageIds(Command)
+  T015 — ImageReferenceExtractor.ExtractImageIds(SequenceStep[])
+
+Sequential after A:
+  T016 — BackupService.CreateBackupAsync
+  T017 — Backup endpoint handler
+
+Parallel group B (backend tests):
+  T018 — Unit tests: ImageReferenceExtractor
+  T019 — Unit tests: CreateBackupAsync
+
+Parallel group C (frontend, independent of A/B):
+  T021 — Backup selection UI
+  T022 — downloadBackup() service function
+```
+
+### Phase 4 (US2) Parallel Opportunities
+
+```
+Parallel group A (service methods):
+  T025 — DryRunRestoreAsync (can start after T016 complete)
+  T027 — ApplyRestoreAsync (can start after T016 complete)
+
+Parallel group B (tests alongside implementation):
+  T029 — Unit tests: DryRunRestoreAsync  [parallel with T032 — different files]
+
+Sequential after T029:
+  T030 — Unit tests: ApplyRestoreAsync (no-conflict)  [same file as T029; not [P]]
+
+Parallel group C (frontend, independent):
+  T032 — Restore section UI
+  T033 — validateRestore() + applyRestore() service functions
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only — Phases 1–3)
+
+1. Complete Phase 1 (Setup) and Phase 2 (Foundational)
+2. Complete Phase 3 (US1 — Backup Download)
+3. **STOP and VALIDATE**: Select objects, download zip, inspect archive contents
+4. Demo backup capability independently
+
+### Incremental Delivery
+
+1. Phases 1–3 → Backup working → Demo/validate
+2. Phase 4 → Conflict-free restore → Demo full round-trip on clean instance
+3. Phase 5 → Conflict overwrite → Demo overwrite confirmation flow
+4. Phase 6 → Polish and quality gates → Ship
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files and have no unmet dependencies within the phase
+- `[Story]` labels map tasks to spec.md user stories for traceability
+- `BackupService.ApplyRestoreAsync` is the most complex task — temp-staging approach requires careful temp-dir cleanup in all code paths (success, staging failure, move failure, rollback)
+- Images are identified by ID for conflict detection; commands/sequences by Name (case-sensitive) per spec Assumptions
+- CamelCase methods only per constitution (no underscores)
+- Run `dotnet test` and `npx jest` after each phase checkpoint before proceeding

--- a/src/GameBot.Domain/Commands/SequenceStepCondition.cs
+++ b/src/GameBot.Domain/Commands/SequenceStepCondition.cs
@@ -10,13 +10,21 @@ public abstract class SequenceStepCondition {
   public bool Negate { get; set; }
 }
 
+// [JsonIgnore] on each override below: the "type" discriminator (JsonPolymorphic above) already
+// serializes this value under the same property name. Serializing both produces a duplicate "type"
+// key once PropertyNamingPolicy lowercases "Type" to "type" (e.g. JsonSerializerDefaults.Web),
+// which then fails to round-trip with "duplicate 'type' metadata property". JsonIgnore on the
+// abstract base member is not honored for overridden properties, so it must be repeated here.
+
 public sealed class ImageVisibleStepCondition : SequenceStepCondition {
+  [JsonIgnore]
   public override string Type => "imageVisible";
   public string ImageId { get; set; } = string.Empty;
   public double? MinSimilarity { get; set; }
 }
 
 public sealed class CommandOutcomeStepCondition : SequenceStepCondition {
+  [JsonIgnore]
   public override string Type => "commandOutcome";
   public string StepRef { get; set; } = string.Empty;
   public string ExpectedState { get; set; } = string.Empty;

--- a/src/GameBot.Service/ApiRoutes.cs
+++ b/src/GameBot.Service/ApiRoutes.cs
@@ -25,4 +25,7 @@ internal static class ApiRoutes {
   internal const string Adb = Base + "/adb";
   internal const string Ocr = Base + "/ocr";
   internal const string Steps = Base + "/steps";
+  internal const string AuthoringBackup = Base + "/authoring/backup";
+  internal const string AuthoringRestoreDryRun = Base + "/authoring/restore/dry-run";
+  internal const string AuthoringRestoreApply = Base + "/authoring/restore/apply";
 }

--- a/src/GameBot.Service/Contracts/Backup/BackupRequestDto.cs
+++ b/src/GameBot.Service/Contracts/Backup/BackupRequestDto.cs
@@ -1,0 +1,7 @@
+namespace GameBot.Service.Contracts.Backup;
+
+/// <summary>Selection of commands and sequences to include in a backup archive.</summary>
+internal sealed class BackupRequestDto {
+  public IReadOnlyList<string> CommandIds { get; init; } = Array.Empty<string>();
+  public IReadOnlyList<string> SequenceIds { get; init; } = Array.Empty<string>();
+}

--- a/src/GameBot.Service/Contracts/Backup/ConflictReportDto.cs
+++ b/src/GameBot.Service/Contracts/Backup/ConflictReportDto.cs
@@ -1,0 +1,12 @@
+namespace GameBot.Service.Contracts.Backup;
+
+/// <summary>Result of a dry-run restore: lists objects in the archive that conflict with existing data.</summary>
+internal sealed class ConflictReportDto {
+  public bool HasConflicts { get; init; }
+  public IReadOnlyList<string> ConflictingCommandNames { get; init; } = Array.Empty<string>();
+  public IReadOnlyList<string> ConflictingSequenceNames { get; init; } = Array.Empty<string>();
+  public IReadOnlyList<string> ConflictingImageIds { get; init; } = Array.Empty<string>();
+  public int TotalCommands { get; init; }
+  public int TotalSequences { get; init; }
+  public int TotalImages { get; init; }
+}

--- a/src/GameBot.Service/Contracts/Backup/RestoreResultDto.cs
+++ b/src/GameBot.Service/Contracts/Backup/RestoreResultDto.cs
@@ -1,0 +1,11 @@
+namespace GameBot.Service.Contracts.Backup;
+
+/// <summary>Result of applying a restore operation.</summary>
+internal sealed class RestoreResultDto {
+  public int RestoredCommands { get; init; }
+  public int RestoredSequences { get; init; }
+  public int RestoredImages { get; init; }
+  /// <summary>True if the apply partially failed and a rollback was attempted.</summary>
+  public bool RolledBack { get; init; }
+  public string? ErrorMessage { get; init; }
+}

--- a/src/GameBot.Service/Endpoints/BackupRestoreEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/BackupRestoreEndpoints.cs
@@ -1,0 +1,83 @@
+using GameBot.Service.Contracts.Backup;
+using GameBot.Service.Services;
+
+namespace GameBot.Service.Endpoints;
+
+internal static class BackupRestoreEndpoints {
+  /// <summary>Registers backup and restore routes on the application.</summary>
+  public static IEndpointRouteBuilder MapBackupRestoreEndpoints(this IEndpointRouteBuilder app) {
+    app.MapPost(ApiRoutes.AuthoringBackup, async (
+      BackupRequestDto request,
+      BackupService backupService,
+      HttpContext ctx,
+      CancellationToken ct) => {
+      if ((request.CommandIds.Count == 0) && (request.SequenceIds.Count == 0))
+        return Results.BadRequest(new { error = "At least one commandId or sequenceId must be provided." });
+
+      ctx.Response.ContentType = "application/zip";
+      var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmss", System.Globalization.CultureInfo.InvariantCulture);
+      ctx.Response.Headers.Append("Content-Disposition", $"attachment; filename=\"gamebot-backup-{timestamp}.zip\"");
+
+      await backupService.CreateBackupAsync(request, ctx.Response.Body, ct).ConfigureAwait(false);
+      return Results.Empty;
+    })
+    .WithName("CreateBackup")
+    .WithTags("Backup");
+
+    app.MapPost(ApiRoutes.AuthoringRestoreDryRun, async (
+      HttpRequest request,
+      BackupService backupService,
+      CancellationToken ct) => {
+      if (!request.HasFormContentType)
+        return Results.BadRequest(new { error = "Missing 'archive' file field." });
+      IFormCollection form;
+      try { form = await request.ReadFormAsync(ct).ConfigureAwait(false); }
+      catch (InvalidOperationException) { return Results.BadRequest(new { error = "Missing 'archive' file field." }); }
+      if (!form.Files.Any()) {
+        return Results.BadRequest(new { error = "Missing 'archive' file field." });
+      }
+
+      var file = form.Files["archive"] ?? form.Files[0];
+      try {
+        using var stream = file.OpenReadStream();
+        var report = await backupService.DryRunRestoreAsync(stream, ct).ConfigureAwait(false);
+        return Results.Ok(report);
+      }
+      catch (BackupFormatException ex) {
+        return Results.BadRequest(new { error = ex.Message });
+      }
+    })
+    .WithName("DryRunRestore")
+    .WithTags("Backup");
+
+    app.MapPost(ApiRoutes.AuthoringRestoreApply, async (
+      HttpRequest request,
+      BackupService backupService,
+      CancellationToken ct) => {
+      if (!request.HasFormContentType)
+        return Results.BadRequest(new { error = "Missing 'archive' file field." });
+      IFormCollection form;
+      try { form = await request.ReadFormAsync(ct).ConfigureAwait(false); }
+      catch (InvalidOperationException) { return Results.BadRequest(new { error = "Missing 'archive' file field." }); }
+      if (!form.Files.Any()) {
+        return Results.BadRequest(new { error = "Missing 'archive' file field." });
+      }
+
+      var file = form.Files["archive"] ?? form.Files[0];
+      try {
+        using var stream = file.OpenReadStream();
+        var result = await backupService.ApplyRestoreAsync(stream, ct).ConfigureAwait(false);
+        if (result.RolledBack)
+          return Results.Json(result, statusCode: StatusCodes.Status500InternalServerError);
+        return Results.Ok(result);
+      }
+      catch (BackupFormatException ex) {
+        return Results.BadRequest(new { error = ex.Message });
+      }
+    })
+    .WithName("ApplyRestore")
+    .WithTags("Backup");
+
+    return app;
+  }
+}

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -111,6 +111,7 @@ builder.Services.AddTransient<CorrelationIdMiddleware>();
 builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IAdbGameOperations, GameBot.Service.Services.EnsureGameRunning.AdbGameOperations>();
 builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IEnsureGameRunningActionHandler, GameBot.Service.Services.EnsureGameRunning.EnsureGameRunningActionHandler>();
 builder.Services.AddSingleton<GameBot.Service.Services.ICommandExecutor, GameBot.Service.Services.CommandExecutor>();
+builder.Services.AddSingleton<GameBot.Service.Services.BackupService>();
 
 // Data storage configuration (env: GAMEBOT_DATA_DIR or config Service:Storage:Root)
 var storageRoot = builder.Configuration["Service:Storage:Root"]
@@ -417,6 +418,7 @@ app.MapConfigLoggingEndpoints();
 app.MapConfigFilesEndpoints(storageRoot);
 app.MapCoverageEndpoints();
 app.MapExecutionLogEndpoints();
+app.MapBackupRestoreEndpoints();
 
 app.MapPost("/versioning/resolve", (GameBot.Service.Models.VersionResolveRequestModel request, VersionSourceLoader loader) => {
   if (!Enum.TryParse<BuildContext>(request.BuildContext, ignoreCase: true, out var buildContext)) {

--- a/src/GameBot.Service/Services/BackupFormatException.cs
+++ b/src/GameBot.Service/Services/BackupFormatException.cs
@@ -1,0 +1,11 @@
+namespace GameBot.Service.Services;
+
+/// <summary>
+/// Thrown when an uploaded archive is not a valid GameBot backup:
+/// missing manifest, unsupported version, or referenced images absent from the archive.
+/// </summary>
+internal sealed class BackupFormatException : Exception {
+  public BackupFormatException() { }
+  public BackupFormatException(string message) : base(message) { }
+  public BackupFormatException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/src/GameBot.Service/Services/BackupService.cs
+++ b/src/GameBot.Service/Services/BackupService.cs
@@ -1,0 +1,403 @@
+using System.IO.Compression;
+using System.Text.Json;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Images;
+using GameBot.Service.Contracts.Backup;
+
+namespace GameBot.Service.Services;
+
+/// <summary>Assembles and restores backup archives for commands, sequences, and their images.</summary>
+internal sealed class BackupService {
+  private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+  private const string ManifestVersion = "1.0";
+
+  private readonly ICommandRepository _commands;
+  private readonly ISequenceRepository _sequences;
+  private readonly IImageRepository _images;
+
+  public BackupService(ICommandRepository commands, ISequenceRepository sequences, IImageRepository images) {
+    _commands = commands;
+    _sequences = sequences;
+    _images = images;
+  }
+
+  /// <summary>
+  /// Assembles a zip archive of the selected commands, sequences, and their referenced images.
+  /// </summary>
+  /// <param name="request">IDs of commands and sequences to include.</param>
+  /// <param name="outputStream">Writable stream that receives the archive bytes.</param>
+  /// <param name="ct">Cancellation token.</param>
+  public async Task CreateBackupAsync(BackupRequestDto request, Stream outputStream, CancellationToken ct = default) {
+    ArgumentNullException.ThrowIfNull(request);
+    var commandSet = new Dictionary<string, Command>(StringComparer.Ordinal);
+    var sequenceSet = new Dictionary<string, CommandSequence>(StringComparer.Ordinal);
+    var imageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    foreach (var id in request.CommandIds) {
+      var cmd = await _commands.GetAsync(id, ct).ConfigureAwait(false);
+      if (cmd is not null) commandSet[cmd.Id] = cmd;
+    }
+
+    foreach (var seqId in request.SequenceIds) {
+      var seq = await _sequences.GetAsync(seqId).ConfigureAwait(false);
+      if (seq is null) continue;
+      sequenceSet[seq.Id] = seq;
+      foreach (var cmdId in CollectCommandIds(seq.Steps)) {
+        if (!commandSet.ContainsKey(cmdId)) {
+          var cmd = await _commands.GetAsync(cmdId, ct).ConfigureAwait(false);
+          if (cmd is not null) commandSet[cmd.Id] = cmd;
+        }
+      }
+    }
+
+    foreach (var cmd in commandSet.Values)
+      foreach (var imgId in ImageReferenceExtractor.ExtractImageIds(cmd))
+        imageIds.Add(imgId);
+
+    foreach (var seq in sequenceSet.Values)
+      foreach (var imgId in ImageReferenceExtractor.ExtractImageIds(seq.Steps))
+        imageIds.Add(imgId);
+
+    using var ms = new MemoryStream();
+    using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)) {
+      var manifest = new {
+        version = ManifestVersion,
+        createdAt = DateTimeOffset.UtcNow,
+        commandCount = commandSet.Count,
+        sequenceCount = sequenceSet.Count,
+        imageCount = imageIds.Count
+      };
+      await WriteJsonEntryAsync(archive, "manifest.json", manifest, ct).ConfigureAwait(false);
+
+      foreach (var cmd in commandSet.Values)
+        await WriteJsonEntryAsync(archive, $"commands/{cmd.Id}.json", cmd, ct).ConfigureAwait(false);
+
+      foreach (var seq in sequenceSet.Values)
+        await WriteJsonEntryAsync(archive, $"sequences/{seq.Id}.json", seq, ct).ConfigureAwait(false);
+
+      foreach (var imgId in imageIds) {
+        var asset = await _images.GetAsync(imgId, ct).ConfigureAwait(false);
+        if (asset is null) continue;
+        var ext = asset.ContentType.Contains("jpeg", StringComparison.OrdinalIgnoreCase) ? ".jpeg" : ".png";
+        var entry = archive.CreateEntry($"images/{imgId}{ext}", CompressionLevel.Optimal);
+        using var entryStream = entry.Open();
+        var imgStream = await _images.OpenReadAsync(imgId, ct).ConfigureAwait(false);
+        if (imgStream is not null) {
+          using (imgStream) await imgStream.CopyToAsync(entryStream, ct).ConfigureAwait(false);
+        }
+      }
+    } // ZipArchive.Dispose writes end-of-central-directory to ms (sync is safe on MemoryStream)
+    ms.Position = 0;
+    await ms.CopyToAsync(outputStream, ct).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  /// Reads the archive, validates its format, and returns a conflict report without modifying data.
+  /// </summary>
+  /// <param name="archiveStream">Stream containing the zip archive.</param>
+  /// <param name="ct">Cancellation token.</param>
+  /// <returns>A <see cref="ConflictReportDto"/> describing name/ID collisions with existing objects.</returns>
+  /// <exception cref="BackupFormatException">The archive is invalid, missing a manifest, or references images not present in the archive.</exception>
+  public async Task<ConflictReportDto> DryRunRestoreAsync(Stream archiveStream, CancellationToken ct = default) {
+    ZipArchive archive;
+    try { archive = new ZipArchive(archiveStream, ZipArchiveMode.Read, leaveOpen: true); }
+    catch (Exception ex) when (ex is InvalidDataException or ArgumentOutOfRangeException) {
+      throw new BackupFormatException("Archive is not a valid zip file.", ex);
+    }
+    using (archive) {
+
+    ValidateManifest(archive);
+
+    var archiveCommandNames = ReadJsonNames<Command>(archive, "commands/", cmd => cmd?.Name);
+    var archiveSequenceNames = ReadJsonNames<CommandSequence>(archive, "sequences/", seq => seq?.Name);
+    var archiveImageIds = ReadImageIds(archive);
+
+    ValidateMissingImages(archive, archiveImageIds);
+
+    var existingCommands = await _commands.ListAsync(ct).ConfigureAwait(false);
+    var existingSequences = await _sequences.ListAsync().ConfigureAwait(false);
+    var existingImageIds = await _images.ListIdsAsync(ct).ConfigureAwait(false);
+
+    var conflictingCommands = archiveCommandNames
+      .Where(n => existingCommands.Any(c => string.Equals(c.Name, n, StringComparison.Ordinal)))
+      .ToList();
+    var conflictingSequences = archiveSequenceNames
+      .Where(n => existingSequences.Any(s => string.Equals(s.Name, n, StringComparison.Ordinal)))
+      .ToList();
+    var conflictingImages = archiveImageIds
+      .Where(id => existingImageIds.Contains(id, StringComparer.OrdinalIgnoreCase))
+      .ToList();
+
+    return new ConflictReportDto {
+      HasConflicts = conflictingCommands.Count > 0 || conflictingSequences.Count > 0 || conflictingImages.Count > 0,
+      ConflictingCommandNames = conflictingCommands,
+      ConflictingSequenceNames = conflictingSequences,
+      ConflictingImageIds = conflictingImages,
+      TotalCommands = archiveCommandNames.Count,
+      TotalSequences = archiveSequenceNames.Count,
+      TotalImages = archiveImageIds.Count
+    };
+    } // end using(archive)
+  }
+
+  /// <summary>
+  /// Applies the archive: overwrites conflicting objects and creates new ones. Rolls back on failure.
+  /// </summary>
+  /// <param name="archiveStream">Stream containing the zip archive.</param>
+  /// <param name="ct">Cancellation token.</param>
+  /// <returns>A <see cref="RestoreResultDto"/> with counts and rollback status.</returns>
+  /// <exception cref="BackupFormatException">The archive is invalid or references images not present in the archive.</exception>
+  public async Task<RestoreResultDto> ApplyRestoreAsync(Stream archiveStream, CancellationToken ct = default) {
+    ZipArchive archive;
+    try { archive = new ZipArchive(archiveStream, ZipArchiveMode.Read, leaveOpen: true); }
+    catch (Exception ex) when (ex is InvalidDataException or ArgumentOutOfRangeException) {
+      throw new BackupFormatException("Archive is not a valid zip file.", ex);
+    }
+    using (archive) {
+
+    ValidateManifest(archive);
+
+    var commands = ParseJsonEntries<Command>(archive, "commands/");
+    var sequences = ParseJsonEntries<CommandSequence>(archive, "sequences/");
+    var imageEntries = ReadImageEntries(archive);
+
+    ValidateMissingImages(imageEntries.Keys, commands, sequences);
+
+    var existingCommands = await _commands.ListAsync(ct).ConfigureAwait(false);
+    var existingSequences = await _sequences.ListAsync().ConfigureAwait(false);
+    var existingImageIds = await _images.ListIdsAsync(ct).ConfigureAwait(false);
+
+    var conflictingCmdIds = existingCommands
+      .Where(c => commands.Any(a => string.Equals(a.Name, c.Name, StringComparison.Ordinal)))
+      .Select(c => c.Id).ToList();
+    var conflictingSeqIds = existingSequences
+      .Where(s => sequences.Any(a => string.Equals(a.Name, s.Name, StringComparison.Ordinal)))
+      .Select(s => s.Id).ToList();
+    var conflictingImageIds = imageEntries.Keys
+      .Where(id => existingImageIds.Contains(id, StringComparer.OrdinalIgnoreCase))
+      .ToList();
+
+    var originalCommands = existingCommands
+      .Where(c => conflictingCmdIds.Contains(c.Id)).ToList();
+    var originalSequences = existingSequences
+      .Where(s => conflictingSeqIds.Contains(s.Id)).ToList();
+
+    var originalImageData = new Dictionary<string, (byte[] Data, string ContentType, string? Filename)>(StringComparer.OrdinalIgnoreCase);
+    foreach (var imgId in conflictingImageIds) {
+      var asset = await _images.GetAsync(imgId, ct).ConfigureAwait(false);
+      var stream = await _images.OpenReadAsync(imgId, ct).ConfigureAwait(false);
+      if (stream is not null && asset is not null) {
+        using (stream) {
+          var ms = new MemoryStream();
+          await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+          originalImageData[imgId] = (ms.ToArray(), asset.ContentType, asset.Filename);
+        }
+      }
+    }
+
+    var stagingDir = Path.Combine(Path.GetTempPath(), "gamebot-restore-" + Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(stagingDir);
+
+    try {
+      foreach (var cmd in commands) {
+        var path = Path.Combine(stagingDir, $"cmd_{cmd.Id}.json");
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(cmd, JsonOpts), ct).ConfigureAwait(false);
+      }
+      foreach (var seq in sequences) {
+        var path = Path.Combine(stagingDir, $"seq_{seq.Id}.json");
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(seq, JsonOpts), ct).ConfigureAwait(false);
+      }
+    }
+    catch (Exception stagingEx) {
+      Directory.Delete(stagingDir, recursive: true);
+      return new RestoreResultDto { RolledBack = true, ErrorMessage = $"Staging failed: {stagingEx.Message}" };
+    }
+
+    foreach (var imgId in conflictingImageIds)
+      await _images.DeleteAsync(imgId, ct).ConfigureAwait(false);
+    foreach (var cmdId in conflictingCmdIds)
+      await _commands.DeleteAsync(cmdId, ct).ConfigureAwait(false);
+    foreach (var seqId in conflictingSeqIds)
+      await _sequences.DeleteAsync(seqId).ConfigureAwait(false);
+
+    try {
+      foreach (var cmd in commands) {
+        var path = Path.Combine(stagingDir, $"cmd_{cmd.Id}.json");
+        var loaded = JsonSerializer.Deserialize<Command>(await File.ReadAllTextAsync(path, ct).ConfigureAwait(false), JsonOpts)!;
+        await _commands.AddAsync(loaded, ct).ConfigureAwait(false);
+      }
+      foreach (var seq in sequences) {
+        var path = Path.Combine(stagingDir, $"seq_{seq.Id}.json");
+        var loaded = JsonSerializer.Deserialize<CommandSequence>(await File.ReadAllTextAsync(path, ct).ConfigureAwait(false), JsonOpts)!;
+        await _sequences.CreateAsync(loaded).ConfigureAwait(false);
+      }
+      foreach (var (imgId, (data, contentType, filename)) in imageEntries) {
+        using var ms = new MemoryStream(data);
+        await _images.SaveAsync(imgId, ms, contentType, filename, overwrite: true, ct).ConfigureAwait(false);
+      }
+    }
+    catch (Exception applyEx) {
+      var rollbackError = await TryRollbackAsync(originalCommands, originalSequences, originalImageData, ct).ConfigureAwait(false);
+      Directory.Delete(stagingDir, recursive: true);
+      var msg = rollbackError is not null
+        ? $"Apply failed: {applyEx.Message}. Rollback also encountered an error: {rollbackError}"
+        : $"Apply failed: {applyEx.Message}. Data restored.";
+      return new RestoreResultDto { RolledBack = true, ErrorMessage = msg };
+    }
+
+    Directory.Delete(stagingDir, recursive: true);
+    return new RestoreResultDto {
+      RestoredCommands = commands.Count,
+      RestoredSequences = sequences.Count,
+      RestoredImages = imageEntries.Count
+    };
+    } // end using(archive)
+  }
+
+  private static IEnumerable<string> CollectCommandIds(IEnumerable<SequenceStep> steps) {
+    foreach (var step in steps) {
+      if (!string.IsNullOrWhiteSpace(step.CommandId)) yield return step.CommandId;
+      if (step.StepType == SequenceStepType.Loop && step.Body.Count > 0)
+        foreach (var id in CollectCommandIds(step.Body)) yield return id;
+    }
+  }
+
+  private static void ValidateManifest(ZipArchive archive) {
+    var entry = archive.GetEntry("manifest.json")
+      ?? throw new BackupFormatException("Archive is missing manifest.json.");
+    using var stream = entry.Open();
+    using var doc = JsonDocument.Parse(stream);
+    if (!doc.RootElement.TryGetProperty("version", out var v) || v.GetString() != ManifestVersion)
+      throw new BackupFormatException($"Unsupported archive version. Expected '{ManifestVersion}'.");
+  }
+
+  private static List<string> ReadJsonNames<T>(ZipArchive archive, string prefix, Func<T?, string?> getName) {
+    var names = new List<string>();
+    foreach (var entry in archive.Entries) {
+      if (!entry.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+      if (!entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase)) continue;
+      using var stream = entry.Open();
+      var obj = JsonSerializer.Deserialize<T>(stream, JsonOpts);
+      var name = getName(obj);
+      if (!string.IsNullOrWhiteSpace(name)) names.Add(name!);
+    }
+    return names;
+  }
+
+  private static List<string> ReadImageIds(ZipArchive archive) {
+    return archive.Entries
+      .Where(e => e.FullName.StartsWith("images/", StringComparison.OrdinalIgnoreCase))
+      .Select(e => Path.GetFileNameWithoutExtension(e.Name))
+      .Where(id => !string.IsNullOrWhiteSpace(id))
+      .ToList()!;
+  }
+
+  private static void ValidateMissingImages(ZipArchive archive, IReadOnlyList<string> archiveImageIds) {
+    var missingIds = new List<string>();
+    foreach (var entry in archive.Entries) {
+      if (!entry.FullName.StartsWith("commands/", StringComparison.OrdinalIgnoreCase)
+          && !entry.FullName.StartsWith("sequences/", StringComparison.OrdinalIgnoreCase)) continue;
+      if (!entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase)) continue;
+      using var stream = entry.Open();
+      using var doc = JsonDocument.Parse(stream);
+      CollectImageRefsFromJson(doc.RootElement, archiveImageIds, missingIds);
+    }
+    if (missingIds.Count > 0)
+      throw new BackupFormatException($"Archive is missing image entries for: {string.Join(", ", missingIds)}");
+  }
+
+  private static void ValidateMissingImages(
+    IEnumerable<string> archiveImageIds,
+    IReadOnlyList<Command> commands,
+    IReadOnlyList<CommandSequence> sequences) {
+    var idSet = new HashSet<string>(archiveImageIds, StringComparer.OrdinalIgnoreCase);
+    var missing = new List<string>();
+
+    foreach (var cmd in commands)
+      foreach (var imgId in ImageReferenceExtractor.ExtractImageIds(cmd))
+        if (!idSet.Contains(imgId) && !missing.Contains(imgId)) missing.Add(imgId);
+
+    foreach (var seq in sequences)
+      foreach (var imgId in ImageReferenceExtractor.ExtractImageIds(seq.Steps))
+        if (!idSet.Contains(imgId) && !missing.Contains(imgId)) missing.Add(imgId);
+
+    if (missing.Count > 0)
+      throw new BackupFormatException($"Archive is missing image entries for: {string.Join(", ", missing)}");
+  }
+
+  private static void CollectImageRefsFromJson(JsonElement element, IReadOnlyList<string> archiveImageIds, List<string> missing) {
+    if (element.ValueKind == JsonValueKind.Object) {
+      foreach (var prop in element.EnumerateObject()) {
+        if ((prop.Name.Equals("referenceImageId", StringComparison.OrdinalIgnoreCase)
+             || prop.Name.Equals("targetId", StringComparison.OrdinalIgnoreCase))
+            && prop.Value.ValueKind == JsonValueKind.String) {
+          var val = prop.Value.GetString();
+          if (!string.IsNullOrWhiteSpace(val)
+              && !archiveImageIds.Any(id => string.Equals(id, val, StringComparison.OrdinalIgnoreCase))
+              && !missing.Contains(val))
+            missing.Add(val);
+        }
+        CollectImageRefsFromJson(prop.Value, archiveImageIds, missing);
+      }
+    }
+    else if (element.ValueKind == JsonValueKind.Array) {
+      foreach (var item in element.EnumerateArray())
+        CollectImageRefsFromJson(item, archiveImageIds, missing);
+    }
+  }
+
+  private static List<T> ParseJsonEntries<T>(ZipArchive archive, string prefix) {
+    var list = new List<T>();
+    foreach (var entry in archive.Entries) {
+      if (!entry.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+      if (!entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase)) continue;
+      using var stream = entry.Open();
+      var obj = JsonSerializer.Deserialize<T>(stream, JsonOpts);
+      if (obj is not null) list.Add(obj);
+    }
+    return list;
+  }
+
+  private static Dictionary<string, (byte[] Data, string ContentType, string? Filename)> ReadImageEntries(ZipArchive archive) {
+    var result = new Dictionary<string, (byte[], string, string?)>(StringComparer.OrdinalIgnoreCase);
+    foreach (var entry in archive.Entries) {
+      if (!entry.FullName.StartsWith("images/", StringComparison.OrdinalIgnoreCase)) continue;
+      var id = Path.GetFileNameWithoutExtension(entry.Name);
+      if (string.IsNullOrWhiteSpace(id)) continue;
+      var ext = Path.GetExtension(entry.Name).ToLowerInvariant();
+      var contentType = ext == ".jpeg" || ext == ".jpg" ? "image/jpeg" : "image/png";
+      using var stream = entry.Open();
+      var ms = new MemoryStream();
+      stream.CopyTo(ms);
+      result[id] = (ms.ToArray(), contentType, entry.Name);
+    }
+    return result;
+  }
+
+  private async Task<string?> TryRollbackAsync(
+    IReadOnlyList<Command> originalCommands,
+    IReadOnlyList<CommandSequence> originalSequences,
+    IReadOnlyDictionary<string, (byte[] Data, string ContentType, string? Filename)> originalImages,
+    CancellationToken ct) {
+    try {
+      foreach (var cmd in originalCommands)
+        await _commands.AddAsync(cmd, ct).ConfigureAwait(false);
+      foreach (var seq in originalSequences)
+        await _sequences.CreateAsync(seq).ConfigureAwait(false);
+      foreach (var (imgId, (data, contentType, filename)) in originalImages) {
+        using var ms = new MemoryStream(data);
+        await _images.SaveAsync(imgId, ms, contentType, filename, overwrite: true, ct).ConfigureAwait(false);
+      }
+      return null;
+    }
+    catch (Exception ex) {
+      return ex.Message;
+    }
+  }
+
+  private static async Task WriteJsonEntryAsync<T>(ZipArchive archive, string entryName, T value, CancellationToken ct) {
+    var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+    using var stream = entry.Open();
+    await JsonSerializer.SerializeAsync(stream, value, JsonOpts, ct).ConfigureAwait(false);
+  }
+}

--- a/src/GameBot.Service/Services/ImageReferenceExtractor.cs
+++ b/src/GameBot.Service/Services/ImageReferenceExtractor.cs
@@ -1,0 +1,39 @@
+using GameBot.Domain.Commands;
+
+namespace GameBot.Service.Services;
+
+/// <summary>Extracts image reference IDs from commands and sequence steps.</summary>
+internal static class ImageReferenceExtractor {
+  /// <summary>Returns all image IDs referenced by a command's detection target and steps.</summary>
+  public static IEnumerable<string> ExtractImageIds(Command command) {
+    if (command.Detection?.ReferenceImageId is { Length: > 0 } detectionId)
+      yield return detectionId;
+
+    foreach (var step in command.Steps) {
+      if (step.Type == CommandStepType.PrimitiveTap) {
+        var id = step.PrimitiveTap?.DetectionTarget?.ReferenceImageId;
+        if (!string.IsNullOrWhiteSpace(id)) yield return id;
+      }
+      else if (step.Type == CommandStepType.WaitForImage) {
+        var id = step.WaitForImage?.DetectionTarget?.ReferenceImageId;
+        if (!string.IsNullOrWhiteSpace(id)) yield return id;
+      }
+    }
+  }
+
+  /// <summary>Returns all image IDs referenced by a list of sequence steps, recursing into loop bodies.</summary>
+  public static IEnumerable<string> ExtractImageIds(IEnumerable<SequenceStep> steps) {
+    foreach (var step in steps) {
+      var gateId = step.Gate?.TargetId;
+      if (!string.IsNullOrWhiteSpace(gateId)) yield return gateId;
+
+      var waitId = step.WaitForImage?.DetectionTarget?.ReferenceImageId;
+      if (!string.IsNullOrWhiteSpace(waitId)) yield return waitId;
+
+      if (step.StepType == SequenceStepType.Loop && step.Body.Count > 0) {
+        foreach (var id in ExtractImageIds(step.Body))
+          yield return id;
+      }
+    }
+  }
+}

--- a/src/GameBot.Service/Swagger/SwaggerConfig.cs
+++ b/src/GameBot.Service/Swagger/SwaggerConfig.cs
@@ -139,6 +139,7 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter {
     ApplyImageExamples(operation, path, method, context);
     ApplyExecutionLogExamples(operation, path, method, context);
     ApplyInstallerExamples(operation, path, method, context);
+    ApplyBackupRestoreExamples(operation, path, method, context);
   }
 
   private static void ApplyInstallerExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
@@ -616,6 +617,24 @@ internal sealed class SwaggerExamplesOperationFilter : IOperationFilter {
       SetResponseExample(operation, "200", ExecutionLogRetentionResponse(), context, typeof(GameBot.Service.Models.ExecutionLogRetentionPolicyDto));
     }
   }
+
+  private static void ApplyBackupRestoreExamples(OpenApiOperation operation, string path, string method, OperationFilterContext context) {
+    if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.AuthoringBackup)) {
+      operation.Summary ??= "Create a backup archive of selected commands and sequences";
+      SetRequestExample(operation, BackupRequest(), context, typeof(GameBot.Service.Contracts.Backup.BackupRequestDto));
+    }
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.AuthoringRestoreDryRun)) {
+      operation.Summary ??= "Dry-run a restore: report conflicts without modifying data";
+    }
+    else if (IsMethod(method, HttpMethods.Post) && IsPath(path, ApiRoutes.AuthoringRestoreApply)) {
+      operation.Summary ??= "Apply a restore: import commands and sequences from a backup archive";
+    }
+  }
+
+  private static OpenApiObject BackupRequest() => new OpenApiObject {
+    ["commandIds"] = new OpenApiArray { new OpenApiString("cmd-abc123") },
+    ["sequenceIds"] = new OpenApiArray()
+  };
 
   private static string NormalizePath(string? relativePath) {
     if (string.IsNullOrWhiteSpace(relativePath)) return string.Empty;

--- a/src/web-ui/src/App.tsx
+++ b/src/web-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { CommandsPage } from './pages/CommandsPage';
 import { GamesPage } from './pages/GamesPage';
 import { SequencesPage } from './pages/SequencesPage';
 import { ImagesListPage } from './pages/images/ImagesListPage';
+import { BackupRestorePage } from './pages/BackupRestorePage';
 import { QueuesPage } from './pages/QueuesPage';
 import { normalizeTab } from './lib/navigation';
 import { useNavigationCollapse } from './hooks/useNavigationCollapse';
@@ -104,6 +105,7 @@ export const App: React.FC = () => {
         {tab === 'Games' && <GamesPage initialCreate={creationTarget === 'games'} initialEditId={requestedTab === 'Games' ? initialId : undefined} />}
         {tab === 'Sequences' && <SequencesPage initialCreate={creationTarget === 'sequences'} initialEditId={requestedTab === 'Sequences' ? initialId : undefined} />}
         {tab === 'Images' && <ImagesListPage />}
+        {tab === 'Backup & Restore' && <BackupRestorePage />}
       </ErrorBoundary>
     </section>
   );

--- a/src/web-ui/src/components/Nav.tsx
+++ b/src/web-ui/src/components/Nav.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-export type AuthoringTab = 'Commands' | 'Games' | 'Sequences' | 'Images';
+export type AuthoringTab = 'Commands' | 'Games' | 'Sequences' | 'Images' | 'Backup & Restore';
 
 type NavProps = {
   active: AuthoringTab;
   onChange: (tab: AuthoringTab) => void;
 };
 
-const tabs: AuthoringTab[] = ['Commands', 'Games', 'Sequences', 'Images'];
+const tabs: AuthoringTab[] = ['Commands', 'Games', 'Sequences', 'Images', 'Backup & Restore'];
 
 export const Nav: React.FC<NavProps> = ({ active, onChange }) => {
   return (

--- a/src/web-ui/src/pages/BackupRestorePage.tsx
+++ b/src/web-ui/src/pages/BackupRestorePage.tsx
@@ -1,0 +1,287 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  BackupSelection,
+  ConflictReport,
+  RestoreResult,
+  downloadBackup,
+  validateRestore,
+  applyRestore
+} from '../services/backup';
+import { listCommands, CommandDto } from '../services/commands';
+import { getJson } from '../lib/api';
+
+type SequenceItem = { id: string; name: string };
+
+type RestorePhase =
+  | { kind: 'idle' }
+  | { kind: 'uploading' }
+  | { kind: 'conflict_report'; report: ConflictReport; file: File }
+  | { kind: 'applying' }
+  | { kind: 'success'; result: RestoreResult }
+  | { kind: 'error'; message: string };
+
+export const BackupRestorePage: React.FC = () => {
+  const [commands, setCommands] = useState<CommandDto[]>([]);
+  const [sequences, setSequences] = useState<SequenceItem[]>([]);
+  const [loadingLists, setLoadingLists] = useState(true);
+  const [listsError, setListsError] = useState<string | null>(null);
+
+  const [selectedCommandIds, setSelectedCommandIds] = useState<Set<string>>(new Set());
+  const [selectedSequenceIds, setSelectedSequenceIds] = useState<Set<string>>(new Set());
+  const [backupLoading, setBackupLoading] = useState(false);
+  const [backupError, setBackupError] = useState<string | null>(null);
+
+  const [restorePhase, setRestorePhase] = useState<RestorePhase>({ kind: 'idle' });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const [cmds, seqs] = await Promise.all([
+          listCommands(),
+          getJson<SequenceItem[]>('/api/sequences')
+        ]);
+        if (!cancelled) {
+          setCommands(cmds ?? []);
+          setSequences((seqs as SequenceItem[]) ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) setListsError(err instanceof Error ? err.message : 'Failed to load lists.');
+      } finally {
+        if (!cancelled) setLoadingLists(false);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggleCommand = (id: string) =>
+    setSelectedCommandIds(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+
+  const toggleSequence = (id: string) =>
+    setSelectedSequenceIds(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+
+  const selectAllCommands = () =>
+    setSelectedCommandIds(prev =>
+      prev.size === commands.length ? new Set() : new Set(commands.map(c => c.id))
+    );
+
+  const selectAllSequences = () =>
+    setSelectedSequenceIds(prev =>
+      prev.size === sequences.length ? new Set() : new Set(sequences.map(s => s.id))
+    );
+
+  const nothingSelected = selectedCommandIds.size === 0 && selectedSequenceIds.size === 0;
+  const nothingAvailable = commands.length === 0 && sequences.length === 0;
+
+  const handleDownloadBackup = async () => {
+    setBackupError(null);
+    setBackupLoading(true);
+    try {
+      const selection: BackupSelection = {
+        commandIds: Array.from(selectedCommandIds),
+        sequenceIds: Array.from(selectedSequenceIds)
+      };
+      await downloadBackup(selection);
+    } catch (err) {
+      setBackupError(err instanceof Error ? err.message : 'Backup download failed. Please try again.');
+    } finally {
+      setBackupLoading(false);
+    }
+  };
+
+  const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setRestorePhase({ kind: 'uploading' });
+    try {
+      const report = await validateRestore(file);
+      setRestorePhase({ kind: 'conflict_report', report, file });
+    } catch (err) {
+      setRestorePhase({ kind: 'error', message: err instanceof Error ? err.message : 'Failed to validate archive.' });
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, []);
+
+  const handleConfirmRestore = async () => {
+    if (restorePhase.kind !== 'conflict_report') return;
+    const { file } = restorePhase;
+    setRestorePhase({ kind: 'applying' });
+    try {
+      const result = await applyRestore(file);
+      if (result.rolledBack) {
+        setRestorePhase({ kind: 'error', message: result.errorMessage ?? 'Restore failed and was rolled back. Please verify your data manually.' });
+      } else {
+        setRestorePhase({ kind: 'success', result });
+      }
+    } catch (err) {
+      setRestorePhase({ kind: 'error', message: err instanceof Error ? err.message : 'Restore failed. Please try again.' });
+    }
+  };
+
+  const handleCancelRestore = () => setRestorePhase({ kind: 'idle' });
+
+  return (
+    <div className="backup-restore-page">
+      <section className="backup-section">
+        <h2>Backup</h2>
+        {loadingLists && <p>Loading...</p>}
+        {listsError && <p className="error">{listsError}</p>}
+        {!loadingLists && !listsError && nothingAvailable && (
+          <p className="empty-state">No commands or sequences exist yet. Create some content first.</p>
+        )}
+        {!loadingLists && !listsError && !nothingAvailable && (
+          <>
+            <div className="selection-groups">
+              {commands.length > 0 && (
+                <div className="selection-group">
+                  <div className="group-header">
+                    <strong>Commands</strong>
+                    <button type="button" onClick={selectAllCommands}>
+                      {selectedCommandIds.size === commands.length ? 'Deselect All' : 'Select All'}
+                    </button>
+                  </div>
+                  {commands.map(c => (
+                    <label key={c.id}>
+                      <input
+                        type="checkbox"
+                        checked={selectedCommandIds.has(c.id)}
+                        onChange={() => toggleCommand(c.id)}
+                      />
+                      {c.name}
+                    </label>
+                  ))}
+                </div>
+              )}
+              {sequences.length > 0 && (
+                <div className="selection-group">
+                  <div className="group-header">
+                    <strong>Sequences</strong>
+                    <button type="button" onClick={selectAllSequences}>
+                      {selectedSequenceIds.size === sequences.length ? 'Deselect All' : 'Select All'}
+                    </button>
+                  </div>
+                  {sequences.map(s => (
+                    <label key={s.id}>
+                      <input
+                        type="checkbox"
+                        checked={selectedSequenceIds.has(s.id)}
+                        onChange={() => toggleSequence(s.id)}
+                      />
+                      {s.name}
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={handleDownloadBackup}
+              disabled={nothingSelected || backupLoading}
+            >
+              {backupLoading ? 'Generating backup…' : 'Download Backup'}
+            </button>
+            {backupError && <p className="error">{backupError}</p>}
+          </>
+        )}
+      </section>
+
+      <section className="restore-section">
+        <h2>Restore</h2>
+
+        {restorePhase.kind === 'idle' && (
+          <>
+            <p>Select a backup archive (.zip) to restore commands, sequences, and images.</p>
+            <label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".zip"
+                onChange={handleFileChange}
+                style={{ display: 'none' }}
+                data-testid="restore-file-input"
+              />
+              <button type="button" onClick={() => fileInputRef.current?.click()}>
+                Upload &amp; Check Archive
+              </button>
+            </label>
+          </>
+        )}
+
+        {restorePhase.kind === 'uploading' && <p>Checking archive for conflicts…</p>}
+
+        {restorePhase.kind === 'applying' && <p>Restoring… please wait.</p>}
+
+        {restorePhase.kind === 'conflict_report' && (
+          <div className="conflict-dialog" role="dialog" aria-modal="true">
+            <h3>Restore Confirmation</h3>
+            <p>
+              Archive contains {restorePhase.report.totalCommands} command(s),{' '}
+              {restorePhase.report.totalSequences} sequence(s), and{' '}
+              {restorePhase.report.totalImages} image(s).
+            </p>
+            {restorePhase.report.hasConflicts && (
+              <div className="conflict-details">
+                <p className="warning">
+                  The following existing objects will be <strong>overwritten</strong>:
+                </p>
+                {restorePhase.report.conflictingCommandNames.length > 0 && (
+                  <>
+                    <strong>Commands:</strong>
+                    <ul>{restorePhase.report.conflictingCommandNames.map(n => <li key={n}>{n}</li>)}</ul>
+                  </>
+                )}
+                {restorePhase.report.conflictingSequenceNames.length > 0 && (
+                  <>
+                    <strong>Sequences:</strong>
+                    <ul>{restorePhase.report.conflictingSequenceNames.map(n => <li key={n}>{n}</li>)}</ul>
+                  </>
+                )}
+                {restorePhase.report.conflictingImageIds.length > 0 && (
+                  <>
+                    <strong>Images:</strong>
+                    <ul>{restorePhase.report.conflictingImageIds.map(id => <li key={id}>{id}</li>)}</ul>
+                  </>
+                )}
+              </div>
+            )}
+            {!restorePhase.report.hasConflicts && <p>No conflicts detected.</p>}
+            <div className="dialog-actions">
+              <button type="button" onClick={handleCancelRestore}>Cancel</button>
+              <button type="button" onClick={handleConfirmRestore}>
+                {restorePhase.report.hasConflicts ? 'Confirm Overwrite' : 'Confirm Restore'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {restorePhase.kind === 'success' && (
+          <div className="restore-success">
+            <p>
+              Restore complete: {restorePhase.result.restoredCommands} command(s),{' '}
+              {restorePhase.result.restoredSequences} sequence(s),{' '}
+              {restorePhase.result.restoredImages} image(s) restored.
+            </p>
+            <button type="button" onClick={handleCancelRestore}>Restore Another</button>
+          </div>
+        )}
+
+        {restorePhase.kind === 'error' && (
+          <div className="restore-error">
+            <p className="error">{restorePhase.message}</p>
+            <button type="button" onClick={handleCancelRestore}>Try Again</button>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/src/web-ui/src/pages/__tests__/BackupRestorePage.test.tsx
+++ b/src/web-ui/src/pages/__tests__/BackupRestorePage.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BackupRestorePage } from '../BackupRestorePage';
+import { downloadBackup, validateRestore, applyRestore } from '../../services/backup';
+import { listCommands } from '../../services/commands';
+import { getJson } from '../../lib/api';
+
+jest.mock('../../services/backup');
+jest.mock('../../services/commands');
+jest.mock('../../lib/api');
+
+const mockDownloadBackup = downloadBackup as jest.MockedFunction<typeof downloadBackup>;
+const mockValidateRestore = validateRestore as jest.MockedFunction<typeof validateRestore>;
+const mockApplyRestore = applyRestore as jest.MockedFunction<typeof applyRestore>;
+const mockListCommands = listCommands as jest.MockedFunction<typeof listCommands>;
+const mockGetJson = getJson as jest.MockedFunction<typeof getJson>;
+
+const mockCommands = [
+  { id: 'c1', name: 'Attack', steps: [] },
+  { id: 'c2', name: 'Defend', steps: [] },
+];
+const mockSequences = [
+  { id: 's1', name: 'Combo A' },
+];
+
+const noConflictReport = {
+  hasConflicts: false,
+  conflictingCommandNames: [],
+  conflictingSequenceNames: [],
+  conflictingImageIds: [],
+  totalCommands: 1,
+  totalSequences: 0,
+  totalImages: 0,
+};
+
+const conflictReport = {
+  hasConflicts: true,
+  conflictingCommandNames: ['Attack'],
+  conflictingSequenceNames: [],
+  conflictingImageIds: [],
+  totalCommands: 1,
+  totalSequences: 0,
+  totalImages: 0,
+};
+
+describe('BackupRestorePage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockListCommands.mockResolvedValue(mockCommands);
+    mockGetJson.mockResolvedValue(mockSequences);
+  });
+
+  it('shows loading state initially', () => {
+    render(<BackupRestorePage />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders commands and sequences after load', async () => {
+    render(<BackupRestorePage />);
+    expect(await screen.findByText('Attack')).toBeInTheDocument();
+    expect(screen.getByText('Defend')).toBeInTheDocument();
+    expect(screen.getByText('Combo A')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no commands or sequences', async () => {
+    mockListCommands.mockResolvedValue([]);
+    mockGetJson.mockResolvedValue([]);
+    render(<BackupRestorePage />);
+    expect(await screen.findByText(/No commands or sequences exist yet/)).toBeInTheDocument();
+  });
+
+  it('Download Backup button is disabled when nothing selected', async () => {
+    render(<BackupRestorePage />);
+    await screen.findByText('Attack');
+    const btn = screen.getByRole('button', { name: 'Download Backup' });
+    expect(btn).toBeDisabled();
+  });
+
+  it('Download Backup button enables when a command is selected', async () => {
+    render(<BackupRestorePage />);
+    await screen.findByText('Attack');
+    fireEvent.click(screen.getByLabelText(/Attack/));
+    const btn = screen.getByRole('button', { name: 'Download Backup' });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('Select All selects all commands', async () => {
+    render(<BackupRestorePage />);
+    await screen.findByText('Attack');
+    // First "Select All" button belongs to the commands group
+    fireEvent.click(screen.getAllByRole('button', { name: 'Select All' })[0]);
+    const attackBox = screen.getByLabelText(/Attack/i) as HTMLInputElement;
+    const defendBox = screen.getByLabelText(/Defend/i) as HTMLInputElement;
+    expect(attackBox.checked).toBe(true);
+    expect(defendBox.checked).toBe(true);
+  });
+
+  it('calls downloadBackup with selected ids on Download Backup click', async () => {
+    mockDownloadBackup.mockResolvedValue(undefined);
+    render(<BackupRestorePage />);
+    await screen.findByText('Attack');
+    fireEvent.click(screen.getByLabelText(/Attack/i));
+    fireEvent.click(screen.getByRole('button', { name: 'Download Backup' }));
+    await waitFor(() => expect(mockDownloadBackup).toHaveBeenCalledWith(
+      expect.objectContaining({ commandIds: ['c1'], sequenceIds: [] })
+    ));
+  });
+
+  it('calls validateRestore on file upload and shows conflict dialog', async () => {
+    mockValidateRestore.mockResolvedValue(noConflictReport);
+    render(<BackupRestorePage />);
+    await screen.findByText(/Upload & Check Archive/);
+
+    const fileInput = screen.getByTestId('restore-file-input');
+    const file = new File(['dummy'], 'backup.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(await screen.findByText('Restore Confirmation')).toBeInTheDocument();
+    expect(screen.getByText('No conflicts detected.')).toBeInTheDocument();
+  });
+
+  it('shows conflict names in conflict dialog', async () => {
+    mockValidateRestore.mockResolvedValue(conflictReport);
+    render(<BackupRestorePage />);
+    await screen.findByText(/Upload & Check Archive/);
+
+    const fileInput = screen.getByTestId('restore-file-input');
+    const file = new File(['dummy'], 'backup.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(await screen.findByText('Attack')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm Overwrite' })).toBeInTheDocument();
+  });
+
+  it('Cancel in conflict dialog returns to idle', async () => {
+    mockValidateRestore.mockResolvedValue(noConflictReport);
+    render(<BackupRestorePage />);
+    await screen.findByText(/Upload & Check Archive/);
+
+    const fileInput = screen.getByTestId('restore-file-input');
+    fireEvent.change(fileInput, { target: { files: [new File(['x'], 'b.zip')] } });
+    await screen.findByText('Restore Confirmation');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Restore Confirmation')).not.toBeInTheDocument();
+    expect(screen.getByText(/Upload & Check Archive/)).toBeInTheDocument();
+  });
+
+  it('Confirm Restore calls applyRestore and shows success state', async () => {
+    mockValidateRestore.mockResolvedValue(noConflictReport);
+    mockApplyRestore.mockResolvedValue({ restoredCommands: 1, restoredSequences: 0, restoredImages: 0, rolledBack: false });
+    render(<BackupRestorePage />);
+    await screen.findByText(/Upload & Check Archive/);
+
+    const fileInput = screen.getByTestId('restore-file-input');
+    fireEvent.change(fileInput, { target: { files: [new File(['x'], 'b.zip')] } });
+    await screen.findByText('Restore Confirmation');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Restore' }));
+    expect(await screen.findByText(/Restore complete/)).toBeInTheDocument();
+  });
+
+  it('rolledBack result shows error state', async () => {
+    mockValidateRestore.mockResolvedValue(noConflictReport);
+    mockApplyRestore.mockResolvedValue({ restoredCommands: 0, restoredSequences: 0, restoredImages: 0, rolledBack: true, errorMessage: 'Storage failure' });
+    render(<BackupRestorePage />);
+    await screen.findByText(/Upload & Check Archive/);
+
+    const fileInput = screen.getByTestId('restore-file-input');
+    fireEvent.change(fileInput, { target: { files: [new File(['x'], 'b.zip')] } });
+    await screen.findByText('Restore Confirmation');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Restore' }));
+    expect(await screen.findByText(/Storage failure/)).toBeInTheDocument();
+  });
+});

--- a/src/web-ui/src/services/backup.ts
+++ b/src/web-ui/src/services/backup.ts
@@ -1,0 +1,81 @@
+import { ApiError, buildApiUrl, buildAuthHeaders } from '../lib/api';
+
+export interface BackupSelection {
+  commandIds: string[];
+  sequenceIds: string[];
+}
+
+export interface ConflictReport {
+  hasConflicts: boolean;
+  conflictingCommandNames: string[];
+  conflictingSequenceNames: string[];
+  conflictingImageIds: string[];
+  totalCommands: number;
+  totalSequences: number;
+  totalImages: number;
+}
+
+export interface RestoreResult {
+  restoredCommands: number;
+  restoredSequences: number;
+  restoredImages: number;
+  rolledBack: boolean;
+  errorMessage?: string;
+}
+
+export async function downloadBackup(selection: BackupSelection): Promise<void> {
+  const res = await fetch(buildApiUrl('/api/authoring/backup'), {
+    method: 'POST',
+    headers: buildAuthHeaders(true),
+    body: JSON.stringify(selection)
+  });
+  if (!res.ok) {
+    const payload = await res.json().catch(() => undefined);
+    const message = payload?.error ?? `HTTP ${res.status}`;
+    throw new ApiError(res.status, typeof message === 'string' ? message : JSON.stringify(message), undefined, payload);
+  }
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  const disposition = res.headers.get('content-disposition') ?? '';
+  const match = disposition.match(/filename="?([^"]+)"?/);
+  a.download = match?.[1] ?? 'gamebot-backup.zip';
+  a.href = url;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export async function validateRestore(file: File): Promise<ConflictReport> {
+  const form = new FormData();
+  form.append('archive', file);
+  const res = await fetch(buildApiUrl('/api/authoring/restore/dry-run'), {
+    method: 'POST',
+    headers: buildAuthHeaders(false),
+    body: form
+  });
+  if (!res.ok) {
+    const payload = await res.json().catch(() => undefined);
+    const message = payload?.error ?? `HTTP ${res.status}`;
+    throw new ApiError(res.status, typeof message === 'string' ? message : JSON.stringify(message), undefined, payload);
+  }
+  return res.json() as Promise<ConflictReport>;
+}
+
+export async function applyRestore(file: File): Promise<RestoreResult> {
+  const form = new FormData();
+  form.append('archive', file);
+  const res = await fetch(buildApiUrl('/api/authoring/restore/apply'), {
+    method: 'POST',
+    headers: buildAuthHeaders(false),
+    body: form
+  });
+  const payload = await res.json().catch(() => undefined);
+  if (!res.ok && res.status !== 500) {
+    const message = payload?.error ?? `HTTP ${res.status}`;
+    throw new ApiError(res.status, typeof message === 'string' ? message : JSON.stringify(message), undefined, payload);
+  }
+  return payload as RestoreResult;
+}

--- a/tests/integration/BackupRestoreEndpointsTests.cs
+++ b/tests/integration/BackupRestoreEndpointsTests.cs
@@ -1,0 +1,261 @@
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests;
+
+[Collection("ConfigIsolation")]
+public sealed class BackupRestoreEndpointsTests : IDisposable {
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevDataDir;
+
+  public BackupRestoreEndpointsTests() {
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevDataDir = Environment.GetEnvironmentVariable("GAMEBOT_DATA_DIR");
+
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _prevDataDir);
+    GC.SuppressFinalize(this);
+  }
+
+  // ────────────── T020: POST /api/authoring/backup ──────────────
+
+  [Fact(DisplayName = "Backup: empty selection returns 400")]
+  public async Task BackupEmptySelectionReturnsBadRequest() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    var response = await client.PostAsJsonAsync("/api/authoring/backup",
+      new { commandIds = Array.Empty<string>(), sequenceIds = Array.Empty<string>() }).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
+  [Fact(DisplayName = "Backup: selected command produces zip archive")]
+  public async Task BackupSelectedCommandProducesZip() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    var cmdId = await CreateCommandAsync(client, "cmd-for-backup").ConfigureAwait(false);
+
+    var response = await client.PostAsJsonAsync("/api/authoring/backup",
+      new { commandIds = new[] { cmdId }, sequenceIds = Array.Empty<string>() }).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    response.Content.Headers.ContentType?.MediaType.Should().Be("application/zip");
+
+    var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+    using var archive = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+    archive.GetEntry("manifest.json").Should().NotBeNull();
+    archive.Entries.Any(e => e.FullName.StartsWith("commands/", StringComparison.Ordinal)).Should().BeTrue();
+  }
+
+  // ────────────── T029: DryRunRestore — no conflicts ──────────────
+
+  [Fact(DisplayName = "DryRunRestore: archive with no conflicts returns no-conflict report")]
+  public async Task DryRunRestoreNoConflictsReturnsReport() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    var cmdId = await CreateCommandAsync(client, "cmd-dry-run-unique").ConfigureAwait(false);
+    var archive = await DownloadBackupAsync(client, new[] { cmdId }, Array.Empty<string>()).ConfigureAwait(false);
+
+    // delete the command so there is no name conflict on a fresh restore
+    await client.DeleteAsync(new Uri($"/api/commands/{cmdId}", UriKind.Relative)).ConfigureAwait(false);
+
+    var report = await PostDryRunAsync(client, archive).ConfigureAwait(false);
+
+    report.Should().NotBeNull();
+    report.Value.TryGetProperty("hasConflicts", out var hc).Should().BeTrue();
+    hc.GetBoolean().Should().BeFalse();
+    report.Value.TryGetProperty("totalCommands", out var tc).Should().BeTrue();
+    tc.GetInt32().Should().Be(1);
+  }
+
+  // ────────────── T030: DryRunRestore — name conflict ──────────────
+
+  [Fact(DisplayName = "DryRunRestore: archive with name-conflicting command returns conflict report")]
+  public async Task DryRunRestoreNameConflictReturnsConflictReport() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    var cmdId = await CreateCommandAsync(client, "cmd-conflict-dry").ConfigureAwait(false);
+    var archive = await DownloadBackupAsync(client, new[] { cmdId }, Array.Empty<string>()).ConfigureAwait(false);
+
+    // Command with same name still exists → conflict
+    var report = await PostDryRunAsync(client, archive).ConfigureAwait(false);
+
+    report.Should().NotBeNull();
+    report.Value.TryGetProperty("hasConflicts", out var hc).Should().BeTrue();
+    hc.GetBoolean().Should().BeTrue();
+    report.Value.TryGetProperty("conflictingCommandNames", out var names).Should().BeTrue();
+    names.EnumerateArray().Select(n => n.GetString()).Should().Contain("cmd-conflict-dry");
+  }
+
+  // ────────────── T031: ApplyRestore — no conflict ──────────────
+
+  [Fact(DisplayName = "ApplyRestore: restoring archive with no conflicts creates objects")]
+  public async Task ApplyRestoreNoConflictCreatesObjects() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    var cmdId = await CreateCommandAsync(client, "cmd-apply-unique").ConfigureAwait(false);
+    var archive = await DownloadBackupAsync(client, new[] { cmdId }, Array.Empty<string>()).ConfigureAwait(false);
+
+    // Delete the command so restoring has no conflict and creates anew
+    await client.DeleteAsync(new Uri($"/api/commands/{cmdId}", UriKind.Relative)).ConfigureAwait(false);
+
+    var result = await PostApplyAsync(client, archive).ConfigureAwait(false);
+
+    result.Should().NotBeNull();
+    result.Value.TryGetProperty("restoredCommands", out var rc).Should().BeTrue();
+    rc.GetInt32().Should().Be(1);
+    result.Value.TryGetProperty("rolledBack", out var rb).Should().BeTrue();
+    rb.GetBoolean().Should().BeFalse();
+  }
+
+  // ────────────── T037: ApplyRestore — with conflict ──────────────
+
+  [Fact(DisplayName = "ApplyRestore: restoring archive with conflicting command overwrites it")]
+  public async Task ApplyRestoreConflictOverwritesExistingCommand() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    // Create command, back it up, then re-create the same-named command to produce a conflict
+    var originalId = await CreateCommandAsync(client, "cmd-overwrite-target").ConfigureAwait(false);
+    var archive = await DownloadBackupAsync(client, new[] { originalId }, Array.Empty<string>()).ConfigureAwait(false);
+
+    // Delete and re-create to give it a different ID — same name, different content
+    await client.DeleteAsync(new Uri($"/api/commands/{originalId}", UriKind.Relative)).ConfigureAwait(false);
+    await CreateCommandAsync(client, "cmd-overwrite-target").ConfigureAwait(false);
+
+    // Dry-run should show conflict
+    var dryRun = await PostDryRunAsync(client, archive).ConfigureAwait(false);
+    dryRun.Should().NotBeNull();
+    dryRun.Value.GetProperty("hasConflicts").GetBoolean().Should().BeTrue();
+
+    // Apply should succeed: overwrite the conflicting command
+    var result = await PostApplyAsync(client, archive).ConfigureAwait(false);
+    result.Should().NotBeNull();
+    result.Value.GetProperty("rolledBack").GetBoolean().Should().BeFalse();
+    result.Value.GetProperty("restoredCommands").GetInt32().Should().Be(1);
+  }
+
+  // ────────────── T040: 400 edge cases ──────────────
+
+  [Fact(DisplayName = "DryRunRestore: corrupt zip file returns 400")]
+  public async Task DryRunRestoreCorruptZipReturnsBadRequest() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    var corrupt = new byte[] { 0x00, 0xFF, 0xAB, 0xCD };
+    using var content = new MultipartFormDataContent();
+    using var fileContent = new ByteArrayContent(corrupt);
+    fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+    content.Add(fileContent, "archive", "corrupt.zip");
+
+    var response = await client.PostAsync(new Uri("/api/authoring/restore/dry-run", UriKind.Relative), content).ConfigureAwait(false);
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
+  [Fact(DisplayName = "ApplyRestore: corrupt zip file returns 400")]
+  public async Task ApplyRestoreCorruptZipReturnsBadRequest() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    var corrupt = new byte[] { 0x00, 0xFF, 0xAB, 0xCD };
+    using var content = new MultipartFormDataContent();
+    using var fileContent = new ByteArrayContent(corrupt);
+    fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+    content.Add(fileContent, "archive", "corrupt.zip");
+
+    var response = await client.PostAsync(new Uri("/api/authoring/restore/apply", UriKind.Relative), content).ConfigureAwait(false);
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
+  [Fact(DisplayName = "DryRunRestore: missing archive file returns 400")]
+  public async Task DryRunRestoreMissingFileReturnsBadRequest() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    // POST with no multipart body → no form content type → 400
+    var response = await client.PostAsync(new Uri("/api/authoring/restore/dry-run", UriKind.Relative), null).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
+  [Fact(DisplayName = "ApplyRestore: missing archive file returns 400")]
+  public async Task ApplyRestoreMissingFileReturnsBadRequest() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Authorize(app.CreateClient());
+
+    // POST with no multipart body → no form content type → 400
+    var response = await client.PostAsync(new Uri("/api/authoring/restore/apply", UriKind.Relative), null).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
+  // ────────────── helpers ──────────────
+
+  private static HttpClient Authorize(HttpClient client) {
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+    return client;
+  }
+
+  private static async Task<string> CreateCommandAsync(HttpClient client, string name) {
+    var resp = await client.PostAsJsonAsync("/api/commands", new {
+      name,
+      steps = Array.Empty<object>()
+    }).ConfigureAwait(false);
+    resp.EnsureSuccessStatusCode();
+    var json = await resp.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    return json.GetProperty("id").GetString()!;
+  }
+
+  private static async Task<byte[]> DownloadBackupAsync(HttpClient client, string[] commandIds, string[] sequenceIds) {
+    var resp = await client.PostAsJsonAsync("/api/authoring/backup",
+      new { commandIds, sequenceIds }).ConfigureAwait(false);
+    resp.EnsureSuccessStatusCode();
+    return await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+  }
+
+  private static async Task<JsonElement?> PostDryRunAsync(HttpClient client, byte[] archive) {
+    using var content = new MultipartFormDataContent();
+    using var fileContent = new ByteArrayContent(archive);
+    fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+    content.Add(fileContent, "archive", "backup.zip");
+    var resp = await client.PostAsync(new Uri("/api/authoring/restore/dry-run", UriKind.Relative), content).ConfigureAwait(false);
+    if (!resp.IsSuccessStatusCode) return null;
+    return await resp.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+  }
+
+  private static async Task<JsonElement?> PostApplyAsync(HttpClient client, byte[] archive) {
+    using var content = new MultipartFormDataContent();
+    using var fileContent = new ByteArrayContent(archive);
+    fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+    content.Add(fileContent, "archive", "backup.zip");
+    var resp = await client.PostAsync(new Uri("/api/authoring/restore/apply", UriKind.Relative), content).ConfigureAwait(false);
+    if (!resp.IsSuccessStatusCode && (int)resp.StatusCode != 500) return null;
+    return await resp.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+  }
+}

--- a/tests/integration/BackupRestoreEndpointsTests.cs
+++ b/tests/integration/BackupRestoreEndpointsTests.cs
@@ -86,9 +86,10 @@ public sealed class BackupRestoreEndpointsTests : IDisposable {
     var report = await PostDryRunAsync(client, archive).ConfigureAwait(false);
 
     report.Should().NotBeNull();
-    report.Value.TryGetProperty("hasConflicts", out var hc).Should().BeTrue();
+    var reportEl1 = report!.Value;
+    reportEl1.TryGetProperty("hasConflicts", out var hc).Should().BeTrue();
     hc.GetBoolean().Should().BeFalse();
-    report.Value.TryGetProperty("totalCommands", out var tc).Should().BeTrue();
+    reportEl1.TryGetProperty("totalCommands", out var tc).Should().BeTrue();
     tc.GetInt32().Should().Be(1);
   }
 
@@ -106,9 +107,10 @@ public sealed class BackupRestoreEndpointsTests : IDisposable {
     var report = await PostDryRunAsync(client, archive).ConfigureAwait(false);
 
     report.Should().NotBeNull();
-    report.Value.TryGetProperty("hasConflicts", out var hc).Should().BeTrue();
+    var reportEl2 = report!.Value;
+    reportEl2.TryGetProperty("hasConflicts", out var hc).Should().BeTrue();
     hc.GetBoolean().Should().BeTrue();
-    report.Value.TryGetProperty("conflictingCommandNames", out var names).Should().BeTrue();
+    reportEl2.TryGetProperty("conflictingCommandNames", out var names).Should().BeTrue();
     names.EnumerateArray().Select(n => n.GetString()).Should().Contain("cmd-conflict-dry");
   }
 
@@ -128,9 +130,10 @@ public sealed class BackupRestoreEndpointsTests : IDisposable {
     var result = await PostApplyAsync(client, archive).ConfigureAwait(false);
 
     result.Should().NotBeNull();
-    result.Value.TryGetProperty("restoredCommands", out var rc).Should().BeTrue();
+    var resultEl1 = result!.Value;
+    resultEl1.TryGetProperty("restoredCommands", out var rc).Should().BeTrue();
     rc.GetInt32().Should().Be(1);
-    result.Value.TryGetProperty("rolledBack", out var rb).Should().BeTrue();
+    resultEl1.TryGetProperty("rolledBack", out var rb).Should().BeTrue();
     rb.GetBoolean().Should().BeFalse();
   }
 
@@ -152,13 +155,14 @@ public sealed class BackupRestoreEndpointsTests : IDisposable {
     // Dry-run should show conflict
     var dryRun = await PostDryRunAsync(client, archive).ConfigureAwait(false);
     dryRun.Should().NotBeNull();
-    dryRun.Value.GetProperty("hasConflicts").GetBoolean().Should().BeTrue();
+    dryRun!.Value.GetProperty("hasConflicts").GetBoolean().Should().BeTrue();
 
     // Apply should succeed: overwrite the conflicting command
     var result = await PostApplyAsync(client, archive).ConfigureAwait(false);
     result.Should().NotBeNull();
-    result.Value.GetProperty("rolledBack").GetBoolean().Should().BeFalse();
-    result.Value.GetProperty("restoredCommands").GetInt32().Should().Be(1);
+    var resultEl2 = result!.Value;
+    resultEl2.GetProperty("rolledBack").GetBoolean().Should().BeFalse();
+    resultEl2.GetProperty("restoredCommands").GetInt32().Should().Be(1);
   }
 
   // ────────────── T040: 400 edge cases ──────────────

--- a/tests/unit/BackupServiceTests.cs
+++ b/tests/unit/BackupServiceTests.cs
@@ -1,0 +1,377 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text.Json;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Images;
+using GameBot.Service.Contracts.Backup;
+using GameBot.Service.Services;
+using Xunit;
+
+namespace GameBot.UnitTests;
+
+public sealed class BackupServiceTests {
+  private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+  // ────────────── helpers ──────────────
+
+  private static Command MakeCommand(string id, string name, string? imgId = null) {
+    var cmd = new Command { Id = id, Name = name };
+    if (imgId is not null)
+      cmd.Steps.Add(new CommandStep {
+        Type = CommandStepType.PrimitiveTap,
+        Order = 0,
+        PrimitiveTap = new PrimitiveTapConfig {
+          DetectionTarget = new DetectionTarget(imgId, 0.8, 0, 0, DetectionSelectionStrategy.HighestConfidence)
+        }
+      });
+    return cmd;
+  }
+
+  private static CommandSequence MakeSequence(string id, string name, params string[] commandIds) {
+    var seq = new CommandSequence { Id = id, Name = name };
+    var steps = commandIds.Select((cid, i) => new SequenceStep { Order = i, CommandId = cid }).ToList();
+    seq.SetSteps(steps);
+    return seq;
+  }
+
+  private static Stream BuildZip(
+    object manifest,
+    IEnumerable<Command>? commands = null,
+    IEnumerable<CommandSequence>? sequences = null,
+    IEnumerable<(string Id, byte[] Data)>? images = null) {
+    var ms = new MemoryStream();
+    using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)) {
+      WriteJsonEntry(archive, "manifest.json", manifest);
+      foreach (var cmd in commands ?? []) WriteJsonEntry(archive, $"commands/{cmd.Id}.json", cmd);
+      foreach (var seq in sequences ?? []) WriteJsonEntry(archive, $"sequences/{seq.Id}.json", seq);
+      foreach (var (id, data) in images ?? []) {
+        var entry = archive.CreateEntry($"images/{id}.png");
+        using var s = entry.Open();
+        s.Write(data, 0, data.Length);
+      }
+    }
+    ms.Position = 0;
+    return ms;
+  }
+
+  private static void WriteJsonEntry(ZipArchive archive, string name, object value) {
+    var entry = archive.CreateEntry(name);
+    using var s = entry.Open();
+    JsonSerializer.Serialize(s, value, JsonOpts);
+  }
+
+  // ────────────── spy repos ──────────────
+
+  private sealed class StubCommandRepo : ICommandRepository {
+    private readonly Dictionary<string, Command> _store;
+    public List<Command> Added { get; } = new();
+    public List<string> Deleted { get; } = new();
+
+    public StubCommandRepo(params Command[] commands) =>
+      _store = commands.ToDictionary(c => c.Id, StringComparer.Ordinal);
+
+    public Task<Command> AddAsync(Command c, CancellationToken ct = default) {
+      Added.Add(c);
+      _store[c.Id] = c;
+      return Task.FromResult(c);
+    }
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) {
+      Deleted.Add(id);
+      return Task.FromResult(_store.Remove(id));
+    }
+    public Task<Command?> GetAsync(string id, CancellationToken ct = default) =>
+      Task.FromResult(_store.TryGetValue(id, out var c) ? c : null);
+    public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) =>
+      Task.FromResult<IReadOnlyList<Command>>(_store.Values.ToList());
+    public Task<Command?> UpdateAsync(Command c, CancellationToken ct = default) => Task.FromResult<Command?>(c);
+  }
+
+  private sealed class StubSequenceRepo : ISequenceRepository {
+    private readonly Dictionary<string, CommandSequence> _store;
+    public List<CommandSequence> Created { get; } = new();
+    public List<string> Deleted { get; } = new();
+
+    public StubSequenceRepo(params CommandSequence[] seqs) =>
+      _store = seqs.ToDictionary(s => s.Id, StringComparer.Ordinal);
+
+    public Task<CommandSequence?> GetAsync(string id) =>
+      Task.FromResult(_store.TryGetValue(id, out var s) ? s : null);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() =>
+      Task.FromResult<IReadOnlyList<CommandSequence>>(_store.Values.ToList());
+    public Task<CommandSequence> CreateAsync(CommandSequence s) {
+      Created.Add(s);
+      _store[s.Id] = s;
+      return Task.FromResult(s);
+    }
+    public Task<CommandSequence> UpdateAsync(CommandSequence s) => Task.FromResult(s);
+    public Task<bool> DeleteAsync(string id) {
+      Deleted.Add(id);
+      return Task.FromResult(_store.Remove(id));
+    }
+  }
+
+  private sealed class StubImageRepo : IImageRepository {
+    private readonly Dictionary<string, (byte[] Data, string ContentType)> _store;
+    public List<(string Id, byte[] Data)> Saved { get; } = new();
+
+    public StubImageRepo(params (string Id, byte[] Data, string ContentType)[] images) =>
+      _store = images.ToDictionary(i => i.Id, i => (i.Data, i.ContentType), StringComparer.OrdinalIgnoreCase);
+
+    public Task<IReadOnlyCollection<string>> ListIdsAsync(CancellationToken ct = default) =>
+      Task.FromResult<IReadOnlyCollection<string>>(_store.Keys.ToList());
+    public Task<ImageAsset?> GetAsync(string id, CancellationToken ct = default) {
+      if (!_store.TryGetValue(id, out var entry)) return Task.FromResult<ImageAsset?>(null);
+      return Task.FromResult<ImageAsset?>(new ImageAsset(id, entry.ContentType, entry.Data.Length, null, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+    }
+    public Task<Stream?> OpenReadAsync(string id, CancellationToken ct = default) {
+      if (!_store.TryGetValue(id, out var entry)) return Task.FromResult<Stream?>(null);
+      return Task.FromResult<Stream?>(new MemoryStream(entry.Data));
+    }
+    public async Task<ImageAsset> SaveAsync(string id, Stream content, string contentType, string? filename, bool overwrite, CancellationToken ct = default) {
+      var ms = new MemoryStream();
+      await content.CopyToAsync(ms, ct).ConfigureAwait(false);
+      var data = ms.ToArray();
+      Saved.Add((id, data));
+      _store[id] = (data, contentType);
+      return new ImageAsset(id, contentType, ms.Length, filename, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+    }
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) {
+      return Task.FromResult(_store.Remove(id));
+    }
+    public Task<bool> ExistsAsync(string id, CancellationToken ct = default) =>
+      Task.FromResult(_store.ContainsKey(id));
+  }
+
+  // ────────────── CreateBackupAsync ──────────────
+
+  [Fact]
+  public async Task CreateBackupAsync_SelectedCommandAndImage_ProducesArchiveWithEntries() {
+    var imgData = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+    var cmd = MakeCommand("cmd1", "Attack", "img-tap");
+    var cmdRepo = new StubCommandRepo(cmd);
+    var seqRepo = new StubSequenceRepo();
+    var imgRepo = new StubImageRepo(("img-tap", imgData, "image/png"));
+    var svc = new BackupService(cmdRepo, seqRepo, imgRepo);
+
+    var output = new MemoryStream();
+    await svc.CreateBackupAsync(new BackupRequestDto { CommandIds = ["cmd1"] }, output, CancellationToken.None).ConfigureAwait(false);
+
+    output.Position = 0;
+    using var archive = new ZipArchive(output, ZipArchiveMode.Read);
+    archive.GetEntry("manifest.json").Should().NotBeNull();
+    archive.GetEntry("commands/cmd1.json").Should().NotBeNull();
+    archive.GetEntry("images/img-tap.png").Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task CreateBackupAsync_SequenceTransitivelyIncludesReferencedCommand() {
+    var cmd = MakeCommand("cmd1", "Attack");
+    var seq = MakeSequence("seq1", "MySeq", "cmd1");
+    var cmdRepo = new StubCommandRepo(cmd);
+    var seqRepo = new StubSequenceRepo(seq);
+    var imgRepo = new StubImageRepo();
+    var svc = new BackupService(cmdRepo, seqRepo, imgRepo);
+
+    var output = new MemoryStream();
+    await svc.CreateBackupAsync(new BackupRequestDto { SequenceIds = ["seq1"] }, output, CancellationToken.None).ConfigureAwait(false);
+
+    output.Position = 0;
+    using var archive = new ZipArchive(output, ZipArchiveMode.Read);
+    archive.GetEntry("commands/cmd1.json").Should().NotBeNull("sequence references it transitively");
+    archive.GetEntry("sequences/seq1.json").Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task CreateBackupAsync_DeduplicatesCommandsAndImages() {
+    var imgData = new byte[] { 1, 2, 3 };
+    var cmd = MakeCommand("cmd1", "Attack", "img-shared");
+    var seq = MakeSequence("seq1", "MySeq", "cmd1");
+    var cmdRepo = new StubCommandRepo(cmd);
+    var seqRepo = new StubSequenceRepo(seq);
+    var imgRepo = new StubImageRepo(("img-shared", imgData, "image/png"));
+    var svc = new BackupService(cmdRepo, seqRepo, imgRepo);
+
+    var output = new MemoryStream();
+    await svc.CreateBackupAsync(new BackupRequestDto { CommandIds = ["cmd1"], SequenceIds = ["seq1"] }, output, CancellationToken.None).ConfigureAwait(false);
+
+    output.Position = 0;
+    using var archive = new ZipArchive(output, ZipArchiveMode.Read);
+    archive.Entries.Count(e => e.FullName.StartsWith("commands/", StringComparison.Ordinal)).Should().Be(1);
+    archive.Entries.Count(e => e.FullName.StartsWith("images/", StringComparison.Ordinal)).Should().Be(1);
+  }
+
+  // ────────────── DryRunRestoreAsync ──────────────
+
+  [Fact]
+  public async Task DryRunRestoreAsync_NoConflicts_ReturnsEmptyReport() {
+    var manifest = new { version = "1.0", createdAt = DateTimeOffset.UtcNow, commandCount = 1, sequenceCount = 0, imageCount = 0 };
+    var archiveCmd = MakeCommand("cmd1", "NewCmd");
+    using var stream = BuildZip(manifest, commands: [archiveCmd]);
+
+    var cmdRepo = new StubCommandRepo();
+    var seqRepo = new StubSequenceRepo();
+    var imgRepo = new StubImageRepo();
+    var svc = new BackupService(cmdRepo, seqRepo, imgRepo);
+
+    var report = await svc.DryRunRestoreAsync(stream, CancellationToken.None).ConfigureAwait(false);
+
+    report.HasConflicts.Should().BeFalse();
+    report.TotalCommands.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task DryRunRestoreAsync_NameConflict_ReturnsConflictReport() {
+    var manifest = new { version = "1.0", createdAt = DateTimeOffset.UtcNow, commandCount = 1, sequenceCount = 0, imageCount = 0 };
+    var archiveCmd = MakeCommand("cmd-new", "Attack");
+    using var stream = BuildZip(manifest, commands: [archiveCmd]);
+
+    var existingCmd = MakeCommand("cmd-old", "Attack");
+    var cmdRepo = new StubCommandRepo(existingCmd);
+    var seqRepo = new StubSequenceRepo();
+    var imgRepo = new StubImageRepo();
+    var svc = new BackupService(cmdRepo, seqRepo, imgRepo);
+
+    var report = await svc.DryRunRestoreAsync(stream, CancellationToken.None).ConfigureAwait(false);
+
+    report.HasConflicts.Should().BeTrue();
+    report.ConflictingCommandNames.Should().Contain("Attack");
+  }
+
+  [Fact]
+  public async Task DryRunRestoreAsync_MissingManifest_ThrowsBackupFormatException() {
+    var ms = new MemoryStream();
+    using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)) {
+      var entry = archive.CreateEntry("commands/cmd1.json");
+      using var s = entry.Open();
+      JsonSerializer.Serialize(s, MakeCommand("cmd1", "C"), JsonOpts);
+    }
+    ms.Position = 0;
+
+    var svc = new BackupService(new StubCommandRepo(), new StubSequenceRepo(), new StubImageRepo());
+    var act = () => svc.DryRunRestoreAsync(ms, CancellationToken.None);
+    await act.Should().ThrowAsync<BackupFormatException>().ConfigureAwait(false);
+  }
+
+  [Fact]
+  public async Task DryRunRestoreAsync_MissingImageInArchive_ThrowsBackupFormatException() {
+    var manifest = new { version = "1.0", createdAt = DateTimeOffset.UtcNow, commandCount = 1, sequenceCount = 0, imageCount = 0 };
+    var cmd = MakeCommand("cmd1", "C", "missing-img");
+    using var stream = BuildZip(manifest, commands: [cmd]);
+
+    var svc = new BackupService(new StubCommandRepo(), new StubSequenceRepo(), new StubImageRepo());
+    var act = () => svc.DryRunRestoreAsync(stream, CancellationToken.None);
+    await act.Should().ThrowAsync<BackupFormatException>().WithMessage("*missing-img*").ConfigureAwait(false);
+  }
+
+  // ────────────── ApplyRestoreAsync (no-conflict) ──────────────
+
+  [Fact]
+  public async Task ApplyRestoreAsync_NoConflict_CreatesAllObjectsWithoutDelete() {
+    var manifest = new { version = "1.0", createdAt = DateTimeOffset.UtcNow, commandCount = 1, sequenceCount = 1, imageCount = 0 };
+    var archiveCmd = MakeCommand("cmd1", "Attack");
+    var archiveSeq = MakeSequence("seq1", "MySeq");
+    using var stream = BuildZip(manifest, commands: [archiveCmd], sequences: [archiveSeq]);
+
+    var cmdRepo = new StubCommandRepo();
+    var seqRepo = new StubSequenceRepo();
+    var imgRepo = new StubImageRepo();
+    var svc = new BackupService(cmdRepo, seqRepo, imgRepo);
+
+    var result = await svc.ApplyRestoreAsync(stream, CancellationToken.None).ConfigureAwait(false);
+
+    result.RolledBack.Should().BeFalse();
+    result.RestoredCommands.Should().Be(1);
+    result.RestoredSequences.Should().Be(1);
+    cmdRepo.Added.Should().HaveCount(1);
+    cmdRepo.Deleted.Should().BeEmpty();
+    seqRepo.Created.Should().HaveCount(1);
+    seqRepo.Deleted.Should().BeEmpty();
+  }
+
+  // ────────────── ApplyRestoreAsync (conflict + rollback) ──────────────
+
+  [Fact]
+  public async Task ApplyRestoreAsync_WithConflict_DeletesOldAndCreatesNew() {
+    var manifest = new { version = "1.0", createdAt = DateTimeOffset.UtcNow, commandCount = 1, sequenceCount = 0, imageCount = 0 };
+    var archiveCmd = MakeCommand("cmd-new", "Attack");
+    using var stream = BuildZip(manifest, commands: [archiveCmd]);
+
+    var existingCmd = MakeCommand("cmd-old", "Attack");
+    var cmdRepo = new StubCommandRepo(existingCmd);
+    var seqRepo = new StubSequenceRepo();
+    var imgRepo = new StubImageRepo();
+    var svc = new BackupService(cmdRepo, seqRepo, imgRepo);
+
+    var result = await svc.ApplyRestoreAsync(stream, CancellationToken.None).ConfigureAwait(false);
+
+    result.RolledBack.Should().BeFalse();
+    cmdRepo.Deleted.Should().Contain("cmd-old");
+    cmdRepo.Added.Any(c => c.Name == "Attack").Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task ApplyRestoreAsync_MissingImageInArchive_ThrowsBackupFormatException() {
+    var manifest = new { version = "1.0", createdAt = DateTimeOffset.UtcNow, commandCount = 1, sequenceCount = 0, imageCount = 0 };
+    var cmd = MakeCommand("cmd1", "C", "missing-img");
+    using var stream = BuildZip(manifest, commands: [cmd]);
+
+    var svc = new BackupService(new StubCommandRepo(), new StubSequenceRepo(), new StubImageRepo());
+    var act = () => svc.ApplyRestoreAsync(stream, CancellationToken.None);
+    await act.Should().ThrowAsync<BackupFormatException>().WithMessage("*missing-img*").ConfigureAwait(false);
+  }
+
+  // ────────────── ApplyRestoreAsync rollback on apply failure ──────────────
+
+  [Fact]
+  public async Task ApplyRestoreAsync_ApplyFails_RollsBackAndReturnsRolledBackTrue() {
+    var manifest = new { version = "1.0", createdAt = DateTimeOffset.UtcNow, commandCount = 1, sequenceCount = 0, imageCount = 0 };
+    var archiveCmd = MakeCommand("cmd-new", "Attack");
+    using var stream = BuildZip(manifest, commands: [archiveCmd]);
+
+    var existingCmd = MakeCommand("cmd-old", "Attack");
+    var faultyCmdRepo = new FaultyAfterDeleteCommandRepo(existingCmd);
+    var svc = new BackupService(faultyCmdRepo, new StubSequenceRepo(), new StubImageRepo());
+
+    var result = await svc.ApplyRestoreAsync(stream, CancellationToken.None).ConfigureAwait(false);
+
+    result.RolledBack.Should().BeTrue();
+    // Rollback should have re-added the original command
+    faultyCmdRepo.RollbackAddCalled.Should().BeTrue();
+  }
+
+  // Throws on AddAsync for new objects (after delete), but allows rollback adds
+  private sealed class FaultyAfterDeleteCommandRepo : ICommandRepository {
+    private readonly Command _original;
+    private bool _deleted;
+    public bool RollbackAddCalled { get; private set; }
+
+    public FaultyAfterDeleteCommandRepo(Command original) => _original = original;
+
+    public Task<Command> AddAsync(Command c, CancellationToken ct = default) {
+      if (_deleted) {
+        // First call after delete = new object from archive → throw to trigger rollback
+        if (!RollbackAddCalled && string.Equals(c.Id, _original.Id, StringComparison.Ordinal) == false) {
+          throw new InvalidOperationException("Simulated apply failure.");
+        }
+        // Second call = rollback of original
+        RollbackAddCalled = true;
+        return Task.FromResult(c);
+      }
+      return Task.FromResult(c);
+    }
+
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) {
+      _deleted = true;
+      return Task.FromResult(true);
+    }
+
+    public Task<Command?> GetAsync(string id, CancellationToken ct = default) =>
+      Task.FromResult<Command?>(_original.Id == id ? _original : null);
+
+    public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) =>
+      Task.FromResult<IReadOnlyList<Command>>(new List<Command> { _original });
+
+    public Task<Command?> UpdateAsync(Command c, CancellationToken ct = default) => Task.FromResult<Command?>(c);
+  }
+}

--- a/tests/unit/BackupServiceTests.cs
+++ b/tests/unit/BackupServiceTests.cs
@@ -182,6 +182,32 @@ public sealed class BackupServiceTests {
     archive.GetEntry("sequences/seq1.json").Should().NotBeNull();
   }
 
+  [Fact(DisplayName = "Sequence with per-step break condition round-trips through backup JSON options")]
+  public void BackupJsonOptions_SequenceWithBreakConditionRoundTripsWithoutDuplicateTypeKey() {
+    var seq = new CommandSequence { Id = "seq1", Name = "LoopSeq" };
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepType = SequenceStepType.Loop,
+      Loop = new CountLoopConfig { Count = 3 },
+      Body = new List<SequenceStep> {
+        new SequenceStep {
+          Order = 0,
+          StepType = SequenceStepType.Break,
+          BreakCondition = new ImageVisibleStepCondition { ImageId = "img1", MinSimilarity = 0.9 }
+        }
+      }
+    };
+    seq.SetSteps([loopStep]);
+
+    var json = JsonSerializer.Serialize(seq, JsonOpts);
+    var loaded = JsonSerializer.Deserialize<CommandSequence>(json, JsonOpts);
+
+    loaded.Should().NotBeNull();
+    var breakCondition = loaded!.Steps[0].Body[0].BreakCondition;
+    breakCondition.Should().BeOfType<ImageVisibleStepCondition>();
+    ((ImageVisibleStepCondition)breakCondition!).ImageId.Should().Be("img1");
+  }
+
   [Fact]
   public async Task CreateBackupAsync_DeduplicatesCommandsAndImages() {
     var imgData = new byte[] { 1, 2, 3 };

--- a/tests/unit/GlobalSuppressions.cs
+++ b/tests/unit/GlobalSuppressions.cs
@@ -4,3 +4,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "xUnit discovers test classes via reflection; analyzers cannot see instantiation.", Scope = "module")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types", Justification = "Test classes need not be sealed; suppress to reduce noise.", Scope = "module")]
 [assembly: SuppressMessage("xUnit", "xUnit1030:Test methods should not call ConfigureAwait(false)", Justification = "ConfigureAwait(false) usage is acceptable in our tests; parallelism is managed elsewhere.", Scope = "module")]
+[assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Underscore-separated test method names are the accepted xUnit naming convention.", Scope = "module")]
+[assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "Test helpers intentionally use interface return types for readability.", Scope = "module")]

--- a/tests/unit/GlobalSuppressions.cs
+++ b/tests/unit/GlobalSuppressions.cs
@@ -6,3 +6,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("xUnit", "xUnit1030:Test methods should not call ConfigureAwait(false)", Justification = "ConfigureAwait(false) usage is acceptable in our tests; parallelism is managed elsewhere.", Scope = "module")]
 [assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Underscore-separated test method names are the accepted xUnit naming convention.", Scope = "module")]
 [assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "Test helpers intentionally use interface return types for readability.", Scope = "module")]
+[assembly: SuppressMessage("Reliability", "CA2025:Ensure tasks using IDisposable instances complete before the instances are disposed", Justification = "ThrowAsync awaits the lambda before the using scope exits; disposal is safe.", Scope = "module")]

--- a/tests/unit/ImageReferenceExtractorTests.cs
+++ b/tests/unit/ImageReferenceExtractorTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.ObjectModel;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Service.Services;
+using Xunit;
+
+namespace GameBot.UnitTests;
+
+public sealed class ImageReferenceExtractorTests {
+  [Fact]
+  public void ExtractImageIds_CommandWithDetection_ReturnsId() {
+    var cmd = new Command {
+      Id = "cmd1", Name = "C",
+      Detection = new DetectionTarget("img-detect", 0.8, 0, 0, DetectionSelectionStrategy.HighestConfidence)
+    };
+    ImageReferenceExtractor.ExtractImageIds(cmd).Should().Contain("img-detect");
+  }
+
+  [Fact]
+  public void ExtractImageIds_CommandWithPrimitiveTapStep_ReturnsId() {
+    var cmd = new Command {
+      Id = "cmd1", Name = "C",
+      Steps = new Collection<CommandStep> {
+        new CommandStep {
+          Type = CommandStepType.PrimitiveTap, Order = 0,
+          PrimitiveTap = new PrimitiveTapConfig {
+            DetectionTarget = new DetectionTarget("img-tap", 0.9, 0, 0, DetectionSelectionStrategy.HighestConfidence)
+          }
+        }
+      }
+    };
+    ImageReferenceExtractor.ExtractImageIds(cmd).Should().Contain("img-tap");
+  }
+
+  [Fact]
+  public void ExtractImageIds_CommandWithWaitForImageStep_ReturnsId() {
+    var cmd = new Command {
+      Id = "cmd1", Name = "C",
+      Steps = new Collection<CommandStep> {
+        new CommandStep {
+          Type = CommandStepType.WaitForImage, Order = 0,
+          WaitForImage = new WaitForImageConfig {
+            DetectionTarget = new DetectionTarget("img-wait", 0.8, 0, 0, DetectionSelectionStrategy.HighestConfidence)
+          }
+        }
+      }
+    };
+    ImageReferenceExtractor.ExtractImageIds(cmd).Should().Contain("img-wait");
+  }
+
+  [Fact]
+  public void ExtractImageIds_CommandWithMultipleStepTypes_ReturnsAllIds() {
+    var cmd = new Command {
+      Id = "cmd1", Name = "C",
+      Detection = new DetectionTarget("img-d", 0.8, 0, 0, DetectionSelectionStrategy.HighestConfidence),
+      Steps = new Collection<CommandStep> {
+        new CommandStep {
+          Type = CommandStepType.PrimitiveTap, Order = 0,
+          PrimitiveTap = new PrimitiveTapConfig {
+            DetectionTarget = new DetectionTarget("img-tap", 0.9, 0, 0, DetectionSelectionStrategy.HighestConfidence)
+          }
+        },
+        new CommandStep {
+          Type = CommandStepType.WaitForImage, Order = 1,
+          WaitForImage = new WaitForImageConfig {
+            DetectionTarget = new DetectionTarget("img-wait", 0.8, 0, 0, DetectionSelectionStrategy.HighestConfidence)
+          }
+        }
+      }
+    };
+    var ids = ImageReferenceExtractor.ExtractImageIds(cmd).ToList();
+    ids.Should().Contain("img-d");
+    ids.Should().Contain("img-tap");
+    ids.Should().Contain("img-wait");
+  }
+
+  [Fact]
+  public void ExtractImageIds_CommandWithNoImageRefs_ReturnsEmpty() {
+    var cmd = new Command {
+      Id = "cmd1", Name = "C",
+      Steps = new Collection<CommandStep> {
+        new CommandStep { Type = CommandStepType.EnsureGameRunning, Order = 0 }
+      }
+    };
+    ImageReferenceExtractor.ExtractImageIds(cmd).Should().BeEmpty();
+  }
+
+  [Fact]
+  public void ExtractImageIds_SequenceStepsWithGate_ReturnsGateTargetId() {
+    var steps = new List<SequenceStep> {
+      new SequenceStep { Gate = new GateConfig { TargetId = "img-gate" } }
+    };
+    ImageReferenceExtractor.ExtractImageIds(steps).Should().Contain("img-gate");
+  }
+
+  [Fact]
+  public void ExtractImageIds_SequenceStepsWithWaitForImage_ReturnsId() {
+    var steps = new List<SequenceStep> {
+      new SequenceStep {
+        WaitForImage = new WaitForImageConfig {
+          DetectionTarget = new DetectionTarget("img-seq-wait", 0.8, 0, 0, DetectionSelectionStrategy.HighestConfidence)
+        }
+      }
+    };
+    ImageReferenceExtractor.ExtractImageIds(steps).Should().Contain("img-seq-wait");
+  }
+
+  [Fact]
+  public void ExtractImageIds_SequenceLoopBody_RecursesIntoBody() {
+    var loopStep = new SequenceStep {
+      StepType = SequenceStepType.Loop,
+      Body = new List<SequenceStep> {
+        new SequenceStep { Gate = new GateConfig { TargetId = "img-loop-body" } }
+      }
+    };
+    ImageReferenceExtractor.ExtractImageIds(new[] { loopStep }).Should().Contain("img-loop-body");
+  }
+
+  [Fact]
+  public void ExtractImageIds_EmptySequenceSteps_ReturnsEmpty() {
+    ImageReferenceExtractor.ExtractImageIds(Array.Empty<SequenceStep>()).Should().BeEmpty();
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes CS8629/CA2025 analyzer errors that surfaced only on CI (newer SDK/analyzer toolchain) by extracting null-forgiving locals in `BackupRestoreEndpointsTests` and suppressing CA2025 in test `GlobalSuppressions`.
- Fixes a restore bug: `SequenceStepCondition`'s `Type` property collided with its `JsonPolymorphic` "type" discriminator once `BackupService`'s `JsonSerializerDefaults.Web` options camelCased `Type` → `type`, producing a duplicate `"type"` key that failed to round-trip with `"Deserialized object contains a duplicate 'type' metadata property"`. `[JsonIgnore]` on the derived `Type` overrides removes the redundant property so only the discriminator is written.

## Test plan
- [x] `dotnet build GameBot.sln --no-restore -c Release` — 0 warnings/0 errors
- [x] `dotnet test GameBot.sln --no-restore -c Release` — all tests pass
- [x] New regression test `BackupJsonOptions_SequenceWithBreakConditionRoundTripsWithoutDuplicateTypeKey` reproduces the duplicate-key failure pre-fix and passes post-fix
- [x] Manually verified backup → restore round trip of a sequence with a per-step break condition via the running service

🤖 Generated with [Claude Code](https://claude.com/claude-code)