### PR TITLE
Drag-and-drop scheduling areas in the queue template editor (#061)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/060-queue-start-after-every-scheduling"
+  "feature_directory": "specs/061-queue-scheduling-areas"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/060-queue-start-after-every-scheduling/plan.md
+at specs/061-queue-scheduling-areas/plan.md
 <!-- SPECKIT END -->

--- a/specs/061-queue-scheduling-areas/checklists/requirements.md
+++ b/specs/061-queue-scheduling-areas/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Drag-and-Drop Scheduling Areas in the Queue Template Editor
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- "Scheduled" area intentionally represents the single "Timer" schedule option; its two sub-modes are per-card settings, not separate areas (documented in Assumptions).
+- Two minor UX details (retain vs clear timer details when leaving "Scheduled"; default timer value on entering "Scheduled") are deferred to design via Assumptions, not raised as blocking clarifications.

--- a/specs/061-queue-scheduling-areas/contracts/scheduling-areas-ui.md
+++ b/specs/061-queue-scheduling-areas/contracts/scheduling-areas-ui.md
@@ -1,0 +1,84 @@
+# UI / Component Contract: Scheduling Areas Editor
+
+This feature is web-UI-only. **No HTTP API contract changes.** The "contracts" here are the component interfaces and observable interaction behaviors that tests assert against. Existing endpoints (`/api/queues/*`, `/api/queue-templates`) are used unchanged.
+
+## Unchanged API surface (explicit non-goals)
+
+- `POST /api/queue-templates` (save), `GET /api/queue-templates/{id}` (load) — payloads and `ScheduleType` values unchanged (`OncePerRun`, `EveryStep`, `Timer`, `AtQueueStart`).
+- `PUT /api/queues/{id}/entries` (`replaceQueueEntries`), `POST/DELETE .../entries` (add/remove) — unchanged.
+- No new schedule option; `EveryStep` remains the stored/wire identifier behind the "After every step" label.
+
+## Component: `QueueSchedulingAreas`
+
+Replaces `QueueEntryList` in the editor. Props:
+
+```ts
+type QueueSchedulingAreasProps = {
+  entries: QueueEntryDto[];                 // runtime entries, in current order
+  sequences: SequenceDto[];                 // for the add control + labels
+  entrySchedule: Record<string, EntrySchedule>;
+  onAdd: (sequenceId: string) => void;      // routes to "Once per run" by default (caller seeds OncePerRun)
+  onRemove: (entryId: string) => void;
+  // Drag result: the new linear order + the new schedule map (already computed by the pure reducer).
+  onReorderAndReassign: (next: { orderedEntryIds: string[]; schedule: Record<string, EntrySchedule> }) => void;
+  // Timer detail edits within the "Scheduled" area (reuse existing handlers).
+  onTimerTimeChange?: (entryId: string, timerTimeOfDay: string) => void;
+  onTimerModeChange?: (entryId: string, mode: TimerMode) => void;
+  onTimerRelativeOffsetChange?: (entryId: string, offset: string) => void;
+  disabled?: boolean;
+};
+```
+
+### Observable behaviors (test assertions)
+
+| ID | Behavior |
+|----|----------|
+| C1 | Renders exactly four areas with accessible labels "Start of execution", "Once per run", "Scheduled", "After every step". |
+| C2 | Each entry renders as a card in the area matching `entrySchedule[entryId].scheduleType` (default `OncePerRun` when absent). |
+| C3 | "Start of execution" is the only full-width area (top); "Once per run" above "Scheduled" on the left; "After every step" on the right. (Layout asserted via container class/structure.) |
+| C4 | An empty area still renders with its label and an empty-state hint and is a valid drop target. |
+| C5 | A card shows the schedule badge consistent with its area (At Queue Start / After Every Step / Timer / Timer · relative); `OncePerRun` shows no schedule badge. Stale entries keep the stale badge and remain present. |
+| C6 | In the "Scheduled" area only, a card exposes timer controls (mode toggle + time-of-day input or relative offset inputs). |
+| C7 | When `disabled`, cards are not draggable and schedule controls are disabled, but grouping still renders. |
+
+## Pure module: `schedulingAreas.ts`
+
+```ts
+function areaForScheduleType(t: ScheduleType): SchedulingAreaId;
+function scheduleTypeForArea(a: SchedulingAreaId): ScheduleType;
+
+function groupEntriesIntoAreas(
+  orderedEntryIds: string[],
+  schedule: Record<string, EntrySchedule>,
+  entries: Record<string, QueueEntryDto>,
+): Record<SchedulingAreaId, SchedulingCard[]>;
+
+function applyDragMove(
+  state: { orderedEntryIds: string[]; schedule: Record<string, EntrySchedule> },
+  move: { entryId: string; targetArea: SchedulingAreaId; targetIndex: number },
+): { orderedEntryIds: string[]; schedule: Record<string, EntrySchedule> };
+```
+
+### Reducer contract (test assertions)
+
+| ID | Given | When | Then |
+|----|-------|------|------|
+| R1 | entry in `oncePerRun` | move to `afterEveryStep` | `schedule[id].scheduleType === 'EveryStep'`; card now in `afterEveryStep`; persisted-order updated |
+| R2 | entry in `afterEveryStep` | move to `startOfExecution` | `scheduleType === 'AtQueueStart'` |
+| R3 | any entry | move to `scheduled` | `scheduleType === 'Timer'`; timer fields empty if none prior |
+| R4 | `Timer` entry with `timerTimeOfDay='15:30'` | move out of `scheduled` to `oncePerRun` | `scheduleType === 'OncePerRun'`; `timerTimeOfDay` **retained** in state (inactive) |
+| R5 | the R4 entry | move back into `scheduled` | `scheduleType === 'Timer'`; `timerTimeOfDay` still `'15:30'` |
+| R6 | three entries A,B,C in one area | move C before A | within-area order becomes C,A,B; no `scheduleType` change |
+| R7 | entry | drop at its own current position | state unchanged (no-op) |
+| R8 | newly added entry (`OncePerRun`) | — | appears last in `oncePerRun` |
+| R9 | entry | cancelled / dropped outside any area (no/`null` target — FR-013) | state unchanged; entry returns to its origin area and position |
+
+## Integration contract: `QueuesPage` save/load round-trip
+
+| ID | Behavior |
+|----|----------|
+| I1 | Reassigning a card to another area, saving, then reloading the template shows the card in the destination area with its new `scheduleType` (round-trips for every ordered area pair). |
+| I2 | Reordering within an area, saving, reloading preserves the within-area order (and thus the per-type execution order). |
+| I3 | Adding a sequence places it in "Once per run"; saving emits it with `scheduleType: 'OncePerRun'`. |
+| I4 | A template with a `Timer` card retains `timerTimeOfDay`/`timerRelativeOffset` across save/reload; a card moved out of "Scheduled" before save is emitted with the destination type and **no** timer fields. |
+| I5 | Existing scheduling/queue tests pass unchanged (no runtime/API behavior change). |

--- a/specs/061-queue-scheduling-areas/data-model.md
+++ b/specs/061-queue-scheduling-areas/data-model.md
@@ -1,0 +1,83 @@
+# Phase 1 Data Model: Drag-and-Drop Scheduling Areas
+
+This feature introduces **no new persisted entities**. The data model below is the **client-side view model** the editor derives from existing state and maps back to the existing template/queue payloads on save. Persisted shapes (`QueueTemplateEntryDto`, `QueueEntryDto`, `ScheduleType`) are unchanged.
+
+## Existing types reused (unchanged)
+
+- `ScheduleType = 'OncePerRun' | 'EveryStep' | 'Timer' | 'AtQueueStart'` — from `services/queueTemplates.ts`.
+- `EntrySchedule = { scheduleType, timerTimeOfDay, timerMode?, timerRelativeOffset? }` — from `components/queues/QueueEntryList.tsx` (UI-local per-entry schedule state, keyed by runtime `entryId`).
+- `QueueEntryDto = { entryId, sequenceId, sequenceName, stale }` — runtime queue entry (ordered).
+- `QueueTemplateEntryDto` / `TemplateEntrySaveDto` — template persistence shapes.
+
+## New view-model concepts (client-only)
+
+### SchedulingAreaId
+
+Enumeration of the four areas, each mapped 1:1 to a `ScheduleType`:
+
+| `SchedulingAreaId` | Label | `ScheduleType` |
+|--------------------|-------|----------------|
+| `startOfExecution` | "Start of execution" | `AtQueueStart` |
+| `oncePerRun` | "Once per run" | `OncePerRun` |
+| `scheduled` | "Scheduled" | `Timer` |
+| `afterEveryStep` | "After every step" | `EveryStep` |
+
+Mapping helpers (pure):
+- `scheduleTypeForArea(areaId): ScheduleType`
+- `areaForScheduleType(scheduleType): SchedulingAreaId`
+
+**Canonical area order** (for the linear save order, invisible to execution): `startOfExecution`, `oncePerRun`, `scheduled`, `afterEveryStep`.
+
+### SchedulingCard
+
+A presentational projection of one entry within an area:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `entryId` | `QueueEntryDto.entryId` | Stable drag id during an edit session |
+| `sequenceId` | `QueueEntryDto.sequenceId` | |
+| `label` | `sequenceName ?? sequenceId` | |
+| `stale` | `QueueEntryDto.stale` | Renders stale badge; card stays draggable (FR-016) |
+| `schedule` | `EntrySchedule` for this entry | Drives badge + (in "Scheduled") timer controls |
+
+### SchedulingAreasState
+
+The editor's working state, derived from `detail.entries` (order) + `entrySchedule`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `orderedEntryIds` | `string[]` | Single linear order = concatenation of areas in canonical order, within-area drag order preserved. Source of truth for display and save. |
+| `schedule` | `Record<string, EntrySchedule>` | Per-entry schedule incl. retained-but-inactive timer details. |
+| `areas` | `Record<SchedulingAreaId, SchedulingCard[]>` | Derived view: entries grouped by `areaForScheduleType(schedule[id].scheduleType)`, ordered per `orderedEntryIds`. |
+
+## Validation & rules
+
+- **Grouping (FR-003)**: every entry appears in exactly one area, the one matching its current `scheduleType`; no entry lost or duplicated.
+- **Default (FR-007)**: a new entry has `scheduleType: 'OncePerRun'` and therefore lands in `oncePerRun`, appended last in that area.
+- **Cross-area move (FR-004)**: dropping an entry into an area sets `schedule[id].scheduleType = scheduleTypeForArea(targetArea)`.
+- **Into "Scheduled" (FR-008)**: sets `Timer`; if no prior timer value, `timerTimeOfDay`/`timerRelativeOffset` start empty (operator fills in).
+- **Out of "Scheduled" (FR-009)**: changes `scheduleType` to the destination's; **retains** existing `timerTimeOfDay`/`timerRelativeOffset`/`timerMode` in state (inactive) for restoration if dragged back.
+- **Within-area reorder (FR-005)**: only `orderedEntryIds` changes for the affected cards; `scheduleType` unchanged.
+- **No-op drop (Edge case)**: dropping at origin position leaves both `orderedEntryIds` and `schedule` unchanged.
+- **Disabled/running (FR-014)**: when `disabled`, areas still render grouped; cards are not draggable and schedule is not reassignable.
+
+## State transitions (drag reducer)
+
+`applyDragMove(state, move) -> state'` where `move` carries the dragged `entryId`, the target area, and the target index within that area:
+
+1. Determine `targetArea` and `targetIndex` from the drop.
+2. If `targetArea === currentArea(entryId)` and index unchanged → return `state` unchanged (no-op).
+3. Set `schedule'[entryId].scheduleType = scheduleTypeForArea(targetArea)` (preserving retained timer fields per FR-009; clearing active application only).
+4. Rebuild `orderedEntryIds'` by removing `entryId` and reinserting it at the position corresponding to `targetIndex` within `targetArea`, keeping the canonical inter-area order.
+5. Return `{ orderedEntryIds', schedule' }`.
+
+## Save mapping (to existing payloads)
+
+On Save Template (`QueuesPage.handleSaveTemplate`, order-aware):
+1. `orderedSequenceIds = orderedEntryIds.map(id -> sequenceId)`.
+2. `await replaceQueueEntries(detail.id, orderedSequenceIds)` → reordered runtime entries (new `entryId`s, same order).
+3. `const refreshed = await getQueue(detail.id)`.
+4. Build `TemplateEntrySaveDto[]` from `refreshed.entries` **in order**, taking each position's intended `scheduleType` (and, only for `Timer`, the timer fields) from the position-aligned schedule.
+5. `await saveQueueTemplate({ name, entries, overwrite })`; re-key `entrySchedule` onto `refreshed.entries` by position.
+
+On Load/reload: unchanged — `buildScheduleFromTemplateEntries` already maps template entry *i* ↔ runtime entry *i*; because save now guarantees identical order, restoration is correct.

--- a/specs/061-queue-scheduling-areas/plan.md
+++ b/specs/061-queue-scheduling-areas/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Drag-and-Drop Scheduling Areas in the Queue Template Editor
+
+**Branch**: `061-queue-scheduling-areas` | **Date**: 2026-06-18 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/061-queue-scheduling-areas/spec.md`
+
+## Summary
+
+Replace the queue template editor's single flat sequence list with **four labeled, drag-and-drop areas** — one per schedule option:
+
+- **Start of execution** (full-width top) ↔ `AtQueueStart`
+- **Once per run** (upper-left) ↔ `OncePerRun`
+- **Scheduled** (lower-left, under "Once per run") ↔ `Timer`
+- **After every step** (right column) ↔ `EveryStep`
+
+Operators drag sequence cards **between** areas (which auto-changes the sequence's schedule option to the destination area's type) and **within** an area (which reorders execution). New sequences default to the "Once per run" area. This is a **web-UI-only** change: no API, scheduler, or stored-model changes. It reuses the existing `@dnd-kit` multi-container drag pattern already established in the sequence step editor. Schedule assignment and within-area order round-trip through the existing template save/load path; timer details are retained (inactive) when a card leaves "Scheduled" and restored if it returns.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.6, React 18.3 (ESM, Vite 7)
+**Primary Dependencies**: `@dnd-kit/core` 6.3, `@dnd-kit/sortable` 10.0, `@dnd-kit/utilities` 3.2 (all already installed and used by `SortableSequenceStepList`/`SortableStepItem`)
+**Storage**: None new. Schedule option + timer details persist via the existing `/api/queue-templates` save/load; runtime entry order persists via the existing `/api/queues/{id}/entries` (`replaceQueueEntries`)
+**Testing**: Jest + `@testing-library/react` (unit/component), Playwright (e2e). Quality gate per memory: `vite build` + `jest` must be green (lint/`tsc --noEmit` have pre-existing failures and are NOT the gate)
+**Target Platform**: Modern browser (web UI served by the GameBot backend)
+**Project Type**: Web application — frontend change only (`src/web-ui`)
+**Performance Goals**: Editor interaction is local React state; drag operations must feel instant (<16ms frame budget; no API call during a drag). Persistence (save) is an existing, already-acceptable round-trip
+**Constraints**: No API/contract/scheduler changes; fully backward compatible with existing templates; reuse existing dnd-kit patterns and CSS conventions; no new runtime dependencies
+**Scale/Scope**: One queue template at a time; a handful to a few dozen sequence cards across four areas. New/changed files confined to `src/web-ui/src/components/queues/` and `src/web-ui/src/pages/QueuesPage.tsx`, plus styles and tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Code Quality Discipline | PASS — change is contained, modular (new presentational components + a view-model mapping helper), no dead code, CamelCase methods, no new deps. Reuses existing dnd-kit + `DropIndicator` building blocks. |
+| II. Testing Standards | PASS — component tests for grouping/empty-areas/badges, drag-reassign and drag-reorder via the same `onDragEnd` handler tested directly (jsdom can't do real pointer DnD, so the reorder/reassign reducer is unit-tested as a pure function), and a `QueuesPage` integration test for save/reload round-trip and the "new sequence → Once per run" default. Existing scheduling/queue suite must stay green (no behavior change). |
+| III. User Experience Consistency | PASS — labels, badges, and empty-state hints follow existing conventions; the schedule selector remains available as the non-drag path (keyboard alternative explicitly out of scope per clarification). Error/disabled (running) states preserved. |
+| IV. Performance Requirements | PASS — pure client-side state manipulation; no new hot paths or N+1; no API calls mid-drag. Perf note: save reuses the existing single round-trip. |
+
+**Gate result: PASS** (no violations; Complexity Tracking not required).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/061-queue-scheduling-areas/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (UI view model)
+├── quickstart.md        # Phase 1 output (manual + test walkthrough)
+├── contracts/
+│   └── scheduling-areas-ui.md   # Phase 1 output (component/interaction contract — no API change)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/web-ui/src/
+├── components/queues/
+│   ├── QueueSchedulingAreas.tsx        # NEW — four-area layout + DndContext orchestration
+│   ├── SchedulingArea.tsx              # NEW — one droppable area (label, empty state, sortable list)
+│   ├── SchedulingSequenceCard.tsx      # NEW — one draggable/sortable sequence card (badge, timer controls, remove)
+│   ├── schedulingAreas.ts              # NEW — pure view-model: group entries by area, drag reducer, area↔scheduleType map
+│   ├── QueueEntryList.tsx              # EXISTING — kept for non-area callers / fallback; areas component supersedes it in the editor
+│   └── __tests__/
+│       ├── QueueSchedulingAreas.test.tsx   # NEW — grouping, empty areas, badges, render
+│       └── schedulingAreas.test.ts         # NEW — pure reducer: reassign + reorder + default add + timer retention
+├── pages/
+│   ├── QueuesPage.tsx                  # EDIT — render areas component; route new entries to OncePerRun; order-aware save
+│   └── __tests__/QueuesPage.templates.spec.tsx  # EDIT — round-trip + default-area integration tests
+└── components/queues/
+    └── QueueSchedulingAreas.css        # NEW — four-area responsive grid + area/card styling (co-located; follows existing reorderable-list/empty-state conventions)
+```
+
+**Structure Decision**: Web application, frontend-only. All work lives under `src/web-ui/src`. The four-area editor is implemented as a small component tree (`QueueSchedulingAreas` → `SchedulingArea` → `SchedulingSequenceCard`) backed by a pure, fully unit-testable view-model module (`schedulingAreas.ts`) so the drag/reorder/reassign logic is verifiable without simulating pointer events. `QueuesPage` wires the component to existing state (`entrySchedule`, `detail.entries`) and the existing save/load handlers.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/061-queue-scheduling-areas/quickstart.md
+++ b/specs/061-queue-scheduling-areas/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart: Drag-and-Drop Scheduling Areas
+
+## What this delivers
+
+The queue template editor shows sequences in four labeled, drag-and-drop areas instead of a flat list:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Start of execution                       (At Queue Start)   │  ← full width
+├───────────────────────────────┬─────────────────────────────┤
+│  Once per run   (Once Per Run)│                             │
+├───────────────────────────────┤  After every step           │
+│  Scheduled            (Timer)  │      (After Every Step)     │
+└───────────────────────────────┴─────────────────────────────┘
+```
+
+Drag a card **between** areas to change its schedule; drag **within** an area to reorder. New sequences land in **Once per run**.
+
+## Run the web UI locally
+
+```powershell
+# From the web UI project
+& "C:\src\GameBot\src\web-ui"   # (open this folder)
+npm install        # @dnd-kit/* already in package.json
+npm run dev        # Vite dev server
+```
+
+Open the app, go to **Queues**, edit a queue with a few sequences, and use the four scheduling areas in the template editor section.
+
+## Manual verification (maps to spec acceptance scenarios)
+
+1. **Grouping (US1)**: Open a template containing one of each schedule type → each sequence sits in its matching area; all four areas are visible and labeled, empty ones show a drop hint.
+2. **Reassign by drag (US2)**: Drag a card from "Once per run" to "After every step" → its badge becomes "After Every Step". Save the template, reload → card stays in "After every step".
+3. **Timer area (US2)**: Drag a card into "Scheduled" → it becomes a Timer with empty time; set a time. Drag it out to "Once per run" → timer controls disappear; drag it back into "Scheduled" → the time you set is restored.
+4. **Reorder (US3)**: In an area with A, B, C, drag C above A → order becomes C, A, B; save/reload preserves it.
+5. **Default add (US4)**: Add a sequence → it appears at the bottom of "Once per run".
+
+## Automated tests (quality gate: `vite build` + `jest` green)
+
+```powershell
+& "C:\src\GameBot\src\web-ui\node_modules\.bin\jest" --config "C:\src\GameBot\src\web-ui\jest.config.cjs"
+# or from the project: npm test ; npm run build
+```
+
+Test coverage to add:
+- `schedulingAreas.test.ts` — pure reducer: R1–R8 from the contract (cross-area reassign for each pair, into/out of Timer with retention, within-area reorder, no-op, default add).
+- `QueueSchedulingAreas.test.tsx` — C1–C7: four labeled areas, grouping by schedule type, empty-area hints, badges, Timer-only controls, disabled state.
+- `QueuesPage.templates.spec.tsx` (extend) — I1–I4: save/reload round-trip for reassign + reorder, default-to-OncePerRun on add, timer-detail retention vs emission.
+- Existing scheduling/queue suite (`QueueEntryList.test.tsx`, `QueuesPage.templates.spec.tsx`) — must stay green (I5); no runtime/API behavior changes.
+
+## Out of scope (do not implement here)
+
+- Any API, scheduler, or stored-model change.
+- Keyboard-operable drag-and-drop alternative (explicitly deferred — clarified 2026-06-18).
+- Splitting "Timer" into separate time-of-day / relative areas.

--- a/specs/061-queue-scheduling-areas/research.md
+++ b/specs/061-queue-scheduling-areas/research.md
@@ -1,0 +1,86 @@
+# Phase 0 Research: Drag-and-Drop Scheduling Areas
+
+All Technical Context items were resolvable from the existing codebase; there were no open `NEEDS CLARIFICATION` markers (the two spec ambiguities were resolved in `/speckit-clarify`). This document records the design decisions that shape Phase 1.
+
+## Decision 1 — Drag-and-drop library and pattern
+
+**Decision**: Use `@dnd-kit/core` + `@dnd-kit/sortable` in a **multi-container** configuration: a single `DndContext` wrapping four droppable areas, each rendering a `SortableContext` of cards. Reuse the existing `DropIndicator` and the `SortableStepItem`/`useSortable` conventions already used by `SortableSequenceStepList`.
+
+**Rationale**: These packages are already direct dependencies and are the established DnD primitives in this repo (sequence step editor). Multi-container sorting (drag within and across lists, with the area itself as a drop target so empty areas can receive cards) is a first-class dnd-kit use case. Reusing the in-repo pattern keeps the code idiomatic and avoids a new dependency (Constitution I).
+
+**Alternatives considered**:
+- HTML5 native drag-and-drop — rejected: clunky cross-list semantics, inconsistent across browsers, no momentum from existing code.
+- `react-beautiful-dnd` / `react-dnd` — rejected: new dependency duplicating capability already present via dnd-kit.
+
+## Decision 2 — Area ↔ schedule-option mapping
+
+**Decision**: Exactly four areas, each bound 1:1 to a `ScheduleType`:
+
+| Area label | `ScheduleType` |
+|------------|----------------|
+| Start of execution | `AtQueueStart` |
+| Once per run | `OncePerRun` |
+| Scheduled | `Timer` |
+| After every step | `EveryStep` (display label "After Every Step") |
+
+The "Scheduled" area hosts both Timer sub-modes (time-of-day and relative offset); the sub-mode and its values are per-card controls inside the area, not separate areas.
+
+**Rationale**: Directly satisfies FR-001/FR-002 and the Assumptions ("one area per schedule option"). Keeps the wire/stored identifier `EveryStep` unchanged (feature 060 backward-compat), with the area label being the only operator-facing text.
+
+**Alternatives considered**: A fifth area splitting Timer into time-of-day vs relative — rejected: contradicts the single "Timer" schedule option and the spec's explicit one-area-per-option assumption.
+
+## Decision 3 — Ordering & persistence strategy (the key design constraint)
+
+**Context**: Schedule type is **UI-local** (`entrySchedule`, keyed by runtime `entryId`); it is not stored on the runtime queue. It round-trips to disk only through the linked template. Critically, `QueuesPage.buildScheduleFromTemplateEntries` restores schedule state by **positional index** — runtime entry *i* is paired with template entry *i*. Therefore **runtime entry order must equal the saved template entry order** for schedule restoration to remain correct on reload.
+
+**Decision**:
+- During editing, area membership and within-area order live entirely in client state (no API calls per drag). The view-model derives, from `detail.entries` order + each entry's `scheduleType`, the cards in each area; a drag produces a new `(entryId → scheduleType)` map plus a new desired linear order of `entryId`s.
+- The **canonical linear order** is the concatenation of areas in a fixed sequence — **AtQueueStart → OncePerRun → Timer → EveryStep** — and, within each area, the operator's drag order. This linear order is the single source of truth that both the editor display and the save path use.
+- On **Save Template**: first persist the linear order to the runtime queue via the existing `replaceQueueEntries(detail.id, orderedSequenceIds)`, then `getQueue` to obtain the regenerated entries (in that order), then build the template entries from those entries in order, applying the schedule type the operator assigned to each position. Because runtime order now equals template order, reload's index pairing stays correct (SC-002/SC-003, FR-011).
+- `replaceQueueEntries` regenerates `entryId`s, so the schedule map is re-keyed onto the new entries **by position** as part of the save, exactly as the existing load path already maps by position.
+
+**Rationale**: Respects the existing positional coupling rather than fighting it, keeps drag interactions instant (state-only), and reuses endpoints that already exist (no API change, FR-012). The fixed inter-area order is invisible to execution (each schedule type runs in its own pass — see spec "Cross-area order" assumption), so concatenation order only needs to be *stable*, which it is.
+
+**Alternatives considered**:
+- Reorder runtime entries on every drag via the API — rejected: needless latency and entryId churn mid-edit; violates the "no API call during a drag" performance note.
+- Decouple template order from runtime order — rejected: would break the positional `buildScheduleFromTemplateEntries` restore without a larger refactor that the spec scopes out.
+- A dedicated reorder endpoint — rejected: out of scope (no API changes); `replaceQueueEntries` already expresses "set this exact order".
+
+## Decision 4 — Cross-area move auto-changes schedule type; timer-detail retention
+
+**Decision**: Dropping a card into an area sets that card's `scheduleType` to the area's type (FR-004). Moving **into** "Scheduled" sets `Timer` with an unset/empty timer value the operator then fills in (FR-008, matching today's freshly-chosen-Timer behavior). Moving **out of** "Scheduled" changes the type to the destination's and stops applying timer details at run time, but **retains** the previously entered `timerTimeOfDay` / `timerRelativeOffset` (inactive) on the card's UI state so they are restored if the card is dragged back into "Scheduled" (clarified 2026-06-18; FR-009).
+
+**Rationale**: Implements the clarified retain-inactive behavior with the least surprise and full recoverability. Retention is purely client-side view state; the saved template only emits timer fields for entries whose current `scheduleType` is `Timer` (the existing `handleSaveTemplate` already gates timer fields on `scheduleType === 'Timer'`), so inactive details never leak into a non-Timer saved entry.
+
+**Alternatives considered**: Clearing timer details on exit — rejected by clarification (Option A chosen).
+
+## Decision 5 — Default area for newly added sequences
+
+**Decision**: A newly added sequence is placed in the **Once per run** area with `scheduleType: 'OncePerRun'` (FR-007). The existing `onAddEntry` already seeds `entrySchedule[newEntry.entryId] = { scheduleType: 'OncePerRun', ... }`; the area view-model will render any entry with that type in the "Once per run" area, so the default falls out naturally. New cards append to the end of that area.
+
+**Rationale**: Matches the existing add behavior and the spec default; minimal change.
+
+## Decision 6 — Layout & responsive behavior
+
+**Decision**: CSS Grid for the editor: row 1 is the full-width "Start of execution" area; row 2 is a two-column grid where the left column stacks "Once per run" (top) and "Scheduled" (bottom) and the right column holds "After every step" spanning both. Each area is always rendered (even when empty) with a heading and an empty-state drop hint (FR-010). Areas scroll/grow within their panel for many cards. Styling follows existing `reorderable-list` / `empty-state` class conventions.
+
+**Rationale**: Directly encodes the layout in FR-002 with standard CSS Grid; reuses existing visual language. On narrow viewports the columns can collapse to stacked full-width areas (progressive enhancement; not a hard requirement of the spec).
+
+**Alternatives considered**: Flexbox-only — workable but Grid expresses the "full-width top + 2×2-ish body" intent more directly and keeps the empty areas sized consistently.
+
+## Decision 7 — Testability of drag logic
+
+**Decision**: Extract all move/reorder/reassign/default logic into a pure module (`schedulingAreas.ts`): `groupEntriesIntoAreas(entries, schedule)`, `applyDragMove(state, { activeId, overAreaOrIndex })` → new `{ orderedEntryIds, schedule }`, and `areaForScheduleType` / `scheduleTypeForArea`. Component tests cover rendering/grouping/badges/empty areas; the pure module is unit-tested for every cross-area pair, within-area reorder, default-add, no-op drop, and timer-detail retention.
+
+**Rationale**: jsdom cannot faithfully simulate pointer-based dnd-kit dragging, so testing the *decision logic* as pure functions (fed the same inputs dnd-kit's `onDragEnd` provides) gives deterministic, fast coverage (Constitution II) without brittle DOM-drag simulation. A thin `onDragEnd` in the component just forwards to the pure reducer.
+
+## Resolved unknowns summary
+
+| Unknown | Resolution |
+|---------|-----------|
+| Which DnD approach | dnd-kit multi-container, reuse existing in-repo pattern |
+| How order persists given UI-local schedule | Canonical linear order → `replaceQueueEntries` on save → positional template build/restore |
+| What happens to timer details on area exit | Retained inactive, restored on return (client state only) |
+| Default area for new sequences | Once per run (existing add seed already does this) |
+| Layout mechanism | CSS Grid: full-width top + left stack + right column |
+| How to test pointer drag | Pure reducer module unit-tested; components tested for render/grouping |

--- a/specs/061-queue-scheduling-areas/spec.md
+++ b/specs/061-queue-scheduling-areas/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: Drag-and-Drop Scheduling Areas in the Queue Template Editor
+
+**Feature Branch**: `061-queue-scheduling-areas`  
+**Created**: 2026-06-18  
+**Status**: Draft  
+**Input**: User description: "In order to provide a better overview of the queue execution scheduling, I want to see distinct areas when defining a queue template: Start of execution (full page/area on the page width at the top), \"Once per run\" and \"scheduled\" under each other on the left side, \"After every step\" to the right of the \"once per run\" and \"scheduled\". I should be able to move the sequences from one area to the other as well as change the order of the sequences by drag and drop. If a sequence moves from one area to the other, its scheduling type has to be adjusted automatically. By default new sequences should be added to the \"once per run\" area."
+
+## Clarifications
+
+### Session 2026-06-18
+
+- Q: When a Timer sequence is dragged out of the "Scheduled" area, what happens to its configured timer details (time-of-day / relative offset)? → A: Retain the details on the entry but keep them inactive; restore them if the sequence is dragged back into "Scheduled".
+- Q: Is a keyboard-accessible alternative to drag-and-drop (for reassigning/reordering sequences) in scope for this feature? → A: No — drag-and-drop only; the keyboard-parity requirement is dropped for this feature.
+
+## User Scenarios & Testing *(mandatory)*
+
+A queue template is an ordered list of sequence references, each tagged with a **schedule option** that controls when, during a run, that sequence executes. The available schedule options today are: **At Queue Start**, **Once Per Run**, **Timer** (time-of-day or relative offset), and **After Every Step**. Today the template editor presents these as a single flat list of rows, where each row carries a drop-down to pick its schedule option.
+
+This feature replaces that flat list with **four visually distinct areas**, one per schedule option, laid out so the operator can see at a glance how the run is organized:
+
+- **Start of execution** — a full-width area across the top of the editor (maps to the "At Queue Start" schedule option).
+- **Once per run** — a panel on the upper-left (maps to the "Once Per Run" schedule option).
+- **Scheduled** — a panel on the lower-left, directly under "Once per run" (maps to the "Timer" schedule option, both time-of-day and relative-offset modes).
+- **After every step** — a panel on the right, spanning beside both "Once per run" and "Scheduled" (maps to the "After Every Step" schedule option).
+
+An operator arranges the template by **dragging sequence cards** between areas and **reordering** them within an area. Moving a card from one area to another automatically changes that sequence's schedule option to the destination area's type. Newly added sequences land in the **Once per run** area by default. The change is purely an editor/presentation-and-interaction reorganization: it does not change run-time execution semantics, the stored data model's meaning, or the API.
+
+### User Story 1 - See the template organized by schedule type (Priority: P1)
+
+As an operator, I want the template editor to show my sequences grouped into four labeled areas by schedule type — "Start of execution" across the top, "Once per run" and "Scheduled" stacked on the left, and "After every step" on the right — so I can understand at a glance what runs first, what runs each cycle, what runs on a timer, and what runs after every step, without reading a per-row drop-down for every sequence.
+
+**Why this priority**: The core value the user asked for is "a better overview of the queue execution scheduling." The grouped, labeled layout delivers that overview on its own — even before drag-and-drop is added — and is the foundation every other story builds on.
+
+**Independent Test**: Open an existing template that has at least one sequence of each schedule type; confirm each sequence appears in exactly the area matching its current schedule option, that the four areas are laid out as described (full-width top, stacked left pair, right column), and that each area is clearly labeled.
+
+**Acceptance Scenarios**:
+
+1. **Given** a template with an "At Queue Start" sequence, a "Once Per Run" sequence, a "Timer" sequence, and an "After Every Step" sequence, **When** the operator opens the editor, **Then** each sequence appears in its corresponding area ("Start of execution", "Once per run", "Scheduled", "After every step" respectively).
+2. **Given** the editor is open, **When** the operator views the layout, **Then** "Start of execution" spans the full width at the top, "Once per run" and "Scheduled" are stacked vertically on the left, and "After every step" occupies the right column beside them.
+3. **Given** an area that currently contains no sequences, **When** the operator views it, **Then** the area is still visible and clearly labeled, indicating it can receive sequences (e.g. an empty drop zone with a hint).
+
+---
+
+### User Story 2 - Reassign a sequence's schedule by dragging it to another area (Priority: P1)
+
+As an operator, I want to drag a sequence card from one area into another so its schedule option is automatically changed to the destination area's type, so I can reschedule a sequence without hunting for a drop-down.
+
+**Why this priority**: This is the primary interaction the user requested ("move the sequences from one area to the other … its scheduling type has to be adjusted automatically"). Together with Story 1 it forms the MVP: a grouped layout you can actually rearrange.
+
+**Independent Test**: Drag a sequence from "Once per run" to "After every step", save, reload, and confirm the sequence now has the "After Every Step" schedule option; repeat for each pair of areas.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence in the "Once per run" area, **When** the operator drags it into the "After every step" area and drops it, **Then** the sequence moves to that area and its schedule option becomes "After Every Step".
+2. **Given** a sequence in the "After every step" area, **When** the operator drags it into the "Start of execution" area, **Then** the sequence moves there and its schedule option becomes "At Queue Start".
+3. **Given** a sequence dragged into the "Scheduled" area, **When** it is dropped, **Then** its schedule option becomes "Timer" and the operator can then set the timer details (time-of-day or relative offset) for it within that area.
+4. **Given** a sequence dragged into the "Scheduled" area and given the "Timer" type, **When** the operator later drags it out into another area, **Then** its schedule option changes to the destination type and the timer-specific details are no longer applied while it is outside the "Scheduled" area.
+5. **Given** any schedule reassignment via drag, **When** the operator saves and reloads the template, **Then** the new schedule option persists and the sequence appears in the destination area.
+
+---
+
+### User Story 3 - Reorder sequences within an area by dragging (Priority: P2)
+
+As an operator, I want to drag sequence cards up and down within an area to change their order, so I control the order in which same-type sequences execute (e.g. the order of "At Queue Start" or "After Every Step" sequences).
+
+**Why this priority**: Ordering within a type is already meaningful to run execution (e.g. "At Queue Start" and "After Every Step" run in template order). Surfacing it as in-area drag reordering is valuable but secondary to having the grouped layout and cross-area reassignment.
+
+**Independent Test**: In an area with three sequences, drag the third above the first, save, reload, and confirm the new within-area order is preserved and reflected in the order those sequences execute for that schedule type.
+
+**Acceptance Scenarios**:
+
+1. **Given** three sequences in the "Start of execution" area in order A, B, C, **When** the operator drags C above A, **Then** the area shows C, A, B and that becomes the execution order for those "At Queue Start" sequences.
+2. **Given** sequences reordered within an area, **When** the operator saves and reloads, **Then** the within-area order is preserved.
+3. **Given** a sequence dragged within its own area, **When** it is dropped, **Then** only the order changes — its schedule option is unchanged.
+
+---
+
+### User Story 4 - New sequences default to "Once per run" (Priority: P2)
+
+As an operator, I want a newly added sequence to appear in the "Once per run" area by default, so adding a sequence has a predictable, sensible starting schedule that I can then drag elsewhere if needed.
+
+**Why this priority**: Establishes a clear default for the add flow that complements the drag interactions; without it the add behavior is ambiguous, but it is a small, well-bounded rule rather than the headline interaction.
+
+**Independent Test**: Add a sequence to the template; confirm it appears at the end of the "Once per run" area with the "Once Per Run" schedule option, regardless of which area (if any) was focused.
+
+**Acceptance Scenarios**:
+
+1. **Given** the template editor with any current contents, **When** the operator adds a sequence, **Then** the sequence appears in the "Once per run" area with the "Once Per Run" schedule option.
+2. **Given** a sequence was just added to "Once per run", **When** the operator drags it to another area, **Then** it behaves like any other sequence (schedule option updates to the destination type).
+
+---
+
+### Edge Cases
+
+- **Empty areas**: Each of the four areas is always shown even when empty, with a label and a drop target, so the operator can drop a sequence into it.
+- **Dropping into the same area at the same position**: A no-op drag (drop where it started) leaves both order and schedule option unchanged.
+- **Timer details on move into/out of "Scheduled"**: Moving into "Scheduled" assigns the "Timer" type and lets the operator configure timer details; moving a "Timer" sequence out of "Scheduled" changes its type to the destination's and stops applying the timer details at run time, while retaining them (inactive) on the entry so they are restored if the sequence is dragged back into "Scheduled".
+- **Stale / unresolved sequence reference**: A sequence whose reference is stale still appears as a card in the area matching its current schedule option, retains its stale indicator, and remains draggable.
+- **Many sequences in one area**: An area with many cards scrolls or grows within its panel without breaking the overall four-area layout.
+- **Cross-area order vs within-area order**: Each schedule type executes its own sequences in their within-area order; rearranging the relative position of the areas themselves on screen has no execution effect (only within-area order matters per type).
+- **Disabled / read-only state**: When the editor is in a disabled/read-only state, areas still render grouped but cards cannot be dragged or reassigned.
+- **Drag cancelled** (e.g. dropped outside any area, or via the Escape key during a drag): the sequence returns to its origin area and position with no change.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The template editor MUST present queue sequences grouped into four distinct, labeled areas, one per schedule option: "Start of execution" (At Queue Start), "Once per run" (Once Per Run), "Scheduled" (Timer), and "After every step" (After Every Step).
+- **FR-002**: The four areas MUST be laid out as: "Start of execution" full-width across the top; "Once per run" and "Scheduled" stacked vertically (Once per run above Scheduled) on the left; "After every step" on the right, beside the stacked left pair.
+- **FR-003**: On opening a template, each sequence MUST appear in exactly the area whose schedule option matches that sequence's current schedule option.
+- **FR-004**: The operator MUST be able to drag a sequence card from one area to another, which MUST move the card into the destination area and automatically set that sequence's schedule option to the destination area's type.
+- **FR-005**: The operator MUST be able to reorder sequence cards within an area by dragging, changing only their order within that area and not their schedule option.
+- **FR-006**: The within-area order of sequences MUST define the execution order for that schedule type (consistent with existing "template order" semantics for At Queue Start, Once Per Run, and After Every Step, and ordering among Timer entries).
+- **FR-007**: A newly added sequence MUST be placed in the "Once per run" area with the "Once Per Run" schedule option by default.
+- **FR-008**: When a sequence is moved into the "Scheduled" area, its schedule option MUST become "Timer", and the operator MUST be able to configure the timer details (time-of-day or relative offset) for it within that area.
+- **FR-009**: When a sequence is moved out of the "Scheduled" area into another area, its schedule option MUST change to the destination area's type and the timer details MUST no longer be applied at run time while the sequence is not a Timer entry. The previously configured timer details MUST be retained (inactive) on the entry and restored if the sequence is later dragged back into "Scheduled".
+- **FR-010**: Each area MUST remain visible and act as a valid drop target even when it contains no sequences, with a clear label and an empty-state hint.
+- **FR-011**: All schedule reassignments and reorderings performed via drag MUST persist when the template is saved and MUST be reflected correctly when the template is reloaded.
+- **FR-012**: This reorganization MUST NOT change run-time execution semantics, the stored schedule-option values/identifiers, or the API contract; it is an editor presentation-and-interaction change only, fully backward compatible with existing templates.
+- **FR-013**: A drag that is cancelled or dropped outside any valid area MUST leave the template unchanged (sequence returns to its origin area and position).
+- **FR-014**: When the editor is disabled/read-only, the four-area grouping MUST still render but sequences MUST NOT be draggable or reassignable.
+- **FR-015**: Each card MUST clearly indicate the area/schedule it currently belongs to.
+- **FR-016**: Stale or unresolved sequence references MUST still render as cards in the area matching their current schedule option, retain their stale indicator, and remain movable.
+
+### Key Entities *(include if feature involves data)*
+
+- **Queue Template Entry**: a positional reference to a sequence within a template, carrying a schedule option (and, for Timer entries, timer details). This feature changes how entries are *presented and manipulated* in the editor (grouped into areas, drag to move/reorder) but does not change the entry's stored shape or meaning.
+- **Scheduling Area**: an editor-only grouping that corresponds one-to-one with a schedule option — "Start of execution" ↔ At Queue Start, "Once per run" ↔ Once Per Run, "Scheduled" ↔ Timer, "After every step" ↔ After Every Step. An area has a label, a position in the layout, an ordered set of sequence cards, and an empty state.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Opening any existing template shows 100% of its sequences in the area matching their schedule option, with no sequence lost, duplicated, or mis-placed, across a sample template containing all four schedule types.
+- **SC-002**: An operator can change a sequence's schedule option by dragging it to another area and have that change persist across save/reload in 100% of attempts, for every ordered pair of areas.
+- **SC-003**: An operator can reorder sequences within an area by dragging, and the new within-area order persists across save/reload and matches the resulting execution order for that schedule type in 100% of attempts.
+- **SC-004**: A newly added sequence appears in the "Once per run" area with the "Once Per Run" option in 100% of adds.
+- **SC-005**: Run-time execution outcomes for any template are identical before and after this change (no scheduling regression), verified by the existing scheduling/queue test suite continuing to pass.
+- **SC-006**: A first-time operator can identify which sequences run first, each run, on a timer, and after every step within 10 seconds of opening the editor, without consulting documentation.
+
+## Assumptions
+
+- **Schedule options are unchanged**: The four schedule options and their stored/wire identifiers (At Queue Start, Once Per Run / `OncePerRun`, Timer, After Every Step / `EveryStep`) are exactly those established in feature 060; this feature only reorganizes their presentation. No new schedule option is introduced.
+- **One area per schedule option**: "Scheduled" represents the single "Timer" schedule option; its two sub-modes (time-of-day and relative offset) are configured per-card within that area rather than as separate areas.
+- **Timer details when leaving "Scheduled"**: When a Timer sequence is dragged out of "Scheduled", its previously entered timer details are not applied at run time (the sequence is no longer a Timer entry), but they are retained (inactive) on the entry and restored if the sequence is dragged back into "Scheduled".
+- **Default timer configuration on entering "Scheduled"**: A sequence newly assigned "Timer" by dropping it into "Scheduled" starts with an unset/empty timer value that the operator must fill in, consistent with how a freshly chosen Timer is configured today.
+- **Cross-area ordering**: Because each schedule type is executed in its own pass, only the order of cards *within* an area affects execution. There is no need to define a single global order spanning areas; the editor persists each area's internal order.
+- **Add control**: The existing "Add sequence" control continues to add a single selected sequence; the only change is that the new sequence is routed to the "Once per run" area by default (rather than appended to a single flat list).
+- **No backend/API changes**: Persistence uses the existing template-entry storage and API; the editor maps area membership to the existing schedule-option field on save and back to area membership on load.
+- **Scope**: This feature covers the web UI template editor only. The API surface, run-time scheduler, and stored data model are unchanged.
+- **Keyboard accessibility out of scope**: A keyboard-operable alternative to drag-and-drop is not required for this feature (clarified 2026-06-18). Reassign/reorder are delivered via drag-and-drop; a keyboard-accessible path may be added in a later feature.

--- a/specs/061-queue-scheduling-areas/tasks.md
+++ b/specs/061-queue-scheduling-areas/tasks.md
@@ -25,8 +25,8 @@ Web application, frontend only. All paths under `src/web-ui/src/`:
 
 **Purpose**: Confirm prerequisites and create file skeletons. Dependencies (`@dnd-kit/*`) are already installed.
 
-- [ ] T001 Verify `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` resolve and review the existing dnd-kit usage in `src/web-ui/src/components/SortableSequenceStepList.tsx`, `src/web-ui/src/components/SortableStepItem.tsx`, and `src/web-ui/src/components/DropIndicator.tsx` to reuse their conventions.
-- [ ] T002 Create empty skeleton files: `src/web-ui/src/components/queues/schedulingAreas.ts`, `src/web-ui/src/components/queues/SchedulingSequenceCard.tsx`, `src/web-ui/src/components/queues/SchedulingArea.tsx`, `src/web-ui/src/components/queues/QueueSchedulingAreas.tsx`, and `src/web-ui/src/components/queues/QueueSchedulingAreas.css`.
+- [X] T001 Verify `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` resolve and review the existing dnd-kit usage in `src/web-ui/src/components/SortableSequenceStepList.tsx`, `src/web-ui/src/components/SortableStepItem.tsx`, and `src/web-ui/src/components/DropIndicator.tsx` to reuse their conventions.
+- [X] T002 Create empty skeleton files: `src/web-ui/src/components/queues/schedulingAreas.ts`, `src/web-ui/src/components/queues/SchedulingSequenceCard.tsx`, `src/web-ui/src/components/queues/SchedulingArea.tsx`, `src/web-ui/src/components/queues/QueueSchedulingAreas.tsx`, and `src/web-ui/src/components/queues/QueueSchedulingAreas.css`.
 
 ---
 
@@ -36,8 +36,8 @@ Web application, frontend only. All paths under `src/web-ui/src/`:
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T003 In `src/web-ui/src/components/queues/schedulingAreas.ts`, define `SchedulingAreaId` (`'startOfExecution' | 'oncePerRun' | 'scheduled' | 'afterEveryStep'`), `AREA_LABELS`, `CANONICAL_AREA_ORDER` (`startOfExecution, oncePerRun, scheduled, afterEveryStep`), and the pure helpers `areaForScheduleType(scheduleType): SchedulingAreaId` and `scheduleTypeForArea(areaId): ScheduleType` (1:1 with `ScheduleType` from `services/queueTemplates.ts`; `Timer`↔`scheduled`, `EveryStep`↔`afterEveryStep`).
-- [ ] T004 [P] Add `src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts` covering the mapping helpers round-trip (every `ScheduleType` ↔ `SchedulingAreaId` both directions) and the canonical order constant.
+- [X] T003 In `src/web-ui/src/components/queues/schedulingAreas.ts`, define `SchedulingAreaId` (`'startOfExecution' | 'oncePerRun' | 'scheduled' | 'afterEveryStep'`), `AREA_LABELS`, `CANONICAL_AREA_ORDER` (`startOfExecution, oncePerRun, scheduled, afterEveryStep`), and the pure helpers `areaForScheduleType(scheduleType): SchedulingAreaId` and `scheduleTypeForArea(areaId): ScheduleType` (1:1 with `ScheduleType` from `services/queueTemplates.ts`; `Timer`↔`scheduled`, `EveryStep`↔`afterEveryStep`).
+- [X] T004 [P] Add `src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts` covering the mapping helpers round-trip (every `ScheduleType` ↔ `SchedulingAreaId` both directions) and the canonical order constant.
 
 **Checkpoint**: Mapping foundation ready.
 
@@ -51,17 +51,17 @@ Web application, frontend only. All paths under `src/web-ui/src/`:
 
 ### Tests for User Story 1
 
-- [ ] T005 [P] [US1] In `src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts`, add tests for `groupEntriesIntoAreas` (entries grouped by current `scheduleType`; missing schedule defaults to `oncePerRun`; ordering within an area follows `orderedEntryIds`; no entry lost/duplicated).
-- [ ] T006 [P] [US1] Add `src/web-ui/src/components/queues/__tests__/QueueSchedulingAreas.test.tsx` asserting contract C1–C5 and C7: four labeled areas render, entries grouped by schedule type, empty area shows label + hint, badges per type (At Queue Start / After Every Step / Timer; none for OncePerRun), stale badge preserved, and `disabled` renders grouping without draggable cards.
+- [X] T005 [P] [US1] In `src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts`, add tests for `groupEntriesIntoAreas` (entries grouped by current `scheduleType`; missing schedule defaults to `oncePerRun`; ordering within an area follows `orderedEntryIds`; no entry lost/duplicated).
+- [X] T006 [P] [US1] Add `src/web-ui/src/components/queues/__tests__/QueueSchedulingAreas.test.tsx` asserting contract C1–C5 and C7: four labeled areas render, entries grouped by schedule type, empty area shows label + hint, badges per type (At Queue Start / After Every Step / Timer; none for OncePerRun), stale badge preserved, and `disabled` renders grouping without draggable cards.
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] Implement `groupEntriesIntoAreas(orderedEntryIds, schedule, entriesById)` in `src/web-ui/src/components/queues/schedulingAreas.ts` returning `Record<SchedulingAreaId, SchedulingCard[]>` (uses `areaForScheduleType`; default `OncePerRun`).
-- [ ] T008 [P] [US1] Implement `SchedulingSequenceCard` in `src/web-ui/src/components/queues/SchedulingSequenceCard.tsx`: renders label, stale badge, schedule badge consistent with its area, and a Remove button; uses `useSortable` (drag handle/attributes) following `SortableStepItem` conventions; respects `disabled`.
-- [ ] T009 [P] [US1] Implement `SchedulingArea` in `src/web-ui/src/components/queues/SchedulingArea.tsx`: a droppable area with heading (`AREA_LABELS`), a `SortableContext` over its card ids, an empty-state hint when no cards, and `DropIndicator` support (reuse existing `DropIndicator`).
-- [ ] T010 [US1] Implement `QueueSchedulingAreas` shell in `src/web-ui/src/components/queues/QueueSchedulingAreas.tsx`: props per contract (`entries`, `sequences`, `entrySchedule`, `onAdd`, `onRemove`, `onReorderAndReassign`, timer handlers, `disabled`); derive areas via `groupEntriesIntoAreas`; render the four `SchedulingArea`s inside one `DndContext`; keep the existing "Add sequence" control (routes through `onAdd`). Drag handlers may be stubs at this stage (wired in US2/US3).
-- [ ] T011 [US1] Add four-area responsive CSS grid in `src/web-ui/src/components/queues/QueueSchedulingAreas.css` (full-width top row; left column stacking Once-per-run over Scheduled; right column "After every step" spanning both) and import it in `QueueSchedulingAreas.tsx`; follow existing `reorderable-list`/`empty-state` visual conventions.
-- [ ] T012 [US1] Wire `QueueSchedulingAreas` into `src/web-ui/src/pages/QueuesPage.tsx` in place of `QueueEntryList` (within `QueueTemplateControls`), passing existing `detail.entries`, `entrySchedule`, `onAdd`/`onRemove`, and `disabled={detail.status === 'Running'}`; existing `buildScheduleFromTemplateEntries` continues to restore grouping on open.
+- [X] T007 [US1] Implement `groupEntriesIntoAreas(orderedEntryIds, schedule, entriesById)` in `src/web-ui/src/components/queues/schedulingAreas.ts` returning `Record<SchedulingAreaId, SchedulingCard[]>` (uses `areaForScheduleType`; default `OncePerRun`).
+- [X] T008 [P] [US1] Implement `SchedulingSequenceCard` in `src/web-ui/src/components/queues/SchedulingSequenceCard.tsx`: renders label, stale badge, schedule badge consistent with its area, and a Remove button; uses `useSortable` (drag handle/attributes) following `SortableStepItem` conventions; respects `disabled`.
+- [X] T009 [P] [US1] Implement `SchedulingArea` in `src/web-ui/src/components/queues/SchedulingArea.tsx`: a droppable area with heading (`AREA_LABELS`), a `SortableContext` over its card ids, an empty-state hint when no cards, and `DropIndicator` support (reuse existing `DropIndicator`).
+- [X] T010 [US1] Implement `QueueSchedulingAreas` shell in `src/web-ui/src/components/queues/QueueSchedulingAreas.tsx`: props per contract (`entries`, `sequences`, `entrySchedule`, `onAdd`, `onRemove`, `onReorderAndReassign`, timer handlers, `disabled`); derive areas via `groupEntriesIntoAreas`; render the four `SchedulingArea`s inside one `DndContext`; keep the existing "Add sequence" control (routes through `onAdd`). Drag handlers may be stubs at this stage (wired in US2/US3).
+- [X] T011 [US1] Add four-area responsive CSS grid in `src/web-ui/src/components/queues/QueueSchedulingAreas.css` (full-width top row; left column stacking Once-per-run over Scheduled; right column "After every step" spanning both) and import it in `QueueSchedulingAreas.tsx`; follow existing `reorderable-list`/`empty-state` visual conventions.
+- [X] T012 [US1] Wire `QueueSchedulingAreas` into `src/web-ui/src/pages/QueuesPage.tsx` in place of `QueueEntryList` (within `QueueTemplateControls`), passing existing `detail.entries`, `entrySchedule`, `onAdd`/`onRemove`, and `disabled={detail.status === 'Running'}`; existing `buildScheduleFromTemplateEntries` continues to restore grouping on open.
 
 **Checkpoint**: Read-only grouped four-area view works end-to-end and is independently testable (MVP).
 
@@ -75,16 +75,16 @@ Web application, frontend only. All paths under `src/web-ui/src/`:
 
 ### Tests for User Story 2
 
-- [ ] T013 [P] [US2] In `schedulingAreas.test.ts`, add reducer tests R1–R5 and R7 for `applyDragMove`: cross-area reassign sets destination `scheduleType` (each pair incl. → `scheduled` = `Timer`), move out of `scheduled` retains `timerTimeOfDay`/`timerRelativeOffset`/`timerMode` (inactive), move back restores them, a no-op drop leaves state unchanged, and a cancelled/out-of-area drop (no/`null` target area, FR-013) leaves both `orderedEntryIds` and `schedule` unchanged.
-- [ ] T014 [P] [US2] In `QueueSchedulingAreas.test.tsx`, add contract C6: a card in the "Scheduled" area exposes timer controls (mode toggle + time-of-day input or relative-offset inputs); cards in other areas do not.
-- [ ] T015 [P] [US2] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration tests I1 and I4: reassigning a card to another area then saving + reloading the template shows it in the destination area with the new `scheduleType`; a `Timer` card retains its timer value across save/reload, and a card moved out of "Scheduled" before save is emitted with the destination type and no timer fields.
+- [X] T013 [P] [US2] In `schedulingAreas.test.ts`, add reducer tests R1–R5 and R7 for `applyDragMove`: cross-area reassign sets destination `scheduleType` (each pair incl. → `scheduled` = `Timer`), move out of `scheduled` retains `timerTimeOfDay`/`timerRelativeOffset`/`timerMode` (inactive), move back restores them, a no-op drop leaves state unchanged, and a cancelled/out-of-area drop (no/`null` target area, FR-013) leaves both `orderedEntryIds` and `schedule` unchanged.
+- [X] T014 [P] [US2] In `QueueSchedulingAreas.test.tsx`, add contract C6: a card in the "Scheduled" area exposes timer controls (mode toggle + time-of-day input or relative-offset inputs); cards in other areas do not.
+- [X] T015 [P] [US2] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration tests I1 and I4: reassigning a card to another area then saving + reloading the template shows it in the destination area with the new `scheduleType`; a `Timer` card retains its timer value across save/reload, and a card moved out of "Scheduled" before save is emitted with the destination type and no timer fields.
 
 ### Implementation for User Story 2
 
-- [ ] T016 [US2] Implement the cross-area branch of `applyDragMove(state, { entryId, targetArea, targetIndex })` in `src/web-ui/src/components/queues/schedulingAreas.ts`: set `schedule[entryId].scheduleType = scheduleTypeForArea(targetArea)`; on enter `scheduled` keep/empty timer fields; on exit `scheduled` retain timer fields inactive; rebuild `orderedEntryIds` keeping canonical inter-area order; no-op when area+index unchanged.
-- [ ] T017 [US2] Render per-card Timer controls in `SchedulingSequenceCard`/`SchedulingArea` for cards in the "Scheduled" area only (mode toggle, time-of-day input, relative-offset inputs), reusing the existing markup/handlers from `QueueEntryList.tsx` and forwarding `onTimerTimeChange`/`onTimerModeChange`/`onTimerRelativeOffsetChange`.
-- [ ] T018 [US2] Wire `onDragEnd` in `QueueSchedulingAreas.tsx` to translate the dnd-kit event into `{ entryId, targetArea, targetIndex }`, call `applyDragMove`, and invoke `onReorderAndReassign(next)`; track `activeId`/`overId` for `DropIndicator`. Guard a cancelled/dropped-outside drag (FR-013): when the dnd-kit `over` is `null` or resolves to no valid area, return early without calling `applyDragMove`/`onReorderAndReassign` so the card returns to its origin unchanged.
-- [ ] T019 [US2] In `src/web-ui/src/pages/QueuesPage.tsx`, add an `onReorderAndReassign` handler that updates `entrySchedule` (and the working ordered-entry state) from the reducer output so reassignment is reflected immediately; cross-area reassignment persists via the existing `handleSaveTemplate` (schedule type is stored positionally — no entry reorder needed for US2).
+- [X] T016 [US2] Implement the cross-area branch of `applyDragMove(state, { entryId, targetArea, targetIndex })` in `src/web-ui/src/components/queues/schedulingAreas.ts`: set `schedule[entryId].scheduleType = scheduleTypeForArea(targetArea)`; on enter `scheduled` keep/empty timer fields; on exit `scheduled` retain timer fields inactive; rebuild `orderedEntryIds` keeping canonical inter-area order; no-op when area+index unchanged.
+- [X] T017 [US2] Render per-card Timer controls in `SchedulingSequenceCard`/`SchedulingArea` for cards in the "Scheduled" area only (mode toggle, time-of-day input, relative-offset inputs), reusing the existing markup/handlers from `QueueEntryList.tsx` and forwarding `onTimerTimeChange`/`onTimerModeChange`/`onTimerRelativeOffsetChange`.
+- [X] T018 [US2] Wire `onDragEnd` in `QueueSchedulingAreas.tsx` to translate the dnd-kit event into `{ entryId, targetArea, targetIndex }`, call `applyDragMove`, and invoke `onReorderAndReassign(next)`; track `activeId`/`overId` for `DropIndicator`. Guard a cancelled/dropped-outside drag (FR-013): when the dnd-kit `over` is `null` or resolves to no valid area, return early without calling `applyDragMove`/`onReorderAndReassign` so the card returns to its origin unchanged.
+- [X] T019 [US2] In `src/web-ui/src/pages/QueuesPage.tsx`, add an `onReorderAndReassign` handler that updates `entrySchedule` (and the working ordered-entry state) from the reducer output so reassignment is reflected immediately; cross-area reassignment persists via the existing `handleSaveTemplate` (schedule type is stored positionally — no entry reorder needed for US2).
 
 **Checkpoint**: Cross-area reassignment + Timer retention work and round-trip; US1 still functions.
 
@@ -98,13 +98,13 @@ Web application, frontend only. All paths under `src/web-ui/src/`:
 
 ### Tests for User Story 3
 
-- [ ] T020 [P] [US3] In `schedulingAreas.test.ts`, add reducer test R6: within-area reorder changes only `orderedEntryIds` for the affected cards and leaves every `scheduleType` unchanged.
-- [ ] T021 [P] [US3] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration test I2: reordering within an area, saving, and reloading preserves the within-area order (and thus per-type execution order), verifying the order-aware save path.
+- [X] T020 [P] [US3] In `schedulingAreas.test.ts`, add reducer test R6: within-area reorder changes only `orderedEntryIds` for the affected cards and leaves every `scheduleType` unchanged.
+- [X] T021 [P] [US3] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration test I2: reordering within an area, saving, and reloading preserves the within-area order (and thus per-type execution order), verifying the order-aware save path.
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] Implement the within-area reorder branch of `applyDragMove` in `src/web-ui/src/components/queues/schedulingAreas.ts` (reinsert `entryId` at `targetIndex` within the same area; `scheduleType` unchanged); confirm `onDragEnd` already routes same-area drops here.
-- [ ] T023 [US3] Make `handleSaveTemplate` in `src/web-ui/src/pages/QueuesPage.tsx` order-aware: before saving, compute `orderedSequenceIds` from the working ordered-entry state, call `replaceQueueEntries(detail.id, orderedSequenceIds)`, `getQueue` to fetch reordered entries, re-key `entrySchedule` onto the new entries by position, then build the template entries in that order (timer fields only for `Timer`). Keeps runtime order == saved template order so positional reload restore stays correct.
+- [X] T022 [US3] Implement the within-area reorder branch of `applyDragMove` in `src/web-ui/src/components/queues/schedulingAreas.ts` (reinsert `entryId` at `targetIndex` within the same area; `scheduleType` unchanged); confirm `onDragEnd` already routes same-area drops here.
+- [X] T023 [US3] Make `handleSaveTemplate` in `src/web-ui/src/pages/QueuesPage.tsx` order-aware: before saving, compute `orderedSequenceIds` from the working ordered-entry state, call `replaceQueueEntries(detail.id, orderedSequenceIds)`, `getQueue` to fetch reordered entries, re-key `entrySchedule` onto the new entries by position, then build the template entries in that order (timer fields only for `Timer`). Keeps runtime order == saved template order so positional reload restore stays correct.
 
 **Checkpoint**: Within-area reorder persists; US1 and US2 still function.
 
@@ -118,12 +118,12 @@ Web application, frontend only. All paths under `src/web-ui/src/`:
 
 ### Tests for User Story 4
 
-- [ ] T024 [P] [US4] In `schedulingAreas.test.ts`, add reducer/grouping test R8: an entry with `scheduleType 'OncePerRun'` appears last in the `oncePerRun` area after being appended to `orderedEntryIds`.
-- [ ] T025 [P] [US4] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration test I3: adding a sequence places it in "Once per run" and saving emits it with `scheduleType: 'OncePerRun'`.
+- [X] T024 [P] [US4] In `schedulingAreas.test.ts`, add reducer/grouping test R8: an entry with `scheduleType 'OncePerRun'` appears last in the `oncePerRun` area after being appended to `orderedEntryIds`.
+- [X] T025 [P] [US4] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration test I3: adding a sequence places it in "Once per run" and saving emits it with `scheduleType: 'OncePerRun'`.
 
 ### Implementation for User Story 4
 
-- [ ] T026 [US4] Confirm/adjust `onAddEntry` in `src/web-ui/src/pages/QueuesPage.tsx` so a new entry seeds `entrySchedule[newEntry.entryId] = { scheduleType: 'OncePerRun', timerTimeOfDay: '' }` and is appended to the working ordered-entry state (so it renders last in "Once per run"); ensure `QueueSchedulingAreas` reflects the new card without manual area selection.
+- [X] T026 [US4] Confirm/adjust `onAddEntry` in `src/web-ui/src/pages/QueuesPage.tsx` so a new entry seeds `entrySchedule[newEntry.entryId] = { scheduleType: 'OncePerRun', timerTimeOfDay: '' }` and is appended to the working ordered-entry state (so it renders last in "Once per run"); ensure `QueueSchedulingAreas` reflects the new card without manual area selection.
 
 **Checkpoint**: All four user stories independently functional.
 
@@ -133,9 +133,9 @@ Web application, frontend only. All paths under `src/web-ui/src/`:
 
 **Purpose**: Consistency, regression safety, and gate validation.
 
-- [ ] T027 [P] Responsive/empty-area polish in `src/web-ui/src/components/queues/QueueSchedulingAreas.css` (narrow-viewport stacking; consistent empty-area sizing) and verify ARIA labels on areas/cards/badges follow existing conventions.
-- [ ] T028 Confirm the existing scheduling/queue suites pass unchanged (I5): run `src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx` and existing `QueuesPage.templates.spec.tsx` cases; update only references made obsolete by replacing `QueueEntryList` in the editor (do not change runtime/API behavior).
-- [ ] T029 Run the quality gate: `npm run build` (vite) and `npm test` (jest) from `src/web-ui` must both be green; fix any failures before marking complete (constitution NON-NEGOTIABLE).
+- [X] T027 [P] Responsive/empty-area polish in `src/web-ui/src/components/queues/QueueSchedulingAreas.css` (narrow-viewport stacking; consistent empty-area sizing) and verify ARIA labels on areas/cards/badges follow existing conventions.
+- [X] T028 Confirm the existing scheduling/queue suites pass unchanged (I5): run `src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx` and existing `QueuesPage.templates.spec.tsx` cases; update only references made obsolete by replacing `QueueEntryList` in the editor (do not change runtime/API behavior).
+- [X] T029 Run the quality gate: `npm run build` (vite) and `npm test` (jest) from `src/web-ui` must both be green; fix any failures before marking complete (constitution NON-NEGOTIABLE).
 - [ ] T030 [P] Execute the `specs/061-queue-scheduling-areas/quickstart.md` manual verification (US1–US4 walkthroughs incl. Timer retain/restore) and note results.
 
 ---

--- a/specs/061-queue-scheduling-areas/tasks.md
+++ b/specs/061-queue-scheduling-areas/tasks.md
@@ -1,0 +1,213 @@
+---
+description: "Task list for Drag-and-Drop Scheduling Areas in the Queue Template Editor"
+---
+
+# Tasks: Drag-and-Drop Scheduling Areas in the Queue Template Editor
+
+**Input**: Design documents from `specs/061-queue-scheduling-areas/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/scheduling-areas-ui.md, quickstart.md
+
+**Tests**: Included — the project constitution (Testing Standards, NON-NEGOTIABLE) requires tests for executable logic, and the quality gate is `vite build` + `jest` green.
+
+**Organization**: Tasks are grouped by user story (US1–US4 from spec.md) for independent implementation and testing.
+
+## Path Conventions
+
+Web application, frontend only. All paths under `src/web-ui/src/`:
+- Components: `components/queues/`
+- Page: `pages/QueuesPage.tsx`
+- Tests: co-located `__tests__/` (Jest + `@testing-library/react`)
+- Styles: co-located `components/queues/QueueSchedulingAreas.css`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm prerequisites and create file skeletons. Dependencies (`@dnd-kit/*`) are already installed.
+
+- [ ] T001 Verify `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` resolve and review the existing dnd-kit usage in `src/web-ui/src/components/SortableSequenceStepList.tsx`, `src/web-ui/src/components/SortableStepItem.tsx`, and `src/web-ui/src/components/DropIndicator.tsx` to reuse their conventions.
+- [ ] T002 Create empty skeleton files: `src/web-ui/src/components/queues/schedulingAreas.ts`, `src/web-ui/src/components/queues/SchedulingSequenceCard.tsx`, `src/web-ui/src/components/queues/SchedulingArea.tsx`, `src/web-ui/src/components/queues/QueueSchedulingAreas.tsx`, and `src/web-ui/src/components/queues/QueueSchedulingAreas.css`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Pure area↔schedule-type mapping used by every user story.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T003 In `src/web-ui/src/components/queues/schedulingAreas.ts`, define `SchedulingAreaId` (`'startOfExecution' | 'oncePerRun' | 'scheduled' | 'afterEveryStep'`), `AREA_LABELS`, `CANONICAL_AREA_ORDER` (`startOfExecution, oncePerRun, scheduled, afterEveryStep`), and the pure helpers `areaForScheduleType(scheduleType): SchedulingAreaId` and `scheduleTypeForArea(areaId): ScheduleType` (1:1 with `ScheduleType` from `services/queueTemplates.ts`; `Timer`↔`scheduled`, `EveryStep`↔`afterEveryStep`).
+- [ ] T004 [P] Add `src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts` covering the mapping helpers round-trip (every `ScheduleType` ↔ `SchedulingAreaId` both directions) and the canonical order constant.
+
+**Checkpoint**: Mapping foundation ready.
+
+---
+
+## Phase 3: User Story 1 - See the template organized by schedule type (Priority: P1) 🎯 MVP
+
+**Goal**: Replace the flat list with four labeled areas (full-width "Start of execution" top; "Once per run" above "Scheduled" left; "After every step" right), each rendering its sequences with the correct badge and an empty-state drop hint.
+
+**Independent Test**: Open a template containing one sequence of each schedule type → each appears in its matching area, all four areas render labeled (empty ones show a hint), layout matches the spec.
+
+### Tests for User Story 1
+
+- [ ] T005 [P] [US1] In `src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts`, add tests for `groupEntriesIntoAreas` (entries grouped by current `scheduleType`; missing schedule defaults to `oncePerRun`; ordering within an area follows `orderedEntryIds`; no entry lost/duplicated).
+- [ ] T006 [P] [US1] Add `src/web-ui/src/components/queues/__tests__/QueueSchedulingAreas.test.tsx` asserting contract C1–C5 and C7: four labeled areas render, entries grouped by schedule type, empty area shows label + hint, badges per type (At Queue Start / After Every Step / Timer; none for OncePerRun), stale badge preserved, and `disabled` renders grouping without draggable cards.
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Implement `groupEntriesIntoAreas(orderedEntryIds, schedule, entriesById)` in `src/web-ui/src/components/queues/schedulingAreas.ts` returning `Record<SchedulingAreaId, SchedulingCard[]>` (uses `areaForScheduleType`; default `OncePerRun`).
+- [ ] T008 [P] [US1] Implement `SchedulingSequenceCard` in `src/web-ui/src/components/queues/SchedulingSequenceCard.tsx`: renders label, stale badge, schedule badge consistent with its area, and a Remove button; uses `useSortable` (drag handle/attributes) following `SortableStepItem` conventions; respects `disabled`.
+- [ ] T009 [P] [US1] Implement `SchedulingArea` in `src/web-ui/src/components/queues/SchedulingArea.tsx`: a droppable area with heading (`AREA_LABELS`), a `SortableContext` over its card ids, an empty-state hint when no cards, and `DropIndicator` support (reuse existing `DropIndicator`).
+- [ ] T010 [US1] Implement `QueueSchedulingAreas` shell in `src/web-ui/src/components/queues/QueueSchedulingAreas.tsx`: props per contract (`entries`, `sequences`, `entrySchedule`, `onAdd`, `onRemove`, `onReorderAndReassign`, timer handlers, `disabled`); derive areas via `groupEntriesIntoAreas`; render the four `SchedulingArea`s inside one `DndContext`; keep the existing "Add sequence" control (routes through `onAdd`). Drag handlers may be stubs at this stage (wired in US2/US3).
+- [ ] T011 [US1] Add four-area responsive CSS grid in `src/web-ui/src/components/queues/QueueSchedulingAreas.css` (full-width top row; left column stacking Once-per-run over Scheduled; right column "After every step" spanning both) and import it in `QueueSchedulingAreas.tsx`; follow existing `reorderable-list`/`empty-state` visual conventions.
+- [ ] T012 [US1] Wire `QueueSchedulingAreas` into `src/web-ui/src/pages/QueuesPage.tsx` in place of `QueueEntryList` (within `QueueTemplateControls`), passing existing `detail.entries`, `entrySchedule`, `onAdd`/`onRemove`, and `disabled={detail.status === 'Running'}`; existing `buildScheduleFromTemplateEntries` continues to restore grouping on open.
+
+**Checkpoint**: Read-only grouped four-area view works end-to-end and is independently testable (MVP).
+
+---
+
+## Phase 4: User Story 2 - Reassign a sequence's schedule by dragging it to another area (Priority: P1)
+
+**Goal**: Dragging a card into another area changes its schedule option to that area's type; the change persists across save/reload. Moving into/out of "Scheduled" handles Timer details with retain-on-exit.
+
+**Independent Test**: Drag a card "Once per run" → "After every step"; its badge becomes "After Every Step"; save + reload keeps it there. Timer: drag into "Scheduled", set a time, drag out (controls hide), drag back (time restored).
+
+### Tests for User Story 2
+
+- [ ] T013 [P] [US2] In `schedulingAreas.test.ts`, add reducer tests R1–R5 and R7 for `applyDragMove`: cross-area reassign sets destination `scheduleType` (each pair incl. → `scheduled` = `Timer`), move out of `scheduled` retains `timerTimeOfDay`/`timerRelativeOffset`/`timerMode` (inactive), move back restores them, a no-op drop leaves state unchanged, and a cancelled/out-of-area drop (no/`null` target area, FR-013) leaves both `orderedEntryIds` and `schedule` unchanged.
+- [ ] T014 [P] [US2] In `QueueSchedulingAreas.test.tsx`, add contract C6: a card in the "Scheduled" area exposes timer controls (mode toggle + time-of-day input or relative-offset inputs); cards in other areas do not.
+- [ ] T015 [P] [US2] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration tests I1 and I4: reassigning a card to another area then saving + reloading the template shows it in the destination area with the new `scheduleType`; a `Timer` card retains its timer value across save/reload, and a card moved out of "Scheduled" before save is emitted with the destination type and no timer fields.
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Implement the cross-area branch of `applyDragMove(state, { entryId, targetArea, targetIndex })` in `src/web-ui/src/components/queues/schedulingAreas.ts`: set `schedule[entryId].scheduleType = scheduleTypeForArea(targetArea)`; on enter `scheduled` keep/empty timer fields; on exit `scheduled` retain timer fields inactive; rebuild `orderedEntryIds` keeping canonical inter-area order; no-op when area+index unchanged.
+- [ ] T017 [US2] Render per-card Timer controls in `SchedulingSequenceCard`/`SchedulingArea` for cards in the "Scheduled" area only (mode toggle, time-of-day input, relative-offset inputs), reusing the existing markup/handlers from `QueueEntryList.tsx` and forwarding `onTimerTimeChange`/`onTimerModeChange`/`onTimerRelativeOffsetChange`.
+- [ ] T018 [US2] Wire `onDragEnd` in `QueueSchedulingAreas.tsx` to translate the dnd-kit event into `{ entryId, targetArea, targetIndex }`, call `applyDragMove`, and invoke `onReorderAndReassign(next)`; track `activeId`/`overId` for `DropIndicator`. Guard a cancelled/dropped-outside drag (FR-013): when the dnd-kit `over` is `null` or resolves to no valid area, return early without calling `applyDragMove`/`onReorderAndReassign` so the card returns to its origin unchanged.
+- [ ] T019 [US2] In `src/web-ui/src/pages/QueuesPage.tsx`, add an `onReorderAndReassign` handler that updates `entrySchedule` (and the working ordered-entry state) from the reducer output so reassignment is reflected immediately; cross-area reassignment persists via the existing `handleSaveTemplate` (schedule type is stored positionally — no entry reorder needed for US2).
+
+**Checkpoint**: Cross-area reassignment + Timer retention work and round-trip; US1 still functions.
+
+---
+
+## Phase 5: User Story 3 - Reorder sequences within an area by dragging (Priority: P2)
+
+**Goal**: Dragging cards up/down within an area changes their order, which becomes the per-type execution order and persists across save/reload.
+
+**Independent Test**: In an area with A, B, C, drag C above A → order C, A, B; save + reload preserves it.
+
+### Tests for User Story 3
+
+- [ ] T020 [P] [US3] In `schedulingAreas.test.ts`, add reducer test R6: within-area reorder changes only `orderedEntryIds` for the affected cards and leaves every `scheduleType` unchanged.
+- [ ] T021 [P] [US3] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration test I2: reordering within an area, saving, and reloading preserves the within-area order (and thus per-type execution order), verifying the order-aware save path.
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] Implement the within-area reorder branch of `applyDragMove` in `src/web-ui/src/components/queues/schedulingAreas.ts` (reinsert `entryId` at `targetIndex` within the same area; `scheduleType` unchanged); confirm `onDragEnd` already routes same-area drops here.
+- [ ] T023 [US3] Make `handleSaveTemplate` in `src/web-ui/src/pages/QueuesPage.tsx` order-aware: before saving, compute `orderedSequenceIds` from the working ordered-entry state, call `replaceQueueEntries(detail.id, orderedSequenceIds)`, `getQueue` to fetch reordered entries, re-key `entrySchedule` onto the new entries by position, then build the template entries in that order (timer fields only for `Timer`). Keeps runtime order == saved template order so positional reload restore stays correct.
+
+**Checkpoint**: Within-area reorder persists; US1 and US2 still function.
+
+---
+
+## Phase 6: User Story 4 - New sequences default to "Once per run" (Priority: P2)
+
+**Goal**: A newly added sequence appears at the bottom of the "Once per run" area with `OncePerRun`.
+
+**Independent Test**: Add a sequence → it appears last in "Once per run"; saving emits it with `scheduleType: 'OncePerRun'`.
+
+### Tests for User Story 4
+
+- [ ] T024 [P] [US4] In `schedulingAreas.test.ts`, add reducer/grouping test R8: an entry with `scheduleType 'OncePerRun'` appears last in the `oncePerRun` area after being appended to `orderedEntryIds`.
+- [ ] T025 [P] [US4] Extend `src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx` with integration test I3: adding a sequence places it in "Once per run" and saving emits it with `scheduleType: 'OncePerRun'`.
+
+### Implementation for User Story 4
+
+- [ ] T026 [US4] Confirm/adjust `onAddEntry` in `src/web-ui/src/pages/QueuesPage.tsx` so a new entry seeds `entrySchedule[newEntry.entryId] = { scheduleType: 'OncePerRun', timerTimeOfDay: '' }` and is appended to the working ordered-entry state (so it renders last in "Once per run"); ensure `QueueSchedulingAreas` reflects the new card without manual area selection.
+
+**Checkpoint**: All four user stories independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Consistency, regression safety, and gate validation.
+
+- [ ] T027 [P] Responsive/empty-area polish in `src/web-ui/src/components/queues/QueueSchedulingAreas.css` (narrow-viewport stacking; consistent empty-area sizing) and verify ARIA labels on areas/cards/badges follow existing conventions.
+- [ ] T028 Confirm the existing scheduling/queue suites pass unchanged (I5): run `src/web-ui/src/components/queues/__tests__/QueueEntryList.test.tsx` and existing `QueuesPage.templates.spec.tsx` cases; update only references made obsolete by replacing `QueueEntryList` in the editor (do not change runtime/API behavior).
+- [ ] T029 Run the quality gate: `npm run build` (vite) and `npm test` (jest) from `src/web-ui` must both be green; fix any failures before marking complete (constitution NON-NEGOTIABLE).
+- [ ] T030 [P] Execute the `specs/061-queue-scheduling-areas/quickstart.md` manual verification (US1–US4 walkthroughs incl. Timer retain/restore) and note results.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories.
+- **User Stories (Phase 3–6)**: All depend on Foundational. US1 is the MVP and establishes the components US2–US4 extend; US2, US3, US4 each depend on US1 (shared components/page wiring) but are independently testable increments and do not depend on each other.
+- **Polish (Phase 7)**: Depends on all targeted stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Foundational. No dependency on other stories.
+- **US2 (P1)**: Builds on US1 components (drag wiring + Timer controls). Independently testable.
+- **US3 (P2)**: Builds on US1 components; adds order-aware save. Independent of US2.
+- **US4 (P2)**: Builds on US1 add flow. Independent of US2/US3.
+
+### Within Each User Story
+
+- Write tests first and confirm they fail before implementing.
+- Pure reducer/grouping logic before component wiring; components before page wiring.
+
+### Parallel Opportunities
+
+- T004 with T003 (test alongside helper) once T003 lands.
+- US1 tests T005, T006 in parallel; components T008, T009 in parallel (different files) before T010 wires them.
+- US2 tests T013, T014, T015 in parallel.
+- US3 tests T020, T021 in parallel; US4 tests T024, T025 in parallel.
+- After US1 completes, US2/US3/US4 can be staffed in parallel by different developers (they touch `applyDragMove`/`QueuesPage` in different branches — coordinate `schedulingAreas.ts` and `QueuesPage.tsx` edits to avoid conflicts).
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests together:
+Task: "groupEntriesIntoAreas tests in schedulingAreas.test.ts"
+Task: "QueueSchedulingAreas render/grouping/badges tests in QueueSchedulingAreas.test.tsx"
+
+# Components together (different files):
+Task: "SchedulingSequenceCard in SchedulingSequenceCard.tsx"
+Task: "SchedulingArea in SchedulingArea.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup → Phase 2 Foundational → Phase 3 US1.
+2. **STOP and VALIDATE**: grouped four-area view renders correctly from existing templates.
+3. Demo: the "better overview" the feature is fundamentally about.
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready.
+2. US1 → grouped layout (MVP) → validate.
+3. US2 → drag-to-reassign + Timer retention → validate round-trip.
+4. US3 → drag-to-reorder + order-aware save → validate.
+5. US4 → default-to-Once-per-run on add → validate.
+6. Polish → gate green.
+
+---
+
+## Notes
+
+- [P] = different files, no dependencies.
+- This is a frontend-only feature: no API/scheduler/stored-model changes (FR-012).
+- Keyboard-operable drag alternative is explicitly out of scope (clarified 2026-06-18); the existing schedule selector path is not required.
+- Quality gate is `vite build` + `jest` green (lint/`tsc --noEmit` have pre-existing failures and are not the gate).
+- Commit after each task or logical group.

--- a/src/web-ui/src/components/queues/QueueSchedulingAreas.css
+++ b/src/web-ui/src/components/queues/QueueSchedulingAreas.css
@@ -1,0 +1,80 @@
+/* Four-area scheduling editor layout.
+   Row 1: full-width "Start of execution".
+   Row 2: left column stacks "Once per run" over "Scheduled"; right column "After every step". */
+.scheduling-areas__grid {
+  display: grid;
+  gap: var(--gb-space-3);
+  margin: var(--gb-space-2) 0;
+}
+
+.scheduling-areas__body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gb-space-3);
+  align-items: stretch;
+}
+
+.scheduling-areas__left {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  gap: var(--gb-space-3);
+}
+
+.scheduling-areas__right {
+  display: grid;
+}
+
+.scheduling-area {
+  border: 1px solid var(--gb-color-border);
+  border-radius: var(--gb-radius-lg);
+  background: var(--gb-color-surface);
+  padding: var(--gb-space-3);
+  min-height: 96px;
+}
+
+.scheduling-area--over {
+  border-color: var(--gb-color-primary, #2563eb);
+  background: var(--gb-color-surface-alt, #f5f7fb);
+}
+
+.scheduling-area__heading {
+  margin: 0 0 var(--gb-space-2);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--gb-color-text-muted, #888);
+}
+
+.scheduling-area__list {
+  min-height: 48px;
+}
+
+.scheduling-card {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--gb-space-2);
+  padding: var(--gb-space-2);
+  border: 1px solid var(--gb-color-border);
+  border-radius: var(--gb-radius-md);
+  background: var(--gb-color-surface-alt, #fafafa);
+}
+
+.scheduling-card__handle {
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.scheduling-card__name {
+  flex: 1 1 auto;
+  min-width: 8rem;
+  font-weight: 500;
+}
+
+/* Narrow viewports: collapse the two columns into a single stacked column. */
+@media (max-width: 720px) {
+  .scheduling-areas__body {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/web-ui/src/components/queues/QueueSchedulingAreas.tsx
+++ b/src/web-ui/src/components/queues/QueueSchedulingAreas.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import {
-  closestCenter,
+  CollisionDetection,
   DndContext,
   DragEndEvent,
   DragOverEvent,
   DragStartEvent,
   PointerSensor,
+  pointerWithin,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
@@ -42,6 +43,20 @@ export type QueueSchedulingAreasProps = {
 
 const isAreaId = (id: string): id is SchedulingAreaId =>
   (CANONICAL_AREA_ORDER as string[]).includes(id);
+
+/**
+ * Pointer-based collision detection: the droppable directly under the cursor is the target,
+ * rather than the dragged card's center (which is offset from the drag handle and feels
+ * counter-intuitive). A card under the pointer wins over its enclosing area so the reorder
+ * index is precise; empty space within an area falls back to the area itself. The dragged card
+ * is excluded so it never targets itself, and releasing outside every area resolves to no target
+ * (a no-op that returns the card to its origin — FR-013).
+ */
+const collisionDetectionStrategy: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args).filter((c) => c.id !== args.active.id);
+  const cardCollision = pointerCollisions.find((c) => !isAreaId(String(c.id)));
+  return cardCollision ? [cardCollision] : pointerCollisions;
+};
 
 export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
   entries,
@@ -130,7 +145,7 @@ export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
     <section className="queue-entries scheduling-areas" aria-label="Queue sequences">
       <DndContext
         sensors={sensors}
-        collisionDetection={closestCenter}
+        collisionDetection={collisionDetectionStrategy}
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}

--- a/src/web-ui/src/components/queues/QueueSchedulingAreas.tsx
+++ b/src/web-ui/src/components/queues/QueueSchedulingAreas.tsx
@@ -1,0 +1,223 @@
+import React, { useMemo, useState } from 'react';
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  DragOverEvent,
+  DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { SearchableDropdown, SearchableOption } from '../SearchableDropdown';
+import { QueueEntryDto } from '../../services/queues';
+import { SequenceDto } from '../../services/sequences';
+import { ScheduleType } from '../../services/queueTemplates';
+import { EntrySchedule, TimerMode } from './QueueEntryList';
+import { SchedulingArea } from './SchedulingArea';
+import {
+  applyDragMove,
+  areaForScheduleType,
+  CANONICAL_AREA_ORDER,
+  DEFAULT_SCHEDULE,
+  groupEntriesIntoAreas,
+  SchedulingAreaId,
+  SchedulingAreasState,
+} from './schedulingAreas';
+import './QueueSchedulingAreas.css';
+
+export type QueueSchedulingAreasProps = {
+  entries: QueueEntryDto[];
+  sequences: SequenceDto[];
+  entrySchedule: Record<string, EntrySchedule>;
+  onAdd: (sequenceId: string) => void;
+  onRemove: (entryId: string) => void;
+  /** Drag result: the new linear order + the new schedule map (already computed by the pure reducer). */
+  onReorderAndReassign: (next: SchedulingAreasState) => void;
+  onTimerTimeChange?: (entryId: string, timerTimeOfDay: string) => void;
+  onTimerModeChange?: (entryId: string, mode: TimerMode) => void;
+  onTimerRelativeOffsetChange?: (entryId: string, offset: string) => void;
+  disabled?: boolean;
+};
+
+const isAreaId = (id: string): id is SchedulingAreaId =>
+  (CANONICAL_AREA_ORDER as string[]).includes(id);
+
+export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
+  entries,
+  sequences,
+  entrySchedule,
+  onAdd,
+  onRemove,
+  onReorderAndReassign,
+  onTimerTimeChange,
+  onTimerModeChange,
+  onTimerRelativeOffsetChange,
+  disabled,
+}) => {
+  const [selected, setSelected] = useState<string | undefined>(undefined);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const orderedEntryIds = useMemo(() => entries.map((e) => e.entryId), [entries]);
+  const entriesById = useMemo(
+    () => Object.fromEntries(entries.map((e) => [e.entryId, e])),
+    [entries]
+  );
+  const state: SchedulingAreasState = { orderedEntryIds, schedule: entrySchedule };
+  const areas = useMemo(
+    () => groupEntriesIntoAreas(orderedEntryIds, entrySchedule, entriesById),
+    [orderedEntryIds, entrySchedule, entriesById]
+  );
+
+  const options = useMemo<SearchableOption[]>(
+    () => sequences.map((s) => ({ value: s.id, label: s.name || s.id })),
+    [sequences]
+  );
+
+  /** Resolve the drop target (area + final index) from the dnd-kit `over` id. */
+  const resolveTarget = (overTarget: string): { area: SchedulingAreaId; index: number } | null => {
+    if (isAreaId(overTarget)) {
+      return { area: overTarget, index: areas[overTarget].length };
+    }
+    for (const area of CANONICAL_AREA_ORDER) {
+      const idx = areas[area].findIndex((c) => c.entryId === overTarget);
+      if (idx !== -1) return { area, index: idx };
+    }
+    return null;
+  };
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+    setOverId(null);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    setOverId((event.over?.id as string) ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    setOverId(null);
+    // FR-013: a cancelled drag or a drop outside any area leaves state unchanged.
+    if (!over) return;
+    const target = resolveTarget(over.id as string);
+    if (!target) return;
+    const next = applyDragMove(state, { entryId: active.id as string, targetArea: target.area, targetIndex: target.index });
+    if (next === state) return; // no-op
+    onReorderAndReassign(next);
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+    setOverId(null);
+  };
+
+  // Non-drag reassign path (schedule selector): move the card to the matching area, appended.
+  const handleReassign = (entryId: string, scheduleType: ScheduleType) => {
+    const targetArea = areaForScheduleType(scheduleType);
+    if (areaForScheduleType((entrySchedule[entryId] ?? DEFAULT_SCHEDULE).scheduleType) === targetArea) return;
+    const targetIndex = areas[targetArea].length;
+    const next = applyDragMove(state, { entryId, targetArea, targetIndex });
+    if (next === state) return;
+    onReorderAndReassign(next);
+  };
+
+  return (
+    <section className="queue-entries scheduling-areas" aria-label="Queue sequences">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <div className="scheduling-areas__grid">
+          <div className="scheduling-areas__top">
+            <SchedulingArea
+              areaId="startOfExecution"
+              cards={areas.startOfExecution}
+              disabled={disabled}
+              activeId={activeId}
+              overId={overId}
+              onRemove={onRemove}
+              onReassign={handleReassign}
+              onTimerTimeChange={onTimerTimeChange}
+              onTimerModeChange={onTimerModeChange}
+              onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
+            />
+          </div>
+          <div className="scheduling-areas__body">
+            <div className="scheduling-areas__left">
+              <SchedulingArea
+                areaId="oncePerRun"
+                cards={areas.oncePerRun}
+                disabled={disabled}
+                activeId={activeId}
+                overId={overId}
+                onRemove={onRemove}
+                onReassign={handleReassign}
+                onTimerTimeChange={onTimerTimeChange}
+                onTimerModeChange={onTimerModeChange}
+                onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
+              />
+              <SchedulingArea
+                areaId="scheduled"
+                cards={areas.scheduled}
+                disabled={disabled}
+                activeId={activeId}
+                overId={overId}
+                onRemove={onRemove}
+                onReassign={handleReassign}
+                onTimerTimeChange={onTimerTimeChange}
+                onTimerModeChange={onTimerModeChange}
+                onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
+              />
+            </div>
+            <div className="scheduling-areas__right">
+              <SchedulingArea
+                areaId="afterEveryStep"
+                cards={areas.afterEveryStep}
+                disabled={disabled}
+                activeId={activeId}
+                overId={overId}
+                onRemove={onRemove}
+                onReassign={handleReassign}
+                onTimerTimeChange={onTimerTimeChange}
+                onTimerModeChange={onTimerModeChange}
+                onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
+              />
+            </div>
+          </div>
+        </div>
+      </DndContext>
+
+      <div className="queue-entry-add">
+        <SearchableDropdown
+          id="queue-add-sequence"
+          label="Add sequence"
+          value={selected}
+          options={options}
+          placeholder="Select a sequence…"
+          disabled={disabled}
+          onChange={(v) => setSelected(v)}
+        />
+        <button
+          type="button"
+          disabled={disabled || !selected}
+          onClick={() => {
+            if (!selected) return;
+            onAdd(selected);
+            setSelected(undefined);
+          }}
+        >
+          Add
+        </button>
+      </div>
+    </section>
+  );
+};

--- a/src/web-ui/src/components/queues/SchedulingArea.tsx
+++ b/src/web-ui/src/components/queues/SchedulingArea.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { DropIndicator, dropIndicatorBefore } from '../DropIndicator';
+import { ScheduleType } from '../../services/queueTemplates';
+import { TimerMode } from './QueueEntryList';
+import { SchedulingSequenceCard } from './SchedulingSequenceCard';
+import { AREA_LABELS, SchedulingAreaId, SchedulingCard } from './schedulingAreas';
+
+type SchedulingAreaProps = {
+  areaId: SchedulingAreaId;
+  cards: SchedulingCard[];
+  disabled?: boolean;
+  activeId?: string | null;
+  overId?: string | null;
+  onRemove: (entryId: string) => void;
+  onReassign: (entryId: string, scheduleType: ScheduleType) => void;
+  onTimerTimeChange?: (entryId: string, timerTimeOfDay: string) => void;
+  onTimerModeChange?: (entryId: string, mode: TimerMode) => void;
+  onTimerRelativeOffsetChange?: (entryId: string, offset: string) => void;
+};
+
+const EMPTY_HINT = 'Drop sequences here.';
+
+export const SchedulingArea: React.FC<SchedulingAreaProps> = ({
+  areaId,
+  cards,
+  disabled,
+  activeId,
+  overId,
+  onRemove,
+  onReassign,
+  onTimerTimeChange,
+  onTimerModeChange,
+  onTimerRelativeOffsetChange,
+}) => {
+  const label = AREA_LABELS[areaId];
+  // The area itself is a droppable so empty areas can receive a dragged card.
+  const { setNodeRef, isOver } = useDroppable({ id: areaId, data: { areaId, isArea: true } });
+  const ids = cards.map((c) => c.entryId);
+  const indicatorBefore = dropIndicatorBefore(ids, activeId ?? null, overId ?? null);
+
+  return (
+    <section
+      ref={setNodeRef}
+      className={`scheduling-area scheduling-area--${areaId}${isOver ? ' scheduling-area--over' : ''}`}
+      aria-label={label}
+      data-area={areaId}
+    >
+      <h4 className="scheduling-area__heading">{label}</h4>
+      <div className="reorderable-list scheduling-area__list">
+        {cards.length === 0 ? (
+          <div className="empty-state">{EMPTY_HINT}</div>
+        ) : (
+          <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+            {cards.map((card, index) => (
+              <React.Fragment key={card.entryId}>
+                {indicatorBefore === index && <DropIndicator />}
+                <div className="reorderable-list__item">
+                  <SchedulingSequenceCard
+                    card={card}
+                    areaId={areaId}
+                    disabled={disabled}
+                    onRemove={onRemove}
+                    onReassign={onReassign}
+                    onTimerTimeChange={onTimerTimeChange}
+                    onTimerModeChange={onTimerModeChange}
+                    onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
+                  />
+                </div>
+              </React.Fragment>
+            ))}
+            {indicatorBefore === cards.length && <DropIndicator />}
+          </SortableContext>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/src/web-ui/src/components/queues/SchedulingSequenceCard.tsx
+++ b/src/web-ui/src/components/queues/SchedulingSequenceCard.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ScheduleType } from '../../services/queueTemplates';
+import { TimerMode } from './QueueEntryList';
+import { SchedulingAreaId, SchedulingCard } from './schedulingAreas';
+
+type SchedulingSequenceCardProps = {
+  card: SchedulingCard;
+  areaId: SchedulingAreaId;
+  disabled?: boolean;
+  onRemove: (entryId: string) => void;
+  /** Non-drag reassign path: change the card's schedule option (moves it to the matching area). */
+  onReassign: (entryId: string, scheduleType: ScheduleType) => void;
+  onTimerTimeChange?: (entryId: string, timerTimeOfDay: string) => void;
+  onTimerModeChange?: (entryId: string, mode: TimerMode) => void;
+  onTimerRelativeOffsetChange?: (entryId: string, offset: string) => void;
+};
+
+const SCHEDULE_LABELS: Record<ScheduleType, string> = {
+  OncePerRun: 'Once Per Run',
+  // Display label only — the stored/wire identifier remains "EveryStep" (FR-002/FR-010).
+  EveryStep: 'After Every Step',
+  Timer: 'Timer',
+  AtQueueStart: 'At Queue Start',
+};
+
+const pad2 = (n: number): string => n.toString().padStart(2, '0');
+
+const parseOffset = (raw: string | undefined): { h: number; m: number; s: number } => {
+  const [h, m, s] = (raw ?? '').split(':').map((x) => parseInt(x, 10));
+  return {
+    h: Number.isFinite(h) ? h : 0,
+    m: Number.isFinite(m) ? m : 0,
+    s: Number.isFinite(s) ? s : 0,
+  };
+};
+
+const composeOffset = (h: number, m: number, s: number): string => `${pad2(h)}:${pad2(m)}:${pad2(s)}`;
+
+export const SchedulingSequenceCard: React.FC<SchedulingSequenceCardProps> = ({
+  card,
+  areaId,
+  disabled,
+  onRemove,
+  onReassign,
+  onTimerTimeChange,
+  onTimerModeChange,
+  onTimerRelativeOffsetChange,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: card.entryId,
+    data: { areaId },
+    disabled,
+  });
+
+  const style: React.CSSProperties = {
+    transform: transform ? CSS.Translate.toString(transform) : undefined,
+    transition,
+    opacity: isDragging ? 0.4 : undefined,
+    position: 'relative',
+  };
+
+  const schedule = card.schedule;
+  const label = card.label;
+  const isScheduled = areaId === 'scheduled';
+  const timerMode: TimerMode = schedule.timerMode ?? (schedule.timerRelativeOffset ? 'relative' : 'timeOfDay');
+  const isRelative = isScheduled && timerMode === 'relative';
+  const offsetParts = parseOffset(schedule.timerRelativeOffset);
+
+  const emitOffset = (h: number, m: number, s: number) => {
+    // Client-side non-negative validation: never emit a negative component (FR-021).
+    if (h < 0 || m < 0 || s < 0) return;
+    onTimerRelativeOffsetChange?.(card.entryId, composeOffset(h, m, s));
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="scheduling-card" data-testid="queue-entry">
+      <span
+        className="scheduling-card__handle"
+        aria-label="Drag to reorder"
+        title="Drag to reorder"
+        {...attributes}
+        {...listeners}
+        style={{ cursor: disabled ? 'not-allowed' : 'grab', userSelect: 'none', padding: '0 6px', color: '#888' }}
+      >
+        ⠿
+      </span>
+
+      <span className="scheduling-card__name">
+        {label}
+        {card.stale && <span className="badge badge-warning" role="status"> (stale)</span>}
+        {areaId === 'startOfExecution' && <span className="badge badge-info" role="status" aria-label="At Queue Start"> At Queue Start</span>}
+        {areaId === 'afterEveryStep' && <span className="badge badge-info" role="status" aria-label="After Every Step"> After Every Step</span>}
+        {isScheduled && !isRelative && <span className="badge badge-info" role="status" aria-label="Timer"> Timer</span>}
+        {isRelative && <span className="badge badge-info" role="status" aria-label="Relative timer"> Timer · relative</span>}
+      </span>
+
+      <select
+        aria-label={`Schedule type for ${label}`}
+        value={schedule.scheduleType}
+        disabled={disabled}
+        onChange={(e) => onReassign(card.entryId, e.target.value as ScheduleType)}
+      >
+        {(Object.keys(SCHEDULE_LABELS) as ScheduleType[]).map((t) => (
+          <option key={t} value={t}>{SCHEDULE_LABELS[t]}</option>
+        ))}
+      </select>
+
+      {isScheduled && onTimerModeChange && (
+        <select
+          aria-label={`Timer mode for ${label}`}
+          value={timerMode}
+          disabled={disabled}
+          onChange={(e) => onTimerModeChange(card.entryId, e.target.value as TimerMode)}
+        >
+          <option value="timeOfDay">Time of day</option>
+          <option value="relative">Relative</option>
+        </select>
+      )}
+
+      {isScheduled && !isRelative && onTimerTimeChange && (
+        <input
+          type="time"
+          aria-label={`Timer time for ${label}`}
+          value={schedule.timerTimeOfDay}
+          disabled={disabled}
+          onChange={(e) => onTimerTimeChange(card.entryId, e.target.value)}
+        />
+      )}
+
+      {isRelative && onTimerRelativeOffsetChange && (
+        <span className="timer-relative-offset" aria-label={`Relative offset for ${label}`}>
+          <input
+            type="number"
+            min={0}
+            aria-label={`Offset hours for ${label}`}
+            value={offsetParts.h}
+            disabled={disabled}
+            onChange={(e) => emitOffset(parseInt(e.target.value, 10) || 0, offsetParts.m, offsetParts.s)}
+          />
+          <span aria-hidden="true">h</span>
+          <input
+            type="number"
+            min={0}
+            max={59}
+            aria-label={`Offset minutes for ${label}`}
+            value={offsetParts.m}
+            disabled={disabled}
+            onChange={(e) => emitOffset(offsetParts.h, parseInt(e.target.value, 10) || 0, offsetParts.s)}
+          />
+          <span aria-hidden="true">m</span>
+          <input
+            type="number"
+            min={0}
+            max={59}
+            aria-label={`Offset seconds for ${label}`}
+            value={offsetParts.s}
+            disabled={disabled}
+            onChange={(e) => emitOffset(offsetParts.h, offsetParts.m, parseInt(e.target.value, 10) || 0)}
+          />
+          <span aria-hidden="true">s</span>
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={() => onRemove(card.entryId)}
+        disabled={disabled}
+        aria-label={`Remove ${label}`}
+      >
+        Remove
+      </button>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/queues/__tests__/QueueSchedulingAreas.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueSchedulingAreas.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueueSchedulingAreas } from '../QueueSchedulingAreas';
+import { EntrySchedule } from '../QueueEntryList';
+import { QueueEntryDto } from '../../../services/queues';
+import { SequenceDto } from '../../../services/sequences';
+
+const sequences = [
+  { id: 'seq-a', name: 'Alpha', steps: [] },
+  { id: 'seq-b', name: 'Bravo', steps: [] },
+] as unknown as SequenceDto[];
+
+const entry = (entryId: string, over: Partial<QueueEntryDto> = {}): QueueEntryDto => ({
+  entryId,
+  sequenceId: `seq-${entryId}`,
+  sequenceName: entryId.toUpperCase(),
+  stale: false,
+  ...over,
+});
+
+const baseProps = () => ({
+  sequences,
+  onAdd: jest.fn(),
+  onRemove: jest.fn(),
+  onReorderAndReassign: jest.fn(),
+  onTimerTimeChange: jest.fn(),
+  onTimerModeChange: jest.fn(),
+  onTimerRelativeOffsetChange: jest.fn(),
+});
+
+const AREA_LABELS = ['Start of execution', 'Once per run', 'Scheduled', 'After every step'];
+
+describe('QueueSchedulingAreas', () => {
+  it('C1: renders exactly four labeled areas', () => {
+    render(<QueueSchedulingAreas entries={[]} entrySchedule={{}} {...baseProps()} />);
+    for (const label of AREA_LABELS) {
+      expect(screen.getByRole('region', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('C2: places each entry in the area matching its scheduleType (default OncePerRun)', () => {
+    const entries = [entry('a'), entry('b'), entry('c'), entry('d'), entry('e')];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      a: { scheduleType: 'AtQueueStart', timerTimeOfDay: '' },
+      b: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+      c: { scheduleType: 'Timer', timerTimeOfDay: '15:30' },
+      d: { scheduleType: 'EveryStep', timerTimeOfDay: '' },
+      // e has no schedule → defaults to OncePerRun
+    };
+    render(<QueueSchedulingAreas entries={entries} entrySchedule={entrySchedule} {...baseProps()} />);
+
+    expect(within(screen.getByRole('region', { name: 'Start of execution' })).getByText('A')).toBeInTheDocument();
+    const oncePerRun = screen.getByRole('region', { name: 'Once per run' });
+    expect(within(oncePerRun).getByText('B')).toBeInTheDocument();
+    expect(within(oncePerRun).getByText('E')).toBeInTheDocument();
+    expect(within(screen.getByRole('region', { name: 'Scheduled' })).getByText('C')).toBeInTheDocument();
+    expect(within(screen.getByRole('region', { name: 'After every step' })).getByText('D')).toBeInTheDocument();
+  });
+
+  it('C3: lays out the areas (full-width top + left stack + right column)', () => {
+    const { container } = render(<QueueSchedulingAreas entries={[]} entrySchedule={{}} {...baseProps()} />);
+    expect(container.querySelector('.scheduling-areas__top')).toBeInTheDocument();
+    expect(container.querySelector('.scheduling-areas__left')).toBeInTheDocument();
+    expect(container.querySelector('.scheduling-areas__right')).toBeInTheDocument();
+  });
+
+  it('C4: an empty area still shows its label and an empty-state hint', () => {
+    render(<QueueSchedulingAreas entries={[]} entrySchedule={{}} {...baseProps()} />);
+    const scheduled = screen.getByRole('region', { name: 'Scheduled' });
+    expect(within(scheduled).getByText(/Drop sequences here/i)).toBeInTheDocument();
+  });
+
+  it('C5: shows badges consistent with the area; OncePerRun shows none; stale preserved', () => {
+    const entries = [entry('a', { stale: true }), entry('b'), entry('c'), entry('d')];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      a: { scheduleType: 'AtQueueStart', timerTimeOfDay: '' },
+      b: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+      c: { scheduleType: 'Timer', timerTimeOfDay: '15:30' },
+      d: { scheduleType: 'EveryStep', timerTimeOfDay: '' },
+    };
+    render(<QueueSchedulingAreas entries={entries} entrySchedule={entrySchedule} {...baseProps()} />);
+
+    expect(screen.getByLabelText('At Queue Start')).toBeInTheDocument();
+    expect(screen.getByLabelText('After Every Step')).toBeInTheDocument();
+    expect(screen.getByLabelText('Timer')).toBeInTheDocument();
+    expect(screen.getByText('(stale)')).toBeInTheDocument();
+    // OncePerRun (B) carries no schedule badge.
+    const oncePerRun = screen.getByRole('region', { name: 'Once per run' });
+    expect(within(oncePerRun).queryByLabelText('At Queue Start')).not.toBeInTheDocument();
+    expect(within(oncePerRun).queryByLabelText('Timer')).not.toBeInTheDocument();
+  });
+
+  it('C6: only the Scheduled area exposes timer controls', () => {
+    const entries = [entry('c'), entry('b')];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      c: { scheduleType: 'Timer', timerTimeOfDay: '15:30', timerMode: 'timeOfDay' },
+      b: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+    };
+    render(<QueueSchedulingAreas entries={entries} entrySchedule={entrySchedule} {...baseProps()} />);
+
+    expect(screen.getByLabelText('Timer mode for C')).toBeInTheDocument();
+    expect(screen.getByLabelText('Timer time for C')).toBeInTheDocument();
+    // The OncePerRun card has no timer controls.
+    expect(screen.queryByLabelText('Timer mode for B')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Timer time for B')).not.toBeInTheDocument();
+  });
+
+  it('C7: when disabled, grouping renders but controls are disabled', () => {
+    const entries = [entry('b')];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      b: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+    };
+    render(<QueueSchedulingAreas entries={entries} entrySchedule={entrySchedule} disabled {...baseProps()} />);
+
+    expect(within(screen.getByRole('region', { name: 'Once per run' })).getByText('B')).toBeInTheDocument();
+    expect(screen.getByLabelText('Schedule type for B')).toBeDisabled();
+    expect(screen.getByLabelText('Remove B')).toBeDisabled();
+  });
+
+  it('reassigns via the schedule selector (non-drag path)', () => {
+    const props = baseProps();
+    const entries = [entry('b')];
+    const entrySchedule: Record<string, EntrySchedule> = {
+      b: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+    };
+    render(<QueueSchedulingAreas entries={entries} entrySchedule={entrySchedule} {...props} />);
+
+    fireEvent.change(screen.getByLabelText('Schedule type for B'), { target: { value: 'EveryStep' } });
+    expect(props.onReorderAndReassign).toHaveBeenCalledTimes(1);
+    const next = props.onReorderAndReassign.mock.calls[0][0];
+    expect(next.schedule.b.scheduleType).toBe('EveryStep');
+  });
+
+  it('adds a sequence through the Add control', () => {
+    const props = baseProps();
+    render(<QueueSchedulingAreas entries={[]} entrySchedule={{}} {...props} />);
+    fireEvent.change(screen.getByLabelText('Add sequence'), { target: { value: 'seq-b' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(props.onAdd).toHaveBeenCalledWith('seq-b');
+  });
+});

--- a/src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts
+++ b/src/web-ui/src/components/queues/__tests__/schedulingAreas.test.ts
@@ -1,0 +1,223 @@
+import {
+  areaForScheduleType,
+  scheduleTypeForArea,
+  groupEntriesIntoAreas,
+  applyDragMove,
+  CANONICAL_AREA_ORDER,
+  SchedulingAreaId,
+  SchedulingAreasState,
+} from '../schedulingAreas';
+import { ScheduleType } from '../../../services/queueTemplates';
+import { QueueEntryDto } from '../../../services/queues';
+import { EntrySchedule } from '../QueueEntryList';
+
+const ALL_TYPES: ScheduleType[] = ['OncePerRun', 'EveryStep', 'Timer', 'AtQueueStart'];
+const ALL_AREAS: SchedulingAreaId[] = ['startOfExecution', 'oncePerRun', 'scheduled', 'afterEveryStep'];
+
+const entry = (entryId: string, over: Partial<QueueEntryDto> = {}): QueueEntryDto => ({
+  entryId,
+  sequenceId: `seq-${entryId}`,
+  sequenceName: entryId.toUpperCase(),
+  stale: false,
+  ...over,
+});
+
+const entriesById = (...ids: string[]): Record<string, QueueEntryDto> =>
+  Object.fromEntries(ids.map((id) => [id, entry(id)]));
+
+const sched = (scheduleType: ScheduleType, extra: Partial<EntrySchedule> = {}): EntrySchedule => ({
+  scheduleType,
+  timerTimeOfDay: '',
+  ...extra,
+});
+
+// ---------------------------------------------------------------------------
+// T003/T004: area ↔ schedule-type mapping
+// ---------------------------------------------------------------------------
+
+describe('schedulingAreas mapping helpers', () => {
+  it('round-trips every ScheduleType through area and back', () => {
+    for (const t of ALL_TYPES) {
+      expect(scheduleTypeForArea(areaForScheduleType(t))).toBe(t);
+    }
+  });
+
+  it('round-trips every SchedulingAreaId through schedule type and back', () => {
+    for (const a of ALL_AREAS) {
+      expect(areaForScheduleType(scheduleTypeForArea(a))).toBe(a);
+    }
+  });
+
+  it('maps Timer↔scheduled and EveryStep↔afterEveryStep', () => {
+    expect(areaForScheduleType('Timer')).toBe('scheduled');
+    expect(areaForScheduleType('EveryStep')).toBe('afterEveryStep');
+    expect(scheduleTypeForArea('scheduled')).toBe('Timer');
+    expect(scheduleTypeForArea('afterEveryStep')).toBe('EveryStep');
+  });
+
+  it('exposes the canonical area order', () => {
+    expect(CANONICAL_AREA_ORDER).toEqual(['startOfExecution', 'oncePerRun', 'scheduled', 'afterEveryStep']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T005 (US1): groupEntriesIntoAreas
+// ---------------------------------------------------------------------------
+
+describe('groupEntriesIntoAreas', () => {
+  it('groups each entry into the area matching its scheduleType', () => {
+    const schedule = {
+      a: sched('AtQueueStart'),
+      b: sched('OncePerRun'),
+      c: sched('Timer'),
+      d: sched('EveryStep'),
+    };
+    const areas = groupEntriesIntoAreas(['a', 'b', 'c', 'd'], schedule, entriesById('a', 'b', 'c', 'd'));
+    expect(areas.startOfExecution.map((x) => x.entryId)).toEqual(['a']);
+    expect(areas.oncePerRun.map((x) => x.entryId)).toEqual(['b']);
+    expect(areas.scheduled.map((x) => x.entryId)).toEqual(['c']);
+    expect(areas.afterEveryStep.map((x) => x.entryId)).toEqual(['d']);
+  });
+
+  it('defaults a missing schedule to oncePerRun', () => {
+    const areas = groupEntriesIntoAreas(['a'], {}, entriesById('a'));
+    expect(areas.oncePerRun.map((x) => x.entryId)).toEqual(['a']);
+  });
+
+  it('preserves orderedEntryIds order within an area', () => {
+    const schedule = { a: sched('OncePerRun'), b: sched('OncePerRun'), c: sched('OncePerRun') };
+    const areas = groupEntriesIntoAreas(['c', 'a', 'b'], schedule, entriesById('a', 'b', 'c'));
+    expect(areas.oncePerRun.map((x) => x.entryId)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('loses or duplicates no entry across areas', () => {
+    const schedule = {
+      a: sched('AtQueueStart'),
+      b: sched('OncePerRun'),
+      c: sched('Timer'),
+      d: sched('EveryStep'),
+      e: sched('OncePerRun'),
+    };
+    const ids = ['a', 'b', 'c', 'd', 'e'];
+    const areas = groupEntriesIntoAreas(ids, schedule, entriesById(...ids));
+    const flat = ALL_AREAS.flatMap((a) => areas[a].map((x) => x.entryId));
+    expect(flat.sort()).toEqual([...ids].sort());
+    expect(flat).toHaveLength(ids.length);
+  });
+
+  it('projects label, stale and schedule onto each card', () => {
+    const schedule = { a: sched('Timer', { timerTimeOfDay: '15:30' }) };
+    const entries = { a: entry('a', { sequenceName: null, stale: true }) };
+    const areas = groupEntriesIntoAreas(['a'], schedule, entries);
+    const card = areas.scheduled[0];
+    expect(card.label).toBe('seq-a'); // falls back to sequenceId when name is null
+    expect(card.stale).toBe(true);
+    expect(card.schedule.timerTimeOfDay).toBe('15:30');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T013 (US2): applyDragMove reassign + timer retention; T020 (US3) reorder;
+// T024 (US4) default-append
+// ---------------------------------------------------------------------------
+
+const state = (orderedEntryIds: string[], schedule: Record<string, EntrySchedule>): SchedulingAreasState => ({
+  orderedEntryIds,
+  schedule,
+});
+
+describe('applyDragMove — cross-area reassign (R1, R2, R3)', () => {
+  it('R1: oncePerRun → afterEveryStep sets EveryStep', () => {
+    const s = state(['a'], { a: sched('OncePerRun') });
+    const next = applyDragMove(s, { entryId: 'a', targetArea: 'afterEveryStep', targetIndex: 0 });
+    expect(next.schedule.a.scheduleType).toBe('EveryStep');
+    expect(groupEntriesIntoAreas(next.orderedEntryIds, next.schedule, entriesById('a')).afterEveryStep.map((x) => x.entryId)).toEqual(['a']);
+  });
+
+  it('R2: afterEveryStep → startOfExecution sets AtQueueStart', () => {
+    const s = state(['a'], { a: sched('EveryStep') });
+    const next = applyDragMove(s, { entryId: 'a', targetArea: 'startOfExecution', targetIndex: 0 });
+    expect(next.schedule.a.scheduleType).toBe('AtQueueStart');
+  });
+
+  it('R3: any → scheduled sets Timer with empty timer when none prior', () => {
+    const s = state(['a'], { a: sched('OncePerRun') });
+    const next = applyDragMove(s, { entryId: 'a', targetArea: 'scheduled', targetIndex: 0 });
+    expect(next.schedule.a.scheduleType).toBe('Timer');
+    expect(next.schedule.a.timerTimeOfDay).toBe('');
+  });
+
+  it('reassigns across every ordered area pair', () => {
+    for (const from of ALL_AREAS) {
+      for (const to of ALL_AREAS) {
+        if (from === to) continue;
+        const s = state(['a'], { a: sched(scheduleTypeForArea(from)) });
+        const next = applyDragMove(s, { entryId: 'a', targetArea: to, targetIndex: 0 });
+        expect(next.schedule.a.scheduleType).toBe(scheduleTypeForArea(to));
+      }
+    }
+  });
+});
+
+describe('applyDragMove — Timer detail retention (R4, R5)', () => {
+  it('R4: moving out of scheduled retains timer details inactive', () => {
+    const s = state(['a'], { a: sched('Timer', { timerTimeOfDay: '15:30', timerMode: 'timeOfDay' }) });
+    const next = applyDragMove(s, { entryId: 'a', targetArea: 'oncePerRun', targetIndex: 0 });
+    expect(next.schedule.a.scheduleType).toBe('OncePerRun');
+    expect(next.schedule.a.timerTimeOfDay).toBe('15:30');
+    expect(next.schedule.a.timerMode).toBe('timeOfDay');
+  });
+
+  it('R5: moving back into scheduled restores retained timer details', () => {
+    const s = state(['a'], { a: sched('OncePerRun', { timerTimeOfDay: '15:30', timerMode: 'timeOfDay' }) });
+    const next = applyDragMove(s, { entryId: 'a', targetArea: 'scheduled', targetIndex: 0 });
+    expect(next.schedule.a.scheduleType).toBe('Timer');
+    expect(next.schedule.a.timerTimeOfDay).toBe('15:30');
+  });
+
+  it('retains a relative offset across the round-trip', () => {
+    const s = state(['a'], { a: sched('Timer', { timerMode: 'relative', timerRelativeOffset: '00:10:00' }) });
+    const out = applyDragMove(s, { entryId: 'a', targetArea: 'oncePerRun', targetIndex: 0 });
+    expect(out.schedule.a.timerRelativeOffset).toBe('00:10:00');
+    const back = applyDragMove(out, { entryId: 'a', targetArea: 'scheduled', targetIndex: 0 });
+    expect(back.schedule.a.scheduleType).toBe('Timer');
+    expect(back.schedule.a.timerRelativeOffset).toBe('00:10:00');
+  });
+});
+
+describe('applyDragMove — within-area reorder (R6) and no-op (R7)', () => {
+  it('R6: within-area reorder changes only order, not scheduleType', () => {
+    const schedule = { a: sched('OncePerRun'), b: sched('OncePerRun'), c: sched('OncePerRun') };
+    const s = state(['a', 'b', 'c'], schedule);
+    const next = applyDragMove(s, { entryId: 'c', targetArea: 'oncePerRun', targetIndex: 0 });
+    expect(next.orderedEntryIds).toEqual(['c', 'a', 'b']);
+    expect(next.schedule.a.scheduleType).toBe('OncePerRun');
+    expect(next.schedule.b.scheduleType).toBe('OncePerRun');
+    expect(next.schedule.c.scheduleType).toBe('OncePerRun');
+  });
+
+  it('R7: dropping at the current position is a no-op (returns the same state)', () => {
+    const schedule = { a: sched('OncePerRun'), b: sched('OncePerRun'), c: sched('OncePerRun') };
+    const s = state(['a', 'b', 'c'], schedule);
+    const next = applyDragMove(s, { entryId: 'b', targetArea: 'oncePerRun', targetIndex: 1 });
+    expect(next).toBe(s);
+  });
+});
+
+describe('applyDragMove — default-add ordering (R8)', () => {
+  it('R8: an appended OncePerRun entry appears last in oncePerRun', () => {
+    const schedule = { a: sched('OncePerRun'), b: sched('OncePerRun') };
+    // A newly added entry is appended to the ordered list with OncePerRun.
+    const s = state(['a', 'b', 'new'], { ...schedule, new: sched('OncePerRun') });
+    const areas = groupEntriesIntoAreas(s.orderedEntryIds, s.schedule, entriesById('a', 'b', 'new'));
+    expect(areas.oncePerRun.map((x) => x.entryId)).toEqual(['a', 'b', 'new']);
+  });
+
+  it('keeps canonical inter-area order when rebuilding the linear order', () => {
+    // afterEveryStep entry first in input, but canonical order puts oncePerRun before it.
+    const s = state(['d', 'b'], { d: sched('EveryStep'), b: sched('OncePerRun') });
+    const next = applyDragMove(s, { entryId: 'b', targetArea: 'scheduled', targetIndex: 0 });
+    // b → scheduled; canonical order = startOfExecution, oncePerRun, scheduled, afterEveryStep.
+    expect(next.orderedEntryIds).toEqual(['b', 'd']);
+  });
+});

--- a/src/web-ui/src/components/queues/schedulingAreas.ts
+++ b/src/web-ui/src/components/queues/schedulingAreas.ts
@@ -1,0 +1,178 @@
+import { ScheduleType } from '../../services/queueTemplates';
+import { QueueEntryDto } from '../../services/queues';
+import { EntrySchedule } from './QueueEntryList';
+
+/**
+ * Pure view-model for the four scheduling areas in the queue template editor.
+ *
+ * The editor groups runtime entries into four labeled areas — one per `ScheduleType` —
+ * and lets the operator drag cards between areas (auto-changing the schedule option) and
+ * within an area (reordering execution). All logic here is pure so the drag/reorder/reassign
+ * decisions are unit-testable without simulating pointer events (jsdom cannot do real DnD).
+ */
+
+export type SchedulingAreaId = 'startOfExecution' | 'oncePerRun' | 'scheduled' | 'afterEveryStep';
+
+/** Operator-facing labels. The wire/stored identifier behind "After every step" stays `EveryStep`. */
+export const AREA_LABELS: Record<SchedulingAreaId, string> = {
+  startOfExecution: 'Start of execution',
+  oncePerRun: 'Once per run',
+  scheduled: 'Scheduled',
+  afterEveryStep: 'After every step',
+};
+
+/**
+ * Fixed inter-area order used to flatten the four areas into a single linear order for
+ * display + save. Invisible to execution (each schedule type runs in its own pass); it only
+ * needs to be stable so the positional template save/restore stays correct.
+ */
+export const CANONICAL_AREA_ORDER: SchedulingAreaId[] = [
+  'startOfExecution',
+  'oncePerRun',
+  'scheduled',
+  'afterEveryStep',
+];
+
+const AREA_TO_SCHEDULE: Record<SchedulingAreaId, ScheduleType> = {
+  startOfExecution: 'AtQueueStart',
+  oncePerRun: 'OncePerRun',
+  scheduled: 'Timer',
+  afterEveryStep: 'EveryStep',
+};
+
+const SCHEDULE_TO_AREA: Record<ScheduleType, SchedulingAreaId> = {
+  AtQueueStart: 'startOfExecution',
+  OncePerRun: 'oncePerRun',
+  Timer: 'scheduled',
+  EveryStep: 'afterEveryStep',
+};
+
+export const scheduleTypeForArea = (areaId: SchedulingAreaId): ScheduleType => AREA_TO_SCHEDULE[areaId];
+export const areaForScheduleType = (scheduleType: ScheduleType): SchedulingAreaId => SCHEDULE_TO_AREA[scheduleType];
+
+/** Default schedule for an entry with no recorded schedule (FR-007: new entries are OncePerRun). */
+export const DEFAULT_SCHEDULE: EntrySchedule = { scheduleType: 'OncePerRun', timerTimeOfDay: '' };
+
+/** A presentational projection of one entry within an area. */
+export type SchedulingCard = {
+  entryId: string;
+  sequenceId: string;
+  label: string;
+  stale: boolean;
+  schedule: EntrySchedule;
+};
+
+export type SchedulingAreasState = {
+  orderedEntryIds: string[];
+  schedule: Record<string, EntrySchedule>;
+};
+
+export type DragMove = {
+  entryId: string;
+  targetArea: SchedulingAreaId;
+  /** Final resting index within the target area's cards (after the dragged card is removed). */
+  targetIndex: number;
+};
+
+const scheduleOf = (schedule: Record<string, EntrySchedule>, entryId: string): EntrySchedule =>
+  schedule[entryId] ?? DEFAULT_SCHEDULE;
+
+const emptyBuckets = (): Record<SchedulingAreaId, string[]> => ({
+  startOfExecution: [],
+  oncePerRun: [],
+  scheduled: [],
+  afterEveryStep: [],
+});
+
+/** Bucket entry ids into their current areas, preserving the given linear order within each area. */
+const bucketEntryIds = (
+  orderedEntryIds: string[],
+  schedule: Record<string, EntrySchedule>,
+): Record<SchedulingAreaId, string[]> => {
+  const buckets = emptyBuckets();
+  for (const id of orderedEntryIds) {
+    buckets[areaForScheduleType(scheduleOf(schedule, id).scheduleType)].push(id);
+  }
+  return buckets;
+};
+
+/**
+ * Group entries into the four areas for rendering. Each entry lands in the area matching its
+ * current `scheduleType` (default `OncePerRun`), ordered per `orderedEntryIds`. No entry is
+ * lost or duplicated; ids without a matching entry are skipped.
+ */
+export const groupEntriesIntoAreas = (
+  orderedEntryIds: string[],
+  schedule: Record<string, EntrySchedule>,
+  entriesById: Record<string, QueueEntryDto>,
+): Record<SchedulingAreaId, SchedulingCard[]> => {
+  const areas: Record<SchedulingAreaId, SchedulingCard[]> = {
+    startOfExecution: [],
+    oncePerRun: [],
+    scheduled: [],
+    afterEveryStep: [],
+  };
+  for (const entryId of orderedEntryIds) {
+    const entry = entriesById[entryId];
+    if (!entry) continue;
+    const sched = scheduleOf(schedule, entryId);
+    areas[areaForScheduleType(sched.scheduleType)].push({
+      entryId: entry.entryId,
+      sequenceId: entry.sequenceId,
+      label: entry.sequenceName ?? entry.sequenceId,
+      stale: entry.stale,
+      schedule: sched,
+    });
+  }
+  return areas;
+};
+
+const sameOrder = (a: string[], b: string[]): boolean =>
+  a.length === b.length && a.every((x, i) => x === b[i]);
+
+/**
+ * Apply a drag move (cross-area reassign or within-area reorder) and return the new state.
+ *
+ * - Cross-area: sets `schedule[entryId].scheduleType` to the destination area's type. Timer
+ *   detail fields (`timerTimeOfDay`/`timerRelativeOffset`/`timerMode`) are RETAINED in state so
+ *   they are restored if the card is dragged back into "Scheduled" (FR-009); they are only
+ *   emitted on save when the current type is `Timer`.
+ * - Within-area: only reorders `orderedEntryIds`; `scheduleType` is unchanged (FR-005).
+ * - No-op (same area + resulting order unchanged): returns the original `state` reference.
+ *
+ * The linear order is always rebuilt in canonical inter-area order with the operator's
+ * within-area order preserved.
+ */
+export const applyDragMove = (state: SchedulingAreasState, move: DragMove): SchedulingAreasState => {
+  const { entryId, targetArea, targetIndex } = move;
+  const currentSchedule = scheduleOf(state.schedule, entryId);
+  const sourceArea = areaForScheduleType(currentSchedule.scheduleType);
+
+  const buckets = bucketEntryIds(state.orderedEntryIds, state.schedule);
+
+  // Remove from source, then insert at the clamped target index within the target area.
+  buckets[sourceArea] = buckets[sourceArea].filter((id) => id !== entryId);
+  const insertAt = Math.max(0, Math.min(targetIndex, buckets[targetArea].length));
+  buckets[targetArea] = [
+    ...buckets[targetArea].slice(0, insertAt),
+    entryId,
+    ...buckets[targetArea].slice(insertAt),
+  ];
+
+  const orderedEntryIds = CANONICAL_AREA_ORDER.flatMap((area) => buckets[area]);
+
+  // No-op: staying in the same area with no change to the linear order leaves state untouched.
+  if (sourceArea === targetArea && sameOrder(orderedEntryIds, state.orderedEntryIds)) {
+    return state;
+  }
+
+  let schedule = state.schedule;
+  if (sourceArea !== targetArea) {
+    schedule = {
+      ...state.schedule,
+      [entryId]: { ...currentSchedule, scheduleType: scheduleTypeForArea(targetArea) },
+    };
+  }
+
+  return { orderedEntryIds, schedule };
+};

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -18,7 +18,9 @@ import {
 } from '../services/queues';
 import { listSequences, SequenceDto } from '../services/sequences';
 import { QueueForm, QueueFormValue } from '../components/queues/QueueForm';
-import { QueueEntryList, EntrySchedule } from '../components/queues/QueueEntryList';
+import { EntrySchedule } from '../components/queues/QueueEntryList';
+import { QueueSchedulingAreas } from '../components/queues/QueueSchedulingAreas';
+import { SchedulingAreasState } from '../components/queues/schedulingAreas';
 import { QueueLiveScheduleControl } from '../components/queues/QueueLiveScheduleControl';
 import { QueueTemplateControls } from '../components/queues/QueueTemplateControls';
 import { QueueGameControls } from '../components/queues/QueueGameControls';
@@ -202,10 +204,37 @@ export const QueuesPage: React.FC = () => {
     await refresh();
   };
 
+  // Reflect a drag reorder/reassign immediately: reorder the working entries into the new
+  // canonical order and apply the new schedule map (cross-area reassignment persists on save).
+  const onReorderAndReassign = (next: SchedulingAreasState) => {
+    setEntrySchedule(next.schedule);
+    setDetail((prev) => {
+      if (!prev) return prev;
+      const byId = new Map(prev.entries.map((e) => [e.entryId, e]));
+      const reordered = next.orderedEntryIds
+        .map((id) => byId.get(id))
+        .filter((e): e is QueueDetailDto['entries'][number] => Boolean(e));
+      return { ...prev, entries: reordered };
+    });
+  };
+
   const handleSaveTemplate = async (name: string, overwrite: boolean) => {
     if (!detail) return;
-    const entries = detail.entries.map((e) => {
-      const sched = entrySchedule[e.entryId] ?? { scheduleType: 'OncePerRun' as ScheduleType, timerTimeOfDay: '' };
+    // Order-aware save: persist the current linear order to the runtime queue first, then build
+    // the template entries in that exact order so the positional reload restore stays correct.
+    const orderedSequenceIds = detail.entries.map((e) => e.sequenceId);
+    const orderedSchedules = detail.entries.map(
+      (e) => entrySchedule[e.entryId] ?? { scheduleType: 'OncePerRun' as ScheduleType, timerTimeOfDay: '' }
+    );
+    await replaceQueueEntries(detail.id, orderedSequenceIds);
+    const refreshed = await getQueue(detail.id);
+    // replaceQueueEntries regenerates entryIds: re-key the schedule onto the new entries by position.
+    const rekeyed: Record<string, EntrySchedule> = {};
+    refreshed.entries.forEach((e, i) => {
+      rekeyed[e.entryId] = orderedSchedules[i] ?? { scheduleType: 'OncePerRun', timerTimeOfDay: '' };
+    });
+    const entries = refreshed.entries.map((e, i) => {
+      const sched = orderedSchedules[i] ?? { scheduleType: 'OncePerRun' as ScheduleType, timerTimeOfDay: '' };
       const timerMode = sched.timerMode ?? (sched.timerRelativeOffset ? 'relative' : 'timeOfDay');
       const isRelative = sched.scheduleType === 'Timer' && timerMode === 'relative';
       return {
@@ -217,6 +246,8 @@ export const QueuesPage: React.FC = () => {
     });
     const saved = await saveQueueTemplate({ name, entries, overwrite });
     await setQueueTemplateLink(detail.id, saved.id);
+    setDetail(refreshed);
+    setEntrySchedule(rekeyed);
     setAssociatedTemplateName(name);
     setTableMessage(`Template "${name}" saved successfully.`);
   };
@@ -441,13 +472,13 @@ export const QueuesPage: React.FC = () => {
                 onReload={() => void handleReload()}
                 pendingConfirm={templateConfirm}
               >
-                <QueueEntryList
+                <QueueSchedulingAreas
                   entries={detail.entries}
                   sequences={sequences}
                   onAdd={(sid) => void onAddEntry(sid)}
                   onRemove={(eid) => void onRemoveEntry(eid)}
                   entrySchedule={entrySchedule}
-                  onScheduleTypeChange={(eid, st) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'OncePerRun', timerTimeOfDay: '' }, scheduleType: st } }))}
+                  onReorderAndReassign={onReorderAndReassign}
                   onTimerTimeChange={(eid, t) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerTimeOfDay: t } }))}
                   onTimerModeChange={(eid, mode) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerMode: mode } }))}
                   onTimerRelativeOffsetChange={(eid, offset) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerMode: 'relative', timerRelativeOffset: offset } }))}

--- a/src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.reload.spec.tsx
@@ -55,6 +55,9 @@ const openEditAndAssociate = async () => {
   fireEvent.click(within(section).getByText('Save'));
   // After save, the name button reflects the associated template.
   await screen.findByText('Daily Farm');
+  // Order-aware save (feature 061) persists the entry order via replaceQueueEntries; the reload
+  // assertions below only care about what the *reload* action does, so reset the call history.
+  replaceEntriesMock.mockClear();
 };
 
 describe('QueuesPage reload template', () => {

--- a/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueuesPage } from '../QueuesPage';
-import { listQueues, getQueue, replaceQueueEntries } from '../../services/queues';
+import { listQueues, getQueue, replaceQueueEntries, addQueueEntry } from '../../services/queues';
 import { listSequences } from '../../services/sequences';
 import { saveQueueTemplate, getQueueTemplate, listQueueTemplates, deleteQueueTemplate } from '../../services/queueTemplates';
 import { ApiError } from '../../lib/api';
@@ -215,6 +215,166 @@ describe('QueuesPage AtQueueStart round-trip (feature 060, T013)', () => {
 
     // The dropdown still reflects the selected at-queue-start type for the first entry.
     expect((screen.getByLabelText('Schedule type for A') as HTMLSelectElement).value).toBe('AtQueueStart');
+  });
+});
+
+describe('QueuesPage scheduling areas round-trip (feature 061)', () => {
+  // getQueue returns whatever order the last replaceQueueEntries set, with fresh entryIds —
+  // mirroring the runtime API so the order-aware save path can be exercised end-to-end.
+  const wireDynamicEntries = (initial: Array<{ sequenceId: string; sequenceName: string }>) => {
+    let current = initial.map((e, i) => ({ entryId: `e${i + 1}`, sequenceId: e.sequenceId, sequenceName: e.sequenceName, stale: false }));
+    getQueueMock.mockImplementation(() => Promise.resolve({ ...queue({ entryCount: current.length }), entries: current } as any));
+    replaceEntriesMock.mockImplementation((_id: string, seqIds: string[]) => {
+      current = seqIds.map((sid, i) => ({ entryId: `r${i + 1}`, sequenceId: sid, sequenceName: initial.find((x) => x.sequenceId === sid)?.sequenceName ?? sid, stale: false }));
+      return Promise.resolve({} as any);
+    });
+  };
+
+  const openEditor = async () => {
+    render(<QueuesPage />);
+    await screen.findByText('Daily');
+    fireEvent.click(screen.getByText('Daily'));
+    await screen.findByText('Edit Queue');
+  };
+
+  it('I1: reassigning a card then saving persists the destination type in canonical order', async () => {
+    wireDynamicEntries([{ sequenceId: 'seq-a', sequenceName: 'A' }, { sequenceId: 'seq-b', sequenceName: 'B' }]);
+    saveTemplateMock.mockResolvedValue({ id: 't1' } as any);
+    await openEditor();
+
+    // Move A to "After every step" via the non-drag schedule selector.
+    fireEvent.change(screen.getByLabelText('Schedule type for A'), { target: { value: 'EveryStep' } });
+
+    // Canonical order now puts OncePerRun (B) before EveryStep (A).
+    expect(within(screen.getByRole('region', { name: 'After every step' })).getByText('A')).toBeInTheDocument();
+    expect(screen.getByLabelText('After Every Step')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Save Template'));
+    const section = await screen.findByRole('region', { name: 'Save template' });
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Farm' } });
+    fireEvent.click(within(section).getByText('Save'));
+
+    await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-b', 'seq-a']));
+    await waitFor(() =>
+      expect(saveTemplateMock).toHaveBeenCalledWith({
+        name: 'Farm',
+        entries: [
+          { sequenceId: 'seq-b', scheduleType: 'OncePerRun' },
+          { sequenceId: 'seq-a', scheduleType: 'EveryStep' },
+        ],
+        overwrite: false,
+      })
+    );
+  });
+
+  it('I2: saving is order-aware — persists the current linear order and builds the template in that order', async () => {
+    wireDynamicEntries([{ sequenceId: 'seq-a', sequenceName: 'A' }, { sequenceId: 'seq-b', sequenceName: 'B' }]);
+    saveTemplateMock.mockResolvedValue({ id: 't1' } as any);
+    await openEditor();
+
+    fireEvent.click(screen.getByText('Save Template'));
+    const section = await screen.findByRole('region', { name: 'Save template' });
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Ordered' } });
+    fireEvent.click(within(section).getByText('Save'));
+
+    // The runtime queue order is rewritten to the editor's linear order before the template is built.
+    await waitFor(() => expect(replaceEntriesMock).toHaveBeenCalledWith('q1', ['seq-a', 'seq-b']));
+    await waitFor(() =>
+      expect(saveTemplateMock).toHaveBeenCalledWith({
+        name: 'Ordered',
+        entries: [
+          { sequenceId: 'seq-a', scheduleType: 'OncePerRun' },
+          { sequenceId: 'seq-b', scheduleType: 'OncePerRun' },
+        ],
+        overwrite: false,
+      })
+    );
+  });
+
+  it('I3: adding a sequence places it in "Once per run" and saves it as OncePerRun', async () => {
+    wireDynamicEntries([{ sequenceId: 'seq-a', sequenceName: 'A' }]);
+    listSequencesMock.mockResolvedValue([{ id: 'seq-c', name: 'Charlie', steps: [] }] as any);
+    (addQueueEntry as jest.MockedFunction<typeof addQueueEntry>).mockImplementation((_id: string, sequenceId: string) => {
+      return Promise.resolve({ entryId: 'e2', sequenceId, sequenceName: 'Charlie', stale: false } as any);
+    });
+    // After add, getQueue should reflect both entries.
+    getQueueMock.mockResolvedValue({
+      ...queue({ entryCount: 2 }),
+      entries: [
+        { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'A', stale: false },
+        { entryId: 'e2', sequenceId: 'seq-c', sequenceName: 'Charlie', stale: false },
+      ],
+    } as any);
+    replaceEntriesMock.mockResolvedValue({} as any);
+    saveTemplateMock.mockResolvedValue({ id: 't1' } as any);
+    await openEditor();
+
+    fireEvent.change(screen.getByLabelText('Add sequence'), { target: { value: 'seq-c' } });
+    fireEvent.click(screen.getByText('Add'));
+
+    const oncePerRun = await screen.findByRole('region', { name: 'Once per run' });
+    await waitFor(() => expect(within(oncePerRun).getByText('Charlie')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Save Template'));
+    const section = await screen.findByRole('region', { name: 'Save template' });
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Added' } });
+    fireEvent.click(within(section).getByText('Save'));
+
+    await waitFor(() =>
+      expect(saveTemplateMock).toHaveBeenCalledWith({
+        name: 'Added',
+        entries: [
+          { sequenceId: 'seq-a', scheduleType: 'OncePerRun' },
+          { sequenceId: 'seq-c', scheduleType: 'OncePerRun' },
+        ],
+        overwrite: false,
+      })
+    );
+  });
+
+  it('I4: a card moved out of "Scheduled" before save is emitted with the destination type and no timer fields', async () => {
+    // Open a queue linked to a template whose first entry is a Timer with a time-of-day.
+    getQueueMock.mockResolvedValue({
+      ...queue({ entryCount: 2 }),
+      linkedTemplateId: 't1',
+      linkedTemplateName: 'Timed',
+      entries: [
+        { entryId: 'e1', sequenceId: 'seq-a', sequenceName: 'A', stale: false },
+        { entryId: 'e2', sequenceId: 'seq-b', sequenceName: 'B', stale: false },
+      ],
+    } as any);
+    getTemplateMock.mockResolvedValue({
+      id: 't1', name: 'Timed', entryCount: 2, createdAt: null, updatedAt: null,
+      entries: [
+        { sequenceId: 'seq-a', sequenceName: 'A', stale: false, scheduleType: 'Timer', timerTimeOfDay: '15:30', timerRelativeOffset: null },
+        { sequenceId: 'seq-b', sequenceName: 'B', stale: false, scheduleType: 'OncePerRun', timerTimeOfDay: null, timerRelativeOffset: null },
+      ],
+    } as any);
+    replaceEntriesMock.mockResolvedValue({} as any);
+    saveTemplateMock.mockResolvedValue({ id: 't1' } as any);
+    await openEditor();
+
+    // The Timer card renders in "Scheduled" with its time-of-day restored.
+    expect(await screen.findByLabelText('Timer time for A')).toHaveValue('15:30');
+
+    // Move it out to "Once per run"; its timer detail is retained in state but must not be emitted.
+    fireEvent.change(screen.getByLabelText('Schedule type for A'), { target: { value: 'OncePerRun' } });
+
+    fireEvent.click(screen.getByText('Save Template'));
+    const section = await screen.findByRole('region', { name: 'Save template' });
+    fireEvent.change(within(section).getByLabelText('Template name'), { target: { value: 'Moved' } });
+    fireEvent.click(within(section).getByText('Save'));
+
+    await waitFor(() =>
+      expect(saveTemplateMock).toHaveBeenCalledWith({
+        name: 'Moved',
+        entries: [
+          { sequenceId: 'seq-a', scheduleType: 'OncePerRun' },
+          { sequenceId: 'seq-b', scheduleType: 'OncePerRun' },
+        ],
+        overwrite: false,
+      })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Replaces the queue template editor's flat sequence list with **four labeled drag-and-drop areas**, one per schedule option:

- **Start of execution** (full-width top) ↔ `AtQueueStart`
- **Once per run** (upper-left) ↔ `OncePerRun`
- **Scheduled** (lower-left) ↔ `Timer`
- **After every step** (right column) ↔ `EveryStep`

Operators drag sequence cards **between** areas (which auto-changes the schedule option to the destination area's type) and **within** an area (which reorders execution). New sequences default to "Once per run". Timer details are retained (inactive) when a card leaves "Scheduled" and restored if it returns.

This is a **web-UI-only** change: no API, scheduler, or stored-model changes (FR-012). `EveryStep` remains the wire identifier behind the "After every step" label. Schedule assignment and within-area order round-trip through the existing template save/load via an order-aware save (`replaceQueueEntries` → `getQueue` → positional rebuild), so runtime order matches saved template order and positional reload restore stays correct.

## Key files

- `schedulingAreas.ts` — pure view-model: area↔`ScheduleType` mapping, `groupEntriesIntoAreas`, and the `applyDragMove` reducer (cross-area reassign + Timer-detail retention, within-area reorder, canonical-order rebuild, no-op short-circuit).
- `SchedulingSequenceCard.tsx` / `SchedulingArea.tsx` / `QueueSchedulingAreas.tsx` (+ `.css`) — dnd-kit multi-container layout reusing `DropIndicator` + `useSortable` conventions.
- `QueuesPage.tsx` — swaps `QueueEntryList` → `QueueSchedulingAreas`; adds `onReorderAndReassign`; order-aware save.

## Drop targeting

Uses **pointer-based** collision detection: the droppable directly under the cursor is the target (not the dragged card's center, which is offset from the drag handle). A card under the pointer wins over its enclosing area for a precise reorder index; empty space falls back to the area; releasing outside every area is a no-op (FR-013).

## Testing

- Pure reducer: R1–R8 (cross-area reassign for every pair, into/out of Timer with retention, within-area reorder, no-op, default add).
- Component: C1–C7 (four labeled areas, grouping, empty-area hints, badges, Timer-only controls, disabled state).
- Page round-trips: I1–I4 (reassign + order-aware save, default-to-OncePerRun on add, timer-detail retention vs emission).
- Full suite: **511 passed / 511**; `vite build` green.

Spec: `specs/061-queue-scheduling-areas/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
