### PR TITLE
Queue-start & after-every-step scheduling (#060)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/059-relative-schedule-time"
+  "feature_directory": "specs/060-queue-start-after-every-scheduling"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/059-relative-schedule-time/plan.md
+at specs/060-queue-start-after-every-scheduling/plan.md
 <!-- SPECKIT END -->

--- a/specs/060-queue-start-after-every-scheduling/checklists/requirements.md
+++ b/specs/060-queue-start-after-every-scheduling/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Queue-Start and After-Every-Step Scheduling
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- The three open decisions are now resolved via the 2026-06-18 clarification session (see spec's Clarifications section): "After Every Step" is a narrow rename of the existing "Every Step" (display label only, identifier `EveryStep` unchanged); "At Queue Start" counts toward the executed total. No open ambiguities remain.

--- a/specs/060-queue-start-after-every-scheduling/contracts/queue-template-schedule-types.openapi.yaml
+++ b/specs/060-queue-start-after-every-scheduling/contracts/queue-template-schedule-types.openapi.yaml
@@ -1,0 +1,146 @@
+openapi: 3.0.3
+info:
+  title: Queue Template — At-Queue-Start Schedule Type (feature 060)
+  version: 1.0.0
+  description: >
+    Additive extension to the queue-template entry schedule (features 053/059). The schedule-type
+    enumeration gains a new value, "AtQueueStart": entries with this type run once per run, in
+    template order, before the run loop begins (before any timer evaluation and before the first
+    OncePerRun step), and count toward the run's executed total.
+
+    The existing "EveryStep" value is UNCHANGED on the wire — it is only re-labeled "After Every
+    Step" in the operator-facing UI. API request/response identifiers stay "EveryStep" for full
+    backward compatibility (no migration). No new endpoint is introduced; both options flow through
+    the existing template save/read endpoints.
+
+paths:
+  /api/queue-templates:
+    post:
+      summary: Create or update a queue template (schedule-type enum extended with AtQueueStart)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveQueueTemplateRequest'
+      responses:
+        '200':
+          description: Template updated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueTemplateDetailResponse' }
+        '201':
+          description: Template created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueTemplateDetailResponse' }
+        '400':
+          description: >
+            Validation error, including: unrecognized scheduleType (accepted values now:
+            OncePerRun, EveryStep, Timer, AtQueueStart); blank sequenceId; or, for a Timer entry,
+            invalid/ambiguous timer fields. AtQueueStart entries require no timer fields.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+        '409':
+          description: Template name already exists and overwrite=false
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+
+  /api/queue-templates/{id}:
+    get:
+      summary: Read a queue template (scheduleType may be AtQueueStart)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Template detail
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueTemplateDetailResponse' }
+        '404':
+          description: Template not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+
+components:
+  schemas:
+    SaveQueueTemplateRequest:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string, maxLength: 100 }
+        overwrite: { type: boolean, default: false }
+        entries:
+          type: array
+          items: { $ref: '#/components/schemas/TemplateEntrySaveRequest' }
+
+    TemplateEntrySaveRequest:
+      type: object
+      required: [sequenceId]
+      properties:
+        sequenceId: { type: string, minLength: 1 }
+        scheduleType:
+          type: string
+          enum: [OncePerRun, EveryStep, Timer, AtQueueStart]
+          default: OncePerRun
+          description: >
+            Schedule option for this entry. "EveryStep" is displayed as "After Every Step" in the
+            UI but its wire value is unchanged. "AtQueueStart" requires no timer fields.
+        timerTimeOfDay:
+          type: string
+          nullable: true
+          pattern: '^([01]\d|2[0-3]):[0-5]\d$'
+          description: 'HH:mm (24h). Only for a Timer entry in time-of-day mode. Ignored for AtQueueStart.'
+          example: '15:30'
+        timerRelativeOffset:
+          type: string
+          nullable: true
+          pattern: '^([01]?\d|2[0-4]):[0-5]\d:[0-5]\d$'
+          description: 'HH:mm:ss offset from run start. Only for a Timer entry in relative mode. Ignored for AtQueueStart.'
+          example: '00:10:00'
+
+    QueueTemplateDetailResponse:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        entryCount: { type: integer }
+        entries:
+          type: array
+          items: { $ref: '#/components/schemas/QueueTemplateEntryResponse' }
+
+    QueueTemplateEntryResponse:
+      type: object
+      properties:
+        sequenceId: { type: string }
+        sequenceName: { type: string, nullable: true }
+        stale: { type: boolean }
+        scheduleType:
+          type: string
+          enum: [OncePerRun, EveryStep, Timer, AtQueueStart]
+          description: 'Wire value. "EveryStep" is shown as "After Every Step" in the UI only.'
+        timerTimeOfDay:
+          type: string
+          nullable: true
+          example: '15:30'
+        timerRelativeOffset:
+          type: string
+          nullable: true
+          description: 'HH:mm:ss when this entry is a relative-offset timer; null otherwise.'
+          example: '00:10:00'
+
+    ErrorEnvelope:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code: { type: string }
+            message: { type: string }
+            hint: { type: string, nullable: true }

--- a/specs/060-queue-start-after-every-scheduling/data-model.md
+++ b/specs/060-queue-start-after-every-scheduling/data-model.md
@@ -1,0 +1,47 @@
+# Phase 1 Data Model: Queue-Start and After-Every-Step Scheduling
+
+**Feature**: 060-queue-start-after-every-scheduling
+**Date**: 2026-06-18
+
+This feature adds one enumeration value and renames one option's display label. There are no new entities, no new fields, and no persistence-format change.
+
+## Entity: `ScheduleType` (enum) — extended
+
+`GameBot.Domain.QueueTemplates.ScheduleType` governs when a `QueueTemplateEntry` executes during a run. Serialized as its string name via `JsonStringEnumConverter`.
+
+| Value | Numeric | Persisted/API identifier | Display label | Behavior |
+|-------|---------|--------------------------|---------------|----------|
+| `OncePerRun` | 0 | `OncePerRun` | Once Per Run | Default. Normal step; runs in template order; defines run/cycle completion. Counts toward `executed`. (unchanged) |
+| `EveryStep` | 1 | `EveryStep` | **After Every Step** *(renamed label)* | Runs after each `OncePerRun` step and once after the final step; never self-triggers; does NOT count toward `executed`. **Behavior and identifier unchanged.** |
+| `Timer` | 2 | `Timer` | Timer | Evaluated at iteration boundaries; time-of-day or relative-offset / live (feature 059). (unchanged) |
+| `AtQueueStart` | 3 | `AtQueueStart` | At Queue Start | **NEW.** Runs once per run, in template order, before the run loop (before timer evaluation and the first `OncePerRun` step). Counts toward `executed`. Failure is non-fatal. Not repeated per cycle. |
+
+**Notes**
+- Adding `AtQueueStart = 3` is additive; existing serialized templates contain only `OncePerRun`/`EveryStep`/`Timer` and deserialize unchanged.
+- The `EveryStep` change is **display label only** — the enum name, numeric value, persisted string, and API request/response string all remain `EveryStep`. No migration.
+
+## Entity: `QueueTemplateEntry` — unchanged shape
+
+`GameBot.Domain.QueueTemplates.QueueTemplateEntry` is unchanged structurally:
+
+| Field | Type | Relevance to this feature |
+|-------|------|---------------------------|
+| `SequenceId` | `string` | unchanged |
+| `ScheduleType` | `ScheduleType` | may now be `AtQueueStart` |
+| `TimerTimeOfDay` | `TimeOnly?` | null for `AtQueueStart` (timer-only) |
+| `TimerRelativeOffset` | `TimeSpan?` | null for `AtQueueStart` (timer-only) |
+
+**Validation rules** (enforced at the API layer, `QueueTemplatesEndpoints`):
+- `ScheduleType` must parse to a defined `ScheduleType` value (now includes `AtQueueStart`); otherwise 400 with the `{ error: { code, message, hint } }` envelope. The "accepted values" message is updated to list `AtQueueStart`.
+- `TimerTimeOfDay` / `TimerRelativeOffset` validation applies only when `ScheduleType == Timer`; `AtQueueStart` entries ignore both (unchanged logic — the existing code only inspects timer fields under the `Timer` branch).
+- No additional fields are required for `AtQueueStart`.
+
+## Run-time state (no schema change)
+
+`QueueExecutionService.RunAsync` partitions template entries by schedule type at run start. This feature adds an `atQueueStartEntries` partition and a one-time pre-pass that runs them before the iteration loop. This is in-memory run state only; nothing is persisted beyond the existing execution-log entries written per sequence run.
+
+| Run-state element | Lifetime | Purpose |
+|-------------------|----------|---------|
+| `atQueueStartEntries` (local list) | per run | template-ordered `AtQueueStart` entries, executed once before the loop |
+| `executed` counter | per run | now incremented for each at-queue-start firing (FR-015) |
+| `failed` counter | per run | incremented on a non-fatal at-queue-start failure (FR-007) |

--- a/specs/060-queue-start-after-every-scheduling/plan.md
+++ b/specs/060-queue-start-after-every-scheduling/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: Queue-Start and After-Every-Step Scheduling
+
+**Branch**: `060-queue-start-after-every-scheduling` | **Date**: 2026-06-18 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/060-queue-start-after-every-scheduling/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Two changes to queue-template scheduling, building directly on features 053 (schedule types) and 059 (relative timers):
+
+1. **New "At Queue Start" schedule option** — a new `ScheduleType.AtQueueStart` enum value. Entries with this type run **once per run**, in template order, **before** the run loop begins (before the first iteration's timer evaluation and before the first `OncePerRun` step). They **count toward** the run's `executed` total (per clarification), and a failure is non-fatal (recorded in `failed`, run continues), consistent with `OncePerRun` handling. Cycling does not repeat them.
+
+2. **Rename "Every Step" → "After Every Step" (display label only)** — per clarification, the underlying enum/identifier `EveryStep` is **unchanged**; only the operator-facing label changes (UI dropdown + badge). Behavior is identical to today (fires after each `OncePerRun` step and once after the final step; never self-triggers). This keeps existing templates and API/script clients fully backward compatible — no data migration, no new accepted/returned identifier.
+
+No new endpoint is required: both options flow through the existing `POST /api/queue-templates` (save) and `GET /api/queue-templates/{id}` (read). `AtQueueStart` is automatically accepted by the existing `Enum.TryParse` + `Enum.IsDefined` validation once added to the enum; the human-readable "accepted values" error string is updated. The UI dropdown and badges are data-driven from a label map, so adding the option and renaming the label are localized edits.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9 (backend); TypeScript + React (web UI, Vite + Jest)
+**Primary Dependencies**: ASP.NET Core Minimal API, `GameBot.Domain` / `GameBot.Service`, Microsoft.Extensions.Logging; web UI: React, existing `lib/api` client. No new external packages.
+**Storage**: Existing file-backed JSON template store (`IQueueTemplateRepository`). `ScheduleType` serializes as its string name via `JsonStringEnumConverter`; adding `AtQueueStart` is additive and backward compatible. Existing `EveryStep` values keep serializing/deserializing unchanged.
+**Testing**: xUnit + coverlet (backend: contract/integration/unit); Jest + Testing Library (web UI). `vite build` + `jest` is the real web-ui green gate (lint/tsc have pre-existing failures).
+**Target Platform**: Windows desktop service (ASP.NET Core host + static web UI)
+**Project Type**: Web application (ASP.NET Core backend + React frontend) — Option 2 structure.
+**Performance Goals**: At-queue-start execution adds O(at-queue-start entries) sequential sequence runs once per run; iteration-boundary cost is unchanged. No new I/O, no new ADB round-trips, no hot-path allocations.
+**Constraints**: At-queue-start entries MUST execute before any timer evaluation and before the first `OncePerRun` step (FR-003/FR-014); once per run, not per cycle (FR-004); count toward `executed` (FR-015); "After Every Step" behavior and its `EveryStep` identifier MUST be unchanged (FR-002/FR-005/FR-006/FR-010); default schedule option unchanged (FR-011).
+**Scale/Scope**: Operator-scale (≤50 templates, ≤100 entries each). ~1 new enum value, runtime-loop pre-pass, validation-string + doc updates, UI label-map + badge edits, DTO doc updates, ~15-20 new/updated tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality Discipline | PASS | Additive, localized changes: one new enum value, one execution-service pre-pass block, one validation-string update, UI label-map edits, DTO/doc comment updates. No new dependencies. CamelCase identifiers (`AtQueueStart`); public members documented. |
+| II. Testing Standards | PASS (plan) | New unit tests: at-queue-start runs first / in template order / before timers / counts toward `executed` / once-per-run on cycling / non-fatal failure / only-at-queue-start template. Contract tests: save+read `AtQueueStart`; reject invalid; `EveryStep` still round-trips (backward compat). Integration: end-to-end ordering. Web-ui Jest: "At Queue Start" option + badge; "After Every Step" label rename; round-trip. Coverage ≥80% line / ≥70% branch for touched areas. |
+| III. User Experience Consistency | PASS | New option follows the existing schedule-option vocabulary additively; same `{ error: { code, message, hint } }` envelope for invalid schedule types; UI reuses the existing dropdown + badge pattern; the rename is label-only with no breaking API change (identifier `EveryStep` preserved). |
+| IV. Performance Requirements | PASS | At-queue-start is a one-time, O(n) sequential pass over a small operator-scale set; iteration-boundary cadence unchanged; no I/O or new ADB calls. |
+| Quality Gates – DoD | PASS (plan) | No underscores in method names; extended scheduleType documented in contracts/ + quickstart; public DTO/domain members documented; web-ui validated with `vite build` + `jest`; no user-visible breaking change (label-only rename, additive option). |
+
+No violations — Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/060-queue-start-after-every-scheduling/
+├── spec.md              # Feature specification (complete, clarified)
+├── plan.md              # This file (/speckit.plan output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (OpenAPI fragment)
+│   └── queue-template-schedule-types.openapi.yaml
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit.specify)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   └── QueueTemplates/
+│       └── ScheduleType.cs                    # + AtQueueStart = 3; doc note: EveryStep displays as "After Every Step"
+└── GameBot.Service/
+    ├── Contracts/QueueTemplates/
+    │   ├── TemplateEntrySaveRequest.cs        # doc: accepted scheduleType values now include AtQueueStart
+    │   └── QueueTemplateDetailResponse.cs     # doc: ScheduleType may be "AtQueueStart"
+    ├── Endpoints/
+    │   └── QueueTemplatesEndpoints.cs         # update "accepted values" error string to include AtQueueStart
+    └── Services/QueueExecution/
+        └── QueueExecutionService.cs           # partition AtQueueStart entries; run-start pre-pass (before loop); count toward executed
+
+src/web-ui/src/
+├── services/
+│   └── queueTemplates.ts                      # ScheduleType union + 'AtQueueStart'
+├── components/queues/
+│   └── QueueEntryList.tsx                     # SCHEDULE_LABELS: EveryStep→'After Every Step', + AtQueueStart:'At Queue Start'; + badge
+└── pages/
+    └── QueuesPage.tsx                         # no behavioral change (scheduleType passes through); verify defaults
+
+tests/
+├── unit/
+│   └── Queues/
+│       └── QueueExecutionServiceTests.cs      # + at-queue-start: order/before-timers/counts/once-per-run/non-fatal/only-start
+├── contract/QueueTemplates/
+│   └── QueueTemplatesApiContractTests.cs      # + AtQueueStart accept/return/reject-invalid; EveryStep backward-compat round-trip
+├── integration/QueueTemplates/
+│   └── QueueTemplatesScheduleTypeTests.cs     # + at-queue-start end-to-end ordering
+└── (web-ui Jest, colocated __tests__/)
+    ├── QueueEntryList.test.tsx                 # + At Queue Start option/badge; After Every Step label
+    └── QueuesPage.templates.spec.tsx          # + AtQueueStart round-trip
+```
+
+**Structure Decision**: All changes fit the existing `GameBot.Domain` / `GameBot.Service` / `src/web-ui` / `tests` layout established by features 053/059. `AtQueueStart` is a sibling enum value; the execution pre-pass mirrors the existing partition-and-run pattern in `QueueExecutionService`. The "After Every Step" rename is intentionally a label-only change at the UI layer (and doc comments), preserving the `EveryStep` identifier end-to-end for backward compatibility — so it touches no persistence, validation-accept logic, or execution behavior.
+
+## Complexity Tracking
+
+No constitution violations. All changes are additive (new enum value, runtime pre-pass, UI label edits) or label-only (rename), within the existing project structure and scheduling patterns established by features 053/059.

--- a/specs/060-queue-start-after-every-scheduling/quickstart.md
+++ b/specs/060-queue-start-after-every-scheduling/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart: Queue-Start and After-Every-Step Scheduling
+
+**Feature**: 060-queue-start-after-every-scheduling
+
+This feature adds the **At Queue Start** schedule option and renames the **Every Step** option's
+label to **After Every Step** (label only — the API/stored value stays `EveryStep`).
+
+## What changed for operators
+
+- **At Queue Start**: tag template entries so they run once, in template order, the moment the
+  queue starts — before any timer is evaluated and before the first normal step. Use it for
+  startup/setup (open the game, dismiss pop-ups, navigate to a known screen).
+- **After Every Step**: the option formerly labeled "Every Step", with the same behavior (runs
+  after each normal step). Only the name changed.
+
+## Using it in the web UI
+
+1. Open a queue's template editor (Queues page).
+2. For an entry, open the **Schedule type** dropdown. It now lists:
+   `Once Per Run`, `After Every Step`, `Timer`, `At Queue Start`.
+3. Choose **At Queue Start**. A badge indicates the entry runs at queue start.
+4. Save. Reload to confirm the choice persisted.
+
+## Using it via the API
+
+Save a template whose first entry runs at queue start:
+
+```http
+POST /api/queue-templates
+Content-Type: application/json
+
+{
+  "name": "Daily run",
+  "overwrite": true,
+  "entries": [
+    { "sequenceId": "seq-open-game",    "scheduleType": "AtQueueStart" },
+    { "sequenceId": "seq-collect",      "scheduleType": "OncePerRun" },
+    { "sequenceId": "seq-screenshot",   "scheduleType": "EveryStep" }
+  ]
+}
+```
+
+- `AtQueueStart` requires no timer fields.
+- `EveryStep` is still the wire value for the "After Every Step" option (unchanged).
+- An unrecognized `scheduleType` returns 400 with `{ error: { code, message, hint } }`; accepted
+  values are `OncePerRun`, `EveryStep`, `Timer`, `AtQueueStart`.
+
+Read it back with `GET /api/queue-templates/{id}` — `scheduleType` round-trips unchanged.
+
+## Behavior at run time
+
+For the template above on a cycling queue:
+
+1. `seq-open-game` runs first (At Queue Start), before any timer evaluation. Counts toward the
+   run's executed total.
+2. The run loop begins. Each cycle: `seq-collect` (Once Per Run) runs, then `seq-screenshot`
+   (After Every Step) runs after it.
+3. `seq-open-game` does **not** run again on later cycles (once per run).
+4. `seq-screenshot` runs only after normal steps — not after `seq-open-game` and not after timer
+   firings.
+
+A failure in an At Queue Start sequence is non-fatal: it is recorded and the run continues.
+
+## How to verify
+
+- **Backend**: `dotnet test` — see `QueueExecutionServiceTests` (at-queue-start ordering, counting,
+  once-per-run, non-fatal failure), `QueueTemplatesApiContractTests` (AtQueueStart accept/return,
+  reject invalid, EveryStep backward compatibility), and the integration ordering test.
+- **Web UI** (real green gate): from `src/web-ui`, run `npx vite build` and `npx jest` — see the
+  updated `QueueEntryList` and `QueuesPage.templates` specs.
+
+## Backward compatibility
+
+- Existing templates load and run identically; `EveryStep` entries keep working under the new
+  "After Every Step" label with no migration.
+- The default schedule option (entries with no explicit type) remains `OncePerRun`.

--- a/specs/060-queue-start-after-every-scheduling/research.md
+++ b/specs/060-queue-start-after-every-scheduling/research.md
@@ -1,0 +1,41 @@
+# Phase 0 Research: Queue-Start and After-Every-Step Scheduling
+
+**Feature**: 060-queue-start-after-every-scheduling
+**Date**: 2026-06-18
+
+The Technical Context has no open `NEEDS CLARIFICATION` items — the three design decisions were resolved in the spec's clarification session. This document records the design decisions and the existing patterns this feature reuses.
+
+## Decision 1 — Model "At Queue Start" as a new `ScheduleType` enum value
+
+- **Decision**: Add `AtQueueStart = 3` to `GameBot.Domain.QueueTemplates.ScheduleType`. No new domain property is needed (unlike feature 059, which needed `TimerRelativeOffset`); the schedule type alone fully determines the behavior.
+- **Rationale**: The schedule option is already a single enum carried on `QueueTemplateEntry`. A new sibling value is the smallest, most consistent extension and serializes additively via the existing `JsonStringEnumConverter`. Existing templates (no `AtQueueStart` entries) are unaffected; the default remains `OncePerRun`.
+- **Alternatives considered**:
+  - A separate boolean/flag on the entry — rejected: redundant with the existing schedule-type discriminator and would complicate validation and UI.
+  - A template-level "startup sequence list" — rejected: breaks the uniform per-entry scheduling model and the template editor's per-entry control.
+
+## Decision 2 — Execute at-queue-start entries in a one-time pre-pass before the run loop
+
+- **Decision**: In `QueueExecutionService.RunAsync`, after the emulator session is established and before the `do/while` iteration loop, run all `AtQueueStart` entries once, in template order, via the existing `RunOneSequenceAsync`. Increment `executed` per firing; on failure increment `failed` and continue; honor cancellation and the mid-run connection-lost check exactly as the other passes do.
+- **Rationale**: "Before any timer evaluation and before the first `OncePerRun` step" (FR-003/FR-014) maps cleanly to "before the loop", since timer evaluation (step a) and once-per-run steps (step b) both live inside the loop. Placing it before the loop also gives "once per run, not per cycle" (FR-004) for free, because the loop is what cycles. Reusing `RunOneSequenceAsync` inherits non-fatal failure handling, execution-log parenting, and the `++index` ordering.
+- **Counting**: at-queue-start firings call `executed++` (FR-015), matching `OncePerRun` and relative/live firings, and unlike `EveryStep`/time-of-day timers.
+- **Edge — only at-queue-start entries**: the existing loop is guarded by `if (oncePerRunEntries.Count > 0 || everyStepEntries.Count > 0 || timerEntries.Count > 0)`. The at-queue-start pre-pass runs independently of that guard. When only at-queue-start entries exist, they run once, the loop is skipped, and the run completes (`cycles = 1`, as in the empty-template path). No busy-loop on cycling, since there is no per-cycle work.
+- **Alternatives considered**:
+  - Adding at-queue-start as the first thing *inside* the loop guarded by an `oncePerRunDone`-style flag — rejected: more state and easy to accidentally re-run on cycles; the pre-pass is simpler and self-evidently once-per-run.
+
+## Decision 3 — "After Every Step" is a display-label-only rename of `EveryStep`
+
+- **Decision**: Keep the enum value, persisted value, and API request/response identifier as `EveryStep`. Change only the operator-facing label to "After Every Step" in the UI (`SCHEDULE_LABELS` map and the badge text). Add an XML-doc note on `ScheduleType.EveryStep` that it is displayed as "After Every Step".
+- **Rationale**: Per clarification (Q3 = display label only), this is fully backward compatible: previously-saved templates, the file store, and any API/script clients keep using `EveryStep` with zero migration. Behavior is unchanged (FR-005/FR-006/FR-010). The UI is the only place an operator sees the label, and its dropdown/badges are data-driven from a single map, so the rename is a one-line label edit plus the badge string.
+- **Alternatives considered**:
+  - Renaming the enum/identifier to `AfterEveryStep` with a compatibility shim — rejected per clarification; adds migration/shim surface for no functional gain.
+  - Hard rename with no shim — rejected per clarification; would break existing templates and clients.
+
+## Decision 4 — No new API endpoint; reuse existing template save/read
+
+- **Decision**: Both options flow through the existing `POST /api/queue-templates` and `GET /api/queue-templates/{id}`. `AtQueueStart` is accepted automatically once added to the enum, because validation uses `Enum.TryParse(..., ignoreCase: true)` + `Enum.IsDefined`. Only the human-readable "accepted values" message in `QueueTemplatesEndpoints` is updated to include `AtQueueStart`.
+- **Rationale**: Scheduling configuration is a property of a template entry; it is created/edited through the template save path that already exists. No runtime/live channel is needed (unlike feature 059's live-schedule endpoint), because at-queue-start is purely a saved, declarative property.
+- **Alternatives considered**: A dedicated endpoint — rejected: unnecessary surface; inconsistent with how `OncePerRun`/`EveryStep`/`Timer` are configured.
+
+## Determinism / testing note
+
+The existing `QueueExecutionService` already uses an injectable `TimeProvider` (feature 059), so at-queue-start ordering relative to timers is unit-testable with a fake clock. At-queue-start itself involves no time reads — it runs unconditionally at run start — so its tests assert ordering and counts via the execution-log/sequence-execution spy already used by `QueueExecutionServiceTests`.

--- a/specs/060-queue-start-after-every-scheduling/spec.md
+++ b/specs/060-queue-start-after-every-scheduling/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Queue-Start and After-Every-Step Scheduling
+
+**Feature Branch**: `060-queue-start-after-every-scheduling`  
+**Created**: 2026-06-18  
+**Status**: Draft  
+**Input**: User description: "I need two more scheduling options: at queue start and after every sequence. It should work like this: all the sequences that are scheduled to be started at queue start, must be executed in the order of appearing in the template at queue start, before any evaluation of execution timers take place. the 'after every sequence' means that after every sequence step, one or many 'after every sequence' sequences will be executed. 'after every' in this respect doesn't apply to such sequences, so that they don't create endless loops. The functionality has to be enabled in the UI and API."
+
+## Clarifications
+
+### Session 2026-06-18
+
+- Q: How should "after every sequence" relate to the existing "Every Step" option? → A: It is the **same narrow behavior** as today's "Every Step" (fires after each normal "Once Per Run" step only), and it **supersedes** "Every Step" — renamed to **"After Every Step"**. The broad "fires after every executed sequence (start/timer/etc.)" interpretation is **out of scope**.
+- Q: Does "At Queue Start" count toward the run's executed-sequence total? → A: **Yes** — "At Queue Start" executions count toward the executed total (treated as deliberate scheduled work), like "Once Per Run" and relative/live timer firings.
+- Q: For the "Every Step" → "After Every Step" rename, does the API/stored identifier change? → A: **No** — change the **display label only**; keep the existing API/stored identifier (`EveryStep`). Fully backward compatible, no migration.
+
+## User Scenarios & Testing *(mandatory)*
+
+A queue template is an ordered list of sequence references, each tagged with a **schedule option** that controls when, during a run, that sequence executes. Today the available options are: run once per run/cycle as a normal step ("Once Per Run"), run after each normal step (currently labeled "Every Step"), and run on a timer (time-of-day or relative offset). This feature:
+
+1. Adds one genuinely new option, **At Queue Start**, that runs entries in template order at the very start of a run, before any timer is evaluated.
+2. **Renames the existing "Every Step" option to "After Every Step"** for clarity, keeping its current behavior (it fires after each normal step) and its loop-safe property (it never triggers itself).
+
+Both options are surfaced everywhere schedule options are surfaced today: the template editor UI and the template/queue API.
+
+### User Story 1 - Run setup sequences at queue start (Priority: P1)
+
+As an operator, I want to mark one or more sequences in a template as "At Queue Start" so that they run, in template order, the moment the queue begins — before any timer-scheduled sequences are evaluated — so I can reliably perform startup/setup work (e.g. open the game, dismiss daily pop-ups, navigate to a known screen) before the rest of the run proceeds.
+
+**Why this priority**: Startup/setup work is a precondition for the correctness of everything else in the run. Without a guaranteed-first execution slot, operators currently rely on ordering tricks that break as soon as timers or other schedule types are involved. This is the highest-value, independently demonstrable slice and the only genuinely new run behavior in this feature.
+
+**Independent Test**: Create a template with two "At Queue Start" entries and a couple of normal entries, start the queue, and confirm the two start entries execute first, in their template order, before any timer evaluation or normal steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a template with sequences A and B marked "At Queue Start" (A before B in the template) plus normal step C, **When** the queue starts, **Then** A executes, then B executes, then the run proceeds to evaluate timers and run C.
+2. **Given** a template containing both "At Queue Start" entries and timer entries (time-of-day, relative offset), **When** the queue starts, **Then** all "At Queue Start" entries run to completion before any timer is evaluated for the first time.
+3. **Given** a template with no "At Queue Start" entries, **When** the queue starts, **Then** the run behaves exactly as it does today (no change).
+4. **Given** a cycling queue with "At Queue Start" entries, **When** the queue runs multiple cycles, **Then** the "At Queue Start" entries run once at the beginning of the run and are not repeated at the start of each subsequent cycle.
+
+---
+
+### User Story 2 - Rename "Every Step" to "After Every Step" (Priority: P2)
+
+As an operator, I want the existing per-step option to be labeled "After Every Step" (instead of "Every Step") in the UI and API so its meaning — "run this after every normal step" — is self-evident, while its behavior stays exactly as it is today.
+
+**Why this priority**: This is a clarity/usability improvement to an existing capability, not new run behavior. It is independently shippable (a label/identifier change) but lower value than the new "At Queue Start" slot.
+
+**Independent Test**: In the template editor, the per-step option appears as "After Every Step"; selecting it for an entry and running the queue produces the same after-each-normal-step execution as the current "Every Step" option does.
+
+**Acceptance Scenarios**:
+
+1. **Given** a template with normal steps C and D and one "After Every Step" entry X, **When** the queue runs, **Then** X executes after C and after D (and once more after the final normal step), exactly as "Every Step" does today.
+2. **Given** two "After Every Step" entries X and Y (X before Y in the template), **When** a normal step completes, **Then** X executes, then Y executes — and neither X nor Y triggers a further round of "After Every Step" execution (no endless loop).
+3. **Given** "At Queue Start" entry A and "After Every Step" entry X, **When** the queue starts, **Then** X does NOT run after A — "After Every Step" fires only after normal ("Once Per Run") steps, not after queue-start or timer firings.
+4. **Given** a template that previously used the "Every Step" option, **When** it is loaded after this change, **Then** the same entries run with identical behavior under the new "After Every Step" label (no behavioral migration required).
+
+---
+
+### User Story 3 - Configure the options in UI and API (Priority: P3)
+
+As an operator, I want to select "At Queue Start" and "After Every Step" from the same schedule-type control I already use for each template entry — in the web UI and via the API — so the options are discoverable and scriptable alongside the existing ones.
+
+**Why this priority**: The scheduling behavior (Stories 1–2) is the core value; surfacing it is what makes it usable. It is listed separately to make the cross-surface enablement explicit and independently testable.
+
+**Independent Test**: In the template editor, change an entry's schedule type to "At Queue Start" and save; reload and confirm the choice persisted. Via the API, save a template whose entries use the options and read them back, confirming the values round-trip.
+
+**Acceptance Scenarios**:
+
+1. **Given** the template editor, **When** the operator opens an entry's schedule-type selector, **Then** "At Queue Start" and "After Every Step" appear as choices alongside "Once Per Run" and the timer options.
+2. **Given** an entry set to "At Queue Start", **When** the operator saves and reloads the template, **Then** the entry still shows "At Queue Start" and a clear badge/label indicating it.
+3. **Given** an API client, **When** it saves a template entry with the new schedule option and then reads the template, **Then** the schedule option round-trips unchanged.
+4. **Given** an API client, **When** it sends an unrecognized or invalid schedule option, **Then** the request is rejected with a clear validation error and the template is not modified.
+
+---
+
+### Edge Cases
+
+- **At Queue Start with timers**: "At Queue Start" entries always precede the first timer evaluation; timers (time-of-day, relative offset, live schedule) continue to be evaluated only at iteration boundaries as today.
+- **After Every Step excludes itself**: an "After Every Step" execution never counts as a "normal step" that triggers another round — preserving today's loop-safe behavior even with multiple "After Every Step" entries (one completed normal step triggers exactly one pass through all "After Every Step" entries, not a cascading chain).
+- **Empty buckets**: a template with no "At Queue Start" entries (or no "After Every Step" entries) behaves exactly as today for the unaffected paths.
+- **Cycling vs non-cycling**: "At Queue Start" runs once per run regardless of cycling. "After Every Step" runs after each normal step in every cycle, as today.
+- **No normal steps present**: if a template has only "At Queue Start" and/or "After Every Step" entries and no "Once Per Run" steps, "After Every Step" entries behave exactly as the current "Every Step" option does in that situation (no behavior change from today).
+- **Failure of an "At Queue Start" sequence**: a failure is non-fatal — it is recorded and the run continues, consistent with how per-sequence failures are handled today.
+- **Stop mid-start**: if the queue is stopped while "At Queue Start" entries are still running, the run stops promptly and does not proceed to the main loop.
+- **Stale/unresolved sequence reference** in an "At Queue Start" entry: treated as a non-fatal per-sequence failure, same as for existing schedule types.
+- **Ordering among the same type**: "At Queue Start" entries always execute in their order of appearance in the template.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a new schedule option, "At Queue Start", for queue-template entries, in addition to the existing options.
+- **FR-002**: The system MUST rename the existing per-step schedule option's **display label** from "Every Step" to "After Every Step" in operator-facing surfaces (primarily the UI), without changing its run behavior and without changing its underlying API/stored identifier (`EveryStep`), so existing templates and API/script clients keep working unchanged.
+- **FR-003**: The system MUST execute all "At Queue Start" entries once at the beginning of a run, in their order of appearance in the template, before any timer (time-of-day, relative-offset, or live) is evaluated and before the first normal step runs.
+- **FR-004**: The system MUST run "At Queue Start" entries exactly once per run, not once per cycle, for cycling queues.
+- **FR-005**: "After Every Step" entries MUST continue to execute after each normal ("Once Per Run") step (and once more after the final normal step), in their order of appearance in the template — identical to the current "Every Step" behavior. "After Every Step" MUST NOT fire after "At Queue Start" executions or after timer/relative/live firings.
+- **FR-006**: An "After Every Step" execution MUST NOT itself trigger another round of "After Every Step" executions; this loop-prevention guarantee MUST hold for any number of "After Every Step" entries (preserving today's behavior).
+- **FR-007**: A failure in an "At Queue Start" sequence MUST be non-fatal: the failure is recorded and the run continues, consistent with existing per-sequence failure handling.
+- **FR-008**: The system MUST allow a template to contain zero, one, or many "At Queue Start" entries, and MUST allow "At Queue Start" to coexist with all other schedule options in the same template.
+- **FR-009**: The system MUST persist an entry's chosen schedule option (including "At Queue Start") and return it unchanged when the template is read back.
+- **FR-010**: Templates that previously used the "Every Step" option MUST continue to run with identical behavior under the "After Every Step" label, with no data migration required and no change to stored templates' run outcomes.
+- **FR-011**: Existing behavior for "Once Per Run" and the timer modes MUST remain unchanged; "At Queue Start" is purely additive and the default schedule option for entries without an explicit choice MUST be unchanged.
+- **FR-012**: The web UI template editor MUST let the operator select "At Queue Start" (and the renamed "After Every Step") from the same per-entry schedule-type control used for existing options, and MUST clearly indicate (e.g. via a badge/label) when an entry uses "At Queue Start".
+- **FR-013**: The API MUST accept "At Queue Start" on template-entry save and return it on template read, continue to accept and return the existing per-step identifier (`EveryStep`) unchanged, and reject an unrecognized/invalid schedule option with a clear validation error without modifying the template.
+- **FR-014**: "At Queue Start" entries MUST be evaluated/executed only at the start of the run (before the first iteration's timer evaluation), with no new background timers or polling introduced beyond what already exists.
+- **FR-015**: "At Queue Start" executions MUST count toward the run's executed-sequence total (like "Once Per Run" and relative/live firings); "After Every Step" executions MUST NOT count, unchanged from today's "Every Step".
+
+### Key Entities *(include if feature involves data)*
+
+- **Queue Template Entry**: a positional reference to a sequence within a template, carrying a schedule option. This feature adds one possible schedule option ("At Queue Start") and renames one existing option ("Every Step" → "After Every Step"); no other attributes of the entry change.
+- **Schedule Option**: the enumerated choice that governs when an entry's sequence executes during a run. After this feature the set is: Once Per Run, After Every Step (formerly "Every Step"), Timer (time-of-day / relative offset), and At Queue Start.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a template with "At Queue Start" entries, 100% of runs execute those entries first, in template order, before any timer evaluation or normal step — verifiable from the run's execution-log ordering.
+- **SC-002**: For a template with an "After Every Step" entry, the entry executes after each normal step and once after the final normal step, with zero self-triggered executions and no executions after queue-start or timer firings — identical to current "Every Step" behavior across a cycling and a non-cycling run.
+- **SC-003**: A run that includes "At Queue Start" and "After Every Step" entries always terminates (no endless loops), completing within the expected, bounded number of executions.
+- **SC-004**: "At Queue Start" is selectable in the template editor and round-trips through the API: an entry saved with it reads back with the same option in 100% of cases.
+- **SC-005**: Existing templates and the (renamed) per-step behavior, "Once Per Run", and timer behaviors produce identical run ordering and outcomes before and after this feature (no regressions), verified by the existing scheduling test suite continuing to pass (updated only for the rename).
+- **SC-006**: An operator can configure "At Queue Start" for a template entry without consulting documentation, completing the change in under 1 minute in the editor.
+
+## Assumptions
+
+- **Counting toward run totals**: "At Queue Start" executions are deliberate, scheduled work and count toward the run's executed-sequence total (confirmed); "After Every Step" executions remain interstitial and do NOT count toward the executed total (unchanged from today's "Every Step"). Neither option, by itself, defines run completion — completion continues to be governed by the "Once Per Run" steps.
+- **Rename mechanics**: "After Every Step" is a **display-label change only** (confirmed). The underlying persisted/API identifier stays `EveryStep`, so previously-saved templates and existing API/script clients keep working with no migration (FR-002/FR-010/FR-013).
+- **No new persistence format**: the schedule option continues to be stored on the existing template-entry record using the existing storage mechanism; "At Queue Start" is an additive enumeration value and is backward compatible.
+- **No new external dependencies or background services**: the behavior is implemented within the existing run loop.
+- **Naming**: the operator-facing labels are "At Queue Start" and "After Every Step"; exact wording may be refined during design but the meaning is as specified here.

--- a/specs/060-queue-start-after-every-scheduling/tasks.md
+++ b/specs/060-queue-start-after-every-scheduling/tasks.md
@@ -1,4 +1,4 @@
----
+﻿---
 
 description: "Task list for feature 060: Queue-Start and After-Every-Step Scheduling"
 ---
@@ -8,7 +8,7 @@ description: "Task list for feature 060: Queue-Start and After-Every-Step Schedu
 **Input**: Design documents from `/specs/060-queue-start-after-every-scheduling/`
 **Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
 
-**Tests**: REQUIRED by the project constitution (Principle II — Testing Standards). Test tasks are included per story.
+**Tests**: REQUIRED by the project constitution (Principle II â€” Testing Standards). Test tasks are included per story.
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing.
 
@@ -28,7 +28,7 @@ Web application (per plan.md): backend under `src/GameBot.*`, frontend under `sr
 
 **Purpose**: Confirm a green baseline before changes (constitution NON-NEGOTIABLE: no work proceeds on a red build/test).
 
-- [ ] T001 Verify baseline is green: run backend `dotnet build` + `dotnet test`, and from `src/web-ui` run `npx vite build` + `npx jest`. Record that all pass before making changes.
+- [X] T001 Verify baseline is green: run backend `dotnet build` + `dotnet test`, and from `src/web-ui` run `npx vite build` + `npx jest`. Record that all pass before making changes.
 
 ---
 
@@ -36,29 +36,29 @@ Web application (per plan.md): backend under `src/GameBot.*`, frontend under `sr
 
 **Purpose**: The shared domain enum that every story depends on.
 
-**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+**âš ï¸ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 Add `AtQueueStart = 3` (with XML doc describing run-start, template-order, once-per-run, counts-toward-executed behavior) to the `ScheduleType` enum, and add an XML-doc note on `EveryStep` that it is displayed as "After Every Step", in src/GameBot.Domain/QueueTemplates/ScheduleType.cs
+- [X] T002 Add `AtQueueStart = 3` (with XML doc describing run-start, template-order, once-per-run, counts-toward-executed behavior) to the `ScheduleType` enum, and add an XML-doc note on `EveryStep` that it is displayed as "After Every Step", in src/GameBot.Domain/QueueTemplates/ScheduleType.cs
 
-**Checkpoint**: Enum extended — backend execution, API validation, and UI typing can now reference `AtQueueStart`.
+**Checkpoint**: Enum extended â€” backend execution, API validation, and UI typing can now reference `AtQueueStart`.
 
 ---
 
-## Phase 3: User Story 1 - Run setup sequences at queue start (Priority: P1) 🎯 MVP
+## Phase 3: User Story 1 - Run setup sequences at queue start (Priority: P1) ðŸŽ¯ MVP
 
 **Goal**: Entries marked `AtQueueStart` run once per run, in template order, before any timer evaluation and before the first `OncePerRun` step, counting toward the executed total, with non-fatal failure handling.
 
 **Independent Test**: Run `QueueExecutionServiceTests` and the schedule-type integration test; confirm at-queue-start sequences execute first, in order, are counted, run once per run, and a failure does not abort the run.
 
-### Tests for User Story 1 ⚠️ (write first, ensure they FAIL before T006)
+### Tests for User Story 1 âš ï¸ (write first, ensure they FAIL before T006)
 
-- [ ] T003 [US1] Add unit tests to tests/unit/Queues/QueueExecutionServiceTests.cs for at-queue-start ordering and counting: runs before timer evaluation AND before the first `OncePerRun` step; multiple at-queue-start entries run in template order; each firing increments `executed` (FR-003/FR-014/FR-015).
-- [ ] T004 [US1] Add unit tests to tests/unit/Queues/QueueExecutionServiceTests.cs for at-queue-start lifecycle: runs once per run on a cycling queue (not per cycle, FR-004); a failing at-queue-start sequence is non-fatal (increments `failed`, run continues, FR-007); a template containing only at-queue-start entries runs them once and completes (FR-008/SC-003). (Same file as T003 — sequence after it.)
-- [ ] T005 [P] [US1] Add an end-to-end ordering test to tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs asserting at-queue-start entries execute before timers/normal steps in a real run (SC-001).
+- [X] T003 [US1] Add unit tests to tests/unit/Queues/QueueExecutionServiceTests.cs for at-queue-start ordering and counting: runs before timer evaluation AND before the first `OncePerRun` step; multiple at-queue-start entries run in template order; each firing increments `executed` (FR-003/FR-014/FR-015).
+- [X] T004 [US1] Add unit tests to tests/unit/Queues/QueueExecutionServiceTests.cs for at-queue-start lifecycle: runs once per run on a cycling queue (not per cycle, FR-004); a failing at-queue-start sequence is non-fatal (increments `failed`, run continues, FR-007); a template containing only at-queue-start entries runs them once and completes (FR-008/SC-003). (Same file as T003 â€” sequence after it.)
+- [X] T005 [P] [US1] Add an end-to-end ordering test to tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs asserting at-queue-start entries execute before timers/normal steps in a real run (SC-001).
 
 ### Implementation for User Story 1
 
-- [ ] T006 [US1] Implement the at-queue-start pre-pass in src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs: partition `AtQueueStart` entries; run them once, in template order, before the `do/while` loop (after session connect) via `RunOneSequenceAsync`; `executed++` per firing and `failed++` on failure; honor cancellation and the connection-lost check; ensure a template with only at-queue-start entries completes cleanly (`cycles = 1`, no busy-loop).
+- [X] T006 [US1] Implement the at-queue-start pre-pass in src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs: partition `AtQueueStart` entries; run them once, in template order, before the `do/while` loop (after session connect) via `RunOneSequenceAsync`; `executed++` per firing and `failed++` on failure; honor cancellation and the connection-lost check; ensure a template with only at-queue-start entries completes cleanly (`cycles = 1`, no busy-loop).
 
 **Checkpoint**: User Story 1 fully functional and independently testable (MVP).
 
@@ -70,15 +70,15 @@ Web application (per plan.md): backend under `src/GameBot.*`, frontend under `sr
 
 **Independent Test**: Run the Jest `QueueEntryList` label test, the contract backward-compat test, and the every-step negative-trigger unit test; confirm the UI shows "After Every Step", the `EveryStep` wire value round-trips, and every-step fires only after normal steps.
 
-### Tests for User Story 2 ⚠️
+### Tests for User Story 2 âš ï¸
 
-- [ ] T007 [P] [US2] Add a contract test to tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs verifying an `EveryStep` entry still saves and reads back as `EveryStep` (rename does not change the wire value, FR-002/FR-010).
-- [ ] T008 [US2] Add a negative-trigger unit test to tests/unit/Queues/QueueExecutionServiceTests.cs asserting an `EveryStep` entry runs ONLY after `OncePerRun` steps — it does NOT fire after `AtQueueStart` executions and does NOT fire after timer/relative firings (FR-005/FR-006). (Same file as T003/T004; depends on T006 impl so at-start firings exist.)
-- [ ] T009 [P] [US2] Add a Jest test to src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx asserting the per-step option renders with the label/badge text "After Every Step" (FR-002/FR-012).
+- [X] T007 [P] [US2] Add a contract test to tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs verifying an `EveryStep` entry still saves and reads back as `EveryStep` (rename does not change the wire value, FR-002/FR-010).
+- [X] T008 [US2] Add a negative-trigger unit test to tests/unit/Queues/QueueExecutionServiceTests.cs asserting an `EveryStep` entry runs ONLY after `OncePerRun` steps â€” it does NOT fire after `AtQueueStart` executions and does NOT fire after timer/relative firings (FR-005/FR-006). (Same file as T003/T004; depends on T006 impl so at-start firings exist.)
+- [X] T009 [P] [US2] Add a Jest test to src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx asserting the per-step option renders with the label/badge text "After Every Step" (FR-002/FR-012).
 
 ### Implementation for User Story 2
 
-- [ ] T010 [US2] Rename the `EveryStep` display label to "After Every Step" in `SCHEDULE_LABELS` and update the every-step badge text + `aria-label` in src/web-ui/src/components/queues/QueueEntryList.tsx (label-only; do not change the `ScheduleType` value).
+- [X] T010 [US2] Rename the `EveryStep` display label to "After Every Step" in `SCHEDULE_LABELS` and update the every-step badge text + `aria-label` in src/web-ui/src/components/queues/QueueEntryList.tsx (label-only; do not change the `ScheduleType` value).
 
 **Checkpoint**: Rename complete and verified; existing `EveryStep` templates/clients unaffected; narrow trigger confirmed.
 
@@ -90,19 +90,19 @@ Web application (per plan.md): backend under `src/GameBot.*`, frontend under `sr
 
 **Independent Test**: Run the contract tests + Jest option/round-trip specs; confirm `AtQueueStart` is a dropdown option, persists across save/reload, round-trips via the API, and an invalid type returns 400.
 
-### Tests for User Story 3 ⚠️
+### Tests for User Story 3 âš ï¸
 
-- [ ] T011 [US3] Add contract tests to tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs: an `AtQueueStart` entry saves and reads back unchanged; an unrecognized `scheduleType` returns 400 with the `{ error: { code, message, hint } }` envelope (FR-009/FR-013). (Same file as T007 — sequence after it.)
-- [ ] T012 [US3] Add a Jest test to src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx: "At Queue Start" appears as a dropdown option and shows its badge when selected (FR-012). (Same file as T009 — sequence after it.)
-- [ ] T013 [P] [US3] Add a Jest test to src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx asserting an `AtQueueStart` entry round-trips through save and reload (FR-009/SC-004).
+- [X] T011 [US3] Add contract tests to tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs: an `AtQueueStart` entry saves and reads back unchanged; an unrecognized `scheduleType` returns 400 with the `{ error: { code, message, hint } }` envelope (FR-009/FR-013). (Same file as T007 â€” sequence after it.)
+- [X] T012 [US3] Add a Jest test to src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx: "At Queue Start" appears as a dropdown option and shows its badge when selected (FR-012). (Same file as T009 â€” sequence after it.)
+- [X] T013 [P] [US3] Add a Jest test to src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx asserting an `AtQueueStart` entry round-trips through save and reload (FR-009/SC-004).
 
 ### Implementation for User Story 3
 
-- [ ] T014 [US3] Update the "accepted values" validation error string to include `AtQueueStart` (e.g. "OncePerRun, EveryStep, Timer, AtQueueStart") in src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs
-- [ ] T015 [P] [US3] Update doc comments to list `AtQueueStart` as an accepted/returned schedule type in src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs and src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
-- [ ] T016 [P] [US3] Add `'AtQueueStart'` to the `ScheduleType` union in src/web-ui/src/services/queueTemplates.ts
-- [ ] T017 [US3] Add `AtQueueStart: 'At Queue Start'` to `SCHEDULE_LABELS` and render an "At Queue Start" badge for such entries in src/web-ui/src/components/queues/QueueEntryList.tsx (depends on T010 same file, and T016 type)
-- [ ] T018 [US3] Verify (and adjust if needed) that schedule state passes `AtQueueStart` through save/reload defaults in src/web-ui/src/pages/QueuesPage.tsx
+- [X] T014 [US3] Update the "accepted values" validation error string to include `AtQueueStart` (e.g. "OncePerRun, EveryStep, Timer, AtQueueStart") in src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs
+- [X] T015 [P] [US3] Update doc comments to list `AtQueueStart` as an accepted/returned schedule type in src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs and src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
+- [X] T016 [P] [US3] Add `'AtQueueStart'` to the `ScheduleType` union in src/web-ui/src/services/queueTemplates.ts
+- [X] T017 [US3] Add `AtQueueStart: 'At Queue Start'` to `SCHEDULE_LABELS` and render an "At Queue Start" badge for such entries in src/web-ui/src/components/queues/QueueEntryList.tsx (depends on T010 same file, and T016 type)
+- [X] T018 [US3] Verify (and adjust if needed) that schedule state passes `AtQueueStart` through save/reload defaults in src/web-ui/src/pages/QueuesPage.tsx
 
 **Checkpoint**: Both options are fully configurable in UI and API and round-trip correctly.
 
@@ -110,9 +110,9 @@ Web application (per plan.md): backend under `src/GameBot.*`, frontend under `sr
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T019 Add explicit regression assertions for unchanged behavior (FR-011): an entry with no `scheduleType` defaults to `OncePerRun`, and `OncePerRun`/`Timer` ordering and counting are unchanged; and the edge case where a template has `EveryStep` entries but no `OncePerRun` steps behaves as today — in tests/unit/Queues/QueueExecutionServiceTests.cs and/or tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs.
-- [ ] T020 [P] Validate the operator + API + run-time walkthrough in specs/060-queue-start-after-every-scheduling/quickstart.md against the implemented behavior.
-- [ ] T021 Final green gate: backend `dotnet build` + `dotnet test`, and from `src/web-ui` `npx vite build` + `npx jest` — all pass with coverage baselines met for touched areas (≥80% line / ≥70% branch).
+- [X] T019 Add explicit regression assertions for unchanged behavior (FR-011): an entry with no `scheduleType` defaults to `OncePerRun`, and `OncePerRun`/`Timer` ordering and counting are unchanged; and the edge case where a template has `EveryStep` entries but no `OncePerRun` steps behaves as today â€” in tests/unit/Queues/QueueExecutionServiceTests.cs and/or tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs.
+- [X] T020 [P] Validate the operator + API + run-time walkthrough in specs/060-queue-start-after-every-scheduling/quickstart.md against the implemented behavior.
+- [X] T021 Final green gate: backend `dotnet build` + `dotnet test`, and from `src/web-ui` `npx vite build` + `npx jest` â€” all pass with coverage baselines met for touched areas (â‰¥80% line / â‰¥70% branch).
 
 ---
 
@@ -122,7 +122,7 @@ Web application (per plan.md): backend under `src/GameBot.*`, frontend under `sr
 
 - **Setup (Phase 1)**: No dependencies.
 - **Foundational (Phase 2)**: After Setup. **Blocks all user stories** (shared enum).
-- **User Stories (Phase 3–5)**: All depend on Foundational (T002).
+- **User Stories (Phase 3â€“5)**: All depend on Foundational (T002).
   - US1 (P1) is independent and is the MVP.
   - US2 (P2) depends on US1's impl (T006) for the negative-trigger test (T008) and shares the execution test file (T003/T004).
   - US3 (P3) depends on US2 for the shared `QueueEntryList.tsx` label map (T017 after T010).
@@ -130,21 +130,21 @@ Web application (per plan.md): backend under `src/GameBot.*`, frontend under `sr
 
 ### Key task-level dependencies
 
-- T002 → T003, T004, T005, T006, T008, T011, T014, T016 (anything referencing `AtQueueStart`).
-- T003 → T004 → T008 (same execution test file, sequential).
-- T003, T004, T005 → T006 (impl) — TDD: write failing tests first.
-- T006 → T008 (negative-trigger test needs at-start firings to exist).
-- T007 → T011 (same contract test file).
-- T009 → T012 (same Jest test file).
-- T010 → T017 (same `QueueEntryList.tsx`); T016 → T017 (type before use).
-- T009/T012 → T010/T017 (TDD where practical).
+- T002 â†’ T003, T004, T005, T006, T008, T011, T014, T016 (anything referencing `AtQueueStart`).
+- T003 â†’ T004 â†’ T008 (same execution test file, sequential).
+- T003, T004, T005 â†’ T006 (impl) â€” TDD: write failing tests first.
+- T006 â†’ T008 (negative-trigger test needs at-start firings to exist).
+- T007 â†’ T011 (same contract test file).
+- T009 â†’ T012 (same Jest test file).
+- T010 â†’ T017 (same `QueueEntryList.tsx`); T016 â†’ T017 (type before use).
+- T009/T012 â†’ T010/T017 (TDD where practical).
 
 ### Parallel Opportunities
 
-- US1: T005 (integration, different file) runs in parallel with T003/T004; T003→T004 are same-file sequential.
-- US2: T007 and T009 are different files → run in parallel; T008 sequenced in the execution test file.
-- US3: T013, T015, T016 are different files with no shared-file conflict → run in parallel.
-- After Foundational, US1 and US2 can largely proceed together (mind the shared execution test file and T006→T008); US3 follows US2 for the shared UI file.
+- US1: T005 (integration, different file) runs in parallel with T003/T004; T003â†’T004 are same-file sequential.
+- US2: T007 and T009 are different files â†’ run in parallel; T008 sequenced in the execution test file.
+- US3: T013, T015, T016 are different files with no shared-file conflict â†’ run in parallel.
+- After Foundational, US1 and US2 can largely proceed together (mind the shared execution test file and T006â†’T008); US3 follows US2 for the shared UI file.
 
 ---
 
@@ -163,21 +163,22 @@ Task: "Integration test in tests/integration/QueueTemplates/QueueTemplatesSchedu
 
 ### MVP First (User Story 1 only)
 
-1. Phase 1 Setup (T001) → Phase 2 Foundational (T002) → Phase 3 US1 (T003–T006).
+1. Phase 1 Setup (T001) â†’ Phase 2 Foundational (T002) â†’ Phase 3 US1 (T003â€“T006).
 2. **STOP and VALIDATE**: at-queue-start behavior via backend tests. Demo if ready.
 
 ### Incremental Delivery
 
-1. Setup + Foundational → ready.
-2. US1 (At Queue Start behavior) → test → demo (MVP!).
-3. US2 (rename label + narrow-trigger guarantee) → test → demo.
-4. US3 (UI/API enablement) → test → demo.
+1. Setup + Foundational â†’ ready.
+2. US1 (At Queue Start behavior) â†’ test â†’ demo (MVP!).
+3. US2 (rename label + narrow-trigger guarantee) â†’ test â†’ demo.
+4. US3 (UI/API enablement) â†’ test â†’ demo.
 
 ---
 
 ## Notes
 
 - [P] = different files, no dependency on an incomplete task.
-- The "After Every Step" change is label-only — never change the `EveryStep` enum/wire value (FR-002/FR-010).
+- The "After Every Step" change is label-only â€” never change the `EveryStep` enum/wire value (FR-002/FR-010).
 - `AtQueueStart` entries require no timer fields; validation only inspects timer fields under the `Timer` branch.
 - Commit after each task or logical group; keep a green build/test at every checkpoint.
+

--- a/specs/060-queue-start-after-every-scheduling/tasks.md
+++ b/specs/060-queue-start-after-every-scheduling/tasks.md
@@ -1,0 +1,183 @@
+---
+
+description: "Task list for feature 060: Queue-Start and After-Every-Step Scheduling"
+---
+
+# Tasks: Queue-Start and After-Every-Step Scheduling
+
+**Input**: Design documents from `/specs/060-queue-start-after-every-scheduling/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: REQUIRED by the project constitution (Principle II — Testing Standards). Test tasks are included per story.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths are included in each description.
+
+## Path Conventions
+
+Web application (per plan.md): backend under `src/GameBot.*`, frontend under `src/web-ui/src`, tests under `tests/` (backend) and colocated `__tests__/` (web-ui).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm a green baseline before changes (constitution NON-NEGOTIABLE: no work proceeds on a red build/test).
+
+- [ ] T001 Verify baseline is green: run backend `dotnet build` + `dotnet test`, and from `src/web-ui` run `npx vite build` + `npx jest`. Record that all pass before making changes.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared domain enum that every story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Add `AtQueueStart = 3` (with XML doc describing run-start, template-order, once-per-run, counts-toward-executed behavior) to the `ScheduleType` enum, and add an XML-doc note on `EveryStep` that it is displayed as "After Every Step", in src/GameBot.Domain/QueueTemplates/ScheduleType.cs
+
+**Checkpoint**: Enum extended — backend execution, API validation, and UI typing can now reference `AtQueueStart`.
+
+---
+
+## Phase 3: User Story 1 - Run setup sequences at queue start (Priority: P1) 🎯 MVP
+
+**Goal**: Entries marked `AtQueueStart` run once per run, in template order, before any timer evaluation and before the first `OncePerRun` step, counting toward the executed total, with non-fatal failure handling.
+
+**Independent Test**: Run `QueueExecutionServiceTests` and the schedule-type integration test; confirm at-queue-start sequences execute first, in order, are counted, run once per run, and a failure does not abort the run.
+
+### Tests for User Story 1 ⚠️ (write first, ensure they FAIL before T006)
+
+- [ ] T003 [US1] Add unit tests to tests/unit/Queues/QueueExecutionServiceTests.cs for at-queue-start ordering and counting: runs before timer evaluation AND before the first `OncePerRun` step; multiple at-queue-start entries run in template order; each firing increments `executed` (FR-003/FR-014/FR-015).
+- [ ] T004 [US1] Add unit tests to tests/unit/Queues/QueueExecutionServiceTests.cs for at-queue-start lifecycle: runs once per run on a cycling queue (not per cycle, FR-004); a failing at-queue-start sequence is non-fatal (increments `failed`, run continues, FR-007); a template containing only at-queue-start entries runs them once and completes (FR-008/SC-003). (Same file as T003 — sequence after it.)
+- [ ] T005 [P] [US1] Add an end-to-end ordering test to tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs asserting at-queue-start entries execute before timers/normal steps in a real run (SC-001).
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Implement the at-queue-start pre-pass in src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs: partition `AtQueueStart` entries; run them once, in template order, before the `do/while` loop (after session connect) via `RunOneSequenceAsync`; `executed++` per firing and `failed++` on failure; honor cancellation and the connection-lost check; ensure a template with only at-queue-start entries completes cleanly (`cycles = 1`, no busy-loop).
+
+**Checkpoint**: User Story 1 fully functional and independently testable (MVP).
+
+---
+
+## Phase 4: User Story 2 - Rename "Every Step" to "After Every Step" (Priority: P2)
+
+**Goal**: The existing per-step option displays as "After Every Step" in the UI, with behavior and the `EveryStep` wire/stored identifier unchanged (backward compatible). The narrow trigger (only after `OncePerRun` steps) is preserved.
+
+**Independent Test**: Run the Jest `QueueEntryList` label test, the contract backward-compat test, and the every-step negative-trigger unit test; confirm the UI shows "After Every Step", the `EveryStep` wire value round-trips, and every-step fires only after normal steps.
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T007 [P] [US2] Add a contract test to tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs verifying an `EveryStep` entry still saves and reads back as `EveryStep` (rename does not change the wire value, FR-002/FR-010).
+- [ ] T008 [US2] Add a negative-trigger unit test to tests/unit/Queues/QueueExecutionServiceTests.cs asserting an `EveryStep` entry runs ONLY after `OncePerRun` steps — it does NOT fire after `AtQueueStart` executions and does NOT fire after timer/relative firings (FR-005/FR-006). (Same file as T003/T004; depends on T006 impl so at-start firings exist.)
+- [ ] T009 [P] [US2] Add a Jest test to src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx asserting the per-step option renders with the label/badge text "After Every Step" (FR-002/FR-012).
+
+### Implementation for User Story 2
+
+- [ ] T010 [US2] Rename the `EveryStep` display label to "After Every Step" in `SCHEDULE_LABELS` and update the every-step badge text + `aria-label` in src/web-ui/src/components/queues/QueueEntryList.tsx (label-only; do not change the `ScheduleType` value).
+
+**Checkpoint**: Rename complete and verified; existing `EveryStep` templates/clients unaffected; narrow trigger confirmed.
+
+---
+
+## Phase 5: User Story 3 - Configure the options in UI and API (Priority: P3)
+
+**Goal**: `AtQueueStart` (and the renamed "After Every Step") are selectable in the template editor and round-trip through the API; invalid schedule types are rejected with the standard error envelope.
+
+**Independent Test**: Run the contract tests + Jest option/round-trip specs; confirm `AtQueueStart` is a dropdown option, persists across save/reload, round-trips via the API, and an invalid type returns 400.
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T011 [US3] Add contract tests to tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs: an `AtQueueStart` entry saves and reads back unchanged; an unrecognized `scheduleType` returns 400 with the `{ error: { code, message, hint } }` envelope (FR-009/FR-013). (Same file as T007 — sequence after it.)
+- [ ] T012 [US3] Add a Jest test to src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx: "At Queue Start" appears as a dropdown option and shows its badge when selected (FR-012). (Same file as T009 — sequence after it.)
+- [ ] T013 [P] [US3] Add a Jest test to src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx asserting an `AtQueueStart` entry round-trips through save and reload (FR-009/SC-004).
+
+### Implementation for User Story 3
+
+- [ ] T014 [US3] Update the "accepted values" validation error string to include `AtQueueStart` (e.g. "OncePerRun, EveryStep, Timer, AtQueueStart") in src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs
+- [ ] T015 [P] [US3] Update doc comments to list `AtQueueStart` as an accepted/returned schedule type in src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs and src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
+- [ ] T016 [P] [US3] Add `'AtQueueStart'` to the `ScheduleType` union in src/web-ui/src/services/queueTemplates.ts
+- [ ] T017 [US3] Add `AtQueueStart: 'At Queue Start'` to `SCHEDULE_LABELS` and render an "At Queue Start" badge for such entries in src/web-ui/src/components/queues/QueueEntryList.tsx (depends on T010 same file, and T016 type)
+- [ ] T018 [US3] Verify (and adjust if needed) that schedule state passes `AtQueueStart` through save/reload defaults in src/web-ui/src/pages/QueuesPage.tsx
+
+**Checkpoint**: Both options are fully configurable in UI and API and round-trip correctly.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T019 Add explicit regression assertions for unchanged behavior (FR-011): an entry with no `scheduleType` defaults to `OncePerRun`, and `OncePerRun`/`Timer` ordering and counting are unchanged; and the edge case where a template has `EveryStep` entries but no `OncePerRun` steps behaves as today — in tests/unit/Queues/QueueExecutionServiceTests.cs and/or tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs.
+- [ ] T020 [P] Validate the operator + API + run-time walkthrough in specs/060-queue-start-after-every-scheduling/quickstart.md against the implemented behavior.
+- [ ] T021 Final green gate: backend `dotnet build` + `dotnet test`, and from `src/web-ui` `npx vite build` + `npx jest` — all pass with coverage baselines met for touched areas (≥80% line / ≥70% branch).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: After Setup. **Blocks all user stories** (shared enum).
+- **User Stories (Phase 3–5)**: All depend on Foundational (T002).
+  - US1 (P1) is independent and is the MVP.
+  - US2 (P2) depends on US1's impl (T006) for the negative-trigger test (T008) and shares the execution test file (T003/T004).
+  - US3 (P3) depends on US2 for the shared `QueueEntryList.tsx` label map (T017 after T010).
+- **Polish (Phase 6)**: After all desired stories complete.
+
+### Key task-level dependencies
+
+- T002 → T003, T004, T005, T006, T008, T011, T014, T016 (anything referencing `AtQueueStart`).
+- T003 → T004 → T008 (same execution test file, sequential).
+- T003, T004, T005 → T006 (impl) — TDD: write failing tests first.
+- T006 → T008 (negative-trigger test needs at-start firings to exist).
+- T007 → T011 (same contract test file).
+- T009 → T012 (same Jest test file).
+- T010 → T017 (same `QueueEntryList.tsx`); T016 → T017 (type before use).
+- T009/T012 → T010/T017 (TDD where practical).
+
+### Parallel Opportunities
+
+- US1: T005 (integration, different file) runs in parallel with T003/T004; T003→T004 are same-file sequential.
+- US2: T007 and T009 are different files → run in parallel; T008 sequenced in the execution test file.
+- US3: T013, T015, T016 are different files with no shared-file conflict → run in parallel.
+- After Foundational, US1 and US2 can largely proceed together (mind the shared execution test file and T006→T008); US3 follows US2 for the shared UI file.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write US1 tests, confirm they FAIL, then implement T006.
+# T005 (integration) is a different file and can run alongside T003/T004:
+Task: "Integration test in tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs"
+# T003 then T004 in tests/unit/Queues/QueueExecutionServiceTests.cs (same file, sequential)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup (T001) → Phase 2 Foundational (T002) → Phase 3 US1 (T003–T006).
+2. **STOP and VALIDATE**: at-queue-start behavior via backend tests. Demo if ready.
+
+### Incremental Delivery
+
+1. Setup + Foundational → ready.
+2. US1 (At Queue Start behavior) → test → demo (MVP!).
+3. US2 (rename label + narrow-trigger guarantee) → test → demo.
+4. US3 (UI/API enablement) → test → demo.
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on an incomplete task.
+- The "After Every Step" change is label-only — never change the `EveryStep` enum/wire value (FR-002/FR-010).
+- `AtQueueStart` entries require no timer fields; validation only inspects timer fields under the `Timer` branch.
+- Commit after each task or logical group; keep a green build/test at every checkpoint.

--- a/src/GameBot.Domain/QueueTemplates/ScheduleType.cs
+++ b/src/GameBot.Domain/QueueTemplates/ScheduleType.cs
@@ -17,6 +17,8 @@ namespace GameBot.Domain.QueueTemplates {
     /// Executes automatically after each OncePerRun sequence completes, and once more after the
     /// final OncePerRun step. Does not count toward run completion. Multiple EveryStep entries
     /// execute in their template order after each regular step.
+    /// Displayed to operators as "After Every Step"; the stored/wire identifier remains
+    /// <c>EveryStep</c> for backward compatibility.
     /// </summary>
     EveryStep = 1,
 
@@ -26,6 +28,14 @@ namespace GameBot.Domain.QueueTemplates {
     /// (server local time) has passed and the entry has not already fired on the current
     /// calendar date within this run. Resets on queue restart.
     /// </summary>
-    Timer = 2
+    Timer = 2,
+
+    /// <summary>
+    /// Executes once at the start of the run, in template order, before any timer evaluation and
+    /// before the first OncePerRun step. Runs once per run (not per cycle) and counts toward the
+    /// run's executed total. A failure is non-fatal (recorded in failed; the run continues),
+    /// consistent with OncePerRun handling.
+    /// </summary>
+    AtQueueStart = 3
   }
 }

--- a/src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
+++ b/src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
@@ -16,7 +16,8 @@ namespace GameBot.Service.Contracts.QueueTemplates {
     public bool Stale { get; set; }
 
     /// <summary>
-    /// Schedule type of this entry: "OncePerRun", "EveryStep", or "Timer".
+    /// Schedule type of this entry: "OncePerRun", "EveryStep", "Timer", or "AtQueueStart".
+    /// ("EveryStep" is displayed to operators as "After Every Step"; the returned value is unchanged.)
     /// </summary>
     public string ScheduleType { get; set; } = "OncePerRun";
 

--- a/src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs
+++ b/src/GameBot.Service/Contracts/QueueTemplates/TemplateEntrySaveRequest.cs
@@ -8,8 +8,9 @@ namespace GameBot.Service.Contracts.QueueTemplates {
     public string? SequenceId { get; set; }
 
     /// <summary>
-    /// Schedule type string: "OncePerRun", "EveryStep", or "Timer".
-    /// When absent or null, defaults to "OncePerRun".
+    /// Schedule type string: "OncePerRun", "EveryStep", "Timer", or "AtQueueStart".
+    /// When absent or null, defaults to "OncePerRun". ("EveryStep" is displayed to operators as
+    /// "After Every Step"; the wire value is unchanged.)
     /// </summary>
     public string? ScheduleType { get; set; }
 

--- a/src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs
@@ -39,7 +39,7 @@ internal static class QueueTemplatesEndpoints {
 
         if (!TryParseScheduleType(entry.ScheduleType, out var scheduleType))
           return Error(400, "invalid_request",
-            $"entries[{i}].scheduleType '{entry.ScheduleType}' is not valid; accepted values: OncePerRun, EveryStep, Timer");
+            $"entries[{i}].scheduleType '{entry.ScheduleType}' is not valid; accepted values: OncePerRun, EveryStep, Timer, AtQueueStart");
 
         if (scheduleType == ScheduleType.Timer) {
           var hasTimeOfDay = !string.IsNullOrWhiteSpace(entry.TimerTimeOfDay);

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -20,6 +20,8 @@ namespace GameBot.Service.Services.QueueExecution;
 /// execution-log entry with the stop reason. Replaces the placeholder start/stop behavior.
 ///
 /// Schedule types:
+///   AtQueueStart — executed once at run start, in template order, before any timer evaluation and
+///                 before the first OncePerRun step; counts toward executed (feature 060).
 ///   OncePerRun  — executed in template order as the regular "step"; defines run completion.
 ///   EveryStep   — executed after each OncePerRun step (and after the final step); not counted.
 ///   Timer       — evaluated at each iteration boundary; either an absolute time-of-day (fires at
@@ -140,6 +142,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
       else {
         // Pre-partition entries by schedule type (FR-001). Snapshots taken once at run start.
         var allEntries = template.Entries.ToList();
+        var atQueueStartEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.AtQueueStart).ToList();
         var oncePerRunEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.OncePerRun).ToList();
         var everyStepEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.EveryStep).ToList();
         var timerEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.Timer).ToList();
@@ -162,6 +165,19 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
         if (sessionId is not null) {
           try {
             var index = 0;
+
+            // (0) At-queue-start pre-pass (feature 060, FR-003/FR-004/FR-007/FR-014/FR-015).
+            // Run every at-queue-start entry once, in template order, BEFORE any timer evaluation
+            // and before the first OncePerRun step. Runs once per run (outside the do/while, so it
+            // never repeats on a cycling queue). Each firing COUNTS toward `executed`; a failure is
+            // non-fatal (recorded in `failed`, run continues), consistent with OncePerRun handling.
+            foreach (var startEntry in atQueueStartEntries) {
+              ct.ThrowIfCancellationRequested();
+              if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+              var startOk = await RunOneSequenceAsync(startEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+              executed++;
+              if (!startOk) failed++;
+            }
 
             // Per-run timer state: maps timer-entry index → last-fired calendar date (FR-003/FR-012).
             // Declared OUTSIDE the do-while loop so it persists across all cycles of this run.

--- a/src/web-ui/src/components/queues/QueueEntryList.tsx
+++ b/src/web-ui/src/components/queues/QueueEntryList.tsx
@@ -30,8 +30,10 @@ type QueueEntryListProps = {
 
 const SCHEDULE_LABELS: Record<ScheduleType, string> = {
   OncePerRun: 'Once Per Run',
-  EveryStep: 'Every Step',
+  // Display label only — the stored/wire identifier remains "EveryStep" (FR-002/FR-010).
+  EveryStep: 'After Every Step',
   Timer: 'Timer',
+  AtQueueStart: 'At Queue Start',
 };
 
 const pad2 = (n: number): string => n.toString().padStart(2, '0');
@@ -75,6 +77,7 @@ export const QueueEntryList: React.FC<QueueEntryListProps> = ({
           const schedule = entrySchedule[entry.entryId] ?? { scheduleType: 'OncePerRun' as ScheduleType, timerTimeOfDay: '' };
           const isTimer = schedule.scheduleType === 'Timer';
           const isEveryStep = schedule.scheduleType === 'EveryStep';
+          const isAtQueueStart = schedule.scheduleType === 'AtQueueStart';
           const timerMode: TimerMode = schedule.timerMode ?? (schedule.timerRelativeOffset ? 'relative' : 'timeOfDay');
           const isRelative = isTimer && timerMode === 'relative';
           const label = entry.sequenceName ?? entry.sequenceId;
@@ -91,7 +94,8 @@ export const QueueEntryList: React.FC<QueueEntryListProps> = ({
               <span className="queue-entry-name">
                 {label}
                 {entry.stale && <span className="badge badge-warning" role="status"> (stale)</span>}
-                {isEveryStep && <span className="badge badge-info" role="status" aria-label="Every Step"> Every Step</span>}
+                {isAtQueueStart && <span className="badge badge-info" role="status" aria-label="At Queue Start"> At Queue Start</span>}
+                {isEveryStep && <span className="badge badge-info" role="status" aria-label="After Every Step"> After Every Step</span>}
                 {isTimer && !isRelative && <span className="badge badge-info" role="status" aria-label="Timer"> Timer</span>}
                 {isRelative && <span className="badge badge-info" role="status" aria-label="Relative timer"> Timer · relative</span>}
               </span>

--- a/src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { QueueEntryList, EntrySchedule } from '../QueueEntryList';
 import { QueueEntryDto } from '../../../services/queues';
 import { SequenceDto } from '../../../services/sequences';
@@ -115,7 +115,7 @@ describe('QueueEntryList', () => {
     expect(screen.queryByLabelText('Timer time for Alpha')).not.toBeInTheDocument();
   });
 
-  it('shows EveryStep badge for EveryStep entries', () => {
+  it('shows the After Every Step badge for EveryStep entries', () => {
     const entries: QueueEntryDto[] = [
       { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
     ];
@@ -132,7 +132,8 @@ describe('QueueEntryList', () => {
       />
     );
 
-    expect(screen.getByLabelText('Every Step')).toBeInTheDocument();
+    // FR-002/FR-012: the badge is relabeled "After Every Step" (wire value stays EveryStep).
+    expect(screen.getByLabelText('After Every Step')).toBeInTheDocument();
   });
 
   it('shows Timer badge for Timer entries', () => {
@@ -172,8 +173,62 @@ describe('QueueEntryList', () => {
       />
     );
 
-    expect(screen.queryByLabelText('Every Step')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('After Every Step')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Timer')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('At Queue Start')).not.toBeInTheDocument();
+  });
+
+  // feature 060: "After Every Step" rename (US2) + "At Queue Start" option (US3)
+
+  it('renders the per-step schedule option labeled "After Every Step" (T009)', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+        onScheduleTypeChange={jest.fn()}
+        onTimerTimeChange={jest.fn()}
+      />
+    );
+
+    const dropdown = screen.getByLabelText('Schedule type for Alpha');
+    const everyStepOption = within(dropdown).getByRole('option', { name: 'After Every Step' }) as HTMLOptionElement;
+    // The display label changed but the underlying value remains the EveryStep identifier (FR-010).
+    expect(everyStepOption.value).toBe('EveryStep');
+  });
+
+  it('renders "At Queue Start" as a dropdown option and shows its badge when selected (T012)', () => {
+    const entries: QueueEntryDto[] = [
+      { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'Alpha', stale: false },
+    ];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      e1: { scheduleType: 'AtQueueStart', timerTimeOfDay: '' },
+    };
+    render(
+      <QueueEntryList
+        entries={entries}
+        sequences={sequences}
+        onAdd={jest.fn()}
+        onRemove={jest.fn()}
+        entrySchedule={entrySchedule}
+        onScheduleTypeChange={jest.fn()}
+        onTimerTimeChange={jest.fn()}
+      />
+    );
+
+    const dropdown = screen.getByLabelText('Schedule type for Alpha');
+    const option = within(dropdown).getByRole('option', { name: 'At Queue Start' }) as HTMLOptionElement;
+    expect(option.value).toBe('AtQueueStart');
+    // The badge renders for an at-queue-start entry.
+    expect(screen.getByLabelText('At Queue Start')).toBeInTheDocument();
   });
 
   it('calls onScheduleTypeChange when dropdown changes', () => {

--- a/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
@@ -176,6 +176,48 @@ describe('QueuesPage template load wiring', () => {
   });
 });
 
+describe('QueuesPage AtQueueStart round-trip (feature 060, T013)', () => {
+  it('saves an AtQueueStart entry and reflects it after reload', async () => {
+    saveTemplateMock.mockResolvedValue({ id: 't1' } as any);
+    // Reload returns the saved template with the entry typed AtQueueStart.
+    getTemplateMock.mockResolvedValue({
+      id: 't1', name: 'At Start Farm', entryCount: 1, createdAt: null, updatedAt: null,
+      entries: [
+        { sequenceId: 'seq-a', sequenceName: 'A', stale: false, scheduleType: 'AtQueueStart', timerTimeOfDay: null },
+        { sequenceId: 'seq-b', sequenceName: 'B', stale: false, scheduleType: 'OncePerRun', timerTimeOfDay: null },
+      ],
+    } as any);
+
+    render(<QueuesPage />);
+    await screen.findByText('Daily');
+    fireEvent.click(screen.getByText('Daily'));
+    await screen.findByText('Edit Queue');
+
+    // Mark the first entry as "At Queue Start" via the schedule dropdown.
+    fireEvent.change(screen.getByLabelText('Schedule type for A'), { target: { value: 'AtQueueStart' } });
+
+    // Save the template and confirm the schedule type is carried on the wire (SC-004).
+    fireEvent.click(screen.getByText('Save Template'));
+    const section = await screen.findByRole('region', { name: 'Save template' });
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'At Start Farm' } });
+    fireEvent.click(within(section).getByText('Save'));
+
+    await waitFor(() =>
+      expect(saveTemplateMock).toHaveBeenCalledWith({
+        name: 'At Start Farm',
+        entries: [
+          { sequenceId: 'seq-a', scheduleType: 'AtQueueStart' },
+          { sequenceId: 'seq-b', scheduleType: 'OncePerRun' },
+        ],
+        overwrite: false,
+      })
+    );
+
+    // The dropdown still reflects the selected at-queue-start type for the first entry.
+    expect((screen.getByLabelText('Schedule type for A') as HTMLSelectElement).value).toBe('AtQueueStart');
+  });
+});
+
 describe('QueuesPage template delete wiring', () => {
   it('deletes a template from the picker without touching the queue entries', async () => {
     deleteTemplateMock.mockResolvedValue(undefined as any);

--- a/src/web-ui/src/services/queueTemplates.ts
+++ b/src/web-ui/src/services/queueTemplates.ts
@@ -8,7 +8,7 @@ export type QueueTemplateSummary = {
   updatedAt: string | null;
 };
 
-export type ScheduleType = 'OncePerRun' | 'EveryStep' | 'Timer';
+export type ScheduleType = 'OncePerRun' | 'EveryStep' | 'Timer' | 'AtQueueStart';
 
 export type QueueTemplateEntryDto = {
   sequenceId: string;

--- a/tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs
+++ b/tests/contract/QueueTemplates/QueueTemplatesApiContractTests.cs
@@ -118,4 +118,49 @@ public sealed class QueueTemplatesApiContractTests : IDisposable {
       new { name = name + "x", overwrite = true, entries = new[] { new { sequenceId = "seq-x", scheduleType = "Timer", timerRelativeOffset = "25:00:00" } } }).ConfigureAwait(true);
     tooBig.StatusCode.Should().Be(HttpStatusCode.BadRequest);
   }
+
+  [Fact] // feature 060 (T007): renaming "Every Step" → "After Every Step" must not change the wire value
+  public async Task EveryStepEntryRoundTripsUnchanged() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    var name = "EveryStep " + Guid.NewGuid().ToString("N");
+
+    // Saves an EveryStep entry and reads it back as the SAME "EveryStep" identifier (FR-002/FR-010).
+    var entries = new[] { new { sequenceId = "seq-x", scheduleType = "EveryStep" } };
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name, entries, overwrite = true }).ConfigureAwait(true);
+    createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = JsonDocument.Parse(await createResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    var id = created.GetProperty("id").GetString();
+
+    var detail = JsonDocument.Parse(await (await client.GetAsync(new Uri($"/api/queue-templates/{id}", UriKind.Relative)).ConfigureAwait(true)).Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    detail.GetProperty("entries")[0].GetProperty("scheduleType").GetString().Should().Be("EveryStep");
+  }
+
+  [Fact] // feature 060 (T011): AtQueueStart round-trips unchanged; an unknown schedule type is rejected
+  public async Task AtQueueStartRoundTripsAndInvalidScheduleTypeIsRejected() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    var name = "AtQueueStart " + Guid.NewGuid().ToString("N");
+
+    // Saves an AtQueueStart entry and reads it back unchanged (FR-009).
+    var entries = new[] { new { sequenceId = "seq-x", scheduleType = "AtQueueStart" } };
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name, entries, overwrite = true }).ConfigureAwait(true);
+    createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var id = JsonDocument.Parse(await createResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString();
+
+    var detail = JsonDocument.Parse(await (await client.GetAsync(new Uri($"/api/queue-templates/{id}", UriKind.Relative)).ConfigureAwait(true)).Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    detail.GetProperty("entries")[0].GetProperty("scheduleType").GetString().Should().Be("AtQueueStart");
+
+    // An unrecognized scheduleType returns 400 with the { error: { code, message, hint } } envelope (FR-013).
+    var invalid = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = name + "x", overwrite = true, entries = new[] { new { sequenceId = "seq-x", scheduleType = "Whenever" } } }).ConfigureAwait(true);
+    invalid.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var body = JsonDocument.Parse(await invalid.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    body.GetProperty("error").GetProperty("code").GetString().Should().Be("invalid_request");
+    body.GetProperty("error").GetProperty("message").GetString().Should().Contain("Whenever");
+  }
 }

--- a/tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs
+++ b/tests/integration/QueueTemplates/QueueTemplatesScheduleTypeTests.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace GameBot.IntegrationTests.QueueTemplates;
@@ -239,5 +244,97 @@ public sealed class QueueTemplatesScheduleTypeTests {
     var body = await BodyAsync(resp).ConfigureAwait(true);
     body.GetProperty("error").GetProperty("code").GetString().Should().Be("invalid_request");
     body.GetProperty("error").GetProperty("message").GetString().Should().Contain("timerRelativeOffset");
+  }
+
+  // ── feature 060 (T005): at-queue-start round-trip + end-to-end ordering ────
+
+  [Fact]
+  public async Task SaveAtQueueStartEntryRoundTripsCorrectly() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var entries = new[] { new { sequenceId = "seq-a", scheduleType = "AtQueueStart" } };
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "AtStartTemplate", entries, overwrite = false }).ConfigureAwait(true);
+    createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await BodyAsync(createResp).ConfigureAwait(true);
+    var id = created.GetProperty("id").GetString()!;
+
+    var getResp = await client.GetAsync(new Uri($"/api/queue-templates/{id}", UriKind.Relative)).ConfigureAwait(true);
+    var body = await BodyAsync(getResp).ConfigureAwait(true);
+    var entry = body.GetProperty("entries")[0];
+    entry.GetProperty("scheduleType").GetString().Should().Be("AtQueueStart");
+    entry.GetProperty("timerTimeOfDay").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  [Fact] // SC-001: at-queue-start entries execute before timers and normal steps in a real run
+  public async Task AtQueueStartExecutesBeforeTimersAndNormalStepsInRealRun() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    // Three distinct real sequences so each produces its own execution-log entry.
+    var startSeq = await CreateSequenceAsync(client, "AtStart").ConfigureAwait(true);
+    var timerSeq = await CreateSequenceAsync(client, "Timer").ConfigureAwait(true);
+    var stepSeq = await CreateSequenceAsync(client, "Step").ConfigureAwait(true);
+
+    // Template order deliberately lists the at-queue-start entry LAST and the timer is past-due
+    // (00:00), so only the run-start pre-pass can make the at-queue-start sequence fire first.
+    var entries = new object[] {
+      new { sequenceId = timerSeq, scheduleType = "Timer", timerTimeOfDay = "00:00" },
+      new { sequenceId = stepSeq, scheduleType = "OncePerRun" },
+      new { sequenceId = startSeq, scheduleType = "AtQueueStart" },
+    };
+    var tplResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "OrderingTemplate", entries, overwrite = false }).ConfigureAwait(true);
+    tplResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var templateId = (await BodyAsync(tplResp).ConfigureAwait(true)).GetProperty("id").GetString()!;
+
+    // Non-cycling queue so the run executes one pass and settles back to Stopped.
+    var queueResp = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative),
+      new { name = "OrderingQueue", emulatorSerial = "emu-offline", cycleExecution = false }).ConfigureAwait(true);
+    var queueId = (await BodyAsync(queueResp).ConfigureAwait(true)).GetProperty("id").GetString()!;
+    await client.PutAsJsonAsync(new Uri($"/api/queues/{queueId}/template", UriKind.Relative),
+      new { templateId }).ConfigureAwait(true);
+
+    await client.PostAsync(new Uri($"/api/queues/{queueId}/start", UriKind.Relative), null).ConfigureAwait(true);
+    await WaitForStatusAsync(client, queueId, "Stopped").ConfigureAwait(true);
+
+    // Read back the per-sequence execution-log index assigned during the run; the at-queue-start
+    // sequence must have fired before both the timer and the once-per-run sequence.
+    var log = app.Services.GetRequiredService<IExecutionLogService>();
+    var startIdx = await SequenceIndexAsync(log, startSeq).ConfigureAwait(true);
+    var timerIdx = await SequenceIndexAsync(log, timerSeq).ConfigureAwait(true);
+    var stepIdx = await SequenceIndexAsync(log, stepSeq).ConfigureAwait(true);
+
+    startIdx.Should().BeLessThan(timerIdx, "at-queue-start runs before timer evaluation");
+    startIdx.Should().BeLessThan(stepIdx, "at-queue-start runs before the first OncePerRun step");
+  }
+
+  private static async Task<string> CreateSequenceAsync(HttpClient client, string namePrefix) {
+    var resp = await client.PostAsJsonAsync(new Uri("/api/sequences", UriKind.Relative),
+      new { name = namePrefix + " " + Guid.NewGuid().ToString("N"), steps = Array.Empty<string>() }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    return (await BodyAsync(resp).ConfigureAwait(true)).GetProperty("id").GetString()!;
+  }
+
+  private static async Task<int> SequenceIndexAsync(IExecutionLogService log, string sequenceId) {
+    var page = await log.QueryAsync(new ExecutionLogQuery {
+      ObjectType = "sequence", ObjectId = sequenceId, PageSize = 10
+    }).ConfigureAwait(true);
+    var entry = page.Items.Single();
+    return entry.Hierarchy.SequenceIndex ?? int.MaxValue;
+  }
+
+  private static async Task<string> StatusAsync(HttpClient client, string id) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}", UriKind.Relative)).ConfigureAwait(true);
+    return (await BodyAsync(resp).ConfigureAwait(true)).GetProperty("status").GetString()!;
+  }
+
+  private static async Task WaitForStatusAsync(HttpClient client, string id, string expected, int timeoutMs = 5000) {
+    var sw = Stopwatch.StartNew();
+    while (sw.ElapsedMilliseconds < timeoutMs) {
+      if (await StatusAsync(client, id).ConfigureAwait(true) == expected) return;
+      await Task.Delay(25).ConfigureAwait(true);
+    }
   }
 }

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -413,6 +413,7 @@ public sealed class QueueExecutionServiceTests {
 
   private static QueueTemplateEntry OncePerRun(string id) => new() { SequenceId = id, ScheduleType = ScheduleType.OncePerRun };
   private static QueueTemplateEntry EveryStep(string id) => new() { SequenceId = id, ScheduleType = ScheduleType.EveryStep };
+  private static QueueTemplateEntry AtQueueStart(string id) => new() { SequenceId = id, ScheduleType = ScheduleType.AtQueueStart };
   private static QueueTemplateEntry TimerEntry(string id, TimeOnly time) => new() { SequenceId = id, ScheduleType = ScheduleType.Timer, TimerTimeOfDay = time };
   private static QueueTemplateEntry RelativeTimer(string id, TimeSpan offset) => new() { SequenceId = id, ScheduleType = ScheduleType.Timer, TimerRelativeOffset = offset };
 
@@ -811,5 +812,155 @@ public sealed class QueueExecutionServiceTests {
     await WaitUntilStoppedAsync(h.Service, "q1");
 
     h.Sequences.Executed.Should().Equal("T1", "T2", "A");
+  }
+
+  // ── US1 (feature 060): at-queue-start scheduling ─────────────────────────
+
+  [Fact] // T003 — at-queue-start runs before timer evaluation AND before the first OncePerRun step
+  public async Task AtQueueStartRunsBeforeTimersAndBeforeFirstOncePerRunStep() {
+    var h = new Harness();
+    // Timer is past-due (00:00), so it would otherwise fire first at the iteration boundary.
+    AddQueueWithEntries(h, "q1", new[] {
+      OncePerRun("A"),
+      TimerEntry("T", TimeOnly.MinValue),
+      AtQueueStart("S")
+    });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-003: S runs before the timer and before the OncePerRun step.
+    h.Sequences.Executed.Should().Equal("S", "T", "A");
+  }
+
+  [Fact] // T003 — multiple at-queue-start entries run in template order
+  public async Task MultipleAtQueueStartRunInTemplateOrderBeforeRegularSteps() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] {
+      AtQueueStart("S1"),
+      AtQueueStart("S2"),
+      OncePerRun("A")
+    });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-014: at-queue-start entries run in their template order, all before regular steps.
+    h.Sequences.Executed.Should().Equal("S1", "S2", "A");
+  }
+
+  [Fact] // T003 — each at-queue-start firing counts toward executed
+  public async Task AtQueueStartCountsTowardExecuted() {
+    var h = new Harness();
+    // 2 at-queue-start + 1 once-per-run → executed total should be 3.
+    AddQueueWithEntries(h, "q1", new[] {
+      AtQueueStart("S1"),
+      AtQueueStart("S2"),
+      OncePerRun("A")
+    });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-015: at-queue-start firings count toward the executed total.
+    h.Log.Summary.Should().Contain("3 sequence(s) executed");
+  }
+
+  [Fact] // T004 — at-queue-start runs once per run on a cycling queue (not per cycle)
+  public async Task AtQueueStartRunsOncePerRunOnCyclingQueue() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { AtQueueStart("S"), OncePerRun("A") }, cycle: true);
+    h.Sequences.Handler = async (id, ct) => { await Task.Delay(10, ct); return FakeSequenceExecution.Success(id); };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Sequences.Executed.Count(id => id == "A") >= 3); // several cycles
+    await h.Service.StopAsync("q1");
+
+    // FR-004: S fires exactly once even though A cycles repeatedly.
+    h.Sequences.Executed.Count(id => id == "S").Should().Be(1);
+    h.Sequences.Executed[0].Should().Be("S");
+  }
+
+  [Fact] // T004 — a failing at-queue-start sequence is non-fatal
+  public async Task AtQueueStartFailureIsNonFatalRunContinues() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { AtQueueStart("S"), OncePerRun("A") });
+    h.Sequences.Handler = (id, ct) =>
+      Task.FromResult(id == "S" ? FakeSequenceExecution.Failure(id) : FakeSequenceExecution.Success(id));
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-007: the failed at-queue-start firing is counted but the run continues to completion.
+    h.Sequences.Executed.Should().Equal("S", "A");
+    h.Log.FinalStatus.Should().Be("success");
+    h.Log.Summary.Should().Contain("2 sequence(s) executed"); // counted even though it failed
+    h.Log.Summary.Should().Contain("1 failed");
+  }
+
+  [Fact] // T004 — a template with only at-queue-start entries runs them once and completes
+  public async Task OnlyAtQueueStartTemplateRunsOnceAndCompletes() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { AtQueueStart("S1"), AtQueueStart("S2") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-008/SC-003: both entries fire once, then the run completes cleanly (no busy-loop).
+    h.Sequences.Executed.Should().Equal("S1", "S2");
+    h.Log.FinalStatus.Should().Be("success");
+    h.Log.Summary.Should().Contain("completed full run");
+  }
+
+  [Fact] // T004 — only-at-queue-start template completes even when cycling is enabled
+  public async Task OnlyAtQueueStartTemplateCompletesEvenWhenCycling() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { AtQueueStart("S") }, cycle: true);
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // No OncePerRun/EveryStep/Timer work means nothing to cycle: S fires once and the run ends.
+    h.Sequences.Executed.Should().Equal("S");
+    h.Log.FinalStatus.Should().Be("success");
+    h.Log.Summary.Should().Contain("completed full run");
+  }
+
+  // ── US2 (feature 060): "After Every Step" narrow-trigger guarantee ────────
+
+  [Fact] // T008 — EveryStep fires ONLY after OncePerRun steps, never after at-start or timer firings
+  public async Task EveryStepFiresOnlyAfterOncePerRunNotAfterAtQueueStartOrTimer() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] {
+      AtQueueStart("S"),
+      TimerEntry("T", TimeOnly.MinValue),
+      OncePerRun("A"),
+      EveryStep("C")
+    });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // FR-005/FR-006: order is S (at-start), T (timer), A (once-per-run), C (every-step after A only).
+    // C must NOT appear right after S or right after T.
+    h.Sequences.Executed.Should().Equal("S", "T", "A", "C");
+    // EveryStep fired exactly once — only after the single OncePerRun step.
+    h.Sequences.Executed.Count(id => id == "C").Should().Be(1);
+  }
+
+  // ── Polish (feature 060): regression — unchanged OncePerRun/Timer behavior ─
+
+  [Fact] // T019 — default (no scheduleType) entry behaves as OncePerRun; ordering/counting unchanged
+  public async Task DefaultScheduleTypeStillBehavesAsOncePerRun() {
+    var h = new Harness();
+    // No at-queue-start entries: pure OncePerRun + Timer should behave exactly as before.
+    AddQueueWithEntries(h, "q1", new[] { TimerEntry("T", TimeOnly.MinValue), OncePerRun("A"), OncePerRun("B") });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // Timer fires at the boundary, then OncePerRun steps in order; only the two steps are counted.
+    h.Sequences.Executed.Should().Equal("T", "A", "B");
+    h.Log.Summary.Should().Contain("2 sequence(s) executed");
   }
 }


### PR DESCRIPTION
## Summary

Adds two scheduling capabilities to queue templates and renames an existing one for clarity:

- **At Queue Start** (new): entries marked this way run in template order at the very start of a run, before any timer is evaluated. They run once per run (not per cycle) and count toward the run's executed-sequence total.
- **After Every Step** (rename): the existing "Every Step" option is relabeled "After Every Step" in the UI and API. Behavior is unchanged — it fires after each normal "Once Per Run" step only, and never triggers itself (loop-safe). The stored/API identifier remains `EveryStep`, so this is fully backward compatible with no migration.

Both options are surfaced wherever schedule options exist today: the template editor UI and the template/queue API.

## Changes

- **Domain**: extended `ScheduleType` with the queue-start option.
- **Application**: `QueueExecutionService` runs queue-start entries first, before timer evaluation.
- **API**: `QueueTemplateDetailResponse` / `TemplateEntrySaveRequest` / endpoints accept and return the new schedule type.
- **Web UI**: `QueueEntryList` exposes the new option and the "After Every Step" label.
- **Tests**: unit tests for execution ordering, API contract tests, schedule-type tests, and web-ui component/page tests.
- **Spec artifacts** for feature #060.

## Test plan

- `QueueExecutionServiceTests` — queue-start ordering and after-every-step loop-safety
- `QueueTemplatesScheduleTypeTests` / `QueueTemplatesApiContractTests` — API surface
- web-ui: `QueueEntryList` and `QueuesPage.templates` specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
