### PR TITLE
Tap-point jitter: configurable random offset for all taps and swipes (#058)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/057-authoring-backup-restore"
+  "feature_directory": "specs/058-tap-point-jitter"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Tap-point jitter (058-tap-point-jitter)
+  - Every tap and swipe sent to the device now lands within a small random offset of its target instead of always hitting the exact same pixel, making repeated executions look more natural. Each axis offset is drawn independently from `[-radius, +radius]`; swipe start and end points are jittered independently; results are clamped so coordinates are never negative.
+  - Applied automatically and centrally in the session input dispatch path, so it covers all origins: authored steps, image-detection-resolved primitive taps, recorder replays, and the raw `POST /sessions/{id}/inputs` API. No per-step opt-in/opt-out and no new authoring/execution UI controls.
+  - New configuration parameter `GAMEBOT_TAP_JITTER_RADIUS_PX` (default `5`): `0` disables jitter entirely (pixel-exact input); negative/invalid values fall back to the default. Follows the standard precedence (default → saved config file → environment variable), appears in the generic UI Configuration variables list, and is documented in `ENVIRONMENT.md`.
+  - Execution logs and step outcomes now report both the pre-jitter target and the post-jitter executed coordinates: tap details read "Tap targeted (X,Y), executed at (X',Y')" and step outcome payloads gain additive `executedPoint`, `targetSwipe`, and `executedSwipe` fields alongside the existing `resolvedPoint`.
+
 ## [0.7.0] - 2026-06-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/057-authoring-backup-restore/plan.md
+at specs/058-tap-point-jitter/plan.md
 <!-- SPECKIT END -->

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -170,6 +170,12 @@ Examples:
   - Used in: `SessionManager`
   - Default: `100`
 
+- GAMEBOT_TAP_JITTER_RADIUS_PX
+  - Purpose: Maximum random per-axis offset (pixels) applied independently to the X and Y coordinate of every tap and swipe endpoint immediately before dispatch, so repeated executions don't always land on the exact same pixel. Each axis offset is drawn uniformly from `[-radius, +radius]`; results are clamped to be non-negative.
+  - Used in: `SessionManager` (applies to all dispatch paths — command steps, image-detection taps, recorder replays, and the raw `POST /sessions/{id}/inputs` API; set to `0` for pixel-exact input, e.g. calibration)
+  - Default: `5`
+  - Valid range: `0` or greater. `0` disables jitter entirely; negative or non-numeric values fall back to the default `5`.
+
 ## Service Options via ASP.NET Core Configuration
 
 You can set these via appsettings or environment variables using double underscores.

--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "0",
-  "minor": "9",
+  "minor": "10",
   "patch": "0",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-06-06T00:00:00Z"
+  "updatedAtUtc": "2026-06-10T00:00:00Z"
 }

--- a/specs/058-tap-point-jitter/checklists/requirements.md
+++ b/specs/058-tap-point-jitter/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Tap-Point Jitter
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Spec is ready for `/speckit-clarify` (optional) or `/speckit-plan`.

--- a/specs/058-tap-point-jitter/contracts/api-changes.md
+++ b/specs/058-tap-point-jitter/contracts/api-changes.md
@@ -1,0 +1,53 @@
+# API Contract Changes: 058 Tap-Point Jitter
+
+## No New Endpoints
+
+This feature does not add new API endpoints. All changes are to configuration and to additive fields on existing step-outcome/execution-log structures.
+
+## Configuration Parameters (New)
+
+The following environment variable is introduced. It is surfaced in the existing `GET /api/config` snapshot response alongside all other `GAMEBOT_*` parameters, and therefore appears automatically in the web-ui Configuration variables list (no new UI component).
+
+### GAMEBOT_TAP_JITTER_RADIUS_PX
+
+- **Type**: integer (pixels)
+- **Default**: 5
+- **Minimum**: 0 (negative values are rejected and fall back to the default of 5)
+- **Description**: Maximum random offset, in pixels, applied independently to the X and Y coordinate of every tap and swipe endpoint immediately before it is sent to the device. Each axis offset is drawn independently and uniformly from `[-radius, +radius]`. Setting this to `0` disables jitter entirely (coordinates pass through unchanged). Applies automatically to all taps and swipes regardless of how the target coordinates were determined (authored, image-detection-resolved, or replayed); there is no per-step opt-in/opt-out and no per-step UI control.
+
+## PrimitiveTapStepOutcome Contract Changes
+
+The `PrimitiveTapStepOutcome` record gains three new **optional, additive** trailing fields. All existing fields, types, and ordering are unchanged, so existing positional-constructor call sites and serialized payloads remain valid (new fields default/serialize to `null` when absent).
+
+| New Field | Type | Applies To | Description |
+|-----------|------|-----------|-------------|
+| `ExecutedPoint` | `PrimitiveTapResolvedPoint?` | Tap-shaped steps (primitive tap) | Post-jitter (x, y) actually sent to the device. `ResolvedPoint` continues to represent the pre-jitter target. |
+| `TargetSwipe` | `PrimitiveSwipePoints?` (new record: `Start`, `End` each `PrimitiveTapResolvedPoint`) | Explicit swipe steps | Pre-jitter (start, end) target points. |
+| `ExecutedSwipe` | `PrimitiveSwipePoints?` | Explicit swipe steps | Post-jitter (start, end) points actually sent to the device. |
+
+### New Record: PrimitiveSwipePoints
+
+```csharp
+internal sealed record PrimitiveSwipePoints(PrimitiveTapResolvedPoint Start, PrimitiveTapResolvedPoint End);
+```
+
+## DTO Changes (Additive)
+
+- **`src/GameBot.Service/Models/Commands.cs`**: `ResolvedPointDto` is unchanged and is **reused** for all new point shapes (no duplicate point DTO type is introduced). New optional DTO fields are added to the step-outcome response model(s) mirroring the new `PrimitiveTapStepOutcome` fields:
+  - `ResolvedPointDto? ExecutedPoint` (`{ X, Y }`)
+  - `SwipePointsDto? TargetSwipe` and `SwipePointsDto? ExecutedSwipe`, where `SwipePointsDto` is `{ Start: ResolvedPointDto, End: ResolvedPointDto }`
+- **`src/GameBot.Service/Endpoints/CommandsEndpoints.cs`** (~line 178-182): mapping extended to populate the new DTO fields from the new outcome fields when present (omitted/`null` when jitter produced no outcome data, e.g. non-tap/swipe steps).
+- **`src/GameBot.Service/Endpoints/StepsEndpoints.cs`** (~line 170): the anonymous step-result object gains the same additive fields.
+
+All additions are optional/nullable; clients that don't read the new fields are unaffected.
+
+## Execution Log Impact
+
+`src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` (`LogCommandExecutionAsync`) extends the existing detail-item construction (FR-013/SC-006):
+
+- **Tap step, jitter applied (ExecutedPoint differs from ResolvedPoint)**: detail text becomes e.g. `"Tap targeted (X,Y), executed at (X',Y')."` (both pre- and post-jitter coordinates shown).
+- **Tap step, no jitter offset (radius=0 or offset happened to be zero)**: detail text remains `"Tap executed at (X,Y)."` (unchanged when target == executed).
+- **Swipe step, jitter applied**: new detail text e.g. `"Swipe targeted (X1,Y1)->(X2,Y2), executed (X1',Y1')->(X2',Y2')."`.
+- **Failed/skipped steps**: unchanged — `ExecutedPoint`/`ExecutedSwipe` are `null` when no dispatch occurred, and detail text falls back to existing "Step N was not executed: ..." formatting.
+
+No changes to `ExecutionLogService`'s public mapping signatures — only the constructed detail string content and the additive outcome fields it now has access to.

--- a/specs/058-tap-point-jitter/data-model.md
+++ b/specs/058-tap-point-jitter/data-model.md
@@ -1,0 +1,95 @@
+# Data Model: 058 Tap-Point Jitter
+
+## Entities
+
+### AppConfig (Extended)
+
+Existing domain configuration class extended with one new property for tap/swipe jitter.
+
+| Field | Type | Default | Validation | Description |
+|-------|------|---------|------------|-------------|
+| TapRetryCount | int | 3 | ≥ 0 | Existing — primitive tap retry cycles |
+| AdbRetries | int | 2 | ≥ 0 | Existing — ADB operation retries |
+| **TapJitterRadiusPx** | int | 5 | ≥ 0 (negative → fallback to 5) | Maximum random per-axis offset (pixels) applied independently to the X and Y coordinate of every tap and swipe endpoint before dispatch. `0` disables jitter (coordinates pass through unchanged). Maps to `GAMEBOT_TAP_JITTER_RADIUS_PX` env var. |
+
+### CoordinateJitter (New helper)
+
+A new stateless static helper in `GameBot.Domain.Services`, not persisted, used by `SessionManager`.
+
+| Member | Signature | Description |
+|--------|-----------|-------------|
+| `Apply` | `(int X, int Y) Apply(int x, int y, int radiusPx)` | Returns `(x, y)` unchanged if `radiusPx <= 0`. Otherwise returns `(Max(0, x + dx), Max(0, y + dy))` where `dx`, `dy` are independently drawn from `[-radiusPx, +radiusPx]` using a non-cryptographic LCG (seeded from clock ticks XORed with a monotonically incrementing counter, per research R-002). |
+
+### PrimitiveTapResolvedPoint (Unchanged)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| X | int | X coordinate |
+| Y | int | Y coordinate |
+
+### PrimitiveSwipePoints (New)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Start | PrimitiveTapResolvedPoint | Swipe start point (x1, y1) |
+| End | PrimitiveTapResolvedPoint | Swipe end point (x2, y2) |
+
+### PrimitiveTapStepOutcome (Extended, additive)
+
+Existing record gains three new optional trailing fields (default `null`); all existing fields and positional ordering are unchanged.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| StepOrder | int | Position of the step in the command (existing) |
+| Status | string | Outcome status (existing values unchanged) |
+| Reason | string? | Human-readable reason (existing) |
+| ResolvedPoint | PrimitiveTapResolvedPoint? | Pre-jitter target (x, y) for tap-shaped steps (existing — semantics unchanged: "target") |
+| DetectionConfidence | double? | Template match confidence (existing) |
+| StepType | string? | Existing |
+| TimeoutMs / EffectiveTimeoutMs / ReferenceImageId / ImageLoadStatus / ConfiguredConfidence | various | Existing |
+| **ExecutedPoint** | PrimitiveTapResolvedPoint? | **New.** Post-jitter (x, y) actually sent to the device for a tap-shaped step. |
+| **TargetSwipe** | PrimitiveSwipePoints? | **New.** Pre-jitter (start, end) points for an explicit swipe step. |
+| **ExecutedSwipe** | PrimitiveSwipePoints? | **New.** Post-jitter (start, end) points actually sent for an explicit swipe step. |
+
+### Configuration Parameters (Environment Variables + Config File)
+
+| Env Variable | Config Key | Type | Default | Description |
+|-------------|------------|------|---------|-------------|
+| `GAMEBOT_TAP_JITTER_RADIUS_PX` | `TapJitterRadiusPx` | int | 5 | Maximum per-axis random offset (pixels) for tap/swipe coordinates. `0` disables jitter; negative values fall back to 5. |
+
+## Relationships
+
+```
+AppConfig (singleton)
+  └── TapJitterRadiusPx ──→ SessionManager.SendInputsAsync (jitter magnitude for tap/swipe args)
+                                  │
+                                  └──→ CoordinateJitter.Apply (per-coordinate offset + clamp)
+
+SessionManager.SendInputsAsync (jitter normalization pass at method entry,
+                                before the ADB-mode branch — runs in both real-ADB and stub modes)
+  ├── reads InputAction.Args["x"]/["y"] (tap) or ["x1"]["y1"]["x2"]["y2"] (swipe)
+  ├── computes jittered values via CoordinateJitter.Apply
+  ├── writes jittered values back into InputAction.Args (mutating the shared dictionary)
+  └── dispatches jittered coordinates to AdbClient.TapAsync / SwipeAsync (when ADB active)
+
+CommandExecutor
+  ├── constructs InputAction with target (pre-jitter) coordinates in Args
+  ├── awaits SendInputsAsync (Args mutated in place to post-jitter values)
+  ├── reads back jittered Args values
+  └── produces PrimitiveTapStepOutcome
+       ├── ResolvedPoint / TargetSwipe = pre-jitter target (captured before dispatch)
+       ├── ExecutedPoint / ExecutedSwipe = post-jitter values (read back after dispatch)
+       └── consumed by ExecutionLogService, CommandsEndpoints, StepsEndpoints (additive mapping)
+```
+
+## State Transitions
+
+Not applicable — this feature introduces a stateless coordinate transformation (no new entity lifecycle or state machine). The existing primitive-tap/swipe execution flow (validate → resolve target → dispatch → record outcome) is unchanged in shape; jitter is an additional pure transformation applied during dispatch.
+
+## Validation Rules
+
+1. `TapJitterRadiusPx` < 0 → falls back to default 5 (FR-006), applied identically in `Program.cs` startup wiring and `IConfigApplier.Apply` runtime updates.
+2. `TapJitterRadiusPx` == 0 → `CoordinateJitter.Apply` returns coordinates unchanged; no randomness invoked (FR-005).
+3. `TapJitterRadiusPx` > 0 → each of `dx`, `dy` independently and uniformly drawn from `[-TapJitterRadiusPx, +TapJitterRadiusPx]` (FR-003).
+4. Resulting `x + dx` and `y + dy` are clamped with `Math.Max(0, ...)` — never negative (FR-007/SC-005). No upper-bound clamp (per spec Assumptions).
+5. Jitter is applied to both endpoints of a swipe independently (FR-002), including the degenerate "tap-as-swipe" case where `x1==x2, y1==y2` before jitter (may diverge slightly after — documented edge case, acceptable per spec).

--- a/specs/058-tap-point-jitter/plan.md
+++ b/specs/058-tap-point-jitter/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Tap-Point Jitter
+
+**Branch**: `058-tap-point-jitter` | **Date**: 2026-06-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/058-tap-point-jitter/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Apply a small, automatic random offset (default ±5px, independently per axis) to the X/Y coordinates of every tap and swipe endpoint immediately before it is dispatched to the device. Jitter is injected centrally in `SessionManager.SendInputsAsync` (the single ADB dispatch chokepoint for both `InputAction.Type == "tap"`-shaped and `"swipe"`-shaped actions), so it applies uniformly regardless of whether coordinates were authored directly, computed via image detection, or replayed from a recording. The jitter radius is a new `AppConfig.TapJitterRadiusPx` property (default 5, 0 disables, negative falls back to default), wired through the existing config precedence chain (defaults → `data/config/config.json` → `GAMEBOT_*`/`Service__*` env vars) and surfaced in the generic UI Configuration variables list via `ConfigSnapshotService.BuildDefaultRelevantKeys()` — no new UI controls. Because `InputAction.Args` is a mutable `Dictionary<string,object>` passed by reference, `SessionManager` mutates the dispatched coordinates in place so callers (`CommandExecutor`) can read back the post-jitter values and report both the pre-jitter target and post-jitter executed coordinates in step outcomes and execution logs (additive fields on `PrimitiveTapStepOutcome`).
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9
+**Primary Dependencies**: ASP.NET Core Minimal API, SharpAdbClient/ADB integration (`GameBot.Emulator`), Microsoft.Extensions.Logging, existing `GameBot.Domain` and `GameBot.Service` libraries
+**Storage**: Existing file-backed JSON configuration (`data/config/config.json`) via `ConfigSnapshotService`; no new stores
+**Testing**: xUnit + coverlet for coverage enforcement; existing unit/contract/integration suites all passing
+**Target Platform**: Windows (System.Drawing, ADB, SessionManager dependencies are Windows-only)
+**Project Type**: Desktop service (ASP.NET Core Minimal API host + web UI)
+**Performance Goals**: Jitter computation (LCG-based RNG, two subtractions/additions/clamps per coordinate) adds negligible (<0.01ms) overhead per tap/swipe dispatch; no additional ADB calls, no additional allocations beyond a few ints
+**Constraints**: No new external packages; jitter MUST be applied with no per-step opt-in/opt-out (FR-012); jittered coordinates MUST never be negative (FR-007); radius=0 MUST exactly disable jitter (FR-005)
+**Scale/Scope**: ~1 new config property on `AppConfig`, ~1 new shared jitter-offset helper (non-cryptographic LCG, mirroring `SequenceRunner`'s pattern), ~30-50 LOC change in `SessionManager.SendInputsAsync`, additive fields on `PrimitiveTapStepOutcome` + `ExecutionLogService` + DTOs, ~6-10 new unit tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality Discipline | PASS | Feature adds a small jitter helper plus localized changes to `SessionManager.SendInputsAsync`, `AppConfig`, `IConfigApplier`, `ConfigSnapshotService`, `Program.cs`, `CommandExecutor`, `ExecutionLogService`, and DTOs; no new projects/dependencies; all changes additive (new optional record fields, new config property) |
+| II. Testing Standards | PASS (plan) | New unit tests for: jitter helper bounds/clamping (radius=0 passthrough, radius=N stays within [-N,N], negative-result clamped to 0), `AppConfig`/`IConfigApplier` validation (default 5, 0 valid, negative→default), `SessionManager` jitter application to tap and swipe args, `CommandExecutor` outcome population of `ExecutedPoint`/`TargetSwipe`/`ExecutedSwipe`. Coverage targets ≥80% line / ≥70% branch for touched areas. Existing `CommandExecutor` unit tests using `RecordingSessionManager` fakes are unaffected since jitter only applies in the real `SessionManager`. |
+| III. User Experience Consistency | PASS | New config parameter follows existing env-var + `AppConfig` + `ConfigSnapshotService` pattern (same as `TapRetryCount`/`AdbRetries`); execution log/step outcome vocabulary extended additively (`ExecutedPoint`, `TargetSwipe`, `ExecutedSwipe`) without breaking existing `ResolvedPoint` consumers; no new UI controls per FR-011 |
+| IV. Performance Requirements | PASS | Jitter adds O(1) negligible-cost arithmetic per coordinate on the existing dispatch path; no new I/O, no new ADB round-trips, no N+1 patterns |
+| Quality Gates – DoD | PASS (plan) | No underscores in method names (CamelCase); new config parameter documented in `ENVIRONMENT.md` and surfaced in UI config list; all touched public members documented |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/058-tap-point-jitter/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   ├── Config/
+│   │   └── AppConfig.cs                  # + TapJitterRadiusPx property (default 5)
+│   └── Services/
+│       └── CoordinateJitter.cs           # NEW: shared LCG-based jitter offset helper (mirrors SequenceRunner RNG pattern)
+├── GameBot.Emulator/
+│   └── Session/
+│       └── SessionManager.cs             # SendInputsAsync normalization pass (at method entry, before the ADB-mode branch) applies jitter to tap (x,y) and swipe (x1,y1,x2,y2) args in place, clamps to >= 0
+└── GameBot.Service/
+    ├── Program.cs                         # + Wire GAMEBOT_TAP_JITTER_RADIUS_PX env var into AppConfig
+    └── Services/
+        ├── IConfigApplier.cs               # + Apply TapJitterRadiusPx with negative->default(5) fallback (file contains the ConfigApplier implementation)
+        ├── ConfigSnapshotService.cs        # + GAMEBOT_TAP_JITTER_RADIUS_PX in BuildDefaultRelevantKeys()
+        ├── ICommandExecutor.cs             # + PrimitiveSwipePoints record; + ExecutedPoint/TargetSwipe/ExecutedSwipe on PrimitiveTapStepOutcome
+        ├── CommandExecutor.cs              # Read back jittered coordinates from InputAction.Args after SendInputsAsync; populate new outcome fields
+        ├── Endpoints/CommandsEndpoints.cs  # + map new outcome fields to ResolvedPointDto-style DTOs
+        ├── Endpoints/StepsEndpoints.cs     # + include new fields in step result payload
+        ├── Models/Commands.cs              # + DTO additions (additive, optional)
+        └── Services/ExecutionLog/ExecutionLogService.cs  # + include target vs executed coordinates in detail text
+
+ENVIRONMENT.md                              # + GAMEBOT_TAP_JITTER_RADIUS_PX documentation entry
+
+tests/
+└── unit/
+    ├── Config/AppConfigValidationTests.cs           # + TapJitterRadiusPx default/zero/negative tests
+    ├── Domain/CoordinateJitterTests.cs              # NEW: bounds, clamping, disable-at-zero tests
+    ├── Emulator/SessionManagerJitterTests.cs        # NEW: jitter applied to tap/swipe args, clamped, disabled at radius=0
+    └── Commands/CommandExecutorPrimitiveTapTests.cs # + ExecutedPoint/TargetSwipe/ExecutedSwipe outcome tests
+```
+
+**Structure Decision**: All changes fit within the existing `GameBot.Domain` / `GameBot.Emulator` / `GameBot.Service` / `tests` project layout. The jitter-offset computation lives in `GameBot.Domain` (alongside `AppConfig` and `SequenceRunner`, which already hosts the equivalent non-cryptographic RNG pattern) so it can be referenced from `GameBot.Emulator` (which already depends on `GameBot.Domain` for `AppConfig`). The injection point is `SessionManager.SendInputsAsync`, the existing single dispatch chokepoint for all tap/swipe `InputAction`s, requiring no changes to `ISessionManager`'s public signature.
+
+## Complexity Tracking
+
+No constitution violations. All changes are within existing project structure and follow established configuration and randomization patterns.

--- a/specs/058-tap-point-jitter/quickstart.md
+++ b/specs/058-tap-point-jitter/quickstart.md
@@ -1,0 +1,50 @@
+# Quickstart: 058 Tap-Point Jitter
+
+## What Changed
+
+Every tap and swipe sent to the device now lands within a small random offset of its target coordinates instead of always landing on the exact same pixel. This happens automatically for all taps and swipes — authored directly, resolved via image detection, replayed from a recording, or submitted via the raw `POST /sessions/{id}/inputs` API — with no per-step setup or opt-out. If you need pixel-exact input (e.g., calibration via the raw API), set the radius to 0.
+
+## Configuration
+
+One setting controls jitter. It has a sensible default and works out of the box.
+
+| Setting | Env Variable | Default | Description |
+|---------|-------------|---------|-------------|
+| Jitter Radius | `GAMEBOT_TAP_JITTER_RADIUS_PX` | 5 | Maximum per-axis random offset (pixels). `0` disables jitter. |
+
+### Example: Default behaviour (no config needed)
+
+With the default radius of 5px, a tap targeting `(100, 200)`:
+1. Computes an independent random X offset in `[-5, +5]` and an independent random Y offset in `[-5, +5]`.
+2. Sends the resulting coordinates (e.g. `(103, 197)`) to the device, clamped so neither value goes below 0.
+3. Repeats this independently every time the step runs — consecutive runs land at slightly different points.
+
+For a swipe from `(50, 50)` to `(500, 800)`, the start and end points are jittered **independently** — the effective swipe length/direction may vary slightly between runs.
+
+### Example: Disabling jitter
+
+Set `GAMEBOT_TAP_JITTER_RADIUS_PX=0`. All taps and swipes land exactly on their configured/resolved target, with no randomness — useful for precise testing or troubleshooting.
+
+### Example: Larger jitter
+
+Set `GAMEBOT_TAP_JITTER_RADIUS_PX=20` to allow up to ±20px of variation per axis — useful for UIs with larger touch targets where more variation looks more natural.
+
+### Invalid values
+
+A negative value (or anything that fails to parse as a non-negative integer) is ignored and the system falls back to the default of 5.
+
+## Monitoring
+
+- **Execution logs**: Each tap/swipe step's log entry shows both the originally targeted coordinates and the actual (post-jitter) coordinates sent to the device, e.g. `"Tap targeted (100,200), executed at (103,197)."`.
+- **Step outcomes / API**: `PrimitiveTapStepOutcome` (and its API DTO equivalents) include new `ExecutedPoint` (for taps) and `TargetSwipe`/`ExecutedSwipe` (for swipes) fields alongside the existing `ResolvedPoint`.
+
+## UI Configuration
+
+The jitter radius appears in the general Configuration variables list (same view as ADB retry settings), showing its current effective value, default, and source (default/file/environment) — consistent with all other `GAMEBOT_*` parameters. There is **no** dedicated jitter control in the command authoring UI or the execution UI; the configuration list is the only place to view or change it.
+
+## No Impact On
+
+- Sequence/command authoring — no new fields, no new step options.
+- Existing step outcome consumers that only read `ResolvedPoint` — it continues to represent the pre-jitter target, unchanged.
+- Existing API endpoints — no new endpoints; jitter config is visible via the existing `GET /api/config`.
+- Tests using `RecordingSessionManager` fakes — jitter is applied only inside the real `SessionManager`, so fake-based unit tests that assert exact dispatched coordinates are unaffected.

--- a/specs/058-tap-point-jitter/research.md
+++ b/specs/058-tap-point-jitter/research.md
@@ -1,0 +1,97 @@
+# Research: 058 Tap-Point Jitter
+
+## R-001: Jitter Injection Point
+
+**Decision**: Apply jitter inside `SessionManager.SendInputsAsync` (`src/GameBot.Emulator/Session/SessionManager.cs`) as a **normalization pass at the top of the method** — after the session lookup but **before** the `_useAdb`/`DeviceSerial` branch: materialize the `actions` enumerable once, then for each action with `Type == "tap"` jitter `Args["x"]`/`["y"]`, and for `Type == "swipe"` independently jitter `Args["x1"]/["y1"]` and `["x2"]/["y2"]`, writing the jittered values back into the same `Args` dictionary entries before they are used for the ADB call.
+
+**Rationale**: `SendInputsAsync` is the single chokepoint through which every tap and swipe reaches the device, regardless of origin (directly authored steps, image-detection-resolved primitive taps dispatched as zero-length swipes, recorder-replayed actions, or the raw `POST /sessions/{id}/inputs` API). Applying jitter here satisfies FR-012/SC-003 ("100% of tap and swipe actions ... regardless of how their target coordinates were produced") without touching `ISessionManager`'s public signature or any call site. `InputAction.Args` is a `Dictionary<string,object>` (reference type), so mutating it in `SendInputsAsync` is visible to the caller (`CommandExecutor`) after the `await SendInputsAsync(...)` call returns, enabling FR-013 (reporting both pre-jitter target and post-jitter executed coordinates) without changing the method's return type.
+
+The normalization pass MUST run before the ADB-mode branch, not inside it: when `GAMEBOT_USE_ADB=false` or no device serial is bound, `SendInputsAsync` returns via a stub path that never iterates the actions' `Args`. Jittering inside the ADB branch would (a) make stub-mode behaviour diverge from real-mode behaviour (caller-visible `ExecutedPoint` would silently equal the target), and (b) make the jitter path untestable in CI, where tests run with `GAMEBOT_USE_ADB=false` and cannot bind a device. Normalizing up front keeps both modes consistent and lets `SessionManagerJitterTests` exercise the real jitter logic in stub mode.
+
+**Alternatives considered**:
+- Apply jitter in `CommandExecutor` before constructing `InputAction`s — would require duplicating the jitter call at every `InputAction` construction site (primitive tap-as-swipe, explicit swipe step, any future step types) and would miss any future caller of `SendInputsAsync` that bypasses `CommandExecutor`. Centralizing in `SessionManager` is more robust and matches "regardless of origin".
+- Apply jitter in `AdbClient.TapAsync`/`SwipeAsync` — those are lower-level wrappers reused for retries; jittering there would re-jitter on every ADB retry of the *same* logical action, producing a different point per retry attempt, which is undesirable (a single logical tap should have one target point per dispatch).
+
+## R-002: RNG Approach and Seed Uniqueness
+
+**Decision**: Reuse the existing non-cryptographic LCG pattern from `SequenceRunner.GetAppliedDelay`/`SampleInterStepDelay` (seeded from `DateTime.UtcNow.Ticks`), but combine the tick-based seed with a process-wide `Interlocked.Increment`-based counter before the LCG step. Implement as a small static helper, `CoordinateJitter`, in `GameBot.Domain.Services`.
+
+**Rationale**: The constitution and existing code establish that non-cryptographic randomness is acceptable for non-security-sensitive timing/positioning (avoids CA5394). However, a swipe's start and end points (and a tap's X and Y) are jittered via back-to-back calls that can occur within the same clock tick on Windows (`DateTime.UtcNow` resolution is ~1-15ms, while four consecutive offset computations execute in nanoseconds), which would produce identical LCG seeds and therefore identical offsets for all four values — defeating "independently randomized" (FR-002/FR-003). Mixing in a monotonically incrementing counter guarantees each call produces a distinct seed even when the wall-clock tick hasn't advanced, while still avoiding `System.Security.Cryptography` (CA5394) since this is positional jitter, not a security control.
+
+**Alternatives considered**:
+- `System.Random` instance per call (`new Random()`) — pre-.NET 6, seeded from the clock with the same collision risk; also an extra allocation per coordinate.
+- A single shared `System.Random` instance — `System.Random` is not thread-safe; would require a lock, adding contention on a hot path for a non-security feature.
+- `Random.Shared` (.NET 6+, thread-safe) — simplest option, but triggers CA5394 ("Do not use insecure randomness") in this codebase's analyzer configuration unless suppressed; the project's established convention (per `SequenceRunner`) is the LCG fallback specifically to avoid that warning. Following the established pattern keeps the analyzer baseline clean without new suppressions.
+
+## R-003: AppConfig Extension Pattern
+
+**Decision**: Add one new property to `AppConfig` (`src/GameBot.Domain/Config/AppConfig.cs`): `TapJitterRadiusPx` (int, default 5), documented with an XML doc comment following the existing style (purpose, env var mapping, validation behavior), placed near `TapRetryCount`/`AdbRetries`.
+
+**Rationale**: Matches the existing pattern exactly (`TapRetryCount`, `TapRetryProgression`, `AdbRetries`, `AdbRetryDelayMs` are all simple `{ get; set; }` properties with default values and XML docs referencing their `GAMEBOT_*` env var). No structural changes to `AppConfig` needed.
+
+**Alternatives considered**:
+- Separate `JitterConfig` class — adds another DI registration/concept for a single scalar; existing `AppConfig` is the established home for exactly this kind of tunable.
+
+## R-004: Configuration Wiring (Validation, Snapshot, Env Var)
+
+**Decision**: Wire `TapJitterRadiusPx` through all four existing configuration touchpoints, following the `TapRetryProgression`/`TapRetryCount` precedent at each:
+
+1. **`Program.cs`**: parse `GAMEBOT_TAP_JITTER_RADIUS_PX` at startup with `int.TryParse(...) is var v && v >= 0 ? v : 5` (negative → default 5, matching FR-006); pass into `new AppConfig { ... TapJitterRadiusPx = jitterRadius }`.
+2. **`IConfigApplier`/`ConfigApplier.Apply`**: `_appConfig.TapJitterRadiusPx = GetInt(snapshot, "GAMEBOT_TAP_JITTER_RADIUS_PX", 5) is var jitter && jitter >= 0 ? jitter : 5;` — applies the same fallback when configuration is updated at runtime via the snapshot/applier path (default → saved file → env var precedence already implemented generically by `ConfigSnapshotService`).
+3. **`ConfigSnapshotService.BuildDefaultRelevantKeys()`**: add `["GAMEBOT_TAP_JITTER_RADIUS_PX"] = 5` to the dictionary that seeds the generic UI Configuration variables list (satisfies FR-009/FR-011 — no bespoke UI component needed, the existing `ConfigParameterList` in web-ui renders this dictionary generically with current value/default/source).
+4. **`ENVIRONMENT.md`**: add a `GAMEBOT_TAP_JITTER_RADIUS_PX` entry documenting purpose, default (5), and that 0 disables jitter while negative values fall back to 5 (FR-010).
+
+**Rationale**: This is the exact same four-touchpoint wiring used for `GAMEBOT_TAP_RETRY_COUNT`/`GAMEBOT_TAP_RETRY_PROGRESSION` in feature 037. Reusing the established precedence chain (defaults → `data/config/config.json` → environment variables) automatically satisfies FR-008 with no new storage code.
+
+**Alternatives considered**: None — this is a mechanical replication of an established, working pattern; no other approach was considered necessary.
+
+## R-005: Clamping and Disable Semantics
+
+**Decision**: `CoordinateJitter.Apply(x, y, radiusPx)` (and an analogous overload/usage for swipe endpoints) returns `(x, y)` unchanged when `radiusPx <= 0` (FR-005: 0 disables; defensively also treats any non-positive value reaching this point as "disabled", though `AppConfig`/`ConfigApplier` validation already guarantees `radiusPx >= 0` per FR-006/FR-007). When `radiusPx > 0`, each axis offset is drawn independently and uniformly from `[-radiusPx, +radiusPx]` (FR-003, square jitter per spec Assumptions), then `Math.Max(0, value)` clamps the result to non-negative (FR-007/SC-005). No upper-bound (screen size) clamp is applied, per spec Assumptions.
+
+**Rationale**: Directly implements FR-003/FR-005/FR-007 with the simplest possible arithmetic; matches the spec's explicit "square jitter, lower-bound-only clamp" assumption.
+
+**Alternatives considered**:
+- Circular (Euclidean) jitter using polar coordinates — explicitly rejected by the spec's Assumptions section in favor of simpler independent per-axis bounds.
+- Clamping to a configured max screen size — rejected per spec Assumptions (screen dimensions not consistently available at the jitter point; default ±5px is negligible).
+
+## R-006: PrimitiveTapStepOutcome Extension for Pre/Post-Jitter Reporting
+
+**Decision**: Extend `PrimitiveTapStepOutcome` (`src/GameBot.Service/Services/ICommandExecutor.cs`) with three new optional, additive fields (default `null`, appended after existing parameters to preserve positional-constructor compatibility):
+
+- `PrimitiveTapResolvedPoint? ExecutedPoint` — the post-jitter (x, y) actually sent to the device for a tap-shaped step (the existing `ResolvedPoint` continues to represent the pre-jitter target).
+- `PrimitiveSwipePoints? TargetSwipe` — the pre-jitter (start, end) points for an explicit swipe step.
+- `PrimitiveSwipePoints? ExecutedSwipe` — the post-jitter (start, end) points actually sent for an explicit swipe step.
+
+A new record `PrimitiveSwipePoints(PrimitiveTapResolvedPoint Start, PrimitiveTapResolvedPoint End)` is added alongside the existing `PrimitiveTapResolvedPoint(int X, int Y)`.
+
+**Rationale**: Implements the clarified FR-013/SC-006 decision ("Both — keep the existing target/resolved point field, and additionally record the actual jittered coordinates"). Adding new optional trailing parameters to a `sealed record` is backward compatible with all existing positional-constructor call sites (they continue to compile, defaulting the new fields to `null`). `CommandExecutor` populates `ExecutedPoint`/`ExecutedSwipe` by reading the (now-jittered) values back out of the `InputAction.Args` dictionary after `SendInputsAsync` returns (per R-001).
+
+**Alternatives considered**:
+- Encode jittered coordinates as a string suffix in the existing `Reason` field (as feature 037 did for retry counts) — rejected because the clarification explicitly calls for *coordinates* to be recorded structurally (consumed by `ExecutionLogService` and DTOs as points, not parsed from text), and downstream API DTOs (`ResolvedPointDto`) already model points as structured `{X, Y}` objects.
+- Replace `ResolvedPoint` in place with the jittered value — rejected; FR-013 requires *both* pre- and post-jitter values to remain available, and `ResolvedPoint` is consumed by existing tests/DTOs as the "target" semantic.
+
+## R-007: Downstream Consumers of New Outcome Fields
+
+**Decision**: Propagate the new `ExecutedPoint`/`TargetSwipe`/`ExecutedSwipe` fields additively through:
+
+- `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` (`LogCommandExecutionAsync`) — extend the "Tap executed at (X,Y)" detail construction to also include the executed (jittered) point when it differs from the resolved (target) point, and add equivalent detail text for swipe steps showing target vs. executed start/end points.
+- `src/GameBot.Service/Models/Commands.cs` — add `ExecutedPoint`/`TargetSwipe`/`ExecutedSwipe`-equivalent optional properties to the relevant DTOs alongside the existing `ResolvedPointDto`.
+- `src/GameBot.Service/Endpoints/CommandsEndpoints.cs` (~line 178-182) and `src/GameBot.Service/Endpoints/StepsEndpoints.cs` (~line 170) — map the new outcome fields into the response DTOs/anonymous objects, mirroring the existing `ResolvedPoint` → `ResolvedPointDto` mapping.
+
+**Rationale**: All additions are additive (new optional fields/properties); no existing field is renamed, removed, or repurposed, so existing consumers (UI, tests) are unaffected unless they choose to read the new fields.
+
+**Alternatives considered**: None — this is a direct, minimal-churn propagation of the new outcome fields to the points where `ResolvedPoint` is currently surfaced.
+
+## R-008: Test Strategy
+
+**Decision**:
+- `tests/unit/Domain/CoordinateJitterTests.cs` (new): radius=0 → passthrough; radius=N → result within `[target-N, target+N]` on each axis across many samples; near-zero target with radius>0 never produces a negative coordinate; consecutive calls produce varying offsets (seed-uniqueness check per R-002).
+- `tests/unit/Config/AppConfigValidationTests.cs`: add `DefaultTapJitterRadiusPxIsFive`, `TapJitterRadiusPxCanBeSetToZero`, `TapJitterRadiusPxNegativeFallsBackToDefault` (mirroring existing `TapRetryCount`/`TapRetryProgression` tests).
+- `tests/unit/Emulator/SessionManagerJitterTests.cs` (new): verify `SendInputsAsync` mutates `InputAction.Args` for both `"tap"` and `"swipe"` types within the configured radius, that radius=0 leaves args unchanged, and that resulting coordinates are never negative for near-zero targets.
+- `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs` / `CommandExecutorSwipeTests.cs`: extend to assert `ExecutedPoint`/`TargetSwipe`/`ExecutedSwipe` are populated correctly when the (fake) `SessionManager` mutates `Args`, while existing assertions against unmutated `RecordingSessionManager` fakes (which don't apply jitter) continue to pass unchanged.
+
+**Rationale**: Covers all FRs (FR-001 through FR-013) at the unit level, satisfies the constitution's ≥80% line / ≥70% branch coverage target for touched areas, and confirms the "existing tests keep passing" finding from prior research (jitter only applies in the real `SessionManager`, not in `RecordingSessionManager` fakes).
+
+**Alternatives considered**:
+- Integration-level test asserting actual ADB dispatch coordinates — would require a real or mocked `AdbClient`; existing `SessionManager` tests already mock at the `AdbClient` boundary, so a unit-level test against `SendInputsAsync` with a stubbed/no-op ADB path is sufficient and faster.

--- a/specs/058-tap-point-jitter/spec.md
+++ b/specs/058-tap-point-jitter/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Tap-Point Jitter
+
+**Feature Branch**: `058-tap-point-jitter`
+**Created**: 2026-06-10
+**Status**: Draft
+**Input**: User description: "I want to have tap-point jitter (e.g., randomizing X/Y within a small radius of the target). This should be applied automatically to all taps and swipes. Default \"small radius\" should be +/-5 pixels of the target. and should be configurable via configuration parameter. Make sure that the configuration is properly stored/retrieved, documented and included in the UI Configuration variables list, but no specific UI option should be created for this in any of the authoring or execution UIs"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Every executed tap and swipe lands near, not exactly on, the target (Priority: P1)
+
+As an automation operator, when a sequence executes a tap or swipe against the device, I want the actual point touched to vary slightly from run to run instead of always landing on the exact same pixel, so that repeated executions look more natural and are more resilient to UI elements that respond slightly differently to pixel-perfect repeated input.
+
+**Why this priority**: This is the core behavior requested — without it, nothing changes. It must apply automatically, with no per-step setup, to deliver value immediately to every existing and future sequence.
+
+**Independent Test**: Configure a sequence with a primitive tap step at a fixed coordinate and run it multiple times. Observe (e.g., via execution logs or device input trace) that the coordinates actually sent to the device vary slightly between runs while remaining close to the configured target.
+
+**Acceptance Scenarios**:
+
+1. **Given** a primitive tap step targeting coordinates (X, Y), **When** the step executes, **Then** the coordinates sent to the device are within the configured jitter radius of (X, Y) and are not guaranteed to equal (X, Y) exactly.
+2. **Given** a primitive swipe step with start point (X1, Y1) and end point (X2, Y2), **When** the step executes, **Then** both the start and end coordinates sent to the device are independently jittered within the configured radius of their respective targets.
+3. **Given** the same tap step executed multiple times in a row, **When** each execution runs, **Then** the actual coordinates sent to the device vary across executions (are not always identical).
+4. **Given** a tap target at or very near the edge of the screen (e.g., X=2), **When** jitter is applied, **Then** the resulting coordinates are never negative.
+
+---
+
+### User Story 2 - Operator tunes or disables jitter via configuration (Priority: P2)
+
+As an operator/administrator, I want to control how large the random offset can be — including turning it off entirely — by changing a configuration value, without editing any sequence, command, or code.
+
+**Why this priority**: Different games/UIs have different tolerances for off-target taps (e.g., small buttons vs. large areas). Operators need to tune this without redoing authored content, and need an escape hatch (disable) for precise testing or troubleshooting.
+
+**Independent Test**: Change the jitter radius configuration value to 0 and confirm taps/swipes land exactly on target. Change it to a larger value (e.g., 20) and confirm the observed variation increases accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the jitter radius configuration is set to 0, **When** any tap or swipe executes, **Then** the coordinates sent to the device exactly match the configured target (no offset applied).
+2. **Given** the jitter radius configuration is set to a custom positive value, **When** any tap or swipe executes, **Then** the maximum possible offset on each axis matches that configured value (rather than the default of 5).
+3. **Given** no value has been configured, **When** the system runs, **Then** the jitter radius defaults to 5 pixels.
+4. **Given** an invalid value (e.g., negative number) is configured, **When** the system loads configuration, **Then** the system falls back to the default radius rather than failing or applying a nonsensical negative radius.
+
+---
+
+### User Story 3 - Jitter setting is visible alongside other configuration values (Priority: P3)
+
+As an operator reviewing system configuration, I want to see the jitter radius setting listed in the same configuration view as other tunable parameters (with its current value and where it comes from), so I understand and can adjust system behavior in one place.
+
+**Why this priority**: Discoverability and consistency. This does not change runtime behavior but ensures the new setting isn't "hidden" relative to other configuration values, and keeps configuration documentation/tooling accurate.
+
+**Independent Test**: Open the general configuration view and confirm the jitter radius parameter appears in the list with its current effective value, default, and source (default/file/environment), consistent with how other parameters (e.g., ADB retry count) are presented. Confirm no dedicated jitter control exists in the command authoring or execution screens.
+
+**Acceptance Scenarios**:
+
+1. **Given** the general configuration variables list, **When** an operator views it, **Then** the tap jitter radius parameter is present with its name, current effective value, and source.
+2. **Given** the command authoring UI and the execution UI, **When** an operator browses tap or swipe step options, **Then** no jitter-specific control is present (jitter is not configurable per-step).
+3. **Given** project documentation of configuration parameters, **When** an operator looks up the jitter radius parameter, **Then** its purpose, default value, and how to override it are documented.
+
+---
+
+### Edge Cases
+
+- What happens when the jitter radius is configured as 0? Jitter is disabled; coordinates pass through unchanged.
+- What happens when the jittered coordinate would be negative (target near the top-left edge of the screen)? The coordinate is clamped to 0 rather than sent as a negative value.
+- What happens when the jitter radius is configured with an invalid value (negative, non-numeric)? The system falls back to the default radius (5) rather than erroring.
+- What happens for swipes where start and end points are jittered independently? The effective swipe distance/direction may vary slightly between executions; this is expected and acceptable.
+- Does jitter apply to taps/swipes regardless of how the target coordinates were determined (explicitly authored, computed from image detection, or replayed from a recording)? Yes — jitter is applied uniformly to every tap and swipe sent to the device, regardless of origin.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST apply a small random offset to the X and Y coordinates of every tap action before it is sent to the device.
+- **FR-002**: System MUST apply a small random offset, independently for the start point and the end point, to every swipe action before it is sent to the device.
+- **FR-003**: For each tap or swipe endpoint, the offset applied to the X coordinate and the offset applied to the Y coordinate MUST each be independently randomized within the range [-radius, +radius], where "radius" is the configured jitter radius in pixels.
+- **FR-004**: System MUST provide a configuration parameter that controls the jitter radius (in pixels), with a default value of 5.
+- **FR-005**: System MUST treat a configured jitter radius of 0 as "jitter disabled" — coordinates are passed through unchanged.
+- **FR-006**: System MUST reject/ignore invalid configured radius values (e.g., negative numbers) and fall back to the default value (5) in that case.
+- **FR-007**: System MUST clamp jittered coordinates so they are never negative, regardless of the configured radius.
+- **FR-008**: The jitter radius configuration parameter MUST be persisted and retrieved using the same configuration storage/override mechanism as other system configuration parameters (i.e., default → saved configuration file → environment variable override precedence).
+- **FR-009**: The jitter radius configuration parameter MUST appear in the general UI configuration variables list, showing its current effective value, default, and source — consistent with how existing configuration parameters are presented.
+- **FR-010**: The jitter radius configuration parameter MUST be documented in the project's configuration/environment variable reference documentation, including its purpose, default, and valid range.
+- **FR-011**: System MUST NOT introduce any per-step or per-command UI control for jitter in the authoring UI or the execution UI — the only way to view/change the jitter radius is via the general configuration variables list.
+- **FR-012**: Jitter MUST be applied automatically to all taps and swipes sent to the device — there is no per-step opt-in or opt-out.
+- **FR-013**: For executed tap and swipe steps, the execution log/step outcome MUST report both the original (pre-jitter) target coordinates and the actual jittered coordinates sent to the device.
+
+### Key Entities
+
+- **Tap Jitter Radius**: A single configuration value (in pixels) representing the maximum random offset applied independently to each axis (X and Y) of every tap or swipe coordinate sent to the device. Default 5; 0 disables jitter; negative values are invalid and fall back to the default.
+- **Executed Point**: The actual post-jitter coordinates sent to the device for a tap or swipe (or each endpoint of a swipe), recorded alongside the existing pre-jitter target/resolved point in execution logs and step outcomes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With default configuration, repeated executions of the same tap step produce device-level coordinates that vary from run to run, while always staying within 5 pixels of the authored target on each axis.
+- **SC-002**: Operators can change the effective jitter radius (including disabling it by setting it to 0) by changing a single configuration value, with the new behavior taking effect without modifying any sequence, command, or step definition.
+- **SC-003**: 100% of tap and swipe actions executed against a device have jitter applied automatically, regardless of how their target coordinates were produced (authored directly, computed from image detection, or replayed from a recording).
+- **SC-004**: The jitter radius parameter is visible in the same configuration listing as existing parameters (e.g., ADB retry settings) without requiring any new navigation paths or screens.
+- **SC-005**: Jittered tap/swipe coordinates sent to the device are never negative, even when the authored target is at or near coordinate (0, 0).
+- **SC-006**: For every executed tap/swipe step, an operator can find both the originally targeted coordinates and the actual coordinates sent to the device in the execution log/step outcome.
+
+## Clarifications
+
+### Session 2026-06-10
+
+- Q: When a tap/swipe executes with jitter applied, should the execution log/outcome report the original (pre-jitter) target, the actual jittered coordinates, or both? → A: Both — keep the existing target/resolved point field, and additionally record the actual jittered coordinates sent to the device.
+
+## Assumptions
+
+- "Radius" is interpreted as an independent per-axis bound: the X offset and Y offset are each randomly chosen within [-radius, +radius] pixels (a square jitter area), not a strict circular (Euclidean) radius. This matches the simplicity implied by "+/- 5 pixels."
+- Only the lower bound (negative coordinates) is clamped. No attempt is made to clamp jittered coordinates to a maximum screen width/height, since screen dimensions are not consistently available at the point where jitter is applied and a ±5 px (default) offset is negligible relative to typical screen sizes.
+- The configuration parameter is added to the existing global application configuration alongside related tap/ADB settings (e.g., near `TapRetryCount`, `AdbRetries`), following the existing naming and override conventions (default → saved config file → environment variable).
+- Randomization does not need to be cryptographically secure — consistent with the existing sequence random-delay feature, which uses non-cryptographic randomness for non-security-sensitive timing/positioning.

--- a/specs/058-tap-point-jitter/tasks.md
+++ b/specs/058-tap-point-jitter/tasks.md
@@ -19,7 +19,7 @@
 
 **Purpose**: No new projects or directories needed. This phase verifies the build is green before changes begin.
 
-- [ ] T001 Verify build and full test suite pass (`dotnet build -c Debug && dotnet test -c Debug`)
+- [X] T001 Verify build and full test suite pass (`dotnet build -c Debug && dotnet test -c Debug`)
 
 ---
 
@@ -33,16 +33,16 @@
 
 ### Tests for Foundational Phase
 
-- [ ] T002 [P] [US2] Add `tests/unit/Domain/CoordinateJitterTests.cs` — radius=0 returns input unchanged; radius=N produces results within `[x-N,x+N]`/`[y-N,y+N]` across many samples; near-zero coordinates with radius>0 never go negative; consecutive calls (e.g. 4 in a row) produce varying offsets (seed-uniqueness per research R-002)
-- [ ] T003 [P] [US2] Add `DefaultTapJitterRadiusPxIsFive`, `TapJitterRadiusPxCanBeSetToZero`, `TapJitterRadiusPxNegativeFallsBackToDefault` tests to `tests/unit/Config/AppConfigValidationTests.cs`
+- [X] T002 [P] [US2] Add `tests/unit/Domain/CoordinateJitterTests.cs` — radius=0 returns input unchanged; radius=N produces results within `[x-N,x+N]`/`[y-N,y+N]` across many samples; near-zero coordinates with radius>0 never go negative; consecutive calls (e.g. 4 in a row) produce varying offsets (seed-uniqueness per research R-002)
+- [X] T003 [P] [US2] Add `DefaultTapJitterRadiusPxIsFive`, `TapJitterRadiusPxCanBeSetToZero`, `TapJitterRadiusPxNegativeFallsBackToDefault` tests to `tests/unit/Config/AppConfigValidationTests.cs`
 
 ### Implementation for Foundational Phase
 
-- [ ] T004 [P] [US2] Implement `CoordinateJitter` static helper in `src/GameBot.Domain/Services/CoordinateJitter.cs` — `Apply(int x, int y, int radiusPx)` returns `(x, y)` unchanged when `radiusPx <= 0`; otherwise draws independent per-axis offsets from `[-radiusPx, +radiusPx]` using an LCG seeded from `DateTime.UtcNow.Ticks` XORed with an `Interlocked.Increment`-based counter (mirrors `SequenceRunner.GetAppliedDelay` pattern, per research R-002), then clamps each result with `Math.Max(0, ...)`
-- [ ] T005 [P] [US2] Add `TapJitterRadiusPx` property (`int`, default `5`) with XML doc comment to `src/GameBot.Domain/Config/AppConfig.cs`, documenting `GAMEBOT_TAP_JITTER_RADIUS_PX` mapping, `0` disables, negative falls back to 5, per data-model.md
-- [ ] T006 [US2] Wire `GAMEBOT_TAP_JITTER_RADIUS_PX` in the `AppConfig` singleton registration in `src/GameBot.Service/Program.cs` (~line 145-172): `int.TryParse(jitterEnv, out var jParsed) && jParsed >= 0 ? jParsed : 5`, include `TapJitterRadiusPx = jitterRadius` in the constructed `AppConfig`
-- [ ] T007 [US2] Add `_appConfig.TapJitterRadiusPx = GetInt(snapshot, "GAMEBOT_TAP_JITTER_RADIUS_PX", 5) is var jitter && jitter >= 0 ? jitter : 5;` to `Apply` in `src/GameBot.Service/Services/IConfigApplier.cs` (~line 51-56, alongside `TapRetryProgression`)
-- [ ] T008 [US2] Verify build passes and T002-T003 tests are green
+- [X] T004 [P] [US2] Implement `CoordinateJitter` static helper in `src/GameBot.Domain/Services/CoordinateJitter.cs` — `Apply(int x, int y, int radiusPx)` returns `(x, y)` unchanged when `radiusPx <= 0`; otherwise draws independent per-axis offsets from `[-radiusPx, +radiusPx]` using an LCG seeded from `DateTime.UtcNow.Ticks` XORed with an `Interlocked.Increment`-based counter (mirrors `SequenceRunner.GetAppliedDelay` pattern, per research R-002), then clamps each result with `Math.Max(0, ...)`
+- [X] T005 [P] [US2] Add `TapJitterRadiusPx` property (`int`, default `5`) with XML doc comment to `src/GameBot.Domain/Config/AppConfig.cs`, documenting `GAMEBOT_TAP_JITTER_RADIUS_PX` mapping, `0` disables, negative falls back to 5, per data-model.md
+- [X] T006 [US2] Wire `GAMEBOT_TAP_JITTER_RADIUS_PX` in the `AppConfig` singleton registration in `src/GameBot.Service/Program.cs` (~line 145-172): `int.TryParse(jitterEnv, out var jParsed) && jParsed >= 0 ? jParsed : 5`, include `TapJitterRadiusPx = jitterRadius` in the constructed `AppConfig`
+- [X] T007 [US2] Add `_appConfig.TapJitterRadiusPx = GetInt(snapshot, "GAMEBOT_TAP_JITTER_RADIUS_PX", 5) is var jitter && jitter >= 0 ? jitter : 5;` to `Apply` in `src/GameBot.Service/Services/IConfigApplier.cs` (~line 51-56, alongside `TapRetryProgression`)
+- [X] T008 [US2] Verify build passes and T002-T003 tests are green
 
 **Checkpoint**: `AppConfig.TapJitterRadiusPx` and `CoordinateJitter.Apply` are available and validated. US1 dispatch-time jitter can now be implemented.
 
@@ -56,21 +56,21 @@
 
 ### Tests for User Story 1
 
-- [ ] T009 [P] [US1] Add `tests/unit/Emulator/SessionManagerJitterTests.cs` — construct `SessionManager` in stub mode (set `GAMEBOT_USE_ADB=false` for the test) and verify `SendInputsAsync` mutates `InputAction.Args["x"]/["y"]` for `Type=="tap"` and `["x1"]["y1"]["x2"]["y2"]` for `Type=="swipe"` to values within the default ±5px radius of the original targets; start/end swipe offsets are independent (not identical across many samples); near-zero targets never produce negative results (jitter normalization runs before the ADB-mode branch, so stub mode exercises it)
-- [ ] T010 [P] [US1] Add unit test(s) to `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs` — when a primitive tap is detected and dispatched, the resulting `PrimitiveTapStepOutcome.ExecutedPoint` reflects the (possibly jittered) coordinates read back from the dispatched `InputAction.Args`, while `ResolvedPoint` continues to hold the pre-jitter detected target
-- [ ] T011 [P] [US1] Add unit test(s) to `tests/unit/Commands/CommandExecutorSwipeTests.cs` — for an explicit `Swipe` step, `PrimitiveTapStepOutcome.TargetSwipe` reflects `step.Swipe.StartX/Y`/`EndX/Y` and `ExecutedSwipe` reflects the (possibly jittered) coordinates read back from the dispatched `InputAction.Args`
+- [X] T009 [P] [US1] Add `tests/unit/Emulator/SessionManagerJitterTests.cs` — construct `SessionManager` in stub mode (set `GAMEBOT_USE_ADB=false` for the test) and verify `SendInputsAsync` mutates `InputAction.Args["x"]/["y"]` for `Type=="tap"` and `["x1"]["y1"]["x2"]["y2"]` for `Type=="swipe"` to values within the default ±5px radius of the original targets; start/end swipe offsets are independent (not identical across many samples); near-zero targets never produce negative results (jitter normalization runs before the ADB-mode branch, so stub mode exercises it)
+- [X] T010 [P] [US1] Add unit test(s) to `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs` — when a primitive tap is detected and dispatched, the resulting `PrimitiveTapStepOutcome.ExecutedPoint` reflects the (possibly jittered) coordinates read back from the dispatched `InputAction.Args`, while `ResolvedPoint` continues to hold the pre-jitter detected target
+- [X] T011 [P] [US1] Add unit test(s) to `tests/unit/Commands/CommandExecutorSwipeTests.cs` — for an explicit `Swipe` step, `PrimitiveTapStepOutcome.TargetSwipe` reflects `step.Swipe.StartX/Y`/`EndX/Y` and `ExecutedSwipe` reflects the (possibly jittered) coordinates read back from the dispatched `InputAction.Args`
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Add `PrimitiveSwipePoints(PrimitiveTapResolvedPoint Start, PrimitiveTapResolvedPoint End)` record and append optional `ExecutedPoint` (`PrimitiveTapResolvedPoint?`), `TargetSwipe` (`PrimitiveSwipePoints?`), `ExecutedSwipe` (`PrimitiveSwipePoints?`) parameters to `PrimitiveTapStepOutcome` in `src/GameBot.Service/Services/ICommandExecutor.cs`
-- [ ] T013 [US1] In `src/GameBot.Emulator/Session/SessionManager.cs` `SendInputsAsync`, add a jitter normalization pass at the **top of the method** (after the session lookup, **before** the `_useAdb`/`DeviceSerial` branch at ~line 114): materialize `actions` once, and for each action call `CoordinateJitter.Apply` with `_appConfig.TapJitterRadiusPx` — for `Type=="tap"` on `Args["x"]`/`["y"]`, for `Type=="swipe"` independently on `Args["x1"]/["y1"]` and `["x2"]/["y2"]` — writing the jittered values back into the same `Args` entries. This ensures jitter applies (and the caller-visible `Args` mutation occurs) in **both** real-ADB mode and stub mode (`GAMEBOT_USE_ADB=false` / no bound device, where the per-action ADB loop is skipped entirely), keeping behaviour consistent and the T009/T021/T022 tests runnable in CI
-- [ ] T014 [US1] In `TryDetectAndTap` in `src/GameBot.Service/Services/CommandExecutor.cs` (~line 574-585), after `SendInputsAsync` returns, read back `tapArgs["x1"]`/`["y1"]` and pass `new PrimitiveTapResolvedPoint(executedX, executedY)` as `ExecutedPoint` in the constructed `PrimitiveTapStepOutcome` (keeping existing `ResolvedPoint = (x, y)` as the pre-jitter target)
-- [ ] T015 [US1] In the `Swipe` step handling in `src/GameBot.Service/Services/CommandExecutor.cs` (~line 233-249), after `SendInputsAsync` returns, build `TargetSwipe` from `step.Swipe.StartX/Y`/`EndX/Y` and `ExecutedSwipe` by reading back `swipeArgs["x1"]/["y1"]/["x2"]/["y2"]`, and include both in the returned `PrimitiveTapStepOutcome`
-- [ ] T016 [US1] In `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` `LogCommandExecutionAsync` (~line 136-146), extend the "Tap executed at (X,Y)." detail item to include `ExecutedPoint` when present (e.g. `"Tap targeted (X,Y), executed at (X',Y')."` when they differ, otherwise unchanged text), and add an analogous detail item for swipe steps using `TargetSwipe`/`ExecutedSwipe`
-- [ ] T017 [US1] In `src/GameBot.Service/Models/Commands.cs` (~line 80-96), add a `SwipePointsDto` (`{ Start, End }`, each a `ResolvedPointDto`) and add `ResolvedPointDto? ExecutedPoint`, `SwipePointsDto? TargetSwipe`, `SwipePointsDto? ExecutedSwipe` properties to `StepExecutionOutcomeDto` — reuse the existing `ResolvedPointDto` for all point shapes (do NOT add a duplicate `ExecutedPointDto` type)
-- [ ] T018 [P] [US1] Map `ExecutedPoint`/`TargetSwipe`/`ExecutedSwipe` from `PrimitiveTapStepOutcome` to the new DTO fields in `ToResponseOutcome` in `src/GameBot.Service/Endpoints/CommandsEndpoints.cs` (~line 168-184)
-- [ ] T019 [P] [US1] Map `executedPoint`/`targetSwipe`/`executedSwipe` from `PrimitiveTapStepOutcome` into the anonymous outcome object in `ToResponseOutcome` in `src/GameBot.Service/Endpoints/StepsEndpoints.cs` (~line 164-171)
-- [ ] T020 [US1] Verify build passes and T009-T011 tests (plus existing suite) are green
+- [X] T012 [US1] Add `PrimitiveSwipePoints(PrimitiveTapResolvedPoint Start, PrimitiveTapResolvedPoint End)` record and append optional `ExecutedPoint` (`PrimitiveTapResolvedPoint?`), `TargetSwipe` (`PrimitiveSwipePoints?`), `ExecutedSwipe` (`PrimitiveSwipePoints?`) parameters to `PrimitiveTapStepOutcome` in `src/GameBot.Service/Services/ICommandExecutor.cs`
+- [X] T013 [US1] In `src/GameBot.Emulator/Session/SessionManager.cs` `SendInputsAsync`, add a jitter normalization pass at the **top of the method** (after the session lookup, **before** the `_useAdb`/`DeviceSerial` branch at ~line 114): materialize `actions` once, and for each action call `CoordinateJitter.Apply` with `_appConfig.TapJitterRadiusPx` — for `Type=="tap"` on `Args["x"]`/`["y"]`, for `Type=="swipe"` independently on `Args["x1"]/["y1"]` and `["x2"]/["y2"]` — writing the jittered values back into the same `Args` entries. This ensures jitter applies (and the caller-visible `Args` mutation occurs) in **both** real-ADB mode and stub mode (`GAMEBOT_USE_ADB=false` / no bound device, where the per-action ADB loop is skipped entirely), keeping behaviour consistent and the T009/T021/T022 tests runnable in CI
+- [X] T014 [US1] In `TryDetectAndTap` in `src/GameBot.Service/Services/CommandExecutor.cs` (~line 574-585), after `SendInputsAsync` returns, read back `tapArgs["x1"]`/`["y1"]` and pass `new PrimitiveTapResolvedPoint(executedX, executedY)` as `ExecutedPoint` in the constructed `PrimitiveTapStepOutcome` (keeping existing `ResolvedPoint = (x, y)` as the pre-jitter target)
+- [X] T015 [US1] In the `Swipe` step handling in `src/GameBot.Service/Services/CommandExecutor.cs` (~line 233-249), after `SendInputsAsync` returns, build `TargetSwipe` from `step.Swipe.StartX/Y`/`EndX/Y` and `ExecutedSwipe` by reading back `swipeArgs["x1"]/["y1"]/["x2"]/["y2"]`, and include both in the returned `PrimitiveTapStepOutcome`
+- [X] T016 [US1] In `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` `LogCommandExecutionAsync` (~line 136-146), extend the "Tap executed at (X,Y)." detail item to include `ExecutedPoint` when present (e.g. `"Tap targeted (X,Y), executed at (X',Y')."` when they differ, otherwise unchanged text), and add an analogous detail item for swipe steps using `TargetSwipe`/`ExecutedSwipe`
+- [X] T017 [US1] In `src/GameBot.Service/Models/Commands.cs` (~line 80-96), add a `SwipePointsDto` (`{ Start, End }`, each a `ResolvedPointDto`) and add `ResolvedPointDto? ExecutedPoint`, `SwipePointsDto? TargetSwipe`, `SwipePointsDto? ExecutedSwipe` properties to `StepExecutionOutcomeDto` — reuse the existing `ResolvedPointDto` for all point shapes (do NOT add a duplicate `ExecutedPointDto` type)
+- [X] T018 [P] [US1] Map `ExecutedPoint`/`TargetSwipe`/`ExecutedSwipe` from `PrimitiveTapStepOutcome` to the new DTO fields in `ToResponseOutcome` in `src/GameBot.Service/Endpoints/CommandsEndpoints.cs` (~line 168-184)
+- [X] T019 [P] [US1] Map `executedPoint`/`targetSwipe`/`executedSwipe` from `PrimitiveTapStepOutcome` into the anonymous outcome object in `ToResponseOutcome` in `src/GameBot.Service/Endpoints/StepsEndpoints.cs` (~line 164-171)
+- [X] T020 [US1] Verify build passes and T009-T011 tests (plus existing suite) are green
 
 **Checkpoint**: All taps and swipes dispatched via `SessionManager` are jittered automatically (FR-001/002/003/007/012), and step outcomes/execution logs report both target and executed coordinates (FR-013/SC-006).
 
@@ -86,12 +86,12 @@
 
 ### Tests for User Story 2
 
-- [ ] T021 [US2] Add test to `tests/unit/Emulator/SessionManagerJitterTests.cs` (stub mode, as in T009) — construct `SessionManager` with `AppConfig { TapJitterRadiusPx = 0 }`; verify `SendInputsAsync` leaves tap and swipe `Args` coordinates exactly equal to the original target values (FR-005, US2 acceptance scenario 1)
-- [ ] T022 [US2] Add test to `tests/unit/Emulator/SessionManagerJitterTests.cs` (stub mode, as in T009) — construct `SessionManager` with `AppConfig { TapJitterRadiusPx = 20 }`; verify dispatched coordinates fall within `[-20,+20]` of the target across many samples and that values outside the default `[-5,+5]` range occur (confirms the configured radius, not the default, governs the offset; US2 acceptance scenario 2)
+- [X] T021 [US2] Add test to `tests/unit/Emulator/SessionManagerJitterTests.cs` (stub mode, as in T009) — construct `SessionManager` with `AppConfig { TapJitterRadiusPx = 0 }`; verify `SendInputsAsync` leaves tap and swipe `Args` coordinates exactly equal to the original target values (FR-005, US2 acceptance scenario 1)
+- [X] T022 [US2] Add test to `tests/unit/Emulator/SessionManagerJitterTests.cs` (stub mode, as in T009) — construct `SessionManager` with `AppConfig { TapJitterRadiusPx = 20 }`; verify dispatched coordinates fall within `[-20,+20]` of the target across many samples and that values outside the default `[-5,+5]` range occur (confirms the configured radius, not the default, governs the offset; US2 acceptance scenario 2)
 
 ### Implementation for User Story 2
 
-- [ ] T023 [US2] Verify build passes and T021-T022 tests are green
+- [X] T023 [US2] Verify build passes and T021-T022 tests are green
 
 **Checkpoint**: Jitter radius is fully configurable end-to-end, including disabling it (US2 acceptance scenarios 1-4 satisfied).
 
@@ -105,13 +105,13 @@
 
 ### Tests for User Story 3
 
-- [ ] T024 [P] [US3] Add tests to `tests/unit/ConfigMaskingAndMergeTests.cs` (or `ConfigUpdateTests.cs`) asserting (a) `RefreshAsync` snapshot `Parameters` contains `GAMEBOT_TAP_JITTER_RADIUS_PX` with default value `5` and source `Default` when not otherwise set, and (b) a value saved in `config/config.json` for `GAMEBOT_TAP_JITTER_RADIUS_PX` is reflected in the snapshot with source `File` (FR-008 precedence: default → saved file → environment)
+- [X] T024 [P] [US3] Add tests to `tests/unit/ConfigMaskingAndMergeTests.cs` (or `ConfigUpdateTests.cs`) asserting (a) `RefreshAsync` snapshot `Parameters` contains `GAMEBOT_TAP_JITTER_RADIUS_PX` with default value `5` and source `Default` when not otherwise set, and (b) a value saved in `config/config.json` for `GAMEBOT_TAP_JITTER_RADIUS_PX` is reflected in the snapshot with source `File` (FR-008 precedence: default → saved file → environment)
 
 ### Implementation for User Story 3
 
-- [ ] T025 [US3] Add `["GAMEBOT_TAP_JITTER_RADIUS_PX"] = 5` to `BuildDefaultRelevantKeys()` in `src/GameBot.Service/Services/ConfigSnapshotService.cs` (~line 259-260, alongside `GAMEBOT_TAP_RETRY_COUNT`/`GAMEBOT_TAP_RETRY_PROGRESSION`)
-- [ ] T026 [P] [US3] Add a `GAMEBOT_TAP_JITTER_RADIUS_PX` entry to `ENVIRONMENT.md` (alongside the `ADB / Emulator` or tap-retry section) documenting purpose, default `5`, `0` disables jitter, negative values fall back to `5`, and noting that jitter applies to **all** dispatch paths including the raw `POST /sessions/{id}/inputs` API (radius `0` is the escape hatch for pixel-exact input)
-- [ ] T027 [US3] Verify build passes and T024 test is green; manually confirm the web-ui Configuration page lists `GAMEBOT_TAP_JITTER_RADIUS_PX` and that no jitter-specific control exists in the command authoring or execution UIs (FR-011)
+- [X] T025 [US3] Add `["GAMEBOT_TAP_JITTER_RADIUS_PX"] = 5` to `BuildDefaultRelevantKeys()` in `src/GameBot.Service/Services/ConfigSnapshotService.cs` (~line 259-260, alongside `GAMEBOT_TAP_RETRY_COUNT`/`GAMEBOT_TAP_RETRY_PROGRESSION`)
+- [X] T026 [P] [US3] Add a `GAMEBOT_TAP_JITTER_RADIUS_PX` entry to `ENVIRONMENT.md` (alongside the `ADB / Emulator` or tap-retry section) documenting purpose, default `5`, `0` disables jitter, negative values fall back to `5`, and noting that jitter applies to **all** dispatch paths including the raw `POST /sessions/{id}/inputs` API (radius `0` is the escape hatch for pixel-exact input)
+- [X] T027 [US3] Verify build passes and T024 test is green; manually confirm the web-ui Configuration page lists `GAMEBOT_TAP_JITTER_RADIUS_PX` and that no jitter-specific control exists in the command authoring or execution UIs (FR-011)
 
 **Checkpoint**: The jitter radius parameter is discoverable and documented exactly like other `GAMEBOT_*` parameters, with no new UI surface.
 
@@ -121,9 +121,9 @@
 
 **Purpose**: Documentation and final validation.
 
-- [ ] T028 [P] Add `CHANGELOG.md` entry documenting the tap-point jitter feature, the `GAMEBOT_TAP_JITTER_RADIUS_PX` configuration parameter, and its default
-- [ ] T029 Run full regression: `dotnet build -c Debug && dotnet test -c Debug` — all tests pass, 0 warnings, 0 errors
-- [ ] T030 Validate `quickstart.md` scenarios manually: default jitter (±5px) varies dispatched coordinates run-to-run; `GAMEBOT_TAP_JITTER_RADIUS_PX=0` disables jitter; execution log shows target vs. executed coordinates
+- [X] T028 [P] Add `CHANGELOG.md` entry documenting the tap-point jitter feature, the `GAMEBOT_TAP_JITTER_RADIUS_PX` configuration parameter, and its default
+- [X] T029 Run full regression: `dotnet build -c Debug && dotnet test -c Debug` — all tests pass, 0 warnings, 0 errors
+- [X] T030 Validate `quickstart.md` scenarios manually: default jitter (±5px) varies dispatched coordinates run-to-run; `GAMEBOT_TAP_JITTER_RADIUS_PX=0` disables jitter; execution log shows target vs. executed coordinates
 
 ---
 

--- a/specs/058-tap-point-jitter/tasks.md
+++ b/specs/058-tap-point-jitter/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: Tap-Point Jitter
+
+**Input**: Design documents from `/specs/058-tap-point-jitter/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Required per constitution (Principle II: Testing Standards).
+
+**Organization**: Tasks are grouped by user story. US2 (configuration) is foundational — the `TapJitterRadiusPx` config property and the `CoordinateJitter` helper it parameterizes must exist before US1's dispatch-time jitter can be implemented. US3 (UI/docs visibility) only requires the config property to exist and is independent of US1.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new projects or directories needed. This phase verifies the build is green before changes begin.
+
+- [ ] T001 Verify build and full test suite pass (`dotnet build -c Debug && dotnet test -c Debug`)
+
+---
+
+## Phase 2: Foundational — Jitter Helper & Configuration (US2, Priority: P2) 🎯 Prerequisite
+
+**Purpose**: Introduce the `TapJitterRadiusPx` configuration property and the `CoordinateJitter` helper that US1 depends on. Must be complete before US1 work begins.
+
+**Goal**: `AppConfig.TapJitterRadiusPx` (default 5, ≥0, negative→default) is wired through `Program.cs` and `IConfigApplier`; `CoordinateJitter.Apply` computes clamped per-axis offsets per `data-model.md`.
+
+**Independent Test**: Unit tests for `CoordinateJitter.Apply` (radius=0 passthrough, radius=N stays within bounds, never negative, independent calls vary) and for `AppConfig`/`ConfigApplier` validation (default 5, 0 valid, negative falls back to 5) pass.
+
+### Tests for Foundational Phase
+
+- [ ] T002 [P] [US2] Add `tests/unit/Domain/CoordinateJitterTests.cs` — radius=0 returns input unchanged; radius=N produces results within `[x-N,x+N]`/`[y-N,y+N]` across many samples; near-zero coordinates with radius>0 never go negative; consecutive calls (e.g. 4 in a row) produce varying offsets (seed-uniqueness per research R-002)
+- [ ] T003 [P] [US2] Add `DefaultTapJitterRadiusPxIsFive`, `TapJitterRadiusPxCanBeSetToZero`, `TapJitterRadiusPxNegativeFallsBackToDefault` tests to `tests/unit/Config/AppConfigValidationTests.cs`
+
+### Implementation for Foundational Phase
+
+- [ ] T004 [P] [US2] Implement `CoordinateJitter` static helper in `src/GameBot.Domain/Services/CoordinateJitter.cs` — `Apply(int x, int y, int radiusPx)` returns `(x, y)` unchanged when `radiusPx <= 0`; otherwise draws independent per-axis offsets from `[-radiusPx, +radiusPx]` using an LCG seeded from `DateTime.UtcNow.Ticks` XORed with an `Interlocked.Increment`-based counter (mirrors `SequenceRunner.GetAppliedDelay` pattern, per research R-002), then clamps each result with `Math.Max(0, ...)`
+- [ ] T005 [P] [US2] Add `TapJitterRadiusPx` property (`int`, default `5`) with XML doc comment to `src/GameBot.Domain/Config/AppConfig.cs`, documenting `GAMEBOT_TAP_JITTER_RADIUS_PX` mapping, `0` disables, negative falls back to 5, per data-model.md
+- [ ] T006 [US2] Wire `GAMEBOT_TAP_JITTER_RADIUS_PX` in the `AppConfig` singleton registration in `src/GameBot.Service/Program.cs` (~line 145-172): `int.TryParse(jitterEnv, out var jParsed) && jParsed >= 0 ? jParsed : 5`, include `TapJitterRadiusPx = jitterRadius` in the constructed `AppConfig`
+- [ ] T007 [US2] Add `_appConfig.TapJitterRadiusPx = GetInt(snapshot, "GAMEBOT_TAP_JITTER_RADIUS_PX", 5) is var jitter && jitter >= 0 ? jitter : 5;` to `Apply` in `src/GameBot.Service/Services/IConfigApplier.cs` (~line 51-56, alongside `TapRetryProgression`)
+- [ ] T008 [US2] Verify build passes and T002-T003 tests are green
+
+**Checkpoint**: `AppConfig.TapJitterRadiusPx` and `CoordinateJitter.Apply` are available and validated. US1 dispatch-time jitter can now be implemented.
+
+---
+
+## Phase 3: User Story 1 — Every Executed Tap and Swipe Lands Near, Not Exactly On, the Target (Priority: P1) 🎯 MVP
+
+**Goal**: `SessionManager.SendInputsAsync` applies `CoordinateJitter` to tap `(x,y)` and swipe `(x1,y1,x2,y2)` args before dispatch, mutating `InputAction.Args` in place; `CommandExecutor` reads back the post-jitter values and reports both pre-jitter target and post-jitter executed coordinates in step outcomes and execution logs.
+
+**Independent Test**: Run a primitive tap step at a fixed target multiple times; observe (via `SessionManagerJitterTests` and `CommandExecutorPrimitiveTapTests`/`CommandExecutorSwipeTests`) that dispatched coordinates vary within ±default radius of the target, swipe endpoints are jittered independently, coordinates near (0,0) never go negative, and step outcomes/execution log details report both target and executed points.
+
+### Tests for User Story 1
+
+- [ ] T009 [P] [US1] Add `tests/unit/Emulator/SessionManagerJitterTests.cs` — construct `SessionManager` in stub mode (set `GAMEBOT_USE_ADB=false` for the test) and verify `SendInputsAsync` mutates `InputAction.Args["x"]/["y"]` for `Type=="tap"` and `["x1"]["y1"]["x2"]["y2"]` for `Type=="swipe"` to values within the default ±5px radius of the original targets; start/end swipe offsets are independent (not identical across many samples); near-zero targets never produce negative results (jitter normalization runs before the ADB-mode branch, so stub mode exercises it)
+- [ ] T010 [P] [US1] Add unit test(s) to `tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs` — when a primitive tap is detected and dispatched, the resulting `PrimitiveTapStepOutcome.ExecutedPoint` reflects the (possibly jittered) coordinates read back from the dispatched `InputAction.Args`, while `ResolvedPoint` continues to hold the pre-jitter detected target
+- [ ] T011 [P] [US1] Add unit test(s) to `tests/unit/Commands/CommandExecutorSwipeTests.cs` — for an explicit `Swipe` step, `PrimitiveTapStepOutcome.TargetSwipe` reflects `step.Swipe.StartX/Y`/`EndX/Y` and `ExecutedSwipe` reflects the (possibly jittered) coordinates read back from the dispatched `InputAction.Args`
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Add `PrimitiveSwipePoints(PrimitiveTapResolvedPoint Start, PrimitiveTapResolvedPoint End)` record and append optional `ExecutedPoint` (`PrimitiveTapResolvedPoint?`), `TargetSwipe` (`PrimitiveSwipePoints?`), `ExecutedSwipe` (`PrimitiveSwipePoints?`) parameters to `PrimitiveTapStepOutcome` in `src/GameBot.Service/Services/ICommandExecutor.cs`
+- [ ] T013 [US1] In `src/GameBot.Emulator/Session/SessionManager.cs` `SendInputsAsync`, add a jitter normalization pass at the **top of the method** (after the session lookup, **before** the `_useAdb`/`DeviceSerial` branch at ~line 114): materialize `actions` once, and for each action call `CoordinateJitter.Apply` with `_appConfig.TapJitterRadiusPx` — for `Type=="tap"` on `Args["x"]`/`["y"]`, for `Type=="swipe"` independently on `Args["x1"]/["y1"]` and `["x2"]/["y2"]` — writing the jittered values back into the same `Args` entries. This ensures jitter applies (and the caller-visible `Args` mutation occurs) in **both** real-ADB mode and stub mode (`GAMEBOT_USE_ADB=false` / no bound device, where the per-action ADB loop is skipped entirely), keeping behaviour consistent and the T009/T021/T022 tests runnable in CI
+- [ ] T014 [US1] In `TryDetectAndTap` in `src/GameBot.Service/Services/CommandExecutor.cs` (~line 574-585), after `SendInputsAsync` returns, read back `tapArgs["x1"]`/`["y1"]` and pass `new PrimitiveTapResolvedPoint(executedX, executedY)` as `ExecutedPoint` in the constructed `PrimitiveTapStepOutcome` (keeping existing `ResolvedPoint = (x, y)` as the pre-jitter target)
+- [ ] T015 [US1] In the `Swipe` step handling in `src/GameBot.Service/Services/CommandExecutor.cs` (~line 233-249), after `SendInputsAsync` returns, build `TargetSwipe` from `step.Swipe.StartX/Y`/`EndX/Y` and `ExecutedSwipe` by reading back `swipeArgs["x1"]/["y1"]/["x2"]/["y2"]`, and include both in the returned `PrimitiveTapStepOutcome`
+- [ ] T016 [US1] In `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` `LogCommandExecutionAsync` (~line 136-146), extend the "Tap executed at (X,Y)." detail item to include `ExecutedPoint` when present (e.g. `"Tap targeted (X,Y), executed at (X',Y')."` when they differ, otherwise unchanged text), and add an analogous detail item for swipe steps using `TargetSwipe`/`ExecutedSwipe`
+- [ ] T017 [US1] In `src/GameBot.Service/Models/Commands.cs` (~line 80-96), add a `SwipePointsDto` (`{ Start, End }`, each a `ResolvedPointDto`) and add `ResolvedPointDto? ExecutedPoint`, `SwipePointsDto? TargetSwipe`, `SwipePointsDto? ExecutedSwipe` properties to `StepExecutionOutcomeDto` — reuse the existing `ResolvedPointDto` for all point shapes (do NOT add a duplicate `ExecutedPointDto` type)
+- [ ] T018 [P] [US1] Map `ExecutedPoint`/`TargetSwipe`/`ExecutedSwipe` from `PrimitiveTapStepOutcome` to the new DTO fields in `ToResponseOutcome` in `src/GameBot.Service/Endpoints/CommandsEndpoints.cs` (~line 168-184)
+- [ ] T019 [P] [US1] Map `executedPoint`/`targetSwipe`/`executedSwipe` from `PrimitiveTapStepOutcome` into the anonymous outcome object in `ToResponseOutcome` in `src/GameBot.Service/Endpoints/StepsEndpoints.cs` (~line 164-171)
+- [ ] T020 [US1] Verify build passes and T009-T011 tests (plus existing suite) are green
+
+**Checkpoint**: All taps and swipes dispatched via `SessionManager` are jittered automatically (FR-001/002/003/007/012), and step outcomes/execution logs report both target and executed coordinates (FR-013/SC-006).
+
+---
+
+## Phase 4: User Story 2 — Operator Tunes or Disables Jitter via Configuration (Priority: P2)
+
+**Goal**: Confirm end-to-end that changing `GAMEBOT_TAP_JITTER_RADIUS_PX` (including to `0`) changes dispatch behaviour without any sequence/command/step edits.
+
+**Independent Test**: With `TapJitterRadiusPx=0`, dispatched coordinates exactly equal the targets. With `TapJitterRadiusPx=20`, the maximum per-axis offset observed matches 20 (not the default 5).
+
+> **Note**: The configuration plumbing (`AppConfig.TapJitterRadiusPx`, `Program.cs`, `ConfigApplier`) was completed in Phase 2, and the dispatch-time application (`CoordinateJitter.Apply` called from `SendInputsAsync`) was completed in Phase 3. This phase adds end-to-end tests confirming the configured radius actually controls dispatch behaviour.
+
+### Tests for User Story 2
+
+- [ ] T021 [US2] Add test to `tests/unit/Emulator/SessionManagerJitterTests.cs` (stub mode, as in T009) — construct `SessionManager` with `AppConfig { TapJitterRadiusPx = 0 }`; verify `SendInputsAsync` leaves tap and swipe `Args` coordinates exactly equal to the original target values (FR-005, US2 acceptance scenario 1)
+- [ ] T022 [US2] Add test to `tests/unit/Emulator/SessionManagerJitterTests.cs` (stub mode, as in T009) — construct `SessionManager` with `AppConfig { TapJitterRadiusPx = 20 }`; verify dispatched coordinates fall within `[-20,+20]` of the target across many samples and that values outside the default `[-5,+5]` range occur (confirms the configured radius, not the default, governs the offset; US2 acceptance scenario 2)
+
+### Implementation for User Story 2
+
+- [ ] T023 [US2] Verify build passes and T021-T022 tests are green
+
+**Checkpoint**: Jitter radius is fully configurable end-to-end, including disabling it (US2 acceptance scenarios 1-4 satisfied).
+
+---
+
+## Phase 5: User Story 3 — Jitter Setting Visible Alongside Other Configuration Values (Priority: P3)
+
+**Goal**: `GAMEBOT_TAP_JITTER_RADIUS_PX` appears in the general Configuration variables list with its current value, default, and source, and is documented in `ENVIRONMENT.md`. No per-step UI control is introduced.
+
+**Independent Test**: `GET /api/config` (and the web-ui Configuration page it powers) includes `GAMEBOT_TAP_JITTER_RADIUS_PX` with value `5` when unset; `ENVIRONMENT.md` documents the parameter.
+
+### Tests for User Story 3
+
+- [ ] T024 [P] [US3] Add tests to `tests/unit/ConfigMaskingAndMergeTests.cs` (or `ConfigUpdateTests.cs`) asserting (a) `RefreshAsync` snapshot `Parameters` contains `GAMEBOT_TAP_JITTER_RADIUS_PX` with default value `5` and source `Default` when not otherwise set, and (b) a value saved in `config/config.json` for `GAMEBOT_TAP_JITTER_RADIUS_PX` is reflected in the snapshot with source `File` (FR-008 precedence: default → saved file → environment)
+
+### Implementation for User Story 3
+
+- [ ] T025 [US3] Add `["GAMEBOT_TAP_JITTER_RADIUS_PX"] = 5` to `BuildDefaultRelevantKeys()` in `src/GameBot.Service/Services/ConfigSnapshotService.cs` (~line 259-260, alongside `GAMEBOT_TAP_RETRY_COUNT`/`GAMEBOT_TAP_RETRY_PROGRESSION`)
+- [ ] T026 [P] [US3] Add a `GAMEBOT_TAP_JITTER_RADIUS_PX` entry to `ENVIRONMENT.md` (alongside the `ADB / Emulator` or tap-retry section) documenting purpose, default `5`, `0` disables jitter, negative values fall back to `5`, and noting that jitter applies to **all** dispatch paths including the raw `POST /sessions/{id}/inputs` API (radius `0` is the escape hatch for pixel-exact input)
+- [ ] T027 [US3] Verify build passes and T024 test is green; manually confirm the web-ui Configuration page lists `GAMEBOT_TAP_JITTER_RADIUS_PX` and that no jitter-specific control exists in the command authoring or execution UIs (FR-011)
+
+**Checkpoint**: The jitter radius parameter is discoverable and documented exactly like other `GAMEBOT_*` parameters, with no new UI surface.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and final validation.
+
+- [ ] T028 [P] Add `CHANGELOG.md` entry documenting the tap-point jitter feature, the `GAMEBOT_TAP_JITTER_RADIUS_PX` configuration parameter, and its default
+- [ ] T029 Run full regression: `dotnet build -c Debug && dotnet test -c Debug` — all tests pass, 0 warnings, 0 errors
+- [ ] T030 Validate `quickstart.md` scenarios manually: default jitter (±5px) varies dispatched coordinates run-to-run; `GAMEBOT_TAP_JITTER_RADIUS_PX=0` disables jitter; execution log shows target vs. executed coordinates
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2 / US2 config+helper)**: Depends on Phase 1 — BLOCKS Phase 3
+- **Dispatch-Time Jitter (Phase 3 / US1)**: Depends on Phase 2 (needs `AppConfig.TapJitterRadiusPx` and `CoordinateJitter`)
+- **Configurability Verification (Phase 4 / US2)**: Depends on Phase 3 (needs jitter applied in `SendInputsAsync` to verify against)
+- **UI/Docs Visibility (Phase 5 / US3)**: Depends on Phase 2 only (needs the config property to exist in `AppConfig`/snapshot); independent of Phase 3/4
+- **Polish (Phase 6)**: Depends on all prior phases
+
+### User Story Dependencies
+
+- **US2 (Configuration, foundational part)**: No dependencies on other stories — provides `TapJitterRadiusPx` and `CoordinateJitter`
+- **US1 (Automatic Jitter)**: Depends on US2's foundational config/helper (Phase 2)
+- **US2 (Configurability verification, Phase 4)**: Depends on US1 (Phase 3) for the dispatch-time application to verify
+- **US3 (Visibility)**: Depends on US2's foundational config/helper (Phase 2) only
+
+### Within Each Phase
+
+- Tests MUST be written first and MUST fail before implementation
+- Config/helper before dispatch logic
+- Dispatch logic before outcome/log/DTO propagation
+- Verify build + tests green at each checkpoint
+
+### Parallel Opportunities
+
+Within Phase 2:
+- T002, T003 (tests) and T004, T005 (implementation) can all proceed in parallel [P] — different files, no interdependency until T006/T007 wire them together
+
+Within Phase 3:
+- T009, T010, T011 (all tests) can be written in parallel [P]
+- T018, T019 (DTO endpoint mappings) can be done in parallel [P] after T012/T017
+
+Within Phase 4:
+- T021 and T022 edit the same test file (`SessionManagerJitterTests.cs`) and are therefore sequential (no [P])
+
+Within Phase 5:
+- T024 (test) and T026 (docs) can be done in parallel [P]
+
+Within Phase 6:
+- T028 can be done in parallel [P] with final verification
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Launch foundational tests and implementation together:
+Task: "Add tests/unit/Domain/CoordinateJitterTests.cs"
+Task: "Add AppConfig validation tests to tests/unit/Config/AppConfigValidationTests.cs"
+Task: "Implement CoordinateJitter in src/GameBot.Domain/Services/CoordinateJitter.cs"
+Task: "Add TapJitterRadiusPx property to src/GameBot.Domain/Config/AppConfig.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP Scope
+
+The MVP is **Phase 1 + Phase 2 + Phase 3** (US2 foundational config/helper + US1 automatic dispatch-time jitter). This delivers the core value: every tap and swipe lands within a configurable radius of its target, with full pre/post-jitter reporting.
+
+### Incremental Delivery
+
+1. **Increment 1** (Phases 1-2): Config property and jitter helper exist and are validated — no dispatch behaviour change yet
+2. **Increment 2** (Phase 3): Jitter actively applied to every tap/swipe dispatch; outcomes/logs report target vs. executed coordinates
+3. **Increment 3** (Phase 4): Configurability (including disable) verified end-to-end
+4. **Increment 4** (Phase 5): Parameter documented and visible in the UI configuration list
+5. **Increment 5** (Phase 6): Documentation and full regression
+
+### Risk Mitigation
+
+- **Lowest risk**: `AppConfig`/`CoordinateJitter` additions (Phase 2) are additive and backward-compatible
+- **Medium risk**: `SessionManager.SendInputsAsync` change (Phase 3, T013) modifies the hot dispatch path — mitigated by `SessionManagerJitterTests` covering tap, swipe, radius=0, and clamping
+- **Low risk**: Outcome/DTO/log additions (T012, T014-T019) are additive new fields; existing `ResolvedPoint`-based consumers and `RecordingSessionManager`-based tests are unaffected since jitter only applies in the real `SessionManager`

--- a/src/GameBot.Domain/Config/AppConfig.cs
+++ b/src/GameBot.Domain/Config/AppConfig.cs
@@ -41,6 +41,14 @@ public sealed class AppConfig {
   public double TapRetryProgression { get; set; } = 1.0;
 
   /// <summary>
+  /// Maximum random per-axis offset in pixels applied independently to the X and Y coordinate
+  /// of every tap and swipe endpoint immediately before it is sent to the device.
+  /// <c>0</c> disables jitter (coordinates pass through unchanged); negative values fall back
+  /// to the default 5. Maps to <c>GAMEBOT_TAP_JITTER_RADIUS_PX</c> environment variable.
+  /// </summary>
+  public int TapJitterRadiusPx { get; set; } = 5;
+
+  /// <summary>
   /// Maximum number of ADB retries per operation.
   /// Maps to <c>GAMEBOT_ADB_RETRIES</c> environment variable. Default 2.
   /// </summary>

--- a/src/GameBot.Domain/Services/CoordinateJitter.cs
+++ b/src/GameBot.Domain/Services/CoordinateJitter.cs
@@ -1,0 +1,41 @@
+namespace GameBot.Domain.Services;
+
+/// <summary>
+/// Applies a small random offset ("jitter") to tap/swipe coordinates so repeated executions
+/// do not always land on the exact same pixel.
+/// <para>
+/// The X and Y offsets are each independently and uniformly drawn from
+/// <c>[-radiusPx, +radiusPx]</c> (a square jitter area). Results are clamped so they are
+/// never negative; no upper (screen-size) bound is applied. A radius of 0 (or any
+/// non-positive value) disables jitter and returns the input unchanged.
+/// </para>
+/// </summary>
+public static class CoordinateJitter {
+  private static int _sequence;
+
+  /// <summary>
+  /// Returns <paramref name="x"/>/<paramref name="y"/> offset independently per axis by a
+  /// random amount in <c>[-radiusPx, +radiusPx]</c>, clamped to be non-negative.
+  /// Returns the input unchanged when <paramref name="radiusPx"/> is 0 or negative.
+  /// </summary>
+  /// <param name="x">Target X coordinate (pixels).</param>
+  /// <param name="y">Target Y coordinate (pixels).</param>
+  /// <param name="radiusPx">Maximum per-axis offset in pixels; 0 disables jitter.</param>
+  public static (int X, int Y) Apply(int x, int y, int radiusPx) {
+    if (radiusPx <= 0) return (x, y);
+    return (Math.Max(0, x + NextOffset(radiusPx)), Math.Max(0, y + NextOffset(radiusPx)));
+  }
+
+  private static int NextOffset(int radiusPx) {
+    // Use non-crypto randomness via a bounded linear congruential fallback to satisfy CA5394 in non-security context.
+    // The tick-based seed is mixed with a process-wide counter so back-to-back calls within the
+    // same clock tick (e.g. the four offsets of one swipe) still produce independent values.
+    unchecked {
+      var sequence = Interlocked.Increment(ref _sequence);
+      var seed = (int)(DateTime.UtcNow.Ticks & 0x00000000FFFFFFFF) ^ (sequence * 486187739);
+      seed = 1664525 * seed + 1013904223; // LCG step
+      var range = (2 * radiusPx) + 1;
+      return Math.Abs(seed % range) - radiusPx;
+    }
+  }
+}

--- a/src/GameBot.Emulator/Session/SessionManager.cs
+++ b/src/GameBot.Emulator/Session/SessionManager.cs
@@ -108,13 +108,21 @@ public sealed class SessionManager : ISessionManager {
   public async Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) {
     if (!_sessions.TryGetValue(id, out var s)) return 0;
     s.LastActivity = DateTimeOffset.UtcNow;
-    var count = actions?.Count() ?? 0;
+    var actionList = actions?.ToList() ?? new List<InputAction>();
+    var count = actionList.Count;
+
+    // Tap-point jitter normalization: offset tap/swipe coordinates in place before any dispatch
+    // branch, so the ADB call and the caller-visible Args dictionary both reflect the executed
+    // coordinates, in real-ADB and stub modes alike.
+    foreach (var a in actionList) {
+      ApplyTapJitter(a);
+    }
 
     // If ADB enabled and we have a bound device, execute via ADB
     if (_useAdb && OperatingSystem.IsWindows() && !string.IsNullOrWhiteSpace(s.DeviceSerial)) {
       var adb = new AdbClient(_adbLogger).WithSerial(s.DeviceSerial);
       var executed = 0;
-      foreach (var a in actions ?? Array.Empty<InputAction>()) {
+      foreach (var a in actionList) {
         try {
           if (string.Equals(a.Type, "tap", StringComparison.OrdinalIgnoreCase)) {
             var x = GetInt(a.Args, "x");
@@ -211,14 +219,45 @@ public sealed class SessionManager : ISessionManager {
 
     Log.InputsAccepted(_logger, id, count);
     // Still honor delay pacing in stub mode (optional; only if delays exist)
-    if (actions is not null) {
-      foreach (var a in actions) {
-        if (a.DelayMs.HasValue && a.DelayMs.Value > 0) {
-          await Task.Delay(a.DelayMs.Value, ct).ConfigureAwait(false);
-        }
+    foreach (var a in actionList) {
+      if (a.DelayMs.HasValue && a.DelayMs.Value > 0) {
+        await Task.Delay(a.DelayMs.Value, ct).ConfigureAwait(false);
       }
     }
     return count;
+  }
+
+  /// <summary>
+  /// Applies the configured tap-point jitter (<see cref="GameBot.Domain.Config.AppConfig.TapJitterRadiusPx"/>)
+  /// to a tap's (x, y) or, independently per endpoint, a swipe's (x1, y1)/(x2, y2) coordinates,
+  /// mutating <see cref="InputAction.Args"/> in place. Actions of other types, actions with
+  /// missing/malformed coordinate args, and a radius of 0 leave the action unchanged.
+  /// </summary>
+  private void ApplyTapJitter(InputAction action) {
+    var radius = _appConfig.TapJitterRadiusPx;
+    if (radius <= 0) return;
+    try {
+      if (string.Equals(action.Type, "tap", StringComparison.OrdinalIgnoreCase)) {
+        if (!action.Args.ContainsKey("x") || !action.Args.ContainsKey("y")) return;
+        var (x, y) = GameBot.Domain.Services.CoordinateJitter.Apply(GetInt(action.Args, "x"), GetInt(action.Args, "y"), radius);
+        action.Args["x"] = x;
+        action.Args["y"] = y;
+      }
+      else if (string.Equals(action.Type, "swipe", StringComparison.OrdinalIgnoreCase)) {
+        if (!action.Args.ContainsKey("x1") || !action.Args.ContainsKey("y1") ||
+            !action.Args.ContainsKey("x2") || !action.Args.ContainsKey("y2")) return;
+        var (x1, y1) = GameBot.Domain.Services.CoordinateJitter.Apply(GetInt(action.Args, "x1"), GetInt(action.Args, "y1"), radius);
+        var (x2, y2) = GameBot.Domain.Services.CoordinateJitter.Apply(GetInt(action.Args, "x2"), GetInt(action.Args, "y2"), radius);
+        action.Args["x1"] = x1;
+        action.Args["y1"] = y1;
+        action.Args["x2"] = x2;
+        action.Args["y2"] = y2;
+      }
+    }
+    catch (FormatException) { /* malformed args: leave unchanged for the dispatch loop's existing error handling */ }
+    catch (InvalidCastException) { /* as above */ }
+    catch (OverflowException) { /* as above */ }
+    catch (KeyNotFoundException) { /* as above */ }
   }
 
   public async Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) {

--- a/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
@@ -175,13 +175,20 @@ internal static class CommandsEndpoints {
     EffectiveTimeoutMs = outcome.EffectiveTimeoutMs,
     ReferenceImageId = outcome.ReferenceImageId,
     ImageLoadStatus = outcome.ImageLoadStatus,
-    ResolvedPoint = outcome.ResolvedPoint is null
-      ? null
-      : new ResolvedPointDto {
-        X = outcome.ResolvedPoint.X,
-        Y = outcome.ResolvedPoint.Y
-      }
+    ResolvedPoint = ToResolvedPointDto(outcome.ResolvedPoint),
+    ExecutedPoint = ToResolvedPointDto(outcome.ExecutedPoint),
+    TargetSwipe = ToSwipePointsDto(outcome.TargetSwipe),
+    ExecutedSwipe = ToSwipePointsDto(outcome.ExecutedSwipe)
   };
+
+  private static ResolvedPointDto? ToResolvedPointDto(PrimitiveTapResolvedPoint? point) =>
+    point is null ? null : new ResolvedPointDto { X = point.X, Y = point.Y };
+
+  private static SwipePointsDto? ToSwipePointsDto(PrimitiveSwipePoints? points) =>
+    points is null ? null : new SwipePointsDto {
+      Start = new ResolvedPointDto { X = points.Start.X, Y = points.Start.Y },
+      End = new ResolvedPointDto { X = points.End.X, Y = points.End.Y }
+    };
 
   private static DetectionTarget? ToDomainDetection(DetectionTargetDto? dto) {
     if (dto is null) return null;

--- a/src/GameBot.Service/Endpoints/StepsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/StepsEndpoints.cs
@@ -167,7 +167,16 @@ internal static class StepsEndpoints {
     stepType = outcome.StepType,
     reason = outcome.Reason,
     detectionConfidence = outcome.DetectionConfidence,
-    resolvedPoint = outcome.ResolvedPoint is null ? null : new { x = outcome.ResolvedPoint.X, y = outcome.ResolvedPoint.Y }
+    resolvedPoint = outcome.ResolvedPoint is null ? null : new { x = outcome.ResolvedPoint.X, y = outcome.ResolvedPoint.Y },
+    executedPoint = outcome.ExecutedPoint is null ? null : new { x = outcome.ExecutedPoint.X, y = outcome.ExecutedPoint.Y },
+    targetSwipe = outcome.TargetSwipe is null ? null : new {
+      start = new { x = outcome.TargetSwipe.Start.X, y = outcome.TargetSwipe.Start.Y },
+      end = new { x = outcome.TargetSwipe.End.X, y = outcome.TargetSwipe.End.Y }
+    },
+    executedSwipe = outcome.ExecutedSwipe is null ? null : new {
+      start = new { x = outcome.ExecutedSwipe.Start.X, y = outcome.ExecutedSwipe.Start.Y },
+      end = new { x = outcome.ExecutedSwipe.End.X, y = outcome.ExecutedSwipe.End.Y }
+    }
   };
 }
 

--- a/src/GameBot.Service/Models/Commands.cs
+++ b/src/GameBot.Service/Models/Commands.cs
@@ -82,6 +82,11 @@ internal sealed class ResolvedPointDto {
   public required int Y { get; init; }
 }
 
+internal sealed class SwipePointsDto {
+  public required ResolvedPointDto Start { get; init; }
+  public required ResolvedPointDto End { get; init; }
+}
+
 internal sealed class StepExecutionOutcomeDto {
   public required int StepOrder { get; init; }
   public required string Status { get; init; }
@@ -93,6 +98,9 @@ internal sealed class StepExecutionOutcomeDto {
   public int? EffectiveTimeoutMs { get; init; }
   public string? ReferenceImageId { get; init; }
   public string? ImageLoadStatus { get; init; }
+  public ResolvedPointDto? ExecutedPoint { get; init; }
+  public SwipePointsDto? TargetSwipe { get; init; }
+  public SwipePointsDto? ExecutedSwipe { get; init; }
 }
 
 internal enum DetectionSelectionStrategyDto {

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -155,6 +155,9 @@ builder.Services.AddSingleton(_ => {
   var retryProgressionEnv = Environment.GetEnvironmentVariable("GAMEBOT_TAP_RETRY_PROGRESSION");
   var retryProgression = double.TryParse(retryProgressionEnv, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var rpParsed) && rpParsed > 0 ? rpParsed : 1.0;
 
+  var tapJitterEnv = Environment.GetEnvironmentVariable("GAMEBOT_TAP_JITTER_RADIUS_PX");
+  var tapJitterRadius = int.TryParse(tapJitterEnv, out var tjParsed) && tjParsed >= 0 ? tjParsed : 5;
+
   var adbRetriesEnv = Environment.GetEnvironmentVariable("GAMEBOT_ADB_RETRIES");
   var adbRetries = int.TryParse(adbRetriesEnv, out var arParsed) && arParsed >= 0 ? arParsed : 2;
 
@@ -166,6 +169,7 @@ builder.Services.AddSingleton(_ => {
     CaptureIntervalMs = captureInterval,
     TapRetryCount = retryCount,
     TapRetryProgression = retryProgression,
+    TapJitterRadiusPx = tapJitterRadius,
     AdbRetries = adbRetries,
     AdbRetryDelayMs = adbRetryDelay,
   };

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -243,9 +243,22 @@ internal sealed class CommandExecutor : ICommandExecutor {
       if (step.Swipe.DurationMs.HasValue) {
         swipeArgs["durationMs"] = step.Swipe.DurationMs.Value;
       }
+      var targetSwipe = new PrimitiveSwipePoints(
+        new PrimitiveTapResolvedPoint(step.Swipe.StartX, step.Swipe.StartY),
+        new PrimitiveTapResolvedPoint(step.Swipe.EndX, step.Swipe.EndY));
       var swipeAction = new GameBot.Emulator.Session.InputAction("swipe", swipeArgs, null, null);
       var swipeAccepted = await _sessions.SendInputsAsync(sessionId, new[] { swipeAction }, ct).ConfigureAwait(false);
-      return (swipeAccepted, new PrimitiveTapStepOutcome(step.Order, "executed", null, null, null, StepType: "swipe"));
+      // The session manager applies tap-point jitter by mutating the args in place; read the
+      // values back so the outcome reports the coordinates actually sent to the device.
+      var executedSwipe = new PrimitiveSwipePoints(
+        new PrimitiveTapResolvedPoint(
+          Convert.ToInt32(swipeArgs["x1"], CultureInfo.InvariantCulture),
+          Convert.ToInt32(swipeArgs["y1"], CultureInfo.InvariantCulture)),
+        new PrimitiveTapResolvedPoint(
+          Convert.ToInt32(swipeArgs["x2"], CultureInfo.InvariantCulture),
+          Convert.ToInt32(swipeArgs["y2"], CultureInfo.InvariantCulture)));
+      return (swipeAccepted, new PrimitiveTapStepOutcome(step.Order, "executed", null, null, null, StepType: "swipe",
+        TargetSwipe: targetSwipe, ExecutedSwipe: executedSwipe));
     }
 
     if (step.Type == CommandStepType.PrimitiveTap) {
@@ -576,12 +589,18 @@ internal sealed class CommandExecutor : ICommandExecutor {
     var accepted = _sessions.SendInputsAsync(sessionId, new[] { sessionInput }, ct).GetAwaiter().GetResult();
     totalAccepted += accepted;
 
+    // The session manager applies tap-point jitter by mutating the args in place; read the
+    // values back so the outcome reports the coordinates actually sent to the device.
+    var executedX = Convert.ToInt32(tapArgs["x1"], CultureInfo.InvariantCulture);
+    var executedY = Convert.ToInt32(tapArgs["y1"], CultureInfo.InvariantCulture);
+
     var detectionConfidence = primitiveAction.Args.TryGetValue("confidence", out var confidenceVal)
       ? Convert.ToDouble(confidenceVal, CultureInfo.InvariantCulture)
       : (double?)null;
 
     var reason = retryAttempt > 0 ? $"detected_after_{retryAttempt}_retries" : null;
-    stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", reason, new PrimitiveTapResolvedPoint(x, y), detectionConfidence));
+    stepOutcomes.Add(new PrimitiveTapStepOutcome(step.Order, "executed", reason, new PrimitiveTapResolvedPoint(x, y), detectionConfidence,
+      ExecutedPoint: new PrimitiveTapResolvedPoint(executedX, executedY)));
     return true;
   }
 

--- a/src/GameBot.Service/Services/ConfigSnapshotService.cs
+++ b/src/GameBot.Service/Services/ConfigSnapshotService.cs
@@ -258,6 +258,7 @@ internal sealed class ConfigSnapshotService : IConfigSnapshotService, IDisposabl
       ["GAMEBOT_CAPTURE_INTERVAL_MS"] = 500,
       ["GAMEBOT_TAP_RETRY_COUNT"] = 3,
       ["GAMEBOT_TAP_RETRY_PROGRESSION"] = 1.0,
+      ["GAMEBOT_TAP_JITTER_RADIUS_PX"] = 5,
 
       // ASP.NET Core configuration env keys and their documented defaults/effective values
       ["Service__Storage__Root"] = _storageRoot,

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -134,13 +134,42 @@ internal sealed class ExecutionLogService : IExecutionLogService {
           "normal"));
       }
       else if (string.Equals(outcome.Status, "executed", StringComparison.OrdinalIgnoreCase) && outcome.ResolvedPoint is not null) {
+        // Report both the pre-jitter target (ResolvedPoint) and the post-jitter executed point
+        // when they differ; keep the original single-point text when no jitter was applied.
+        var executed = outcome.ExecutedPoint;
+        var text = executed is not null && executed != outcome.ResolvedPoint
+          ? $"Tap targeted ({outcome.ResolvedPoint.X},{outcome.ResolvedPoint.Y}), executed at ({executed.X},{executed.Y})."
+          : $"Tap executed at ({outcome.ResolvedPoint.X},{outcome.ResolvedPoint.Y}).";
         details.Add(new ExecutionDetailItem(
           "tap",
-          $"Tap executed at ({outcome.ResolvedPoint.X},{outcome.ResolvedPoint.Y}).",
+          text,
           new Dictionary<string, object?> {
             ["x"] = outcome.ResolvedPoint.X,
             ["y"] = outcome.ResolvedPoint.Y,
+            ["executedX"] = (executed ?? outcome.ResolvedPoint).X,
+            ["executedY"] = (executed ?? outcome.ResolvedPoint).Y,
             ["confidence"] = outcome.DetectionConfidence
+          },
+          "normal"));
+      }
+      else if (string.Equals(outcome.Status, "executed", StringComparison.OrdinalIgnoreCase) && outcome.ExecutedSwipe is not null) {
+        var target = outcome.TargetSwipe;
+        var swipe = outcome.ExecutedSwipe;
+        var text = target is not null && target != swipe
+          ? $"Swipe targeted ({target.Start.X},{target.Start.Y})->({target.End.X},{target.End.Y}), executed ({swipe.Start.X},{swipe.Start.Y})->({swipe.End.X},{swipe.End.Y})."
+          : $"Swipe executed ({swipe.Start.X},{swipe.Start.Y})->({swipe.End.X},{swipe.End.Y}).";
+        details.Add(new ExecutionDetailItem(
+          "swipe",
+          text,
+          new Dictionary<string, object?> {
+            ["targetX1"] = (target ?? swipe).Start.X,
+            ["targetY1"] = (target ?? swipe).Start.Y,
+            ["targetX2"] = (target ?? swipe).End.X,
+            ["targetY2"] = (target ?? swipe).End.Y,
+            ["executedX1"] = swipe.Start.X,
+            ["executedY1"] = swipe.Start.Y,
+            ["executedX2"] = swipe.End.X,
+            ["executedY2"] = swipe.End.Y
           },
           "normal"));
       }

--- a/src/GameBot.Service/Services/ICommandExecutor.cs
+++ b/src/GameBot.Service/Services/ICommandExecutor.cs
@@ -23,6 +23,9 @@ internal sealed record CommandEvaluationDecision(int Accepted, TriggerStatus Tri
 
 internal sealed record PrimitiveTapResolvedPoint(int X, int Y);
 
+/// <summary>Start/end point pair for a swipe step (pre- or post-jitter).</summary>
+internal sealed record PrimitiveSwipePoints(PrimitiveTapResolvedPoint Start, PrimitiveTapResolvedPoint End);
+
 internal sealed record PrimitiveTapStepOutcome(
   int StepOrder,
   string Status,
@@ -34,7 +37,10 @@ internal sealed record PrimitiveTapStepOutcome(
   int? EffectiveTimeoutMs = null,
   string? ReferenceImageId = null,
   string? ImageLoadStatus = null,
-  double? ConfiguredConfidence = null);
+  double? ConfiguredConfidence = null,
+  PrimitiveTapResolvedPoint? ExecutedPoint = null,
+  PrimitiveSwipePoints? TargetSwipe = null,
+  PrimitiveSwipePoints? ExecutedSwipe = null);
 
 internal sealed record CommandForceExecutionResult(int Accepted, IReadOnlyList<PrimitiveTapStepOutcome> StepOutcomes);
 

--- a/src/GameBot.Service/Services/IConfigApplier.cs
+++ b/src/GameBot.Service/Services/IConfigApplier.cs
@@ -52,6 +52,7 @@ internal sealed class ConfigApplier : IConfigApplier {
     _appConfig.CaptureIntervalMs = Math.Max(50, GetInt(snapshot, "GAMEBOT_CAPTURE_INTERVAL_MS", 500));
     _appConfig.TapRetryCount = Math.Max(0, GetInt(snapshot, "GAMEBOT_TAP_RETRY_COUNT", 3));
     _appConfig.TapRetryProgression = GetDouble(snapshot, "GAMEBOT_TAP_RETRY_PROGRESSION", 1.0) is var prog && prog > 0 ? prog : 1.0;
+    _appConfig.TapJitterRadiusPx = GetInt(snapshot, "GAMEBOT_TAP_JITTER_RADIUS_PX", 5) is var jitter && jitter >= 0 ? jitter : 5;
     _appConfig.AdbRetries = Math.Max(0, GetInt(snapshot, "GAMEBOT_ADB_RETRIES", 2));
     _appConfig.AdbRetryDelayMs = Math.Max(0, GetInt(snapshot, "GAMEBOT_ADB_RETRY_DELAY_MS", 100));
 

--- a/tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs
+++ b/tests/unit/Commands/CommandExecutorPrimitiveTapTests.cs
@@ -355,7 +355,93 @@ public sealed class CommandExecutorPrimitiveTapTests {
     result.StepOutcomes[0].Reason.Should().Be("detection_failed_after_2_retries");
   }
 
+  [Fact]
+  public async Task PrimitiveTapExecutedPointReflectsJitteredArgsWhileResolvedPointKeepsTarget() {
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var matcher = new TemplateMatcherStub(new[] { new TemplateMatch(new BoundingBox(0, 0, 1, 1), 0.95) });
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 3, TapRetryProgression = 1.0 };
+
+    // Simulate the real SessionManager's jitter by mutating the dispatched args in place.
+    var sessions = new MutatingSessionManagerStub(offsetX: 3, offsetY: 4);
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      sessions,
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.StepOutcomes.Should().HaveCount(1);
+    var outcome = result.StepOutcomes[0];
+    outcome.Status.Should().Be("executed");
+    outcome.ResolvedPoint.Should().Be(new PrimitiveTapResolvedPoint(0, 0));
+    outcome.ExecutedPoint.Should().Be(new PrimitiveTapResolvedPoint(3, 4));
+  }
+
+  [Fact]
+  public async Task PrimitiveTapExecutedPointEqualsResolvedPointWhenArgsAreNotMutated() {
+    var command = CreatePrimitiveTapCommand();
+    using var bmp = CreateOneByOneBitmap();
+
+    var screenSource = new ScreenSourceStub(bmp);
+    var imageStore = new ReferenceImageStoreStub(("img-1", bmp));
+    var matcher = new TemplateMatcherStub(new[] { new TemplateMatch(new BoundingBox(0, 0, 1, 1), 0.95) });
+    var config = new AppConfig { CaptureIntervalMs = 50, TapRetryCount = 3, TapRetryProgression = 1.0 };
+
+    var executor = new CommandExecutor(
+      new CommandRepoStub(command),
+      new SessionManagerStub(),
+      new TriggerRepoStub(),
+      new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+      NullLogger<CommandExecutor>.Instance,
+      imageStore, screenSource, matcher,
+      new SessionContextCache(),
+      config);
+
+    var result = await executor.ForceExecuteDetailedAsync("sess-1", command.Id, CancellationToken.None);
+
+    result.StepOutcomes.Should().HaveCount(1);
+    var outcome = result.StepOutcomes[0];
+    outcome.Status.Should().Be("executed");
+    outcome.ExecutedPoint.Should().Be(outcome.ResolvedPoint);
+  }
+
   #region Test stubs
+
+  private sealed class MutatingSessionManagerStub : ISessionManager {
+    private readonly EmulatorSession _session = new() { Id = "sess-1", Status = SessionStatus.Running, GameId = "game-1" };
+    private readonly int _offsetX;
+    private readonly int _offsetY;
+    public MutatingSessionManagerStub(int offsetX, int offsetY) { _offsetX = offsetX; _offsetY = offsetY; }
+    public int ActiveCount => 1;
+    public bool CanCreateSession => true;
+    public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) => _session;
+    public EmulatorSession? GetSession(string id) => id == _session.Id ? _session : null;
+    public IReadOnlyCollection<EmulatorSession> ListSessions() => new[] { _session };
+    public bool StopSession(string id) => true;
+    public Task<int> SendInputsAsync(string id, IEnumerable<GameBot.Emulator.Session.InputAction> actions, CancellationToken ct = default) {
+      var list = actions.ToList();
+      foreach (var a in list) {
+        foreach (var key in new[] { "x1", "x2" }) {
+          if (a.Args.TryGetValue(key, out var v)) a.Args[key] = Convert.ToInt32(v, System.Globalization.CultureInfo.InvariantCulture) + _offsetX;
+        }
+        foreach (var key in new[] { "y1", "y2" }) {
+          if (a.Args.TryGetValue(key, out var v)) a.Args[key] = Convert.ToInt32(v, System.Globalization.CultureInfo.InvariantCulture) + _offsetY;
+        }
+      }
+      return Task.FromResult(list.Count);
+    }
+    public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+  }
 
   private sealed class CommandRepoStub : ICommandRepository {
     private readonly Command _command;

--- a/tests/unit/Commands/CommandExecutorSwipeTests.cs
+++ b/tests/unit/Commands/CommandExecutorSwipeTests.cs
@@ -35,6 +35,8 @@ public sealed class CommandExecutorSwipeTests {
     private readonly EmulatorSession _session;
     public List<InputAction> ReceivedInputs { get; } = new();
     public int SendResult { get; set; } = 1;
+    /// <summary>Optional per-action mutation simulating the real SessionManager's in-place jitter.</summary>
+    public Action<InputAction>? OnSend { get; set; }
     public RecordingSessionManager(EmulatorSession session) => _session = session;
     public int ActiveCount => 1;
     public bool CanCreateSession => false;
@@ -43,7 +45,10 @@ public sealed class CommandExecutorSwipeTests {
     public IReadOnlyCollection<EmulatorSession> ListSessions() => new[] { _session };
     public bool StopSession(string id) => false;
     public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) {
-      ReceivedInputs.AddRange(actions);
+      foreach (var action in actions) {
+        OnSend?.Invoke(action);
+        ReceivedInputs.Add(action);
+      }
       return Task.FromResult(SendResult);
     }
     public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
@@ -162,6 +167,43 @@ public sealed class CommandExecutorSwipeTests {
     result.Accepted.Should().Be(0);
     sessions.ReceivedInputs.Should().BeEmpty();
     result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("skipped_invalid_config");
+  }
+
+  [Fact]
+  public async Task SwipeStepReportsTargetSwipeAndExecutedSwipeFromMutatedArgs() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession()) {
+      // Simulate the real SessionManager's tap-point jitter mutating the args in place.
+      OnSend = a => {
+        a.Args["x1"] = 102;
+        a.Args["y1"] = 199;
+        a.Args["x2"] = 304;
+        a.Args["y2"] = 405;
+      }
+    };
+    cmds.Seed(SwipeCommand(100, 200, 300, 400, null));
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    var outcome = result.StepOutcomes.Should().ContainSingle().Subject;
+    outcome.TargetSwipe.Should().Be(new PrimitiveSwipePoints(
+      new PrimitiveTapResolvedPoint(100, 200), new PrimitiveTapResolvedPoint(300, 400)));
+    outcome.ExecutedSwipe.Should().Be(new PrimitiveSwipePoints(
+      new PrimitiveTapResolvedPoint(102, 199), new PrimitiveTapResolvedPoint(304, 405)));
+  }
+
+  [Fact]
+  public async Task SwipeStepExecutedSwipeEqualsTargetSwipeWhenArgsAreNotMutated() {
+    var cmds = new FakeCommandRepository();
+    var sessions = new RecordingSessionManager(RunningSession());
+    cmds.Seed(SwipeCommand(100, 200, 300, 400, null));
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    var outcome = result.StepOutcomes.Should().ContainSingle().Subject;
+    outcome.ExecutedSwipe.Should().Be(outcome.TargetSwipe);
   }
 
   [Fact]

--- a/tests/unit/Config/AppConfigValidationTests.cs
+++ b/tests/unit/Config/AppConfigValidationTests.cs
@@ -40,4 +40,22 @@ public sealed class AppConfigValidationTests {
     var config = new AppConfig { TapRetryProgression = 2.5 };
     config.TapRetryProgression.Should().Be(2.5);
   }
+
+  [Fact]
+  public void DefaultTapJitterRadiusPxIsFive() {
+    var config = new AppConfig();
+    config.TapJitterRadiusPx.Should().Be(5);
+  }
+
+  [Fact]
+  public void TapJitterRadiusPxCanBeSetToZero() {
+    var config = new AppConfig { TapJitterRadiusPx = 0 };
+    config.TapJitterRadiusPx.Should().Be(0);
+  }
+
+  [Fact]
+  public void TapJitterRadiusPxCanBeSetToCustomValue() {
+    var config = new AppConfig { TapJitterRadiusPx = 20 };
+    config.TapJitterRadiusPx.Should().Be(20);
+  }
 }

--- a/tests/unit/Config/ConfigApplierJitterTests.cs
+++ b/tests/unit/Config/ConfigApplierJitterTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using GameBot.Domain.Config;
+using GameBot.Service.Hosted;
+using GameBot.Service.Models;
+using GameBot.Service.Services;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace GameBot.UnitTests.Config;
+
+public sealed class ConfigApplierJitterTests {
+  private static ConfigurationSnapshot BuildSnapshot(object? jitterValue) {
+    var parameters = new Dictionary<string, ConfigurationParameter>();
+    if (jitterValue is not null) {
+      parameters["GAMEBOT_TAP_JITTER_RADIUS_PX"] = new ConfigurationParameter {
+        Name = "GAMEBOT_TAP_JITTER_RADIUS_PX",
+        Source = "File",
+        Value = jitterValue
+      };
+    }
+    return new ConfigurationSnapshot {
+      GeneratedAtUtc = DateTimeOffset.UtcNow,
+      Parameters = parameters
+    };
+  }
+
+  private static (ConfigApplier Applier, AppConfig Config) BuildApplier() {
+    var config = new AppConfig();
+    var applier = new ConfigApplier(new OptionsCache<TriggerWorkerOptions>(), config);
+    return (applier, config);
+  }
+
+  [Fact]
+  public void MissingJitterValueAppliesDefaultFive() {
+    var (applier, config) = BuildApplier();
+    applier.Apply(BuildSnapshot(null));
+    config.TapJitterRadiusPx.Should().Be(5);
+  }
+
+  [Fact]
+  public void ValidJitterValueIsApplied() {
+    var (applier, config) = BuildApplier();
+    applier.Apply(BuildSnapshot(12));
+    config.TapJitterRadiusPx.Should().Be(12);
+  }
+
+  [Fact]
+  public void ZeroJitterValueIsAppliedAsDisabled() {
+    var (applier, config) = BuildApplier();
+    applier.Apply(BuildSnapshot(0));
+    config.TapJitterRadiusPx.Should().Be(0);
+  }
+
+  [Fact]
+  public void NegativeJitterValueFallsBackToDefaultFive() {
+    var (applier, config) = BuildApplier();
+    applier.Apply(BuildSnapshot(-7));
+    config.TapJitterRadiusPx.Should().Be(5);
+  }
+
+  [Fact]
+  public void NonNumericJitterValueFallsBackToDefaultFive() {
+    var (applier, config) = BuildApplier();
+    applier.Apply(BuildSnapshot("not-a-number"));
+    config.TapJitterRadiusPx.Should().Be(5);
+  }
+}

--- a/tests/unit/Config/TapJitterConfigSnapshotTests.cs
+++ b/tests/unit/Config/TapJitterConfigSnapshotTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using GameBot.Service.Services;
+using Xunit;
+
+namespace GameBot.UnitTests.Config;
+
+public sealed class TapJitterConfigSnapshotTests {
+  [Fact]
+  public async Task SnapshotContainsTapJitterRadiusWithDefaultFiveWhenUnset() {
+    var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(tmp);
+    try {
+      using var svc = new ConfigSnapshotService(tmp);
+      var snap = await svc.RefreshAsync().ConfigureAwait(false);
+
+      snap.Parameters.Should().ContainKey("GAMEBOT_TAP_JITTER_RADIUS_PX");
+      var p = snap.Parameters["GAMEBOT_TAP_JITTER_RADIUS_PX"];
+      p.Source.Should().Be("Default");
+      p.Value.Should().Be(5);
+    }
+    finally {
+      try { Directory.Delete(tmp, recursive: true); } catch { }
+    }
+  }
+
+  [Fact]
+  public async Task SavedFileValueForTapJitterRadiusIsReflectedWithFileSource() {
+    var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+    var cfgDir = Path.Combine(tmp, "config");
+    Directory.CreateDirectory(cfgDir);
+    var cfgFile = Path.Combine(cfgDir, "config.json");
+    await File.WriteAllTextAsync(cfgFile, "{\n  \"parameters\": { \n    \"GAMEBOT_TAP_JITTER_RADIUS_PX\": { \"value\": \"12\" } \n  }\n}").ConfigureAwait(false);
+
+    try {
+      using var svc = new ConfigSnapshotService(tmp);
+      var snap = await svc.RefreshAsync().ConfigureAwait(false);
+
+      snap.Parameters.Should().ContainKey("GAMEBOT_TAP_JITTER_RADIUS_PX");
+      var p = snap.Parameters["GAMEBOT_TAP_JITTER_RADIUS_PX"];
+      p.Source.Should().Be("File");
+      p.Value?.ToString().Should().Be("12");
+    }
+    finally {
+      try { Directory.Delete(tmp, recursive: true); } catch { }
+    }
+  }
+}

--- a/tests/unit/Domain/CoordinateJitterTests.cs
+++ b/tests/unit/Domain/CoordinateJitterTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using GameBot.Domain.Services;
+using Xunit;
+
+namespace GameBot.UnitTests.Domain;
+
+public sealed class CoordinateJitterTests {
+  [Fact]
+  public void RadiusZeroReturnsInputUnchanged() {
+    var (x, y) = CoordinateJitter.Apply(100, 200, 0);
+    x.Should().Be(100);
+    y.Should().Be(200);
+  }
+
+  [Fact]
+  public void NegativeRadiusReturnsInputUnchanged() {
+    var (x, y) = CoordinateJitter.Apply(100, 200, -3);
+    x.Should().Be(100);
+    y.Should().Be(200);
+  }
+
+  [Fact]
+  public void PositiveRadiusStaysWithinBoundsOnEachAxis() {
+    const int radius = 5;
+    for (var i = 0; i < 500; i++) {
+      var (x, y) = CoordinateJitter.Apply(100, 200, radius);
+      x.Should().BeInRange(100 - radius, 100 + radius);
+      y.Should().BeInRange(200 - radius, 200 + radius);
+    }
+  }
+
+  [Fact]
+  public void NearZeroTargetNeverProducesNegativeCoordinates() {
+    for (var i = 0; i < 500; i++) {
+      var (x, y) = CoordinateJitter.Apply(2, 0, 5);
+      x.Should().BeGreaterThanOrEqualTo(0);
+      y.Should().BeGreaterThanOrEqualTo(0);
+    }
+  }
+
+  [Fact]
+  public void ConsecutiveCallsProduceVaryingOffsets() {
+    var distinct = new HashSet<(int X, int Y)>();
+    for (var i = 0; i < 50; i++) {
+      distinct.Add(CoordinateJitter.Apply(100, 200, 5));
+    }
+    distinct.Count.Should().BeGreaterThan(1, "back-to-back calls must not all reuse the same clock-tick seed");
+  }
+
+  [Fact]
+  public void LargerRadiusProducesOffsetsBeyondDefaultRange() {
+    const int radius = 20;
+    var sawBeyondDefault = false;
+    for (var i = 0; i < 2000 && !sawBeyondDefault; i++) {
+      var (x, y) = CoordinateJitter.Apply(100, 200, radius);
+      x.Should().BeInRange(100 - radius, 100 + radius);
+      y.Should().BeInRange(200 - radius, 200 + radius);
+      if (Math.Abs(x - 100) > 5 || Math.Abs(y - 200) > 5) sawBeyondDefault = true;
+    }
+    sawBeyondDefault.Should().BeTrue("with radius 20, offsets larger than the default ±5 range must occur");
+  }
+}

--- a/tests/unit/Emulator/SessionManagerJitterTests.cs
+++ b/tests/unit/Emulator/SessionManagerJitterTests.cs
@@ -1,0 +1,161 @@
+using System.Runtime.Versioning;
+using FluentAssertions;
+using GameBot.Domain.Config;
+using GameBot.Emulator.Adb;
+using GameBot.Emulator.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace GameBot.UnitTests.Emulator;
+
+/// <summary>
+/// Verifies the tap-point jitter normalization in SessionManager.SendInputsAsync.
+/// Runs in stub mode (GAMEBOT_USE_ADB=false) — the normalization pass executes before the
+/// ADB-mode branch, so no device is required.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class SessionManagerJitterTests : IDisposable {
+  private readonly string? _previousUseAdb;
+
+  public SessionManagerJitterTests() {
+    _previousUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+  }
+
+  public void Dispose() => Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _previousUseAdb);
+
+  private static SessionManager BuildManager(int jitterRadiusPx) =>
+    new(Options.Create(new SessionOptions()),
+        NullLogger<SessionManager>.Instance,
+        NullLogger<AdbClient>.Instance,
+        new AppConfig { TapJitterRadiusPx = jitterRadiusPx });
+
+  private static InputAction TapAction(int x, int y) =>
+    new("tap", new Dictionary<string, object> { ["x"] = x, ["y"] = y }, null, null);
+
+  private static InputAction SwipeAction(int x1, int y1, int x2, int y2) =>
+    new("swipe", new Dictionary<string, object> { ["x1"] = x1, ["y1"] = y1, ["x2"] = x2, ["y2"] = y2 }, null, null);
+
+  [Fact]
+  public async Task TapArgsAreJitteredWithinDefaultRadius() {
+    var mgr = BuildManager(5);
+    var session = mgr.CreateSession("game-1");
+
+    for (var i = 0; i < 100; i++) {
+      var action = TapAction(100, 200);
+      await mgr.SendInputsAsync(session.Id, new[] { action });
+      ((int)action.Args["x"]).Should().BeInRange(95, 105);
+      ((int)action.Args["y"]).Should().BeInRange(195, 205);
+    }
+  }
+
+  [Fact]
+  public async Task TapArgsVaryAcrossDispatches() {
+    var mgr = BuildManager(5);
+    var session = mgr.CreateSession("game-1");
+
+    var observed = new HashSet<(int X, int Y)>();
+    for (var i = 0; i < 50; i++) {
+      var action = TapAction(100, 200);
+      await mgr.SendInputsAsync(session.Id, new[] { action });
+      observed.Add(((int)action.Args["x"], (int)action.Args["y"]));
+    }
+    observed.Count.Should().BeGreaterThan(1);
+  }
+
+  [Fact]
+  public async Task SwipeArgsAreJitteredWithinDefaultRadius() {
+    var mgr = BuildManager(5);
+    var session = mgr.CreateSession("game-1");
+
+    for (var i = 0; i < 100; i++) {
+      var action = SwipeAction(100, 200, 300, 400);
+      await mgr.SendInputsAsync(session.Id, new[] { action });
+      ((int)action.Args["x1"]).Should().BeInRange(95, 105);
+      ((int)action.Args["y1"]).Should().BeInRange(195, 205);
+      ((int)action.Args["x2"]).Should().BeInRange(295, 305);
+      ((int)action.Args["y2"]).Should().BeInRange(395, 405);
+    }
+  }
+
+  [Fact]
+  public async Task SwipeEndpointsAreJitteredIndependently() {
+    var mgr = BuildManager(5);
+    var session = mgr.CreateSession("game-1");
+
+    // If start and end were jittered with the same offset, (x1-100,y1-200) would always equal
+    // (x2-300,y2-400). Across many samples at least one pair must differ.
+    var sawIndependentOffsets = false;
+    for (var i = 0; i < 100 && !sawIndependentOffsets; i++) {
+      var action = SwipeAction(100, 200, 300, 400);
+      await mgr.SendInputsAsync(session.Id, new[] { action });
+      var startOffset = ((int)action.Args["x1"] - 100, (int)action.Args["y1"] - 200);
+      var endOffset = ((int)action.Args["x2"] - 300, (int)action.Args["y2"] - 400);
+      if (startOffset != endOffset) sawIndependentOffsets = true;
+    }
+    sawIndependentOffsets.Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task NearZeroTargetsNeverProduceNegativeCoordinates() {
+    var mgr = BuildManager(5);
+    var session = mgr.CreateSession("game-1");
+
+    for (var i = 0; i < 100; i++) {
+      var action = SwipeAction(2, 0, 1, 3);
+      await mgr.SendInputsAsync(session.Id, new[] { action });
+      ((int)action.Args["x1"]).Should().BeGreaterThanOrEqualTo(0);
+      ((int)action.Args["y1"]).Should().BeGreaterThanOrEqualTo(0);
+      ((int)action.Args["x2"]).Should().BeGreaterThanOrEqualTo(0);
+      ((int)action.Args["y2"]).Should().BeGreaterThanOrEqualTo(0);
+    }
+  }
+
+  [Fact]
+  public async Task RadiusZeroDisablesJitterEntirely() {
+    var mgr = BuildManager(0);
+    var session = mgr.CreateSession("game-1");
+
+    for (var i = 0; i < 20; i++) {
+      var tap = TapAction(100, 200);
+      var swipe = SwipeAction(100, 200, 300, 400);
+      await mgr.SendInputsAsync(session.Id, new[] { tap, swipe });
+      tap.Args["x"].Should().Be(100);
+      tap.Args["y"].Should().Be(200);
+      swipe.Args["x1"].Should().Be(100);
+      swipe.Args["y1"].Should().Be(200);
+      swipe.Args["x2"].Should().Be(300);
+      swipe.Args["y2"].Should().Be(400);
+    }
+  }
+
+  [Fact]
+  public async Task ConfiguredRadiusGovernsOffsetRangeNotTheDefault() {
+    var mgr = BuildManager(20);
+    var session = mgr.CreateSession("game-1");
+
+    var sawBeyondDefaultRange = false;
+    for (var i = 0; i < 2000; i++) {
+      var action = TapAction(100, 200);
+      await mgr.SendInputsAsync(session.Id, new[] { action });
+      var x = (int)action.Args["x"];
+      var y = (int)action.Args["y"];
+      x.Should().BeInRange(80, 120);
+      y.Should().BeInRange(180, 220);
+      if (Math.Abs(x - 100) > 5 || Math.Abs(y - 200) > 5) sawBeyondDefaultRange = true;
+    }
+    sawBeyondDefaultRange.Should().BeTrue("with radius 20, offsets beyond the default ±5 range must occur");
+  }
+
+  [Fact]
+  public async Task KeyActionsAreNotJittered() {
+    var mgr = BuildManager(5);
+    var session = mgr.CreateSession("game-1");
+
+    var action = new InputAction("key", new Dictionary<string, object> { ["keyCode"] = 4 }, null, null);
+    await mgr.SendInputsAsync(session.Id, new[] { action });
+
+    action.Args["keyCode"].Should().Be(4);
+  }
+}


### PR DESCRIPTION
## Summary

Implements tap-point jitter (spec 058): every tap and swipe sent to the device now lands within a small random offset of its target instead of always hitting the exact same pixel, making repeated executions look more natural and more resilient to pixel-perfect repetition.

- **Automatic & central**: jitter is applied in a normalization pass at the top of `SessionManager.SendInputsAsync` — the single dispatch chokepoint — so it covers all origins (authored steps, image-detection-resolved primitive taps, recorder replays, and the raw `POST /sessions/{id}/inputs` API). No per-step opt-in/opt-out, no new authoring/execution UI controls.
- **Configurable**: new `GAMEBOT_TAP_JITTER_RADIUS_PX` parameter (default `5`). Each axis offset is drawn independently from `[-radius, +radius]`; swipe start/end endpoints are jittered independently; results are clamped to be non-negative. `0` disables jitter entirely; negative/invalid values fall back to the default. Follows the standard precedence (default → saved config file → environment variable), appears in the generic UI Configuration variables list, and is documented in `ENVIRONMENT.md`.
- **Observable**: step outcomes and execution logs report both the pre-jitter target and the post-jitter executed coordinates ("Tap targeted (X,Y), executed at (X',Y')"); step outcome payloads gain additive `executedPoint`, `targetSwipe`, and `executedSwipe` fields alongside the existing `resolvedPoint`. Also fixes executed swipe steps previously logging as "was not executed".
- **Versioning**: bumps installer minor version to 0.10.0.

## Key implementation notes

- New `CoordinateJitter` helper in GameBot.Domain uses the project's established non-crypto LCG pattern (CA5394-safe), with the tick seed mixed with an atomic counter so back-to-back calls (the four offsets of one swipe) produce independent values.
- `InputAction.Args` is mutated in place by the session manager; `CommandExecutor` reads the jittered values back after dispatch to populate the new outcome fields — no `ISessionManager` signature changes.
- All outcome/DTO additions are additive and nullable; existing `resolvedPoint` consumers are unaffected.

## Test plan

- [x] Full regression: 787/787 tests passing (445 unit, 67 contract, 275 integration), 0 warnings
- [x] 28 new tests: `CoordinateJitterTests` (bounds, clamping, disable-at-zero, seed uniqueness), `SessionManagerJitterTests` (tap/swipe jitter in stub mode, independent endpoints, radius 0/20, key actions untouched), `ConfigApplierJitterTests` (negative/non-numeric fallback), config snapshot default + file-precedence tests, CommandExecutor executed-point/swipe outcome tests

Spec artifacts: `specs/058-tap-point-jitter/` (spec, plan, research, data-model, contracts, quickstart, tasks — all 30 tasks complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
