### PR TITLE
Sequence self-rescheduling into the originating queue run (065)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/062-queue-management-usability"
+  "feature_directory": "specs/065-sequence-self-reschedule"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/062-queue-management-usability/plan.md
+at specs/065-sequence-self-reschedule/plan.md
 <!-- SPECKIT END -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,13 @@ not survive a service restart; queue *configuration* and templates are persisted
   be shared across queues.
 - **Sequence schedule** (within a template) — how/when an entry runs in a queue cycle:
   *Once per run*, *At queue start*, *After every step*, and *Scheduled* (absolute or relative time).
+- **Self-reschedule action** (within a sequence) — an authorable sequence action (`reschedule-self`,
+  placeable under IF/conditional flow) that, when reached during a queue-driven run, schedules **one
+  additional firing of the same sequence into the current run** using any of the schedule options
+  above (At Queue Start / Once Per Run / Timer / After Every Step). It is **ephemeral** (current run
+  only, never persisted) and a **success no-op** when the sequence was not started from a queue. The
+  run's active-run state lives in a singleton `IQueueRunRegistry`; an `ISelfRescheduleCoordinator`
+  injects the ephemeral firing, which the queue run loop drains at the matching boundary.
 - **Trigger** — an evaluation construct (image-visible / text-match / time / delay / schedule),
   used internally to decide whether a step executes. Still present in the domain and on the API,
   but **no longer authored as a standalone object in the UI**.
@@ -68,8 +75,10 @@ not survive a service restart; queue *configuration* and templates are persisted
 - **Vision / OCR**: OpenCV-based template matching (bundled, no external binary) returning
   multiple detections with confidence; Tesseract OCR with TSV-based confidence.
 - **Execution**: per-emulator queues with start/stop, cycle execution, scheduling areas
-  (start / once-per-run / after-every-step / scheduled), a background screen-capture service
-  reporting FPS, and "ensure game running" handling.
+  (start / once-per-run / after-every-step / scheduled), live relative scheduling against a running
+  queue, sequences that can **self-reschedule** into their originating queue run (ephemeral, any
+  schedule option, IF-gated), a background screen-capture service reporting FPS, and "ensure game
+  running" handling.
 - **Execution Logs** (separate tab): filterable/sortable grid, expandable hierarchy reflecting
   what actually executed, deep links into authoring, snapshots and step outcomes; non-technical
   presentation (no raw JSON).

--- a/specs/065-sequence-self-reschedule/checklists/requirements.md
+++ b/specs/065-sequence-self-reschedule/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Sequence Self-Rescheduling into the Originating Queue Run
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Informed guesses were made (documented in the Assumptions section) instead of leaving open
+  clarification markers, grounded in existing features 053, 059, 060, 061 (scheduling options and
+  live/ephemeral run-only scheduling) and 031–033 (conditional logic) and 051/063 (run + logging).
+- Two areas a reviewer may wish to revisit via `/speckit-clarify`: (1) whether a built-in cap on
+  repeated self-rescheduling is desired beyond author-controlled IF conditions; (2) the fallback
+  semantics for the "At Queue Start" option mid-run (FR-009).

--- a/specs/065-sequence-self-reschedule/contracts/sequence-self-reschedule-action.md
+++ b/specs/065-sequence-self-reschedule/contracts/sequence-self-reschedule-action.md
@@ -1,0 +1,78 @@
+# Contract: Sequence Self-Reschedule Action
+
+This feature adds **no new HTTP endpoint**. The action is an opaque payload carried on the existing
+sequence authoring endpoints, and the run-side scheduling is an in-process call. This document pins
+(a) the persisted payload schema that must round-trip through the authoring API and (b) the per-option
+firing semantics the execution engine must honor.
+
+---
+
+## A. Persisted payload (round-trips through `POST/GET/PUT /api/sequences`)
+
+A self-reschedule step is an existing `SequenceStep` with `stepType: "Action"` whose `action` is:
+
+```jsonc
+{
+  "type": "reschedule-self",
+  "schemaVersion": "1",
+  "parameters": {
+    "option": "Timer",                  // required: AtQueueStart | OncePerRun | Timer | EveryStep
+    "timerTimeOfDay": "14:30:00",       // HH:mm:ss; only when option == Timer (time-of-day mode)
+    "timerRelativeOffset": "00:10:00"   // HH:mm:ss; only when option == Timer (relative mode)
+  }
+}
+```
+
+### Round-trip requirements (FR-001a, SC-001)
+- Creating/updating a sequence containing this action and reading it back MUST return the identical
+  `type` and `parameters` (option + the one timer field, if any).
+- The action MUST be placeable inside the sequence's IF/conditional branches and survive the
+  round-trip in that position (FR-002).
+- No queue template or saved configuration is touched by authoring or running the action (FR-010,
+  SC-005).
+
+### Validation (`ActionPayloadValidationService`) — reuses the `{ error: { code, message, hint } }` envelope
+
+| Case | Result |
+|------|--------|
+| `option` missing or not a known value | rejected — `invalid_request` |
+| `option == Timer` with **neither** timer field | rejected (a timer needs a target) |
+| `option == Timer` with **both** timer fields | rejected (mutually exclusive) |
+| `option != Timer` with any timer field present | rejected (malformed) |
+| `timerRelativeOffset` negative or out of range | rejected (same bound as feature 059) |
+| `type == "reschedule-self"` (well-formed) | accepted — recognized action type |
+
+---
+
+## B. Run-time firing semantics (in-process)
+
+Given a running sequence whose `ExecutionLogContext.OriginatingQueueId` is **non-empty**, executing
+the action schedules **exactly one** additional firing of that same sequence into the current run:
+
+| `option` | Firing semantics (MUST) | Spec |
+|----------|-------------------------|------|
+| `OncePerRun` | Appended after the remaining once-per-run steps of the **current cycle**; runs again before that cycle ends | FR-007 |
+| `Timer` (relative) | `fireAt = now + offset`; fires once at the first iteration boundary at/after `fireAt` | FR-005 |
+| `Timer` (time-of-day) | `fireAt = today@time` (if already past ⇒ next boundary); fires once at the first boundary at/after it | FR-006 |
+| `EveryStep` | Registered to fire after each subsequent normal step for the rest of the run; **loop-safe**, idempotent per sequence (no unbounded self-chain) | FR-008 |
+| `AtQueueStart` (cycling) | Fires at the start of the next cycle | FR-009 |
+| `AtQueueStart` (non-cycling) | Falls back to firing at the next iteration boundary | FR-009 |
+
+### Cross-cutting MUSTs
+- The reschedule applies to the **current run only** and is never persisted (FR-010).
+- When `OriginatingQueueId` is empty (standalone/non-queue run): the action performs **no scheduling**
+  and reports **success** (no-op); the sequence continues normally (FR-011, FR-012).
+- The action does not, by itself, terminate the sequence — subsequent steps still run (FR-012).
+- A reschedule accepted but never due before the run ends does **not** fail the run; the log shows it
+  did not fire (FR-015).
+- Rescheduled firings count toward the run's executed-sequence total like other live/scheduled
+  firings; run termination remains governed by once-per-run steps (FR-016).
+- A pending firing not yet fired is abandoned when the run is stopped/aborted (FR-017).
+- Origin propagates through nesting: a child sequence of a queue-driven run treats that run as its
+  originating queue run and reschedules the child into it (FR-018).
+
+### Execution-log MUSTs (FR-013, FR-014)
+- The action entry records: `option`, resolved timing (target instant for timers; "next cycle"/"this
+  cycle" otherwise), and `outcome` = `scheduled` | `noop` (with `noopReason` when no-op).
+- The resulting firing appears as an executed sequence under the run, tagged as originating from the
+  self-reschedule and attributable to the originating sequence.

--- a/specs/065-sequence-self-reschedule/data-model.md
+++ b/specs/065-sequence-self-reschedule/data-model.md
@@ -1,0 +1,165 @@
+# Phase 1 Data Model: Sequence Self-Rescheduling
+
+Entities derived from the spec's **Key Entities** plus the concrete types introduced by the plan.
+Persisted shapes are additive and backward compatible; run-scoped shapes are in-memory only and never
+serialized.
+
+---
+
+## 1. Self-Reschedule Action (persisted, inside the sequence definition)
+
+Carried by the **existing** `SequenceActionPayload` (`src/GameBot.Domain/Commands/SequenceStep.cs`) —
+no new persisted container. A self-reschedule step is a `SequenceStep` with
+`StepType = Action` and:
+
+```jsonc
+"action": {
+  "type": "reschedule-self",
+  "schemaVersion": "1",
+  "parameters": {
+    "option": "Timer",              // AtQueueStart | OncePerRun | Timer | EveryStep
+    "timerTimeOfDay": "14:30:00",   // present only when option == Timer AND time-of-day mode
+    "timerRelativeOffset": "00:10:00" // present only when option == Timer AND relative mode
+  }
+}
+```
+
+### `SelfRescheduleOption` (NEW enum, `GameBot.Domain.Commands.SelfReschedule`)
+
+| Value | Wire string | Meaning |
+|-------|-------------|---------|
+| `AtQueueStart` | `"AtQueueStart"` | Fire at next cycle start (cycling) / next iteration boundary (non-cycling) — FR-009 |
+| `OncePerRun` | `"OncePerRun"` | Append after remaining once-per-run steps of the current cycle — FR-007 |
+| `Timer` | `"Timer"` | Fire once at a target instant (relative offset or time-of-day) — FR-005/FR-006 |
+| `EveryStep` | `"EveryStep"` | Register to fire after each subsequent normal step (loop-safe) — FR-008 |
+
+Mirrors `QueueTemplates.ScheduleType` semantically; named distinctly because the wire value
+`EveryStep` is shared but the at-queue-start mid-run meaning is option-specific.
+
+### `SelfReschedulePayload` (NEW typed view, `GameBot.Domain.Commands.SelfReschedule`)
+
+A thin reader/validator over `SequenceActionPayload.Parameters` (the dictionary stays the storage):
+
+| Field | Type | Rules |
+|-------|------|-------|
+| `Option` | `SelfRescheduleOption` | Required; must parse to a known value |
+| `TimerTimeOfDay` | `TimeOnly?` | Allowed **only** when `Option == Timer`; mutually exclusive with `TimerRelativeOffset` |
+| `TimerRelativeOffset` | `TimeSpan?` | Allowed **only** when `Option == Timer`; non-negative; mutually exclusive with `TimerTimeOfDay` |
+
+**Validation rules** (enforced in `ActionPayloadValidationService`, mirroring the template editor):
+- `option` required and a known enum value.
+- When `option == Timer`: **exactly one** of `timerTimeOfDay` / `timerRelativeOffset` present.
+- When `option != Timer`: neither timer field present (ignored/rejected as malformed).
+- `timerRelativeOffset` ≥ 0 and within the same range bound as feature 059's `RelativeOffsetParser`.
+- `reschedule-self` added to the set of recognized action types so an unknown-type error is not raised.
+
+---
+
+## 2. Originating Queue Run Context (in-memory, threaded)
+
+### `ExecutionLogContext` (MODIFIED, `GameBot.Service.Services.ExecutionLog`)
+
+Add one field; propagated through nesting exactly like `RootExecutionId`:
+
+| New field | Type | Set by | Propagation |
+|-----------|------|--------|-------------|
+| `OriginatingQueueId` | `string?` | `QueueExecutionService.RunOneSequenceAsync` (= `queue.Id`) | Copied onto every child context built in `SequenceExecutionService.ExecuteAsync` |
+
+`OriginatingQueueId == null/empty` ⇒ the running sequence was **not** started from a queue ⇒ the
+action is a no-op success (FR-011). Standalone `sequences/{id}/execute` runs never set it.
+
+---
+
+## 3. Ephemeral Run Schedule Entry (in-memory, run-scoped)
+
+### `SelfRescheduleEntry` (NEW record, `GameBot.Service.Services.QueueExecution`)
+
+```csharp
+internal sealed record SelfRescheduleEntry(
+  string Id,                 // unique; links the action's log entry to the resulting firing
+  string SequenceId,         // the sequence rescheduling itself
+  SelfRescheduleOption Option,
+  DateTimeOffset? FireAt);   // resolved instant for Timer options; null for the others
+```
+
+### `QueueRunHandle` (MODIFIED, `QueueRunHandle.cs`) — new registers, all non-persisted
+
+| Register | Type | Option(s) served | Lifetime / drain |
+|----------|------|------------------|------------------|
+| `PendingOncePerRun` | `ConcurrentQueue<SelfRescheduleEntry>` | OncePerRun, non-cycling AtQueueStart fallback | Drained after the once-per-run pass of the current cycle |
+| `PendingNextCycleStart` | `ConcurrentQueue<SelfRescheduleEntry>` | AtQueueStart (cycling) | Drained at the top of the next cycle, before once-per-run |
+| `PendingTimerFirings` | `List<SelfRescheduleEntry>` (guarded) | Timer (relative + time-of-day) | Each fired once when `now ≥ FireAt`, then removed; unfired entries discarded at run end |
+| `EveryStepInjections` | `ConcurrentDictionary<string,SelfRescheduleEntry>` keyed by `SequenceId` | EveryStep | Drained (snapshot) after each subsequent normal step; idempotent per sequence (loop-safe) |
+
+Existing `PendingLiveSchedules` (feature 059) is unchanged and unrelated. All four new registers are
+created with the handle and die with it — on normal completion **and** on stop/abort (FR-017), because
+the handle is removed and disposed in `RunAsync`'s `finally`.
+
+**State transitions of an entry**:
+`created (Scheduled)` → `due` (Timer: `now ≥ FireAt`; others: matching boundary reached) → `fired`
+(removed; produces a child-sequence log entry) **or** `abandoned` (run ends/stops first → discarded,
+no firing, no failure — FR-015/FR-017).
+
+---
+
+## 4. Execution Log Entries (persisted record of what ran)
+
+No schema change — reuses existing execution-log objects with added detail metadata:
+
+| Log entry | Produced by | Detail added |
+|-----------|-------------|--------------|
+| **Reschedule decision** (a sequence step) | `SequenceExecutionService` via `SequenceExecutionResult` step + `detailItems` | `option`, `resolvedTiming` (instant / "next cycle" / "this cycle"), `outcome` = `scheduled`\|`noop`, `noopReason` (e.g. "not started from a queue") — FR-013 |
+| **Resulting firing** (a child sequence execution) | `QueueExecutionService.RunOneSequenceAsync` | note "scheduled by self-reschedule" + the originating action `Id`, so the extra firing is attributable — FR-014 |
+
+---
+
+## 5. Coordinator contract (in-memory service)
+
+### `ISelfRescheduleCoordinator` (NEW) / `SelfRescheduleCoordinator` (NEW)
+
+```csharp
+SelfRescheduleResult ScheduleSelf(
+  string queueId,
+  string sequenceId,
+  SelfRescheduleOption option,
+  TimeOnly? timerTimeOfDay,
+  TimeSpan? timerRelativeOffset);
+```
+
+| `SelfRescheduleOutcome` | When | Action log outcome |
+|-------------------------|------|--------------------|
+| `Scheduled` | Run found in `IQueueRunRegistry`; entry injected into the matching register | `scheduled` (+ resolved timing) |
+| `NotRunning` | No active run for `queueId` (race: run ended mid-sequence) | treated as no-op; logged with reason |
+
+`SelfRescheduleResult` carries the outcome, the resolved `FireAt`/target description, and the entry
+`Id` for log linkage. The **no-op-because-not-from-a-queue** case (FR-011) is decided *before* the
+coordinator is called (when `OriginatingQueueId` is empty) and never reaches it.
+
+### `IQueueRunRegistry` (NEW) / `QueueRunRegistry` (NEW)
+
+Singleton owner of `ConcurrentDictionary<string queueId, QueueRunHandle>`, extracted from
+`QueueExecutionService._runs`. Methods: `TryAdd`, `TryGet`, `Remove` (names CamelCase). Holds no
+service dependencies, breaking the `SequenceExecutionService ↔ QueueExecutionService` cycle.
+
+---
+
+## Relationships
+
+```
+SequenceStep ──has──▶ SequenceActionPayload (type "reschedule-self")
+                              │ read/validated as
+                              ▼
+                      SelfReschedulePayload { Option, TimerTimeOfDay?, TimerRelativeOffset? }
+
+SequenceExecutionService.ExecuteAsync
+   ├─ reads ExecutionLogContext.OriginatingQueueId   (null ⇒ no-op success)
+   └─ actionDispatcher ─▶ ISelfRescheduleCoordinator.ScheduleSelf
+                                   │ via
+                                   ▼
+                          IQueueRunRegistry.TryGet(queueId) ─▶ QueueRunHandle
+                                   │ injects SelfRescheduleEntry into
+                                   ▼
+       PendingOncePerRun | PendingNextCycleStart | PendingTimerFirings | EveryStepInjections
+
+QueueExecutionService run loop ─ drains each register at its boundary ─▶ RunOneSequenceAsync (the firing)
+```

--- a/specs/065-sequence-self-reschedule/plan.md
+++ b/specs/065-sequence-self-reschedule/plan.md
@@ -175,3 +175,14 @@ referencing any scheduling type directly.
 No constitution violations. The only structural change beyond additive members — extracting the
 active-run registry into `IQueueRunRegistry` — exists solely to keep dependency flow acyclic and
 relocates state that already lives inside `QueueExecutionService`; it adds no new behavior.
+
+## Performance note (implementation, SC-006 / Principle IV)
+
+The self-reschedule action dispatch is O(1) in memory: it reads the typed payload and appends one
+entry to a run-scoped register (`ConcurrentQueue`/`ConcurrentDictionary`/guarded `List`) — no I/O, no
+ADB round-trip, well within the conditional-step p95 ≤ 200 ms budget. The run-loop draining added to
+`QueueExecutionService.RunAsync` is O(pending self-reschedules) per iteration boundary: each register
+is drained with a single dequeue/snapshot pass at the same cadence as the existing template/live
+timer evaluation (features 053/059/060), so it adds no new polling and negligible per-boundary cost
+at operator scale (a handful of pending entries). Unfired entries are discarded with the run handle
+in `RunAsync`'s `finally`, so they never accumulate across runs.

--- a/specs/065-sequence-self-reschedule/plan.md
+++ b/specs/065-sequence-self-reschedule/plan.md
@@ -1,0 +1,177 @@
+# Implementation Plan: Sequence Self-Rescheduling into the Originating Queue Run
+
+**Branch**: `065-sequence-self-reschedule` | **Date**: 2026-06-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/065-sequence-self-reschedule/spec.md`
+
+## Summary
+
+Add an authorable **self-reschedule sequence action** that, when reached during a queue-driven run,
+schedules **one additional firing of the same sequence into the current run** using any of the four
+existing schedule options (**At Queue Start**, **Once Per Run**, **Timer** time-of-day/relative
+offset, **After Every Step**). It is placeable under the sequence's existing IF/conditional flow so
+the decision is made live; it applies only to the current run and is never persisted; it is reflected
+in the execution logs; and when the sequence was not started from a queue it is a **successful
+no-op**.
+
+Technical approach — three layers, all additive:
+
+1. **Origin propagation (Service).** `QueueExecutionService` already creates each sequence firing's
+   `ExecutionLogContext`. Add an `OriginatingQueueId` to that context, set it when the queue run
+   launches a sequence, and copy it through nested invocations (FR-018). A running sequence with a
+   non-empty `OriginatingQueueId` is "started from a queue"; empty → no-op success (FR-011).
+
+2. **Ephemeral run-scoped schedule registers (Service).** The active-run registry (today the
+   private `_runs` dictionary inside `QueueExecutionService`) is extracted into a singleton
+   `IQueueRunRegistry` so it can be shared without a DI cycle. `QueueRunHandle` gains per-option,
+   non-persisted registers for self-rescheduled firings (next-cycle-start, current-cycle once-per-run
+   append, after-every-step set, and resolved timer instants). The run loop drains each register at
+   the matching boundary, exactly mirroring the existing template/live behaviors for each option
+   (features 053/059/060). A self-reschedule whose firing never becomes due is discarded with the
+   handle (FR-015) and never marks the run failed.
+
+3. **The action itself (Domain + UI).** A new `reschedule-self` action type carried in the existing
+   generic `SequenceActionPayload`. `SequenceRunner` dispatches non-command/non-wait actions through
+   a new optional `actionDispatcher` callback; `SequenceExecutionService` supplies a dispatcher that
+   reads `OriginatingQueueId` and calls a narrow `ISelfRescheduleCoordinator` (backed by the run
+   registry) to inject the ephemeral entry, recording the decision (option, resolved timing,
+   scheduled vs. no-op + reason) as a sequence step in the execution log (FR-013). The sequence
+   editor gains the action as a third authorable action type (alongside `command` and
+   `WaitForImage`) with the same schedule-option inputs used in the queue-template editor; it
+   round-trips through the unchanged sequence authoring API as an opaque action payload (FR-001a).
+
+No new external dependencies. Elapsed/wall-clock reads reuse the `TimeProvider` already adopted by
+`QueueExecutionService` in feature 059, keeping firing timing deterministic and unit-testable.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9 (backend `GameBot.Domain` + `GameBot.Service`); TypeScript +
+React 18 (web UI, Vite + Jest)
+**Primary Dependencies**: ASP.NET Core Minimal API, Microsoft.Extensions.Logging,
+`System.TimeProvider` (built-in); web UI: React, existing `lib/api` client, existing sequence editor
+(`SequencesPage.tsx`) and the queue-template timer inputs (`QueueEntryList.tsx`). No new packages.
+**Storage**: File-backed JSON sequence store (`ISequenceRepository`) — the action persists inside the
+existing `SequenceActionPayload` (`Type` + `Parameters` dictionary), additive and backward
+compatible. All run schedules are **in-memory only**, on `QueueRunHandle`; nothing about a reschedule
+is ever written to the queue template or any saved config (FR-010, SC-005).
+**Testing**: xUnit + coverlet (backend contract/integration/unit); Jest + React Testing Library
+(web UI). `vite build` + `jest` is the real web-ui green gate (lint/`tsc` have pre-existing
+failures — see memory).
+**Target Platform**: Windows desktop service (ASP.NET Core host serving the static web UI).
+**Project Type**: Web application (C# backend + React SPA front end) — the existing
+`GameBot.Domain` / `GameBot.Service` / `src/web-ui` / `tests` layout.
+**Performance Goals**: The action's runtime cost is one register append + a timing resolution — O(1),
+no I/O, no ADB round-trip; comfortably within the conditional-step budget of p95 ≤ 200 ms
+established in feature 031 (SC-006). Run-loop draining adds O(pending self-reschedules) comparisons
+per boundary, identical cadence to existing timer/live evaluation (negligible).
+**Constraints**: Reschedule applies to the current run only and MUST NOT persist (FR-010); option
+semantics MUST match existing template/live behavior, the only novel case being *At Queue Start
+mid-run* (FR-009); After-Every-Step injection MUST be loop-safe (FR-008, feature 060); the no-op path
+MUST report success and not terminate the sequence (FR-011/FR-012); pending firings MUST be abandoned
+on stop/abort (FR-017); origin MUST propagate through nesting (FR-018).
+**Scale/Scope**: Operator scale (≤50 templates, ≤100 entries; a handful of pending self-reschedules
+per run). ~1 new action type + validator, ~1 new coordinator interface + run-registry extraction,
+new `QueueRunHandle` registers + run-loop drains, `ExecutionLogContext` field, sequence-editor action
+panel, ~30–45 new tests across unit/contract/integration/Jest.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation
+progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality Discipline | PASS (plan) | Additive, localized changes layered onto established scheduling patterns. New types small and cohesive (`ISelfRescheduleCoordinator`, `IQueueRunRegistry`, a `SelfReschedulePayload`/validator, per-option handle registers). CamelCase method names (`ScheduleSelf`, `ResolveSelfRescheduleTiming`, `DrainNextCycleStart`). No new dependencies. The registry extraction removes duplicated run-lookup state rather than adding dead code. Public members documented. |
+| II. Testing Standards | PASS (plan) | Each option's firing timing covered by unit tests via fake `TimeProvider`: once-per-run append fires before cycle end; relative/time-of-day timer fire-once; after-every-step registers + loop-safe (no unbounded chain); at-queue-start next-cycle vs non-cycling fallback. No-op-success path (no originating queue) and origin-through-nesting covered. Contract tests: action payload round-trips through sequence create/read/update; validation rejects malformed option/timer combos. Integration: end-to-end queue run that self-reschedules and observes the extra firing + log entries. Web-ui Jest: action authorable under an IF branch, option inputs mirror template editor. Coverage ≥80% line / ≥70% branch for touched areas. |
+| III. User Experience Consistency | PASS | Option vocabulary and inputs reuse the queue-template editor verbatim (no new schedule concepts surfaced); validation errors use the existing `{ error: { code, message, hint } }` envelope; the no-op path is a *success* exit with an explicit log reason; logs present the reschedule and its firing consistently with features 059/063. No breaking change — the action payload is additive and optional. |
+| IV. Performance Requirements | PASS | Action dispatch is O(1) in-memory with no I/O (SC-006); run-loop draining is O(pending) per boundary on an operator-scale set, same cadence as today's timer/live checks. Perf note will accompany the run-loop change. |
+| V. Living Documentation | PASS (plan) | `docs/architecture.md` will gain the self-reschedule action in the domain model / capability map / sequence-action surface (refreshed "Last reviewed" date) in the implementation PR; this spec's `Status` and `specs/STATUS.md` updated on completion. No earlier spec is superseded — this extends 059/060/031–033 rather than replacing them. |
+| Quality Gates – DoD | PASS (plan) | No underscores in method names; new behavior documented in `contracts/` + `quickstart.md`; public domain/DTO members documented; web-ui validated with `vite build` + `jest`; no user-visible breaking change. |
+
+No violations → Complexity Tracking left empty. (The `IQueueRunRegistry` extraction is a
+cycle-avoidance refactor, not added complexity — it relocates state that already exists.)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/065-sequence-self-reschedule/
+├── spec.md              # Feature specification (clarified, 5 Q&A)
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output (manual verification)
+├── contracts/           # Phase 1 output
+│   └── sequence-self-reschedule-action.md   # Action payload shape + option semantics contract
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+No OpenAPI fragment: the feature adds **no new HTTP endpoint**. The action is an opaque payload on the
+existing sequence create/read/update endpoints; the run-side scheduling is an in-process call. The
+contract doc pins the payload schema and the per-option firing semantics instead.
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   ├── Actions/
+│   │   └── ActionTypes.cs                     # + RescheduleSelf = "reschedule-self"
+│   ├── Commands/
+│   │   └── SelfReschedule/
+│   │       ├── SelfRescheduleOption.cs        # NEW enum: AtQueueStart | OncePerRun | Timer | EveryStep
+│   │       └── SelfReschedulePayload.cs       # NEW typed view over SequenceActionPayload.Parameters
+│   ├── Services/
+│   │   ├── SequenceRunner.cs                  # + optional actionDispatcher callback; dispatch reschedule-self action step
+│   │   └── ActionPayloadValidationService.cs  # recognize reschedule-self; validate option + timer params
+│   └── (SequenceStep already carries Action: SequenceActionPayload — no change)
+└── GameBot.Service/
+    ├── Services/ExecutionLog/
+    │   └── ExecutionLogContext.cs             # + OriginatingQueueId (propagated through nesting)
+    ├── Services/SequenceExecution/
+    │   └── SequenceExecutionService.cs        # supply actionDispatcher; read OriginatingQueueId; log decision
+    └── Services/QueueExecution/
+        ├── IQueueRunRegistry.cs               # NEW: singleton store of active QueueRunHandles (extracted)
+        ├── QueueRunRegistry.cs                # NEW: implementation
+        ├── ISelfRescheduleCoordinator.cs      # NEW: ScheduleSelf(queueId, sequenceId, option, params) -> result
+        ├── SelfRescheduleCoordinator.cs       # NEW: resolve timing + inject ephemeral entry on the handle
+        ├── QueueRunHandle.cs                  # + ephemeral self-reschedule registers (per option)
+        └── QueueExecutionService.cs           # use registry; drain self-reschedule registers at boundaries; mark firings
+
+src/web-ui/src/
+├── types/
+│   └── sequenceFlow.ts                        # + 'reschedule-self' action shape + option/timer params
+├── pages/
+│   └── SequencesPage.tsx                      # actionType gains 'reschedule-self'; option + timer inputs; IF placement
+└── components/sequences/ (+ a small RescheduleActionConfig component if SequencesPage grows too large)
+
+src/GameBot.Service/Program.cs                 # register IQueueRunRegistry, ISelfRescheduleCoordinator (singletons)
+
+tests/
+├── unit/
+│   ├── Queues/
+│   │   └── SelfRescheduleCoordinatorTests.cs          # NEW: per-option timing resolution + register injection
+│   ├── Queues/QueueExecutionServiceTests.cs           # + run-loop drains each option; loop-safety; not-due-discard
+│   └── Sequences/SequenceRunnerActionDispatchTests.cs # NEW: action dispatched; no-op success; non-terminating
+├── contract/
+│   └── Sequences/SelfRescheduleActionContractTests.cs # NEW: payload round-trips; validation accept/reject
+└── integration/
+    └── Queues/SelfRescheduleRunIntegrationTests.cs    # NEW: end-to-end run self-reschedules; logs show firing + origin propagation
+    (+ web-ui Jest colocated __tests__/ for SequencesPage reschedule action)
+```
+
+**Structure Decision**: All changes fit the existing four-project layout. The DI cycle that would
+arise from `SequenceExecutionService → QueueExecutionService` (the latter already depends on the
+former) is avoided by extracting the active-run registry into a dependency-free singleton
+(`IQueueRunRegistry`) that both the queue engine and the new `SelfRescheduleCoordinator` consume. The
+action stays a generic `SequenceActionPayload` so the authoring API needs no change; `SequenceRunner`
+remains web/queue-agnostic by dispatching the action through an injected callback rather than
+referencing any scheduling type directly.
+
+## Complexity Tracking
+
+No constitution violations. The only structural change beyond additive members — extracting the
+active-run registry into `IQueueRunRegistry` — exists solely to keep dependency flow acyclic and
+relocates state that already lives inside `QueueExecutionService`; it adds no new behavior.

--- a/specs/065-sequence-self-reschedule/quickstart.md
+++ b/specs/065-sequence-self-reschedule/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Sequence Self-Rescheduling
+
+Manual verification of the four user stories. Assumes the GameBot service is running with the built
+web UI, an emulator reachable, and at least one queue linked to a template containing a sequence.
+
+## Prerequisites
+- A sequence `S` (e.g. "Daily Reward") that you can edit in the **Sequences** page.
+- A queue `Q` bound to an emulator, linked to a template whose entries include `S` as a once-per-run
+  entry.
+
+---
+
+## US1 — Author a self-reschedule action gated by an IF condition (P1)
+
+1. Open **Sequences → S** in the editor.
+2. Add an **IF** branch with a condition you can force true (e.g. an image you can show on screen, or
+   a command-outcome condition).
+3. Inside the true branch, add a step → action type **Reschedule this sequence**.
+4. Choose option **Once Per Run**. Save.
+5. Re-open `S`; confirm the reschedule action is still present inside the IF branch (round-trip).
+6. Start `Q` with the condition forced **true**: confirm in **Execution Logs** that `S` fires a
+   **second time** during the same run as a direct result of the action.
+7. Stop `Q`, force the condition **false**, run again: confirm `S` fires only once (no extra firing).
+
+**Expected**: action visible/configurable under the IF branch (AS-3); fires again when true (AS-1);
+no extra firing when false (AS-2); the remaining steps of `S` still run after the action (AS-4).
+
+---
+
+## US2 — Choose any schedule option when rescheduling (P1)
+
+Repeat the authoring step, changing the option each time, and observe the timing in Execution Logs:
+
+| Option configured | Expected firing |
+|-------------------|-----------------|
+| **Once Per Run** | `S` fires again within the current run, as an extra normal step |
+| **Timer → relative offset** `00:10:00` | `S` fires once ~10 min after the action executed, at the first iteration boundary at/after that instant |
+| **Timer → time-of-day** `HH:MM` | `S` fires once at the first boundary at/after that wall-clock time |
+| **After Every Step** | `S` fires after each subsequent normal step for the rest of the run — and the reschedule action does **not** spawn an endless chain |
+| **At Queue Start** (cycling `Q`) | `S` fires at the start of the next cycle |
+| **At Queue Start** (non-cycling `Q`) | `S` fires at the next iteration boundary (fallback) |
+
+Also confirm: when **Timer** is selected the time-of-day / relative-offset inputs appear and match the
+queue-template editor's timer inputs (AS-6).
+
+---
+
+## US3 — No-op with success when not started from a queue (P1)
+
+1. Keep the self-reschedule action in `S` (any option).
+2. From **Sequences → S**, run `S` **standalone** (execute from the authoring UI), not via a queue.
+3. Open **Execution Logs** for that standalone run.
+
+**Expected**: the action appears with a **success** status and a note that there was **no originating
+queue, so no reschedule was performed** (AS-2); nothing is scheduled anywhere (AS-1); the remaining
+steps of `S` run and the overall outcome is unaffected (AS-3).
+
+---
+
+## US4 — See the reschedule reflected in the execution logs (P2)
+
+1. Run `Q` so the action fires (e.g. Timer relative `00:01:00`).
+2. Let the rescheduled firing occur, then open **Execution Logs** for the run.
+
+**Expected**:
+- The **action entry** records the chosen option, the resolved timing (e.g. the target instant for a
+  timer), and that the schedule applies to the current run only (AS-1).
+- The **rescheduled firing** appears as an executed sequence in the run, consistent with other
+  live/scheduled firings, attributable to `S` (AS-2).
+- If you stop the run before a timer becomes due, the action entry shows the reschedule was **accepted
+  but did not fire within the run**, and the run is **not** marked failed (AS-3).
+- For the US3 standalone case, the entry clearly reads **"no-op, not started from a queue"** vs.
+  "scheduled" (AS-4).
+
+---
+
+## Regression checks
+- A self-reschedule never appears in `Q`'s saved template after the run ends (SC-005) — re-open the
+  template editor and confirm no extra entry was added.
+- Existing template/live scheduling (features 053/059/060) behaves unchanged.
+
+## Automated gates
+- Backend: `dotnet test` (unit/contract/integration green; coverage ≥80% line / ≥70% branch for
+  touched areas).
+- Web UI: `vite build` **and** `jest` both green (the real web-ui gate).

--- a/specs/065-sequence-self-reschedule/research.md
+++ b/specs/065-sequence-self-reschedule/research.md
@@ -1,0 +1,195 @@
+# Phase 0 Research: Sequence Self-Rescheduling
+
+All spec ambiguities were resolved in the 2026-06-22 clarification session (5 Q&A). The remaining
+unknowns are **technical** — how to land the behavior inside the existing engine without a DI cycle,
+without persistence, and without breaking established option semantics. Each decision below records
+what was chosen, why, and the alternatives rejected.
+
+---
+
+## D1. How a running sequence learns its originating queue run (FR-011, FR-018)
+
+**Decision**: Add a nullable `OriginatingQueueId` to `ExecutionLogContext`. `QueueExecutionService`
+sets it on the context it builds in `RunOneSequenceAsync` (it already builds one per firing).
+`SequenceExecutionService` copies it onto the child contexts it constructs for nested invocations, so
+it propagates through nesting automatically. A non-empty value ⇒ "started from a queue"; empty/absent
+⇒ no-op success.
+
+**Rationale**: `ExecutionLogContext` is *already* the per-firing context threaded from the queue run
+through `SequenceExecutionService` into nested executions, and it already propagates `RootExecutionId`
+and `Depth` the same way. Reusing it gives origin-through-nesting (FR-018) for free and adds exactly
+one optional field. No new parameter on the public `ISequenceExecutionService.ExecuteAsync` signature.
+
+**Alternatives rejected**:
+- *AsyncLocal/ambient run context* — implicit, hard to test, and leaks across `Task.Run` boundaries
+  used by the queue loop. Rejected for testability.
+- *New explicit `originatingQueueId` parameter on `ExecuteAsync`* — touches every caller and the
+  standalone `sequences/{id}/execute` endpoint; the context object already exists for exactly this
+  kind of ambient-but-explicit data.
+
+---
+
+## D2. Avoiding the DI cycle (the run registry extraction)
+
+**Decision**: Extract the active-run dictionary (today `private ConcurrentDictionary<string,
+QueueRunHandle> _runs` in `QueueExecutionService`) into a singleton `IQueueRunRegistry`.
+`QueueExecutionService` registers/looks up/removes handles via the registry. A new narrow
+`ISelfRescheduleCoordinator` (also depending only on the registry + `ISequenceRepository` +
+`TimeProvider`) performs the inject. `SequenceExecutionService` depends on the coordinator.
+
+**Rationale**: `QueueExecutionService` already depends on `ISequenceExecutionService`. Injecting
+`IQueueExecutionService` back into `SequenceExecutionService` would form a constructor cycle and fail
+DI validation. Routing the self-reschedule through a dependency-free registry breaks the cycle:
+`SequenceExecutionService → ISelfRescheduleCoordinator → IQueueRunRegistry ← QueueExecutionService`.
+The registry is the single owner of run lifetime, so ephemeral schedules naturally die with the run.
+
+**Alternatives rejected**:
+- *Lazy<IQueueExecutionService> / property injection* — hides the cycle rather than removing it and
+  is brittle under DI validation.
+- *Put `ScheduleSelf` directly on `IQueueExecutionService`* — reintroduces the cycle.
+- *Event/queue indirection (mediator)* — overkill for an in-process, synchronous register append.
+
+The existing `ScheduleRelative` (feature 059) keeps working; it can later move onto the coordinator,
+but this feature leaves it in place to minimize churn.
+
+---
+
+## D3. Mapping each schedule option to an ephemeral, run-scoped register
+
+**Decision**: Add per-option registers to `QueueRunHandle`, all in-memory and discarded with the run:
+
+| Option | Register | Drained where in the run loop | Resolved at inject time |
+|--------|----------|-------------------------------|-------------------------|
+| **Once Per Run** | `ConcurrentQueue<SelfRescheduleEntry> PendingOncePerRun` | Immediately after the once-per-run pass of the **current** cycle, before the cycle boundary | nothing (runs this cycle) |
+| **Timer (relative)** | list of resolved instants `PendingTimerFirings` (id, seqId, fireAt) | At each iteration boundary when `now ≥ fireAt`; fired once then removed | `fireAt = now + offset` |
+| **Timer (time-of-day)** | same `PendingTimerFirings` | same | `fireAt = today@time` (if already past ⇒ next boundary, i.e. `now`) |
+| **After Every Step** | `set keyed by sequenceId EveryStepInjections` | After each subsequent normal step for the rest of the run | nothing (registration) |
+| **At Queue Start** | `ConcurrentQueue<SelfRescheduleEntry> PendingNextCycleStart` | Top of the **next** cycle, before once-per-run (cycling); non-cycling ⇒ falls back into `PendingOncePerRun` | n/a |
+
+**Rationale**: Each option's *existing* template/live behavior already has a drain point in the run
+loop (feature 053/059/060). Resolving relative **and** time-of-day timers to an absolute `fireAt` at
+inject time lets both reuse one list and matches the spec ("first iteration boundary at or after that
+instant", FR-005/FR-006) — a past time-of-day collapses to `now`, firing at the next boundary.
+Distinct registers (vs. one keyed dict) preserve "each accepted reschedule is an independent firing"
+(edge case: multiple self-reschedules in one run) — unlike `PendingLiveSchedules`, which is
+most-recent-wins per sequence and would collapse repeats.
+
+**Alternatives rejected**:
+- *Reuse `PendingLiveSchedules` for timers* — it is keyed by sequence id with most-recent-wins, which
+  silently drops a second self-reschedule of the same sequence. Self-reschedules must accumulate.
+- *Time-of-day kept as a clock comparison each boundary* — duplicates the template timer's
+  per-calendar-day logic and complicates "fires once for this run"; resolving to an instant is simpler
+  and fires-once by construction.
+
+---
+
+## D4. At Queue Start mid-run (the only novel semantic, FR-009)
+
+**Decision**: On a **cycling** run, enqueue onto `PendingNextCycleStart`; the run loop drains it at
+the top of the next `do/while` iteration, before the once-per-run pass — i.e. "start of the next
+cycle". On a **non-cycling** run (no further start boundary), enqueue onto `PendingOncePerRun` so it
+fires at the next iteration boundary instead. The coordinator decides which register based on
+`queue.CycleExecution`, which the registry exposes via the handle.
+
+**Rationale**: Directly encodes the clarification ("Cycling run → next cycle start; non-cycling →
+next iteration boundary") and reuses the once-per-run drain for the fallback so there is no special
+non-cycling code path.
+
+**Alternatives rejected**: Treating non-cycling At-Queue-Start as a no-op — contradicts the
+clarification, which requires a fallback firing.
+
+---
+
+## D5. Loop-safety for After Every Step (FR-008, feature 060)
+
+**Decision**: `EveryStepInjections` is a **set keyed by sequence id** — registering the same sequence
+again is idempotent. The after-every-step drain snapshots the set before iterating so a firing's own
+self-reschedule action cannot grow the set mid-pass. The injected every-step firings count toward
+`failed` but **not** `executed`, matching template `EveryStep` semantics.
+
+**Rationale**: The risk is an after-every-step firing reaching the self-reschedule action again and
+appending another after-every-step entry forever. Idempotent set membership bounds it to "this
+sequence fires after every step" regardless of how many times the action runs — the same loop-safe
+model feature 060 established for template every-step entries. The author remains responsible for IF
+gating (per spec Assumptions: no built-in cap), but the engine itself cannot diverge.
+
+**Alternatives rejected**: A per-run firing counter / hard cap — the spec explicitly chose
+author-controlled bounding with no built-in cap (clarification Q1). A list (not a set) — would let the
+same sequence stack unbounded every-step registrations.
+
+---
+
+## D6. Dispatching the action from `SequenceRunner` without web/queue coupling
+
+**Decision**: Add an optional `Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>?
+actionDispatcher` to `SequenceRunner.ExecuteAsync`. In `ExecuteSingleStepAsync`, before the command
+path, when `step.Action?.Type == ActionTypes.RescheduleSelf` and a dispatcher is supplied, call it,
+record the returned outcome as the step result (executed/no-op + message), and continue (never early
+-stop). `SequenceExecutionService` supplies the dispatcher, closing over `OriginatingQueueId` and the
+coordinator.
+
+**Rationale**: `SequenceRunner` lives in `GameBot.Domain` and must not reference queue/service types.
+A callback keeps it agnostic, exactly as `executeCommandAsync` already does for command side effects.
+Today a non-WaitForImage action step falls through to `executeCommandAsync("")` and is swallowed as a
+no-op; the new branch intercepts the reschedule action before that fallback. The action does not, by
+itself, terminate the sequence — the dispatcher returns and execution continues (FR-012).
+
+**Alternatives rejected**:
+- *Handle the action entirely inside `SequenceExecutionService` after the run* — too late; the action
+  must execute at its position in the flow (under its IF branch) and be observable mid-sequence.
+- *A new first-class `PrimitiveAction` variant* — heavier than needed; the generic
+  `SequenceActionPayload` already round-trips arbitrary `{ Type, Parameters }` through the authoring
+  API, satisfying FR-001a with zero API changes.
+
+---
+
+## D7. Execution-log representation (FR-013, FR-014, FR-015)
+
+**Decision**: The action records a sequence **step** entry (via the existing `SequenceExecutionResult`
+step + `detailItems` machinery in `SequenceExecutionService`) capturing: chosen option, resolved
+timing (target instant for timers; "next cycle"/"this cycle" for the others), and outcome —
+`scheduled` vs `noop` with the no-op reason ("not started from a queue"). The resulting firing is the
+normal child-sequence log entry already produced by `RunOneSequenceAsync`; the run loop tags
+self-reschedule-originated firings with a detail note ("scheduled by self-reschedule") so operators can
+attribute the extra firing (FR-014). A reschedule accepted but never due before run end leaves only
+the action entry (outcome `scheduled`, no firing) and does **not** affect the run's success/failure,
+which remains governed by once-per-run completion (FR-015, FR-016).
+
+**Rationale**: Reuses the established sequence-step and queue-child logging paths (features 059/063)
+so the new entries render in the existing Execution Logs grid with no schema change; only detail
+metadata is added.
+
+**Alternatives rejected**: A separate top-level log object for reschedules — diverges from how live
+firings (059) are logged and would need new grid handling.
+
+---
+
+## D8. Web-UI authoring surface (SC-001, FR-002, US2)
+
+**Decision**: Extend the sequence editor's action model in `SequencesPage.tsx` from
+`actionType: 'command' | 'WaitForImage'` to also include `'reschedule-self'`, with an option dropdown
+(At Queue Start / Once Per Run / Timer / After Every Step) and, for Timer, the same time-of-day vs
+relative-offset inputs already used by the queue-template editor (`QueueEntryList.tsx`). The action is
+authorable anywhere a step is, including inside IF/conditional branches (existing conditional-flow
+plumbing). It serializes to `{ action: { type: 'reschedule-self', parameters: { option, timerTimeOfDay?,
+timerRelativeOffset? } } }`.
+
+**Rationale**: Reuses the existing per-step action editor and the existing timer inputs verbatim, so
+operators get option parity (US2) with no new UX vocabulary (Principle III). Persisting through the
+generic `action.parameters` map means the sequence authoring API and store are unchanged.
+
+**Alternatives rejected**: A dedicated standalone "reschedule" node type in the flow graph — more UI
+surface and a new persisted shape for no functional gain over the generic action payload.
+
+---
+
+## D9. Determinism of timing (reuse of `TimeProvider`)
+
+**Decision**: The coordinator and run-loop drains read wall-clock through the `TimeProvider` already
+injected into `QueueExecutionService` (feature 059), not `DateTime.Now`. Unit tests use a fake
+provider to assert fire-once and boundary semantics for every option.
+
+**Rationale**: Consistency with the existing relative/live scheduling tests and deterministic,
+fast unit tests (Principle II; tests <1s).
+
+**Alternatives rejected**: Real-clock tests with sleeps — slow and flaky.

--- a/specs/065-sequence-self-reschedule/spec.md
+++ b/specs/065-sequence-self-reschedule/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `065-sequence-self-reschedule`  
 **Created**: 2026-06-22  
-**Status**: Draft  
+**Status**: Implemented  
 **Input**: User description: "As an author of a sequence I want to be able for a sequence to reschedule itself at the queue it was started from. I want to do it from UI, based on the if conditions during the sequence runs. I want to be able to use all the possible options when rescheduling the sequence. This rescheduling should only apply to the current queue run and must not be persisted, however it should be reflected in the execution logs later on. If the sequence wasn't started from a queue, this should be a no-op with a successful exit code."
 
 ## Context

--- a/specs/065-sequence-self-reschedule/spec.md
+++ b/specs/065-sequence-self-reschedule/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: Sequence Self-Rescheduling into the Originating Queue Run
+
+**Feature Branch**: `065-sequence-self-reschedule`  
+**Created**: 2026-06-22  
+**Status**: Draft  
+**Input**: User description: "As an author of a sequence I want to be able for a sequence to reschedule itself at the queue it was started from. I want to do it from UI, based on the if conditions during the sequence runs. I want to be able to use all the possible options when rescheduling the sequence. This rescheduling should only apply to the current queue run and must not be persisted, however it should be reflected in the execution logs later on. If the sequence wasn't started from a queue, this should be a no-op with a successful exit code."
+
+## Context
+
+Queue runs already support scheduling a sequence into a running queue ephemerally, only for the current run, without persisting to the template — this was established for relative/timer schedules in feature 059 (Relative-Time Sequence Scheduling) and built on the four schedule options surfaced everywhere scheduling is configured: **At Queue Start**, **Once Per Run**, **Timer** (time-of-day or relative offset), and **After Every Step** (features 053, 060, 061).
+
+Separately, sequences support visual **IF-style conditional logic** (features 031–033): an author can branch a sequence's flow based on command success/failure and image detections.
+
+This feature lets a sequence **reschedule itself** into the queue run it was started from, as an authored action placed inside the sequence and gated by the sequence's existing conditional logic. The decision is made *during the run*, based on live conditions, using any of the available schedule options. The reschedule affects only the current queue run, is never written back to the queue's template, and is reflected in the execution logs. When the sequence was not started from a queue (e.g., run standalone from the authoring UI), the action does nothing and reports success.
+
+This is the inverse of feature 059's *external* live-scheduling call: here the running sequence schedules *itself* from *within* its own flow.
+
+## Clarifications
+
+### Session 2026-06-22
+
+- Q: How should repeated self-rescheduling be bounded against runaway loops? → A: No built-in cap — purely author-controlled via the IF condition; the loop risk is the author's responsibility.
+- Q: What does the "At Queue Start" option mean mid-run for a self-reschedule? → A: Cycling run → fire at the start of the next cycle; non-cycling run → fire at the next iteration boundary.
+- Q: Where in the run does a "Once Per Run" self-reschedule fire? → A: Appended after the remaining Once-Per-Run steps of the current cycle (runs again before this cycle ends).
+- Q: Is the self-reschedule action exposed via the API as well as the UI? → A: In scope on both — the action is part of the persisted sequence definition and round-trips through the authoring API like any other action.
+- Q: Does a nested/child sequence inherit the originating queue run of its queue-driven parent? → A: Yes — origin propagates through nesting; the child reschedules itself into that run.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Author a self-reschedule action gated by an IF condition (Priority: P1)
+
+As a sequence author, I want to add a "reschedule this sequence" action inside a sequence and place it behind an IF condition, so that the sequence decides at runtime — based on what it observes (a command result or an image detection) — whether to schedule another firing of itself into the queue run it is part of.
+
+**Why this priority**: This is the core of the request: an author-controlled, condition-driven, in-sequence reschedule. Without the authored action and its conditional gating, none of the rescheduling behavior can be expressed or observed. It is the smallest slice that delivers value on its own.
+
+**Independent Test**: In the sequence editor, add the self-reschedule action under an IF branch whose condition is forced true; run a queue that includes the sequence; confirm the sequence fires a second time during the same run as a direct result of the action, and that forcing the condition false in another run produces no additional firing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence containing a self-reschedule action behind an IF condition that evaluates true, **When** the sequence runs as part of a queue, **Then** the action executes and an additional firing of that same sequence is scheduled into the current run.
+2. **Given** the same sequence where the IF condition evaluates false, **When** it runs as part of a queue, **Then** the self-reschedule action is not reached and no additional firing is scheduled.
+3. **Given** a sequence with the self-reschedule action, **When** the author opens the sequence editor, **Then** the action is visible, configurable, and can be placed inside conditional branches like other sequence actions.
+4. **Given** the self-reschedule action executes successfully, **When** the sequence continues, **Then** the rest of the sequence's steps still run normally (the action does not, by itself, terminate the sequence).
+
+---
+
+### User Story 2 - Choose any schedule option when rescheduling (Priority: P1)
+
+As a sequence author, I want the self-reschedule action to offer every schedule option the queue supports — At Queue Start, Once Per Run, Timer (time-of-day and relative offset), and After Every Step — with the same configuration choices I get when scheduling a sequence in a template, so I can control *when* within the run the re-firing happens.
+
+**Why this priority**: The user explicitly asked to "use all the possible options." Option parity is what makes the action general-purpose rather than a single hard-coded re-fire. It is independently demonstrable by configuring each option and observing the corresponding timing.
+
+**Independent Test**: For each schedule option, configure the action with that option (and its parameters where applicable), run the queue, and confirm the re-firing occurs at the moment dictated by that option (immediately/next normal step for Once Per Run; at the configured/elapsed time for Timer; after each subsequent normal step for After Every Step; at the start of the next cycle for At Queue Start).
+
+**Acceptance Scenarios**:
+
+1. **Given** the action configured as **Once Per Run**, **When** it executes, **Then** the sequence is scheduled as an additional normal step for the current run (fired again within the run rather than at a timed boundary).
+2. **Given** the action configured as **Timer** with a relative offset (e.g., 10 min 0 sec), **When** it executes, **Then** the offset is measured from the moment of execution and the sequence fires once at the first iteration boundary at or after that instant — identical to a live relative schedule (feature 059).
+3. **Given** the action configured as **Timer** with a time-of-day, **When** it executes, **Then** the sequence fires once at the first iteration boundary at or after that wall-clock time during the current run.
+4. **Given** the action configured as **After Every Step**, **When** it executes, **Then** the sequence is registered to fire after each subsequent normal step for the remainder of the current run, and it does not retrigger the self-reschedule action in a way that creates an endless loop (loop-safety as established in feature 060).
+5. **Given** the action configured as **At Queue Start**, **When** it executes during a cycling run, **Then** the sequence is scheduled to fire at the start of the next cycle; **and** during a non-cycling run where no further start boundary exists, the action falls back to firing at the next iteration boundary.
+6. **Given** any option that has additional parameters (timer time/offset), **When** the author selects that option in the editor, **Then** the relevant parameter inputs appear, matching the inputs used when scheduling a sequence in a template.
+
+---
+
+### User Story 3 - No-op with success when not started from a queue (Priority: P1)
+
+As a sequence author, I want a sequence containing the self-reschedule action to still run correctly when it is executed outside any queue (e.g., standalone from the authoring UI or as a nested sequence not driven by a queue run), with the action simply doing nothing and reporting success, so that the same sequence is safe to reuse in both contexts.
+
+**Why this priority**: Sequences are reused across contexts. If the action failed or errored when there is no originating queue, authors could not safely place it in shared sequences. Making it a successful no-op is an explicit requirement and is independently testable.
+
+**Independent Test**: Run a sequence containing the self-reschedule action standalone (not from a queue); confirm the action is recorded as executed-but-no-op with a success outcome, the sequence completes normally, and nothing is scheduled anywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence with the self-reschedule action, **When** it runs standalone (not started from a queue), **Then** the action performs no scheduling and reports success.
+2. **Given** the standalone run from scenario 1, **When** the execution log is inspected, **Then** the action appears with a success status and a clear note that there was no originating queue, so no reschedule was performed.
+3. **Given** the standalone run, **When** the sequence continues after the action, **Then** the remaining steps execute normally and the sequence's overall outcome is unaffected by the no-op.
+
+---
+
+### User Story 4 - See the reschedule reflected in the execution logs (Priority: P2)
+
+As an operator reviewing a run afterward, I want each self-reschedule decision and the firing it produced to appear in the execution logs, so I can understand why the sequence ran more times than the template alone would explain.
+
+**Why this priority**: Observability of an otherwise-invisible runtime decision. The feature still works without rich logging, but the user explicitly asked that the reschedule "be reflected in the execution logs later on," and operators need to reconcile run behavior with the static template.
+
+**Independent Test**: Trigger a self-reschedule during a run, let the rescheduled firing occur, then open the execution logs and confirm both the reschedule action (with its chosen option and resolved timing) and the resulting additional firing are visible and attributable to the originating sequence.
+
+**Acceptance Scenarios**:
+
+1. **Given** a self-reschedule action that executed and scheduled a firing, **When** the execution log is viewed, **Then** the action entry records the chosen schedule option, the resolved timing (e.g., target instant for a timer), and that the schedule applies to the current run only.
+2. **Given** the rescheduled firing later occurs, **When** the execution log is viewed, **Then** the additional firing appears as an executed sequence in the run, consistent with how other scheduled/live firings are logged (features 059, 063).
+3. **Given** a reschedule that could not be applied (e.g., the run ended before the firing was due), **When** the execution log is viewed, **Then** the action entry indicates the reschedule was accepted but did not fire within the run, without marking the run a failure.
+4. **Given** the no-op case (no originating queue), **When** the execution log is viewed, **Then** the action entry clearly distinguishes "no-op, not started from a queue" from "scheduled."
+
+---
+
+### Edge Cases
+
+- **No originating queue**: Sequence run standalone or nested outside a queue run → action is a successful no-op (US3).
+- **Repeated rescheduling / loops**: The action can be reached on the rescheduled firing too. Because it is gated by the author's IF condition and (per Assumptions) schedules at most one additional firing per execution, runaway looping is the author's responsibility — the same model as in-sequence cycles (feature 031, which requires explicit max-iteration limits) and re-issued live schedules (feature 059).
+- **Run is ending / last step**: A timer or At-Queue-Start reschedule whose due moment never arrives before the run completes does not fire and does not make the run a failure (consistent with feature 053 non-cyclic timer behavior).
+- **Relative offset of 0 / past time-of-day**: The sequence fires at the next iteration boundary.
+- **Multiple self-reschedules in one run**: Each accepted reschedule is an independent firing; the run's executed-step total reflects each, consistent with features 059/060.
+- **Manual stop mid-run**: A pending self-rescheduled firing that has not yet occurred is abandoned when the run is stopped/aborted (consistent with feature 051 abort behavior).
+- **Sequence appears multiple times in the template**: The reschedule targets the sequence as run within the current queue run; it adds an additional firing rather than altering existing template entries.
+- **After Every Step self-trigger**: An After-Every-Step reschedule must not cause the self-reschedule action to fire itself in an unbounded chain (loop-safety, feature 060).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a sequence action, configurable in the sequence authoring UI, that reschedules the currently running sequence into the queue run it was started from.
+- **FR-001a**: The self-reschedule action MUST be part of the persisted sequence definition and round-trip through the authoring API (create/read/update) like any other sequence action, preserving UI/API parity.
+- **FR-002**: The self-reschedule action MUST be placeable within the sequence's existing IF/conditional structure, so its execution is gated by the same condition logic available to other actions (features 031–033).
+- **FR-003**: When executed within a queue run, the action MUST schedule one additional firing of the same sequence into the **current** queue run.
+- **FR-004**: The action MUST offer all schedule options available when scheduling a sequence in a queue: At Queue Start, Once Per Run, Timer (time-of-day and relative offset), and After Every Step, with the same parameter inputs used elsewhere for those options.
+- **FR-005**: For the **Timer / relative offset** option, the offset MUST be measured from the moment the action executes ("from now") and resolve to a single target instant for the current run, matching live relative scheduling (feature 059).
+- **FR-006**: For the **Timer / time-of-day** option, the firing MUST occur at the first iteration boundary at or after that wall-clock time during the current run.
+- **FR-007**: For the **Once Per Run** option, the rescheduled firing MUST be appended after the remaining Once-Per-Run steps of the current cycle, so it runs again before that cycle ends.
+- **FR-008**: For the **After Every Step** option, the sequence MUST be registered to fire after each subsequent normal step for the remainder of the run, and this MUST be loop-safe (it does not retrigger the self-reschedule action into an endless chain), consistent with feature 060.
+- **FR-009**: For the **At Queue Start** option in a cycling run, the rescheduled firing MUST occur at the start of the next cycle; in a non-cycling run with no further start boundary, it MUST fall back to firing at the next iteration boundary.
+- **FR-010**: The reschedule MUST apply only to the current queue run and MUST NOT be persisted to the queue template or any saved configuration.
+- **FR-011**: When the sequence was not started from a queue, the action MUST perform no scheduling and MUST report a successful outcome (no-op success).
+- **FR-012**: The action's execution MUST NOT, by itself, terminate the sequence; remaining steps continue regardless of whether a reschedule was performed or was a no-op.
+- **FR-013**: The execution log MUST record each self-reschedule action with: its chosen schedule option, the resolved timing (where applicable), and whether it scheduled a firing or was a no-op (with the reason for the no-op).
+- **FR-014**: The execution log MUST show the resulting rescheduled firing as an executed sequence within the run, consistent with how other live/scheduled firings are logged (features 059, 063), and attributable to the originating sequence.
+- **FR-015**: A self-reschedule that is accepted but whose firing never becomes due before the run ends MUST NOT mark the run as failed; the log MUST indicate it did not fire within the run.
+- **FR-016**: Rescheduled firings MUST count toward the run's executed-sequence total/metrics consistently with other scheduled/live firings (features 059, 060), while run termination remains governed by the once-per-run steps.
+- **FR-017**: A pending self-rescheduled firing that has not yet occurred MUST be abandoned if the run is stopped or aborted (feature 051).
+- **FR-018**: The originating queue run MUST propagate through sequence nesting: a sequence executed as a nested/child of a queue-driven run MUST treat that run as its originating queue run, and the self-reschedule MUST schedule an additional firing of that child sequence into the run.
+
+### Key Entities
+
+- **Self-Reschedule Action**: An authorable sequence action carrying the chosen schedule option and its parameters (timer time-of-day / relative offset where applicable). Lives inside a sequence definition and may sit under conditional branches.
+- **Ephemeral Run Schedule Entry**: A run-scoped, non-persisted record that a sequence is to fire again in the current run, with a resolved option/timing. Exists only for the lifetime of the run.
+- **Execution Log Entry (reschedule)**: A log record capturing the action's decision (option, resolved timing, scheduled vs. no-op + reason) and, separately, the resulting additional firing of the sequence.
+- **Originating Queue Run Context**: The information that tells a running sequence which queue run (if any) started it — propagated through sequence nesting — used to decide between "schedule into this run" and "no-op success."
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An author can add and configure the self-reschedule action — including selecting any of the available schedule options — entirely from the sequence editor, without editing files or calling the API directly.
+- **SC-002**: When a gated self-reschedule action's condition is true during a queue run, the sequence fires again within that same run 100% of the time, at the timing dictated by the chosen option.
+- **SC-003**: The same sequence containing the action runs to a successful completion when executed standalone, with zero scheduling side effects, 100% of the time.
+- **SC-004**: After any run that triggered a self-reschedule, an operator can identify, from the execution logs alone, that a reschedule occurred, which option was used, and that the extra firing came from the self-reschedule (not the static template).
+- **SC-005**: No self-reschedule is ever observable in the queue's saved template or configuration after the run ends (0 persisted reschedules across runs).
+- **SC-006**: The reschedule decision adds no more than a negligible delay to sequence execution (consistent with the conditional-step budget of p95 ≤ 200 ms established in feature 031).
+
+## Assumptions
+
+- **One firing per execution**: Each execution of the action schedules at most one additional firing. Repeated re-firing is achieved only by the action being reached again (on a later step or a rescheduled firing) with its condition still true — there is no built-in automatic recurrence and no built-in recurrence cap; loop control is the author's responsibility via the IF condition, mirroring features 059 (re-issued live schedules) and 031 (cycles need explicit limits).
+- **Option semantics reuse existing behavior**: Each schedule option behaves for the current run exactly as that option behaves when configured live/in a template (features 053, 059, 060), applied to the originating sequence. The only novel interpretation is **At Queue Start mid-run**, defined in FR-009.
+- **Counting**: Rescheduled firings count toward the run's executed-sequence totals like other scheduled/live firings (features 059, 060); they do not change the run's stop condition.
+- **Configuration surface**: The primary authoring surface is the sequence editor ("from UI"). Per clarification, the action is also part of the persisted sequence definition and round-trips through the authoring API with full UI/API parity (FR-001a).
+- **Target identity**: "Reschedule itself" means the same sequence definition currently executing; the reschedule adds a firing to the current run and does not modify or depend on whether that sequence is already an entry in the running template.
+- **No-op breadth**: "Not started from a queue" covers any execution context lacking an originating queue run (standalone authoring runs, or nested executions whose top-level run is not a queue run). A sequence nested under a queue-driven run **does** have an originating queue run (origin propagates through nesting) and reschedules itself into that run (FR-018).

--- a/specs/065-sequence-self-reschedule/tasks.md
+++ b/specs/065-sequence-self-reschedule/tasks.md
@@ -31,8 +31,8 @@ Web UI: `src/web-ui/src/` with colocated `__tests__/`.
 
 **Purpose**: Confirm a green baseline and create the new namespace location.
 
-- [ ] T001 Verify baseline is green: `dotnet build` + `dotnet test`, and `src/web-ui` `vite build` + `jest` (constitution NON-NEGOTIABLE gate — do not start implementation on a red baseline)
-- [ ] T002 [P] Create the `src/GameBot.Domain/Commands/SelfReschedule/` folder for the new action types
+- [X] T001 Verify baseline is green: `dotnet build` + `dotnet test`, and `src/web-ui` `vite build` + `jest` (constitution NON-NEGOTIABLE gate — do not start implementation on a red baseline)
+- [X] T002 [P] Create the `src/GameBot.Domain/Commands/SelfReschedule/` folder for the new action types
 
 **Checkpoint**: Baseline confirmed green; namespace folder ready.
 
@@ -46,26 +46,26 @@ skeleton. No option behavior or logging detail yet.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T003 [P] Add `RescheduleSelf = "reschedule-self"` to `src/GameBot.Domain/Actions/ActionTypes.cs`
-- [ ] T004 [P] Create `SelfRescheduleOption` enum (`AtQueueStart | OncePerRun | Timer | EveryStep`) in `src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOption.cs`
-- [ ] T005 [P] Create `SelfReschedulePayload` (typed reader over `SequenceActionPayload.Parameters`: `Option`, `TimerTimeOfDay?`, `TimerRelativeOffset?`) in `src/GameBot.Domain/Commands/SelfReschedule/SelfReschedulePayload.cs` (depends on T004)
-- [ ] T006 [P] Add `OriginatingQueueId` (`string?`) to `src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs`
-- [ ] T007 Create `IQueueRunRegistry` (TryAdd / TryGet / Remove over active `QueueRunHandle`s) in `src/GameBot.Service/Services/QueueExecution/IQueueRunRegistry.cs`
-- [ ] T008 Implement `QueueRunRegistry` (singleton owning `ConcurrentDictionary<string,QueueRunHandle>`) in `src/GameBot.Service/Services/QueueExecution/QueueRunRegistry.cs` (depends on T007)
-- [ ] T009 Refactor `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` to use `IQueueRunRegistry` instead of the private `_runs` dictionary (register on start, lookup in `ScheduleRelative`, remove in `RunAsync` finally) (depends on T008)
-- [ ] T010 Add the four ephemeral registers + `SelfRescheduleEntry` record (`PendingOncePerRun`, `PendingNextCycleStart`, `PendingTimerFirings`, `EveryStepInjections`) to `src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs` (depends on T004)
-- [ ] T011 Create `ISelfRescheduleCoordinator` + `SelfRescheduleResult` + `SelfRescheduleOutcome` (`Scheduled | NotRunning`) in `src/GameBot.Service/Services/QueueExecution/ISelfRescheduleCoordinator.cs` (depends on T004)
-- [ ] T012 Create `SelfRescheduleCoordinator` skeleton (ctor deps: `IQueueRunRegistry`, `ISequenceRepository`, `TimeProvider`; `ScheduleSelf` throws `NotImplemented` per option for now) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs` (depends on T008, T010, T011)
-- [ ] T013 Register `IQueueRunRegistry` and `ISelfRescheduleCoordinator` as singletons in `src/GameBot.Service/Program.cs` (depends on T008, T012)
-- [ ] T014 Add optional `actionDispatcher` callback (`Func<SequenceActionPayload,CancellationToken,Task<ActionDispatchResult>>?`) to `SequenceRunner.ExecuteAsync`; in `ExecuteSingleStepAsync`, dispatch a `reschedule-self` action step through it before the command fallback, record the returned outcome as the step result, and never early-stop, in `src/GameBot.Domain/Services/SequenceRunner.cs` (depends on T003)
-- [ ] T015 In `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`: read `parentContext.OriginatingQueueId`, copy it onto every child `ExecutionLogContext` it builds (origin-through-nesting, FR-018), and supply an `actionDispatcher` that calls `ISelfRescheduleCoordinator` (or short-circuits to no-op when the id is empty) (depends on T006, T012, T014)
-- [ ] T016 In `QueueExecutionService.RunOneSequenceAsync`, set `OriginatingQueueId = queue.Id` on the parent `ExecutionLogContext` so queue-driven firings are marked as queue-originated, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (depends on T006)
+- [X] T003 [P] Add `RescheduleSelf = "reschedule-self"` to `src/GameBot.Domain/Actions/ActionTypes.cs`
+- [X] T004 [P] Create `SelfRescheduleOption` enum (`AtQueueStart | OncePerRun | Timer | EveryStep`) in `src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOption.cs`
+- [X] T005 [P] Create `SelfReschedulePayload` (typed reader over `SequenceActionPayload.Parameters`: `Option`, `TimerTimeOfDay?`, `TimerRelativeOffset?`) in `src/GameBot.Domain/Commands/SelfReschedule/SelfReschedulePayload.cs` (depends on T004)
+- [X] T006 [P] Add `OriginatingQueueId` (`string?`) to `src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs`
+- [X] T007 Create `IQueueRunRegistry` (TryAdd / TryGet / Remove over active `QueueRunHandle`s) in `src/GameBot.Service/Services/QueueExecution/IQueueRunRegistry.cs`
+- [X] T008 Implement `QueueRunRegistry` (singleton owning `ConcurrentDictionary<string,QueueRunHandle>`) in `src/GameBot.Service/Services/QueueExecution/QueueRunRegistry.cs` (depends on T007)
+- [X] T009 Refactor `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` to use `IQueueRunRegistry` instead of the private `_runs` dictionary (register on start, lookup in `ScheduleRelative`, remove in `RunAsync` finally) (depends on T008)
+- [X] T010 Add the four ephemeral registers + `SelfRescheduleEntry` record (`PendingOncePerRun`, `PendingNextCycleStart`, `PendingTimerFirings`, `EveryStepInjections`) to `src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs` (depends on T004)
+- [X] T011 Create `ISelfRescheduleCoordinator` + `SelfRescheduleResult` + `SelfRescheduleOutcome` (`Scheduled | NotRunning`) in `src/GameBot.Service/Services/QueueExecution/ISelfRescheduleCoordinator.cs` (depends on T004)
+- [X] T012 Create `SelfRescheduleCoordinator` skeleton (ctor deps: `IQueueRunRegistry`, `ISequenceRepository`, `TimeProvider`; `ScheduleSelf` throws `NotImplemented` per option for now) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs` (depends on T008, T010, T011)
+- [X] T013 Register `IQueueRunRegistry` and `ISelfRescheduleCoordinator` as singletons in `src/GameBot.Service/Program.cs` (depends on T008, T012)
+- [X] T014 Add optional `actionDispatcher` callback (`Func<SequenceActionPayload,CancellationToken,Task<ActionDispatchResult>>?`) to `SequenceRunner.ExecuteAsync`; in `ExecuteSingleStepAsync`, dispatch a `reschedule-self` action step through it before the command fallback, record the returned outcome as the step result, and never early-stop, in `src/GameBot.Domain/Services/SequenceRunner.cs` (depends on T003)
+- [X] T015 In `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`: read `parentContext.OriginatingQueueId`, copy it onto every child `ExecutionLogContext` it builds (origin-through-nesting, FR-018), and supply an `actionDispatcher` that calls `ISelfRescheduleCoordinator` (or short-circuits to no-op when the id is empty) (depends on T006, T012, T014)
+- [X] T016 In `QueueExecutionService.RunOneSequenceAsync`, set `OriginatingQueueId = queue.Id` on the parent `ExecutionLogContext` so queue-driven firings are marked as queue-originated, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (depends on T006)
 
 ### Foundational tests
 
-- [ ] T017 [P] Unit test `QueueRunRegistry` add/get/remove + isolation in `tests/unit/Queues/QueueRunRegistryTests.cs` (depends on T008)
-- [ ] T018 [P] Unit test `SelfReschedulePayload` parsing of option + timer fields from a `SequenceActionPayload` in `tests/unit/Sequences/SelfReschedulePayloadTests.cs` (depends on T005)
-- [ ] T019 [P] Unit test `SequenceRunner` dispatches a `reschedule-self` action step through the callback, records the outcome, and continues (non-terminating, FR-012); also assert the dispatch path performs no I/O / ADB call (SC-006), in `tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs` (depends on T014)
+- [X] T017 [P] Unit test `QueueRunRegistry` add/get/remove + isolation in `tests/unit/Queues/QueueRunRegistryTests.cs` (depends on T008)
+- [X] T018 [P] Unit test `SelfReschedulePayload` parsing of option + timer fields from a `SequenceActionPayload` in `tests/unit/Sequences/SelfReschedulePayloadTests.cs` (depends on T005)
+- [X] T019 [P] Unit test `SequenceRunner` dispatches a `reschedule-self` action step through the callback, records the outcome, and continues (non-terminating, FR-012); also assert the dispatch path performs no I/O / ADB call (SC-006), in `tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs` (depends on T014)
 
 **Checkpoint**: Action type, payload, origin propagation, registry, runner dispatch, and coordinator
 shell are in place and unit-covered. User stories can now begin.
@@ -84,22 +84,22 @@ confirm no additional firing.
 
 ### Tests for User Story 1 ⚠️ (write first, ensure they FAIL)
 
-- [ ] T020 [P] [US1] Contract test: a sequence with a `reschedule-self` action (option `OncePerRun`) round-trips unchanged through create/read/update, and the action validates as accepted, in `tests/contract/Sequences/SelfRescheduleActionContractTests.cs`
-- [ ] T021 [P] [US1] Unit test: `SelfRescheduleCoordinator.ScheduleSelf` with `OncePerRun` injects a `SelfRescheduleEntry` into the run's `PendingOncePerRun`, in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
-- [ ] T021a [P] [US1] Unit test: `ScheduleSelf` against a queue with no active run (run removed mid-sequence) returns `NotRunning` and is treated as a logged no-op (data-model §5 race), in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
-- [ ] T022 [P] [US1] Unit test: the run loop drains `PendingOncePerRun` after the once-per-run pass of the current cycle (fires before the cycle ends) and counts the firing toward `executed`, in `tests/unit/Queues/QueueExecutionServiceTests.cs`
-- [ ] T022a [P] [US1] Unit/integration test: two accepted self-reschedules of the same sequence in one run produce two independent firings (validates the list-based registers vs. most-recent-wins, edge case "Multiple self-reschedules in one run"), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
-- [ ] T023 [P] [US1] Integration test: a queue run whose sequence self-reschedules behind an IF forced true produces a second firing; forced false produces exactly one firing; also assert that when the sequence already appears multiple times in the template the reschedule *adds* a firing rather than altering existing entries (edge case), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
-- [ ] T023a [P] [US1] Integration test: a nested child sequence of a queue-driven run self-reschedules into the parent's queue run — origin propagates through nesting (FR-018, clarification Q5), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
-- [ ] T024 [P] [US1] web-ui Jest: author a `reschedule-self` action inside an IF branch in the sequence editor and confirm it serializes/round-trips, in `src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx`
+- [X] T020 [P] [US1] Contract test: a sequence with a `reschedule-self` action (option `OncePerRun`) round-trips unchanged through create/read/update, and the action validates as accepted, in `tests/contract/Sequences/SelfRescheduleActionContractTests.cs`
+- [X] T021 [P] [US1] Unit test: `SelfRescheduleCoordinator.ScheduleSelf` with `OncePerRun` injects a `SelfRescheduleEntry` into the run's `PendingOncePerRun`, in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [X] T021a [P] [US1] Unit test: `ScheduleSelf` against a queue with no active run (run removed mid-sequence) returns `NotRunning` and is treated as a logged no-op (data-model §5 race), in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [X] T022 [P] [US1] Unit test: the run loop drains `PendingOncePerRun` after the once-per-run pass of the current cycle (fires before the cycle ends) and counts the firing toward `executed`, in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+- [X] T022a [P] [US1] Unit/integration test: two accepted self-reschedules of the same sequence in one run produce two independent firings (validates the list-based registers vs. most-recent-wins, edge case "Multiple self-reschedules in one run"), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [X] T023 [P] [US1] Integration test: a queue run whose sequence self-reschedules behind an IF forced true produces a second firing; forced false produces exactly one firing; also assert that when the sequence already appears multiple times in the template the reschedule *adds* a firing rather than altering existing entries (edge case), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [X] T023a [P] [US1] Integration test: a nested child sequence of a queue-driven run self-reschedules into the parent's queue run — origin propagates through nesting (FR-018, clarification Q5), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [X] T024 [P] [US1] web-ui Jest: author a `reschedule-self` action inside an IF branch in the sequence editor and confirm it serializes/round-trips, in `src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx`
 
 ### Implementation for User Story 1
 
-- [ ] T025 [US1] Implement `ScheduleSelf` for `OncePerRun` (enqueue onto `PendingOncePerRun`, return `Scheduled`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
-- [ ] T026 [US1] In the run loop, drain `PendingOncePerRun` immediately after the once-per-run pass within the current cycle, firing each entry via `RunOneSequenceAsync` and counting toward `executed`, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (depends on T025)
-- [ ] T027 [US1] In the `SequenceExecutionService` dispatcher, record the action as a sequence step with outcome `scheduled`/`executed` + a message (basic decision entry) for the queue-run case; the no-queue no-op wording is handled in US3 (T046), in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
-- [ ] T028 [US1] Recognize `reschedule-self` as a supported action type and require a valid `option` in `src/GameBot.Domain/Services/ActionPayloadValidationService.cs`
-- [ ] T029 [US1] Add the `reschedule-self` action type to the sequence editor (third `actionType` alongside `command`/`WaitForImage`) with a `Once Per Run` option and payload serialization, in `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/types/sequenceFlow.ts`
+- [X] T025 [US1] Implement `ScheduleSelf` for `OncePerRun` (enqueue onto `PendingOncePerRun`, return `Scheduled`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [X] T026 [US1] In the run loop, drain `PendingOncePerRun` immediately after the once-per-run pass within the current cycle, firing each entry via `RunOneSequenceAsync` and counting toward `executed`, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (depends on T025)
+- [X] T027 [US1] In the `SequenceExecutionService` dispatcher, record the action as a sequence step with outcome `scheduled`/`executed` + a message (basic decision entry) for the queue-run case; the no-queue no-op wording is handled in US3 (T046), in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [X] T028 [US1] Recognize `reschedule-self` as a supported action type and require a valid `option` in `src/GameBot.Domain/Services/ActionPayloadValidationService.cs`
+- [X] T029 [US1] Add the `reschedule-self` action type to the sequence editor (third `actionType` alongside `command`/`WaitForImage`) with a `Once Per Run` option and payload serialization, in `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/types/sequenceFlow.ts`
 
 **Checkpoint**: US1 fully functional — the IF-gated action fires the sequence again (Once Per Run)
 within the run and round-trips through authoring.
@@ -118,23 +118,23 @@ At Queue Start, with non-cycling fallback to the next iteration boundary).
 
 ### Tests for User Story 2 ⚠️ (write first, ensure they FAIL)
 
-- [ ] T030 [P] [US2] Unit test: `Timer` relative offset resolves `now+offset` and fires once at the first boundary at/after it (fake `TimeProvider`); include the offset-0 case firing at the next boundary (edge case), in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
-- [ ] T031 [P] [US2] Unit test: `Timer` time-of-day resolves to `today@time` (past ⇒ next boundary) and fires once, in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
-- [ ] T032 [P] [US2] Unit test: `EveryStep` fires after each subsequent normal step and is loop-safe/idempotent per sequence (no unbounded self-chain), in `tests/unit/Queues/QueueExecutionServiceTests.cs`
-- [ ] T033 [P] [US2] Unit test: `AtQueueStart` on a cycling run fires at next cycle start; on a non-cycling run falls back to the next iteration boundary, in `tests/unit/Queues/QueueExecutionServiceTests.cs`
-- [ ] T034 [P] [US2] Contract test: validation rejects `Timer` with both/neither timer fields, a negative offset, and a timer field on a non-`Timer` option, in `tests/contract/Sequences/SelfRescheduleActionContractTests.cs`
-- [ ] T035 [P] [US2] web-ui Jest: the option dropdown offers all four options and, for `Timer`, shows time-of-day vs relative-offset inputs matching the queue-template editor, in `src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx`
+- [X] T030 [P] [US2] Unit test: `Timer` relative offset resolves `now+offset` and fires once at the first boundary at/after it (fake `TimeProvider`); include the offset-0 case firing at the next boundary (edge case), in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [X] T031 [P] [US2] Unit test: `Timer` time-of-day resolves to `today@time` (past ⇒ next boundary) and fires once, in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [X] T032 [P] [US2] Unit test: `EveryStep` fires after each subsequent normal step and is loop-safe/idempotent per sequence (no unbounded self-chain), in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+- [X] T033 [P] [US2] Unit test: `AtQueueStart` on a cycling run fires at next cycle start; on a non-cycling run falls back to the next iteration boundary, in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+- [X] T034 [P] [US2] Contract test: validation rejects `Timer` with both/neither timer fields, a negative offset, and a timer field on a non-`Timer` option, in `tests/contract/Sequences/SelfRescheduleActionContractTests.cs`
+- [X] T035 [P] [US2] web-ui Jest: the option dropdown offers all four options and, for `Timer`, shows time-of-day vs relative-offset inputs matching the queue-template editor, in `src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx`
 
 ### Implementation for User Story 2
 
-- [ ] T036 [US2] Implement `ScheduleSelf` `Timer` (relative + time-of-day → resolved `FireAt` into `PendingTimerFirings`, via `TimeProvider`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
-- [ ] T037 [US2] Implement `ScheduleSelf` `EveryStep` (idempotent insert into `EveryStepInjections` keyed by sequence id) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
-- [ ] T038 [US2] Implement `ScheduleSelf` `AtQueueStart` (cycling ⇒ `PendingNextCycleStart`; non-cycling ⇒ `PendingOncePerRun` fallback, decided from `queue.CycleExecution`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
-- [ ] T039 [US2] Run loop: drain `PendingTimerFirings` at each iteration boundary when `now ≥ FireAt`, fire once, remove, count toward `executed`, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
-- [ ] T040 [US2] Run loop: drain a snapshot of `EveryStepInjections` after each subsequent normal step (loop-safe; not counted toward `executed`), in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
-- [ ] T041 [US2] Run loop: drain `PendingNextCycleStart` at the top of the next cycle before the once-per-run pass, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
-- [ ] T042 [US2] Extend validation: `Timer` mutual-exclusivity + non-negative offset (reuse feature 059 `RelativeOffsetParser` bound) + option-specific timer rules, in `src/GameBot.Domain/Services/ActionPayloadValidationService.cs`
-- [ ] T043 [US2] web-ui: option dropdown (all four) + `Timer` time-of-day/relative-offset inputs mirroring `QueueEntryList.tsx`, in `src/web-ui/src/pages/SequencesPage.tsx` (+ a `components/sequences/RescheduleActionConfig.tsx` if the page grows too large)
+- [X] T036 [US2] Implement `ScheduleSelf` `Timer` (relative + time-of-day → resolved `FireAt` into `PendingTimerFirings`, via `TimeProvider`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [X] T037 [US2] Implement `ScheduleSelf` `EveryStep` (idempotent insert into `EveryStepInjections` keyed by sequence id) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [X] T038 [US2] Implement `ScheduleSelf` `AtQueueStart` (cycling ⇒ `PendingNextCycleStart`; non-cycling ⇒ `PendingOncePerRun` fallback, decided from `queue.CycleExecution`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [X] T039 [US2] Run loop: drain `PendingTimerFirings` at each iteration boundary when `now ≥ FireAt`, fire once, remove, count toward `executed`, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [X] T040 [US2] Run loop: drain a snapshot of `EveryStepInjections` after each subsequent normal step (loop-safe; not counted toward `executed`), in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [X] T041 [US2] Run loop: drain `PendingNextCycleStart` at the top of the next cycle before the once-per-run pass, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [X] T042 [US2] Extend validation: `Timer` mutual-exclusivity + non-negative offset (reuse feature 059 `RelativeOffsetParser` bound) + option-specific timer rules, in `src/GameBot.Domain/Services/ActionPayloadValidationService.cs`
+- [X] T043 [US2] web-ui: option dropdown (all four) + `Timer` time-of-day/relative-offset inputs mirroring `QueueEntryList.tsx`, in `src/web-ui/src/pages/SequencesPage.tsx` (+ a `components/sequences/RescheduleActionConfig.tsx` if the page grows too large)
 
 **Checkpoint**: US1 and US2 both work — every option fires at its correct moment with template-parity
 inputs.
@@ -151,13 +151,13 @@ recorded executed-but-no-op with success, the sequence completes normally, and n
 
 ### Tests for User Story 3 ⚠️ (write first, ensure they FAIL)
 
-- [ ] T044 [P] [US3] Unit test: the dispatcher returns a success no-op (no coordinator call) when `OriginatingQueueId` is null/empty, in `tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs`
-- [ ] T045 [P] [US3] Integration test: a standalone sequence run (no queue) records the action as success no-op, schedules nothing, and runs the remaining steps, in `tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs`
+- [X] T044 [P] [US3] Unit test: the dispatcher returns a success no-op (no coordinator call) when `OriginatingQueueId` is null/empty, in `tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs`
+- [X] T045 [P] [US3] Integration test: a standalone sequence run (no queue) records the action as success no-op, schedules nothing, and runs the remaining steps, in `tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T046 [US3] In the dispatcher, when `OriginatingQueueId` is empty, perform no scheduling and record a success no-op step with reason "no originating queue, no reschedule performed", in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
-- [ ] T047 [US3] Confirm the standalone `sequences/{id}/execute` path leaves `OriginatingQueueId` unset (no parent queue context); add a regression assertion in `tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs`
+- [X] T046 [US3] In the dispatcher, when `OriginatingQueueId` is empty, perform no scheduling and record a success no-op step with reason "no originating queue, no reschedule performed", in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [X] T047 [US3] Confirm the standalone `sequences/{id}/execute` path leaves `OriginatingQueueId` unset (no parent queue context); add a regression assertion in `tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs`
 
 **Checkpoint**: The same sequence is safe in both queue and standalone contexts.
 
@@ -174,14 +174,14 @@ an accepted-but-never-due reschedule shows "did not fire" without failing the ru
 
 ### Tests for User Story 4 ⚠️ (write first, ensure they FAIL)
 
-- [ ] T048 [P] [US4] Integration test: logs show the action entry (chosen option, resolved timing, current-run-only) and the rescheduled firing tagged as self-reschedule-originated and attributable to the sequence, in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
-- [ ] T049 [P] [US4] Unit test: a reschedule accepted but not yet due when the run is stopped is abandoned (no firing), the run is not marked failed, and the log indicates it did not fire (FR-015/FR-017), in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+- [X] T048 [P] [US4] Integration test: logs show the action entry (chosen option, resolved timing, current-run-only) and the rescheduled firing tagged as self-reschedule-originated and attributable to the sequence, in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [X] T049 [P] [US4] Unit test: a reschedule accepted but not yet due when the run is stopped is abandoned (no firing), the run is not marked failed, and the log indicates it did not fire (FR-015/FR-017), in `tests/unit/Queues/QueueExecutionServiceTests.cs`
 
 ### Implementation for User Story 4
 
-- [ ] T050 [US4] Enrich the action decision log entry with `option`, resolved timing (target instant / "next cycle" / "this cycle"), and `outcome` (`scheduled`|`noop` + reason), in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
-- [ ] T051 [US4] Tag self-reschedule-originated firings in `RunOneSequenceAsync` with a "scheduled by self-reschedule" note + originating action id for attribution, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
-- [ ] T052 [US4] Ensure accepted-but-never-due entries are discarded at run end without affecting success/failure (run termination stays governed by once-per-run), in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [X] T050 [US4] Enrich the action decision log entry with `option`, resolved timing (target instant / "next cycle" / "this cycle"), and `outcome` (`scheduled`|`noop` + reason), in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [X] T051 [US4] Tag self-reschedule-originated firings in `RunOneSequenceAsync` with a "scheduled by self-reschedule" note + originating action id for attribution, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [X] T052 [US4] Ensure accepted-but-never-due entries are discarded at run end without affecting success/failure (run termination stays governed by once-per-run), in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
 
 **Checkpoint**: All four user stories independently functional and observable.
 
@@ -189,10 +189,10 @@ an accepted-but-never-due reschedule shows "did not fire" without failing the ru
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T053 [P] Update `docs/architecture.md` — add the self-reschedule action to the domain model, capability map, and sequence-action surface; refresh the "Last reviewed" date (constitution Principle V)
-- [ ] T054 [P] Set this spec's `Status` line to Implemented and update `specs/STATUS.md` accordingly
-- [ ] T055 [P] Add a perf note for the run-loop draining change (O(pending) per boundary, no I/O) to the PR description / plan (SC-006, Principle IV)
-- [ ] T056 Run `quickstart.md` end-to-end and confirm full green gates: `dotnet test` + `src/web-ui` `vite build` + `jest`
+- [X] T053 [P] Update `docs/architecture.md` — add the self-reschedule action to the domain model, capability map, and sequence-action surface; refresh the "Last reviewed" date (constitution Principle V)
+- [X] T054 [P] Set this spec's `Status` line to Implemented and update `specs/STATUS.md` accordingly
+- [X] T055 [P] Add a perf note for the run-loop draining change (O(pending) per boundary, no I/O) to the PR description / plan (SC-006, Principle IV)
+- [X] T056 Run `quickstart.md` end-to-end and confirm full green gates: `dotnet test` + `src/web-ui` `vite build` + `jest`
 
 ---
 

--- a/specs/065-sequence-self-reschedule/tasks.md
+++ b/specs/065-sequence-self-reschedule/tasks.md
@@ -1,0 +1,268 @@
+---
+description: "Task list for Sequence Self-Rescheduling into the Originating Queue Run"
+---
+
+# Tasks: Sequence Self-Rescheduling into the Originating Queue Run
+
+**Input**: Design documents from `/specs/065-sequence-self-reschedule/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — the project constitution (Principle II, Testing Standards) makes tests
+mandatory for executable logic, and plan.md commits to them. Write each test before its
+implementation and confirm it fails first.
+
+**Organization**: Tasks are grouped by user story. US1 is the MVP (the authored, IF-gated action that
+fires the sequence again via the Once-Per-Run option). US2 adds option parity, US3 the no-op-success
+path, US4 the execution-log observability.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 / US4 (Setup, Foundational, Polish carry no story label)
+
+## Path Conventions
+
+Backend: `src/GameBot.Domain/`, `src/GameBot.Service/`, tests under `tests/{unit,contract,integration}/`.
+Web UI: `src/web-ui/src/` with colocated `__tests__/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm a green baseline and create the new namespace location.
+
+- [ ] T001 Verify baseline is green: `dotnet build` + `dotnet test`, and `src/web-ui` `vite build` + `jest` (constitution NON-NEGOTIABLE gate — do not start implementation on a red baseline)
+- [ ] T002 [P] Create the `src/GameBot.Domain/Commands/SelfReschedule/` folder for the new action types
+
+**Checkpoint**: Baseline confirmed green; namespace folder ready.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Cross-cutting plumbing every user story needs — the action type/payload, origin
+propagation, the run registry (DI-cycle break), the runner dispatch callback, and the coordinator
+skeleton. No option behavior or logging detail yet.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T003 [P] Add `RescheduleSelf = "reschedule-self"` to `src/GameBot.Domain/Actions/ActionTypes.cs`
+- [ ] T004 [P] Create `SelfRescheduleOption` enum (`AtQueueStart | OncePerRun | Timer | EveryStep`) in `src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOption.cs`
+- [ ] T005 [P] Create `SelfReschedulePayload` (typed reader over `SequenceActionPayload.Parameters`: `Option`, `TimerTimeOfDay?`, `TimerRelativeOffset?`) in `src/GameBot.Domain/Commands/SelfReschedule/SelfReschedulePayload.cs` (depends on T004)
+- [ ] T006 [P] Add `OriginatingQueueId` (`string?`) to `src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs`
+- [ ] T007 Create `IQueueRunRegistry` (TryAdd / TryGet / Remove over active `QueueRunHandle`s) in `src/GameBot.Service/Services/QueueExecution/IQueueRunRegistry.cs`
+- [ ] T008 Implement `QueueRunRegistry` (singleton owning `ConcurrentDictionary<string,QueueRunHandle>`) in `src/GameBot.Service/Services/QueueExecution/QueueRunRegistry.cs` (depends on T007)
+- [ ] T009 Refactor `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` to use `IQueueRunRegistry` instead of the private `_runs` dictionary (register on start, lookup in `ScheduleRelative`, remove in `RunAsync` finally) (depends on T008)
+- [ ] T010 Add the four ephemeral registers + `SelfRescheduleEntry` record (`PendingOncePerRun`, `PendingNextCycleStart`, `PendingTimerFirings`, `EveryStepInjections`) to `src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs` (depends on T004)
+- [ ] T011 Create `ISelfRescheduleCoordinator` + `SelfRescheduleResult` + `SelfRescheduleOutcome` (`Scheduled | NotRunning`) in `src/GameBot.Service/Services/QueueExecution/ISelfRescheduleCoordinator.cs` (depends on T004)
+- [ ] T012 Create `SelfRescheduleCoordinator` skeleton (ctor deps: `IQueueRunRegistry`, `ISequenceRepository`, `TimeProvider`; `ScheduleSelf` throws `NotImplemented` per option for now) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs` (depends on T008, T010, T011)
+- [ ] T013 Register `IQueueRunRegistry` and `ISelfRescheduleCoordinator` as singletons in `src/GameBot.Service/Program.cs` (depends on T008, T012)
+- [ ] T014 Add optional `actionDispatcher` callback (`Func<SequenceActionPayload,CancellationToken,Task<ActionDispatchResult>>?`) to `SequenceRunner.ExecuteAsync`; in `ExecuteSingleStepAsync`, dispatch a `reschedule-self` action step through it before the command fallback, record the returned outcome as the step result, and never early-stop, in `src/GameBot.Domain/Services/SequenceRunner.cs` (depends on T003)
+- [ ] T015 In `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`: read `parentContext.OriginatingQueueId`, copy it onto every child `ExecutionLogContext` it builds (origin-through-nesting, FR-018), and supply an `actionDispatcher` that calls `ISelfRescheduleCoordinator` (or short-circuits to no-op when the id is empty) (depends on T006, T012, T014)
+- [ ] T016 In `QueueExecutionService.RunOneSequenceAsync`, set `OriginatingQueueId = queue.Id` on the parent `ExecutionLogContext` so queue-driven firings are marked as queue-originated, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (depends on T006)
+
+### Foundational tests
+
+- [ ] T017 [P] Unit test `QueueRunRegistry` add/get/remove + isolation in `tests/unit/Queues/QueueRunRegistryTests.cs` (depends on T008)
+- [ ] T018 [P] Unit test `SelfReschedulePayload` parsing of option + timer fields from a `SequenceActionPayload` in `tests/unit/Sequences/SelfReschedulePayloadTests.cs` (depends on T005)
+- [ ] T019 [P] Unit test `SequenceRunner` dispatches a `reschedule-self` action step through the callback, records the outcome, and continues (non-terminating, FR-012); also assert the dispatch path performs no I/O / ADB call (SC-006), in `tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs` (depends on T014)
+
+**Checkpoint**: Action type, payload, origin propagation, registry, runner dispatch, and coordinator
+shell are in place and unit-covered. User stories can now begin.
+
+---
+
+## Phase 3: User Story 1 - Author a self-reschedule action gated by an IF condition (Priority: P1) 🎯 MVP
+
+**Goal**: An author can place a self-reschedule action under an IF branch; when the condition is true
+during a queue run the sequence fires again within the same run (via the Once-Per-Run option); when
+false, no extra firing occurs.
+
+**Independent Test**: Add the action under an IF branch forced true, run a queue containing the
+sequence, confirm a second firing during the same run; force the condition false in another run and
+confirm no additional firing.
+
+### Tests for User Story 1 ⚠️ (write first, ensure they FAIL)
+
+- [ ] T020 [P] [US1] Contract test: a sequence with a `reschedule-self` action (option `OncePerRun`) round-trips unchanged through create/read/update, and the action validates as accepted, in `tests/contract/Sequences/SelfRescheduleActionContractTests.cs`
+- [ ] T021 [P] [US1] Unit test: `SelfRescheduleCoordinator.ScheduleSelf` with `OncePerRun` injects a `SelfRescheduleEntry` into the run's `PendingOncePerRun`, in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [ ] T021a [P] [US1] Unit test: `ScheduleSelf` against a queue with no active run (run removed mid-sequence) returns `NotRunning` and is treated as a logged no-op (data-model §5 race), in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [ ] T022 [P] [US1] Unit test: the run loop drains `PendingOncePerRun` after the once-per-run pass of the current cycle (fires before the cycle ends) and counts the firing toward `executed`, in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+- [ ] T022a [P] [US1] Unit/integration test: two accepted self-reschedules of the same sequence in one run produce two independent firings (validates the list-based registers vs. most-recent-wins, edge case "Multiple self-reschedules in one run"), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [ ] T023 [P] [US1] Integration test: a queue run whose sequence self-reschedules behind an IF forced true produces a second firing; forced false produces exactly one firing; also assert that when the sequence already appears multiple times in the template the reschedule *adds* a firing rather than altering existing entries (edge case), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [ ] T023a [P] [US1] Integration test: a nested child sequence of a queue-driven run self-reschedules into the parent's queue run — origin propagates through nesting (FR-018, clarification Q5), in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [ ] T024 [P] [US1] web-ui Jest: author a `reschedule-self` action inside an IF branch in the sequence editor and confirm it serializes/round-trips, in `src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx`
+
+### Implementation for User Story 1
+
+- [ ] T025 [US1] Implement `ScheduleSelf` for `OncePerRun` (enqueue onto `PendingOncePerRun`, return `Scheduled`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [ ] T026 [US1] In the run loop, drain `PendingOncePerRun` immediately after the once-per-run pass within the current cycle, firing each entry via `RunOneSequenceAsync` and counting toward `executed`, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (depends on T025)
+- [ ] T027 [US1] In the `SequenceExecutionService` dispatcher, record the action as a sequence step with outcome `scheduled`/`executed` + a message (basic decision entry) for the queue-run case; the no-queue no-op wording is handled in US3 (T046), in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [ ] T028 [US1] Recognize `reschedule-self` as a supported action type and require a valid `option` in `src/GameBot.Domain/Services/ActionPayloadValidationService.cs`
+- [ ] T029 [US1] Add the `reschedule-self` action type to the sequence editor (third `actionType` alongside `command`/`WaitForImage`) with a `Once Per Run` option and payload serialization, in `src/web-ui/src/pages/SequencesPage.tsx` and `src/web-ui/src/types/sequenceFlow.ts`
+
+**Checkpoint**: US1 fully functional — the IF-gated action fires the sequence again (Once Per Run)
+within the run and round-trips through authoring.
+
+---
+
+## Phase 4: User Story 2 - Choose any schedule option when rescheduling (Priority: P1)
+
+**Goal**: The action offers all four schedule options with the same inputs as the queue-template
+editor, each firing at the moment its option dictates.
+
+**Independent Test**: Configure the action with each option (and timer params), run the queue, and
+confirm the re-firing occurs at the option's moment (immediately/next step for Once Per Run; at the
+elapsed/target time for Timer; after each subsequent step for After Every Step; next cycle start for
+At Queue Start, with non-cycling fallback to the next iteration boundary).
+
+### Tests for User Story 2 ⚠️ (write first, ensure they FAIL)
+
+- [ ] T030 [P] [US2] Unit test: `Timer` relative offset resolves `now+offset` and fires once at the first boundary at/after it (fake `TimeProvider`); include the offset-0 case firing at the next boundary (edge case), in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [ ] T031 [P] [US2] Unit test: `Timer` time-of-day resolves to `today@time` (past ⇒ next boundary) and fires once, in `tests/unit/Queues/SelfRescheduleCoordinatorTests.cs`
+- [ ] T032 [P] [US2] Unit test: `EveryStep` fires after each subsequent normal step and is loop-safe/idempotent per sequence (no unbounded self-chain), in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+- [ ] T033 [P] [US2] Unit test: `AtQueueStart` on a cycling run fires at next cycle start; on a non-cycling run falls back to the next iteration boundary, in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+- [ ] T034 [P] [US2] Contract test: validation rejects `Timer` with both/neither timer fields, a negative offset, and a timer field on a non-`Timer` option, in `tests/contract/Sequences/SelfRescheduleActionContractTests.cs`
+- [ ] T035 [P] [US2] web-ui Jest: the option dropdown offers all four options and, for `Timer`, shows time-of-day vs relative-offset inputs matching the queue-template editor, in `src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx`
+
+### Implementation for User Story 2
+
+- [ ] T036 [US2] Implement `ScheduleSelf` `Timer` (relative + time-of-day → resolved `FireAt` into `PendingTimerFirings`, via `TimeProvider`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [ ] T037 [US2] Implement `ScheduleSelf` `EveryStep` (idempotent insert into `EveryStepInjections` keyed by sequence id) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [ ] T038 [US2] Implement `ScheduleSelf` `AtQueueStart` (cycling ⇒ `PendingNextCycleStart`; non-cycling ⇒ `PendingOncePerRun` fallback, decided from `queue.CycleExecution`) in `src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs`
+- [ ] T039 [US2] Run loop: drain `PendingTimerFirings` at each iteration boundary when `now ≥ FireAt`, fire once, remove, count toward `executed`, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [ ] T040 [US2] Run loop: drain a snapshot of `EveryStepInjections` after each subsequent normal step (loop-safe; not counted toward `executed`), in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [ ] T041 [US2] Run loop: drain `PendingNextCycleStart` at the top of the next cycle before the once-per-run pass, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [ ] T042 [US2] Extend validation: `Timer` mutual-exclusivity + non-negative offset (reuse feature 059 `RelativeOffsetParser` bound) + option-specific timer rules, in `src/GameBot.Domain/Services/ActionPayloadValidationService.cs`
+- [ ] T043 [US2] web-ui: option dropdown (all four) + `Timer` time-of-day/relative-offset inputs mirroring `QueueEntryList.tsx`, in `src/web-ui/src/pages/SequencesPage.tsx` (+ a `components/sequences/RescheduleActionConfig.tsx` if the page grows too large)
+
+**Checkpoint**: US1 and US2 both work — every option fires at its correct moment with template-parity
+inputs.
+
+---
+
+## Phase 5: User Story 3 - No-op with success when not started from a queue (Priority: P1)
+
+**Goal**: A sequence containing the action runs correctly outside any queue — the action does nothing
+and reports success, with a clear log note.
+
+**Independent Test**: Run a sequence with the action standalone (not from a queue); the action is
+recorded executed-but-no-op with success, the sequence completes normally, and nothing is scheduled.
+
+### Tests for User Story 3 ⚠️ (write first, ensure they FAIL)
+
+- [ ] T044 [P] [US3] Unit test: the dispatcher returns a success no-op (no coordinator call) when `OriginatingQueueId` is null/empty, in `tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs`
+- [ ] T045 [P] [US3] Integration test: a standalone sequence run (no queue) records the action as success no-op, schedules nothing, and runs the remaining steps, in `tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T046 [US3] In the dispatcher, when `OriginatingQueueId` is empty, perform no scheduling and record a success no-op step with reason "no originating queue, no reschedule performed", in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [ ] T047 [US3] Confirm the standalone `sequences/{id}/execute` path leaves `OriginatingQueueId` unset (no parent queue context); add a regression assertion in `tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs`
+
+**Checkpoint**: The same sequence is safe in both queue and standalone contexts.
+
+---
+
+## Phase 6: User Story 4 - See the reschedule reflected in the execution logs (Priority: P2)
+
+**Goal**: Each self-reschedule decision and the firing it produces are visible and attributable in the
+execution logs.
+
+**Independent Test**: Trigger a self-reschedule, let the firing occur, and confirm the logs show the
+action (option + resolved timing + current-run-only) and the resulting attributable firing; and that
+an accepted-but-never-due reschedule shows "did not fire" without failing the run.
+
+### Tests for User Story 4 ⚠️ (write first, ensure they FAIL)
+
+- [ ] T048 [P] [US4] Integration test: logs show the action entry (chosen option, resolved timing, current-run-only) and the rescheduled firing tagged as self-reschedule-originated and attributable to the sequence, in `tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs`
+- [ ] T049 [P] [US4] Unit test: a reschedule accepted but not yet due when the run is stopped is abandoned (no firing), the run is not marked failed, and the log indicates it did not fire (FR-015/FR-017), in `tests/unit/Queues/QueueExecutionServiceTests.cs`
+
+### Implementation for User Story 4
+
+- [ ] T050 [US4] Enrich the action decision log entry with `option`, resolved timing (target instant / "next cycle" / "this cycle"), and `outcome` (`scheduled`|`noop` + reason), in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [ ] T051 [US4] Tag self-reschedule-originated firings in `RunOneSequenceAsync` with a "scheduled by self-reschedule" note + originating action id for attribution, in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [ ] T052 [US4] Ensure accepted-but-never-due entries are discarded at run end without affecting success/failure (run termination stays governed by once-per-run), in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+
+**Checkpoint**: All four user stories independently functional and observable.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T053 [P] Update `docs/architecture.md` — add the self-reschedule action to the domain model, capability map, and sequence-action surface; refresh the "Last reviewed" date (constitution Principle V)
+- [ ] T054 [P] Set this spec's `Status` line to Implemented and update `specs/STATUS.md` accordingly
+- [ ] T055 [P] Add a perf note for the run-loop draining change (O(pending) per boundary, no I/O) to the PR description / plan (SC-006, Principle IV)
+- [ ] T056 Run `quickstart.md` end-to-end and confirm full green gates: `dotnet test` + `src/web-ui` `vite build` + `jest`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: depends on Setup; **blocks all user stories**.
+- **US1 (Phase 3)**: depends on Foundational. MVP.
+- **US2 (Phase 4)**: depends on Foundational; builds on US1's coordinator/run-loop scaffolding (shares those files) but is independently testable per option.
+- **US3 (Phase 5)**: depends on Foundational (origin context); small, mostly independent of US1/US2.
+- **US4 (Phase 6)**: depends on Foundational; logging detail observes firings produced by US1/US2.
+- **Polish (Phase 7)**: depends on all targeted stories being complete.
+
+### Within Each User Story
+
+- Write tests first and confirm they fail.
+- Coordinator option logic → run-loop drain → validation → web-ui.
+- Same-file tasks (the coordinator and `QueueExecutionService` run loop are touched by US1/US2/US4) are **not** marked `[P]` across stories — sequence them to avoid conflicts.
+
+### Parallel Opportunities
+
+- Setup T002 ∥ nothing else needed.
+- Foundational: T003, T004, T006 are `[P]` (distinct files); T005 after T004; the registry chain (T007→T008→T009) and coordinator chain (T010/T011→T012→T013) are sequential; foundational tests T017–T019 are `[P]`.
+- Within a story, all test tasks marked `[P]` run together; web-ui (T024/T029, T035/T043) is `[P]` against backend tasks (different files).
+- US3 (Phase 5) can largely proceed in parallel with US2 — it touches the dispatcher no-op path, not the coordinator option logic.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (all parallel — different files):
+Task: "Contract test SelfRescheduleActionContractTests.cs"
+Task: "Unit test coordinator OncePerRun injection"
+Task: "Unit test run-loop drains PendingOncePerRun"
+Task: "Integration test IF-gated second firing"
+Task: "web-ui Jest author action under IF"
+
+# Then implementation (T025→T026 sequential; T027/T028/T029 parallelizable across files)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → 2 Foundational (critical, blocks everything).
+2. Phase 3 US1 → **STOP and validate**: IF-gated Once-Per-Run reschedule fires the sequence again.
+3. Demo the MVP.
+
+### Incremental Delivery
+
+1. Foundation ready.
+2. US1 (Once Per Run) → validate → demo.
+3. US2 (all options) → validate each option's timing → demo.
+4. US3 (no-op success) → validate standalone safety → demo.
+5. US4 (log observability) → validate attribution + not-due handling → demo.
+6. Polish: architecture doc, spec status, perf note, full quickstart + green gates.
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete dependency.
+- The coordinator (`SelfRescheduleCoordinator.cs`) and the run loop (`QueueExecutionService.cs`) are
+  edited across US1/US2/US4 — keep those edits sequential within a single working copy.
+- Reuse `TimeProvider` (feature 059) for all wall-clock reads so timer tests stay deterministic.
+- Keep everything ephemeral: nothing about a reschedule may touch the queue template or any saved
+  config (FR-010, SC-005) — assert this in T020/T023.
+- Verify each test fails before implementing; commit after each task or logical group.

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -100,6 +100,7 @@ Status vocabulary:
 | 062 | Queue Management Usability | Draft (active) |
 | 063 | Execution Logs Reflect What Was Actually Executed | Implemented (iterated by 050) — renumbered from 049 |
 | 064 | Command Editor Rework | Implemented (iterated by 054) — renumbered from 053 |
+| 065 | Sequence Self-Rescheduling into the Originating Queue Run | Implemented |
 
 ## Numbering notes
 

--- a/src/GameBot.Domain/Actions/ActionTypes.cs
+++ b/src/GameBot.Domain/Actions/ActionTypes.cs
@@ -11,4 +11,10 @@ public static class ActionTypes {
   public const string ConnectToGame = "connect-to-game";
   public const string WaitForImage = "WaitForImage";
   public const string EnsureGameRunning = "ensure-game-running";
+
+  /// <summary>
+  /// Self-reschedule action (feature 065): schedules one additional firing of the current
+  /// sequence into its originating queue run. No-op success when not started from a queue.
+  /// </summary>
+  public const string RescheduleSelf = "reschedule-self";
 }

--- a/src/GameBot.Domain/Commands/FileSequenceRepository.cs
+++ b/src/GameBot.Domain/Commands/FileSequenceRepository.cs
@@ -107,7 +107,8 @@ namespace GameBot.Domain.Commands {
                 ActionTypes.Swipe,
                 ActionTypes.Key,
                 ActionTypes.ConnectToGame,
-                ActionTypes.WaitForImage
+                ActionTypes.WaitForImage,
+                ActionTypes.RescheduleSelf
             };
 
       foreach (var step in sequence.Steps) {

--- a/src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOption.cs
+++ b/src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOption.cs
@@ -1,0 +1,20 @@
+namespace GameBot.Domain.Commands.SelfReschedule;
+
+/// <summary>
+/// The schedule option chosen for a self-reschedule action (feature 065). Mirrors the
+/// queue-template <c>ScheduleType</c> vocabulary so authors see no new concepts; named distinctly
+/// because the <see cref="AtQueueStart"/> mid-run meaning is option-specific (FR-009).
+/// </summary>
+public enum SelfRescheduleOption {
+  /// <summary>Fire at the next cycle start (cycling run) / next iteration boundary (non-cycling). FR-009.</summary>
+  AtQueueStart,
+
+  /// <summary>Append after the remaining once-per-run steps of the current cycle. FR-007.</summary>
+  OncePerRun,
+
+  /// <summary>Fire once at a resolved target instant (relative offset or time-of-day). FR-005/FR-006.</summary>
+  Timer,
+
+  /// <summary>Register to fire after each subsequent normal step (loop-safe). FR-008.</summary>
+  EveryStep
+}

--- a/src/GameBot.Domain/Commands/SelfReschedule/SelfReschedulePayload.cs
+++ b/src/GameBot.Domain/Commands/SelfReschedule/SelfReschedulePayload.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+
+namespace GameBot.Domain.Commands.SelfReschedule;
+
+/// <summary>
+/// Thin typed reader over a <see cref="SequenceActionPayload"/> of type
+/// <c>reschedule-self</c> (feature 065). The dictionary remains the storage; this view parses
+/// <c>option</c>, <c>timerTimeOfDay</c>, and <c>timerRelativeOffset</c>. Cross-field validation
+/// (mutual exclusivity, ranges) lives in <c>ActionPayloadValidationService</c>; this reader only
+/// surfaces parse-level errors (unknown option, malformed timer string).
+/// </summary>
+public sealed class SelfReschedulePayload {
+  /// <summary>Wire key for the chosen schedule option.</summary>
+  public const string OptionKey = "option";
+  /// <summary>Wire key for the Timer time-of-day value (HH:mm:ss).</summary>
+  public const string TimerTimeOfDayKey = "timerTimeOfDay";
+  /// <summary>Wire key for the Timer relative-offset value (HH:mm:ss).</summary>
+  public const string TimerRelativeOffsetKey = "timerRelativeOffset";
+
+  /// <summary>The chosen schedule option.</summary>
+  public required SelfRescheduleOption Option { get; init; }
+
+  /// <summary>Resolved Timer time-of-day, when present.</summary>
+  public TimeOnly? TimerTimeOfDay { get; init; }
+
+  /// <summary>Resolved Timer relative offset, when present.</summary>
+  public TimeSpan? TimerRelativeOffset { get; init; }
+
+  /// <summary>True when at least one timer field was supplied (regardless of option).</summary>
+  public bool HasTimerTimeOfDay { get; init; }
+
+  /// <summary>True when a relative offset was supplied (regardless of option).</summary>
+  public bool HasTimerRelativeOffset { get; init; }
+
+  /// <summary>
+  /// Attempts to read a <c>reschedule-self</c> payload. Returns <c>false</c> with a human-readable
+  /// <paramref name="error"/> when the option is missing/unknown or a timer field is malformed.
+  /// </summary>
+  public static bool TryRead(SequenceActionPayload payload, out SelfReschedulePayload? result, out string? error) {
+    ArgumentNullException.ThrowIfNull(payload);
+    result = null;
+    error = null;
+
+    var rawOption = ReadString(payload.Parameters, OptionKey);
+    if (string.IsNullOrWhiteSpace(rawOption)) {
+      error = "option is required";
+      return false;
+    }
+    if (!Enum.TryParse<SelfRescheduleOption>(rawOption, ignoreCase: true, out var option)) {
+      error = $"option '{rawOption}' is not a known schedule option (expected one of AtQueueStart, OncePerRun, Timer, EveryStep)";
+      return false;
+    }
+
+    TimeOnly? timeOfDay = null;
+    var hasTimeOfDay = TryReadString(payload.Parameters, TimerTimeOfDayKey, out var rawTimeOfDay);
+    if (hasTimeOfDay) {
+      if (!TimeOnly.TryParse(rawTimeOfDay, CultureInfo.InvariantCulture, out var parsedTimeOfDay)) {
+        error = $"timerTimeOfDay '{rawTimeOfDay}' is not a valid HH:mm:ss time-of-day";
+        return false;
+      }
+      timeOfDay = parsedTimeOfDay;
+    }
+
+    TimeSpan? relativeOffset = null;
+    var hasRelative = TryReadString(payload.Parameters, TimerRelativeOffsetKey, out var rawRelative);
+    if (hasRelative) {
+      if (!TimeSpan.TryParse(rawRelative, CultureInfo.InvariantCulture, out var parsedRelative)) {
+        error = $"timerRelativeOffset '{rawRelative}' is not a valid HH:mm:ss duration";
+        return false;
+      }
+      relativeOffset = parsedRelative;
+    }
+
+    result = new SelfReschedulePayload {
+      Option = option,
+      TimerTimeOfDay = timeOfDay,
+      TimerRelativeOffset = relativeOffset,
+      HasTimerTimeOfDay = hasTimeOfDay,
+      HasTimerRelativeOffset = hasRelative
+    };
+    return true;
+  }
+
+  private static string? ReadString(IReadOnlyDictionary<string, object?> parameters, string key) {
+    TryReadString(parameters, key, out var value);
+    return value;
+  }
+
+  private static bool TryReadString(IReadOnlyDictionary<string, object?> parameters, string key, out string? value) {
+    value = null;
+    if (!TryGetIgnoreCase(parameters, key, out var raw) || raw is null) {
+      return false;
+    }
+
+    switch (raw) {
+      case string s:
+        value = s;
+        return !string.IsNullOrWhiteSpace(s);
+      case JsonElement je when je.ValueKind == JsonValueKind.String:
+        value = je.GetString();
+        return !string.IsNullOrWhiteSpace(value);
+      case JsonElement je when je.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined:
+        return false;
+      default:
+        value = raw.ToString();
+        return !string.IsNullOrWhiteSpace(value);
+    }
+  }
+
+  private static bool TryGetIgnoreCase(IReadOnlyDictionary<string, object?> parameters, string key, out object? value) {
+    if (parameters.TryGetValue(key, out value)) {
+      return true;
+    }
+    foreach (var pair in parameters) {
+      if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase)) {
+        value = pair.Value;
+        return true;
+      }
+    }
+    value = null;
+    return false;
+  }
+}

--- a/src/GameBot.Domain/Services/ActionDispatchResult.cs
+++ b/src/GameBot.Domain/Services/ActionDispatchResult.cs
@@ -1,0 +1,11 @@
+namespace GameBot.Domain.Services;
+
+/// <summary>
+/// Result of dispatching a non-command sequence action (e.g. <c>reschedule-self</c>) through the
+/// optional action dispatcher supplied to <see cref="SequenceRunner.ExecuteAsync"/> (feature 065).
+/// The runner records this as the action step's result and continues — the action never, by
+/// itself, terminates the sequence (FR-012).
+/// </summary>
+/// <param name="Outcome">Action outcome recorded on the step (e.g. <c>scheduled</c>, <c>noop</c>).</param>
+/// <param name="Message">Optional human-readable detail for the execution log.</param>
+public sealed record ActionDispatchResult(string Outcome, string? Message);

--- a/src/GameBot.Domain/Services/ActionPayloadValidationService.cs
+++ b/src/GameBot.Domain/Services/ActionPayloadValidationService.cs
@@ -4,7 +4,8 @@ using GameBot.Domain.Commands;
 namespace GameBot.Domain.Services;
 
 public sealed class ActionPayloadValidationService {
-  private readonly HashSet<string> _supportedActionTypes = new(PrimitiveActionTypes.All, StringComparer.OrdinalIgnoreCase);
+  private readonly HashSet<string> _supportedActionTypes =
+    new(PrimitiveActionTypes.All, StringComparer.OrdinalIgnoreCase) { ActionTypes.RescheduleSelf };
 
   public IReadOnlyCollection<string> SupportedActionTypes => _supportedActionTypes;
 

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -49,6 +49,7 @@ namespace GameBot.Domain.Services {
         Func<string, Task> executeCommandAsync,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator = null,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator = null,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher = null,
         CancellationToken ct = default) {
       ArgumentNullException.ThrowIfNull(executeCommandAsync);
       var sequence = await _repository.GetAsync(sequenceId).ConfigureAwait(false);
@@ -81,6 +82,7 @@ namespace GameBot.Domain.Services {
             linearStepOutcomes,
             result,
             sequenceId,
+            actionDispatcher,
             ct).ConfigureAwait(false);
         if (earlyStop) {
           if (_logger != null) LogSequenceEnd(_logger, sequenceId, result.Status, null);
@@ -392,6 +394,7 @@ namespace GameBot.Domain.Services {
         Dictionary<string, string> stepOutcomes,
         SequenceExecutionResult result,
         string sequenceId,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher,
         CancellationToken ct) {
       var stepKey = !string.IsNullOrWhiteSpace(step.StepId) ? step.StepId : step.CommandId;
 
@@ -538,6 +541,26 @@ namespace GameBot.Domain.Services {
         return false;
       }
 
+      // ── reschedule-self action dispatch (feature 065) ─────────────────
+      // A reschedule-self action step is dispatched through the injected callback before the
+      // command fallback. The action records its outcome as the step result and NEVER early-stops
+      // the sequence (FR-012). When no dispatcher is supplied it falls through (legacy no-op).
+      if (step.StepType == SequenceStepType.Action
+          && actionDispatcher is not null
+          && string.Equals(step.Action?.Type, ActionTypes.RescheduleSelf, StringComparison.OrdinalIgnoreCase)) {
+        var dispatch = await actionDispatcher(step.Action!, ct).ConfigureAwait(false);
+        result.AddStep(
+            stepKey,
+            appliedDelay,
+            "Succeeded",
+            conditionType: step.Condition is null ? null : step.Condition.Type,
+            conditionResult: step.Condition is null ? null : "true",
+            actionOutcome: dispatch.Outcome,
+            message: dispatch.Message);
+        if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "success";
+        return false;
+      }
+
       if (_logger != null) LogCommandStart(_logger, step.CommandId, null);
       var cmdStart = DateTimeOffset.UtcNow;
       try {
@@ -677,6 +700,7 @@ namespace GameBot.Domain.Services {
           stepOutcomes: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
           result,
           sequenceId,
+          actionDispatcher: null,
           ct);
     }
 
@@ -1012,6 +1036,7 @@ namespace GameBot.Domain.Services {
             stepOutcomes,
             result,
             sequenceId,
+            actionDispatcher: null,
             ct).ConfigureAwait(false);
         stepsExecuted++;
 

--- a/src/GameBot.Domain/Services/SequenceStepValidationService.cs
+++ b/src/GameBot.Domain/Services/SequenceStepValidationService.cs
@@ -1,4 +1,5 @@
 using GameBot.Domain.Commands;
+using GameBot.Domain.Commands.SelfReschedule;
 using GameBot.Domain.Actions;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -127,7 +128,11 @@ public sealed class SequenceStepValidationService {
       bool insideLoop) {
 
     if (step.Action is not null) {
-      if (string.IsNullOrWhiteSpace(step.Action.Type) || !AllowedPrimitiveActionTypes.Contains(step.Action.Type)) {
+      if (string.Equals(step.Action.Type, ActionTypes.RescheduleSelf, StringComparison.OrdinalIgnoreCase)) {
+        // feature 065: a self-reschedule action carries an option (+ optional Timer fields).
+        ValidateRescheduleSelfPayload(step.Action, stepLabel, errors);
+      }
+      else if (string.IsNullOrWhiteSpace(step.Action.Type) || !AllowedPrimitiveActionTypes.Contains(step.Action.Type)) {
         errors.Add($"Step '{stepLabel}' action type '{step.Action.Type}' is not a supported primitive action type.");
       }
       else if (string.Equals(step.Action.Type, PrimitiveActionTypes.WaitForImage, StringComparison.OrdinalIgnoreCase)) {
@@ -173,6 +178,35 @@ public sealed class SequenceStepValidationService {
     if (step.Condition is ImageVisibleStepCondition imageVisible
         && string.IsNullOrWhiteSpace(imageVisible.ImageId)) {
       errors.Add($"Step '{stepLabel}' imageVisible condition requires imageId.");
+    }
+  }
+
+  // feature 065: validates a reschedule-self action payload, mirroring the queue-template timer rules.
+  private static readonly TimeSpan MaxRescheduleOffset = TimeSpan.FromHours(24);
+
+  private static void ValidateRescheduleSelfPayload(
+      SequenceActionPayload action,
+      string stepLabel,
+      List<string> errors) {
+    if (!SelfReschedulePayload.TryRead(action, out var payload, out var parseError) || payload is null) {
+      errors.Add($"Step '{stepLabel}' reschedule-self action is invalid: {parseError}");
+      return;
+    }
+
+    if (payload.Option == SelfRescheduleOption.Timer) {
+      if (payload.HasTimerTimeOfDay && payload.HasTimerRelativeOffset) {
+        errors.Add($"Step '{stepLabel}' reschedule-self Timer requires exactly one of timerTimeOfDay or timerRelativeOffset, not both.");
+      }
+      else if (!payload.HasTimerTimeOfDay && !payload.HasTimerRelativeOffset) {
+        errors.Add($"Step '{stepLabel}' reschedule-self Timer requires a timerTimeOfDay or timerRelativeOffset.");
+      }
+
+      if (payload.TimerRelativeOffset is { } offset && (offset < TimeSpan.Zero || offset > MaxRescheduleOffset)) {
+        errors.Add($"Step '{stepLabel}' reschedule-self timerRelativeOffset must be between 00:00:00 and 24:00:00.");
+      }
+    }
+    else if (payload.HasTimerTimeOfDay || payload.HasTimerRelativeOffset) {
+      errors.Add($"Step '{stepLabel}' reschedule-self timer fields are only valid when option is Timer.");
     }
   }
 

--- a/src/GameBot.Service/Program.cs
+++ b/src/GameBot.Service/Program.cs
@@ -131,6 +131,10 @@ builder.Services.AddSingleton<IExecutionLogRetentionPolicyRepository>(_ => new E
 builder.Services.AddSingleton<GameBot.Service.Services.ExecutionLog.IExecutionLogService, GameBot.Service.Services.ExecutionLog.ExecutionLogService>();
 builder.Services.AddSingleton<GameBot.Service.Services.SequenceExecution.ISequenceExecutionService, GameBot.Service.Services.SequenceExecution.SequenceExecutionService>();
 builder.Services.AddSingleton<TimeProvider>(TimeProvider.System);
+// Self-reschedule (feature 065): the run registry breaks the SequenceExecutionService ↔
+// QueueExecutionService DI cycle; the coordinator injects ephemeral run-scoped firings.
+builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IQueueRunRegistry, GameBot.Service.Services.QueueExecution.QueueRunRegistry>();
+builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.ISelfRescheduleCoordinator, GameBot.Service.Services.QueueExecution.SelfRescheduleCoordinator>();
 builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IQueueExecutionService, GameBot.Service.Services.QueueExecution.QueueExecutionService>();
 builder.Services.AddSingleton<SemanticVersionComparer>();
 builder.Services.AddSingleton<VersionSourceLoader>();

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogContext.cs
@@ -11,4 +11,17 @@ internal sealed class ExecutionLogContext {
   public string? SequenceLabel { get; init; }
   public string? StepId { get; init; }
   public string? StepLabel { get; init; }
+
+  /// <summary>
+  /// The id of the queue run that launched this sequence firing, propagated through nesting
+  /// (feature 065, FR-018). Non-empty ⇒ the sequence was "started from a queue" and a
+  /// self-reschedule action may schedule into that run; null/empty ⇒ standalone run (no-op success).
+  /// </summary>
+  public string? OriginatingQueueId { get; init; }
+
+  /// <summary>
+  /// When set, this firing was produced by a self-reschedule action; carries the originating
+  /// action's entry id for attribution in the execution log (feature 065, FR-014).
+  /// </summary>
+  public string? SelfRescheduleOriginActionId { get; init; }
 }

--- a/src/GameBot.Service/Services/QueueExecution/IQueueRunRegistry.cs
+++ b/src/GameBot.Service/Services/QueueExecution/IQueueRunRegistry.cs
@@ -1,0 +1,22 @@
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// Singleton store of the <see cref="QueueRunHandle"/>s for queues that are currently running
+/// (feature 065). Extracted from <c>QueueExecutionService._runs</c> so the self-reschedule
+/// coordinator can look up an active run without a constructor dependency on the queue engine,
+/// which would otherwise form a DI cycle (<c>SequenceExecutionService → QueueExecutionService</c>).
+/// Holds no service dependencies; the registry is the single owner of run-handle lifetime.
+/// </summary>
+internal interface IQueueRunRegistry {
+  /// <summary>Registers the handle for a starting run. Returns <c>false</c> if one already exists.</summary>
+  bool TryAdd(string queueId, QueueRunHandle handle);
+
+  /// <summary>Looks up the active run handle for a queue.</summary>
+  bool TryGet(string queueId, out QueueRunHandle handle);
+
+  /// <summary>Removes (and returns) the handle for a run that is ending.</summary>
+  bool Remove(string queueId, out QueueRunHandle handle);
+
+  /// <summary>True iff a run is currently registered for the queue.</summary>
+  bool IsRunning(string queueId);
+}

--- a/src/GameBot.Service/Services/QueueExecution/ISelfRescheduleCoordinator.cs
+++ b/src/GameBot.Service/Services/QueueExecution/ISelfRescheduleCoordinator.cs
@@ -1,0 +1,47 @@
+using System;
+using GameBot.Domain.Commands.SelfReschedule;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>Whether a self-reschedule request found an active run to schedule into (feature 065).</summary>
+internal enum SelfRescheduleOutcome {
+  /// <summary>The run was found and an ephemeral firing was injected into the matching register.</summary>
+  Scheduled,
+
+  /// <summary>No active run for the queue (race: the run ended mid-sequence). Treated as a logged no-op.</summary>
+  NotRunning
+}
+
+/// <summary>
+/// Outcome of a self-reschedule request, including the resolved timing for the execution log.
+/// </summary>
+/// <param name="Outcome">Whether the firing was scheduled or the run was gone.</param>
+/// <param name="EntryId">Unique id linking the action's log entry to the resulting firing (FR-014).</param>
+/// <param name="Option">The chosen schedule option.</param>
+/// <param name="FireAt">Resolved fire instant for Timer options; null otherwise.</param>
+/// <param name="ResolvedTiming">Human-readable timing ("this cycle" / "next cycle" / target instant).</param>
+internal sealed record SelfRescheduleResult(
+  SelfRescheduleOutcome Outcome,
+  string EntryId,
+  SelfRescheduleOption Option,
+  DateTimeOffset? FireAt,
+  string ResolvedTiming);
+
+/// <summary>
+/// Injects one ephemeral, run-scoped additional firing of a sequence into its originating queue run
+/// (feature 065). Depends only on the run registry, the sequence repository, and a
+/// <see cref="TimeProvider"/>, so it does not re-form the queue-engine DI cycle.
+/// </summary>
+internal interface ISelfRescheduleCoordinator {
+  /// <summary>
+  /// Schedules one additional firing of <paramref name="sequenceId"/> into the active run of
+  /// <paramref name="queueId"/> using <paramref name="option"/>. Returns
+  /// <see cref="SelfRescheduleOutcome.NotRunning"/> when no active run exists.
+  /// </summary>
+  SelfRescheduleResult ScheduleSelf(
+    string queueId,
+    string sequenceId,
+    SelfRescheduleOption option,
+    TimeOnly? timerTimeOfDay,
+    TimeSpan? timerRelativeOffset);
+}

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -43,9 +42,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   private readonly ILogger<QueueExecutionService> _logger;
   private readonly TimeProvider _timeProvider;
   private readonly CancellationToken _appStopping;
-
-  private readonly ConcurrentDictionary<string, QueueRunHandle> _runs =
-    new(StringComparer.Ordinal);
+  private readonly IQueueRunRegistry _registry;
 
   // How often a non-cyclic run re-checks pending relative/live timers while waiting for one to become
   // due. Small enough that a firing lands within roughly an iteration interval of the offset, large
@@ -60,6 +57,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     ISessionManager sessions,
     IExecutionLogService log,
     ILogger<QueueExecutionService> logger,
+    IQueueRunRegistry registry,
     IHostApplicationLifetime? lifetime = null,
     BackgroundScreenCaptureService? captureService = null,
     TimeProvider? timeProvider = null) {
@@ -71,14 +69,15 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     _captureService = captureService;
     _log = log;
     _logger = logger;
+    _registry = registry;
     _timeProvider = timeProvider ?? TimeProvider.System;
     _appStopping = lifetime?.ApplicationStopping ?? CancellationToken.None;
   }
 
-  public bool IsRunning(string queueId) => _runs.ContainsKey(queueId);
+  public bool IsRunning(string queueId) => _registry.IsRunning(queueId);
 
   public LiveScheduleResult ScheduleRelative(string queueId, string sequenceId, TimeSpan offset) {
-    if (!_runs.TryGetValue(queueId, out var handle))
+    if (!_registry.TryGet(queueId, out var handle))
       return new LiveScheduleResult(LiveScheduleOutcome.NotRunning, default);
 
     var fireAt = _timeProvider.GetLocalNow() + offset;
@@ -92,8 +91,8 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     if (queue is null) return QueueStartOutcome.NotFound;
 
     var cts = CancellationTokenSource.CreateLinkedTokenSource(_appStopping);
-    var handle = new QueueRunHandle { QueueId = queueId, Cts = cts };
-    if (!_runs.TryAdd(queueId, handle)) {
+    var handle = new QueueRunHandle { QueueId = queueId, Cts = cts, CycleExecution = queue.CycleExecution };
+    if (!_registry.TryAdd(queueId, handle)) {
       cts.Dispose();
       return QueueStartOutcome.AlreadyRunning;
     }
@@ -104,7 +103,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   }
 
   public async Task StopAsync(string queueId, CancellationToken ct = default) {
-    if (!_runs.TryGetValue(queueId, out var handle)) return; // not running → no-op (FR-022)
+    if (!_registry.TryGet(queueId, out var handle)) return; // not running → no-op (FR-022)
     try {
       await handle.Cts.CancelAsync().ConfigureAwait(false);
     }
@@ -174,7 +173,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
             foreach (var startEntry in atQueueStartEntries) {
               ct.ThrowIfCancellationRequested();
               if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
-              var startOk = await RunOneSequenceAsync(startEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+              var startOk = await RunOneSequenceAsync(startEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
               executed++;
               if (!startOk) failed++;
             }
@@ -201,12 +200,26 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                 if (timerEntries[pi].TimerRelativeOffset is not null && !relativeTimerFired.Contains(pi))
                   return true;
               }
-              return !handle.PendingLiveSchedules.IsEmpty;
+              if (!handle.PendingLiveSchedules.IsEmpty) return true;
+              // feature 065: a self-reschedule Timer firing not yet due keeps a non-cyclic run alive
+              // until it lands (or the run is stopped), exactly like a relative/live schedule.
+              return handle.HasPendingTimerFirings;
             }
 
             if (oncePerRunEntries.Count > 0 || everyStepEntries.Count > 0 || timerEntries.Count > 0) {
               do {
                 ct.ThrowIfCancellationRequested();
+
+                // (a0) Self-reschedule AtQueueStart firings (feature 065, FR-009): entries queued
+                // during the previous cycle fire at the top of the next cycle, before timers and the
+                // once-per-run pass. Count toward executed; a failed firing is non-fatal.
+                while (handle.PendingNextCycleStart.TryDequeue(out var nextCycleEntry)) {
+                  ct.ThrowIfCancellationRequested();
+                  if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                  var nextOk = await RunOneSequenceAsync(nextCycleEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct, nextCycleEntry.Id).ConfigureAwait(false);
+                  executed++;
+                  if (!nextOk) failed++;
+                }
 
                 // (a) Evaluate timer entries at iteration boundary (FR-011/FR-012/FR-016).
                 for (var ti = 0; ti < timerEntries.Count; ti++) {
@@ -220,7 +233,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                       && (!timerFiredDate.TryGetValue(ti, out var lastFired) || lastFired != today)) {
                     ct.ThrowIfCancellationRequested();
                     if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
-                    var timerOk = await RunOneSequenceAsync(timerEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                    var timerOk = await RunOneSequenceAsync(timerEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                     if (!timerOk) failed++;
                     // Timer executions do not count toward `executed` (SC-002 analogue for timers)
                     timerFiredDate[ti] = today;
@@ -240,7 +253,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
 
                   ct.ThrowIfCancellationRequested();
                   if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
-                  var relOk = await RunOneSequenceAsync(relEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                  var relOk = await RunOneSequenceAsync(relEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                   executed++;
                   if (!relOk) failed++;
                   relativeTimerFired.Add(ri);
@@ -258,9 +271,21 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                   if (!handle.PendingLiveSchedules.TryRemove(due, out _)) continue;
                   ct.ThrowIfCancellationRequested();
                   if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
-                  var liveOk = await RunOneSequenceAsync(due, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                  var liveOk = await RunOneSequenceAsync(due, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                   executed++;
                   if (!liveOk) failed++;
+                }
+
+                // (a4) Self-reschedule Timer firings (feature 065, FR-005/FR-006): fire those whose
+                // resolved instant is at/before now, once each, then remove. Count toward executed; a
+                // failed firing is non-fatal. Entries never due before the run ends are discarded with
+                // the handle and never fail the run (FR-015).
+                foreach (var timerFiring in handle.DrainDueTimerFirings(_timeProvider.GetLocalNow())) {
+                  ct.ThrowIfCancellationRequested();
+                  if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                  var srTimerOk = await RunOneSequenceAsync(timerFiring.SequenceId, rootId, ++index, sessionId, queue.Id, ct, timerFiring.Id).ConfigureAwait(false);
+                  executed++;
+                  if (!srTimerOk) failed++;
                 }
 
                 // (b) OncePerRun steps, each followed by all EveryStep sequences (FR-006/FR-007/FR-016).
@@ -271,7 +296,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                     foreach (var entry in oncePerRunEntries) {
                       ct.ThrowIfCancellationRequested();
                       if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
-                      var ok = await RunOneSequenceAsync(entry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                      var ok = await RunOneSequenceAsync(entry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                       executed++;
                       if (!ok) failed++;
 
@@ -279,9 +304,19 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                       foreach (var esEntry in everyStepEntries) {
                         ct.ThrowIfCancellationRequested();
                         if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
-                        var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                        var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                         if (!esOk) failed++;
                         // Every-step executions do not count toward `executed` (FR-008/SC-002).
+                      }
+
+                      // Self-reschedule EveryStep injections (feature 065, FR-008): fire after each
+                      // once-per-run step for the rest of the run. Snapshot first so a firing's own
+                      // re-registration cannot grow the pass (loop-safe). Not counted toward executed.
+                      foreach (var injection in handle.EveryStepInjections.Values.ToList()) {
+                        ct.ThrowIfCancellationRequested();
+                        if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                        var injOk = await RunOneSequenceAsync(injection.SequenceId, rootId, ++index, sessionId, queue.Id, ct, injection.Id).ConfigureAwait(false);
+                        if (!injOk) failed++;
                       }
                     }
                   }
@@ -290,9 +325,24 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                     foreach (var esEntry in everyStepEntries) {
                       ct.ThrowIfCancellationRequested();
                       if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
-                      var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, ct).ConfigureAwait(false);
+                      var esOk = await RunOneSequenceAsync(esEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                       if (!esOk) failed++;
                     }
+                  }
+
+                  // OncePerRun self-reschedule firings (feature 065, FR-007), and the non-cycling
+                  // AtQueueStart fallback: drain a snapshot of those queued this cycle and fire each
+                  // before the cycle ends. Count toward executed; failures are non-fatal. Snapshotting
+                  // bounds a single drain so an always-true self-reschedule cannot spin within one cycle
+                  // (further generations fire next cycle / are abandoned at run end — FR-015).
+                  var oncePerRunReschedules = new List<SelfRescheduleEntry>();
+                  while (handle.PendingOncePerRun.TryDequeue(out var oprEntry)) oncePerRunReschedules.Add(oprEntry);
+                  foreach (var oprFiring in oncePerRunReschedules) {
+                    ct.ThrowIfCancellationRequested();
+                    if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
+                    var oprOk = await RunOneSequenceAsync(oprFiring.SequenceId, rootId, ++index, sessionId, queue.Id, ct, oprFiring.Id).ConfigureAwait(false);
+                    executed++;
+                    if (!oprOk) failed++;
                   }
 
                   oncePerRunDone = true;
@@ -350,7 +400,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
       catch (Exception ex) { QueueExecutionLog.FinalizeFailed(_logger, queue.Id, ex); }
 
       _runtime.SetStatus(queue.Id, QueueExecutionStatus.Stopped);
-      _runs.TryRemove(queue.Id, out _);
+      _registry.Remove(queue.Id, out _);
       handle.Cts.Dispose();
     }
   }
@@ -359,13 +409,17 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   /// Runs one sequence as a child of the queue run. Per-sequence failures are non-fatal (FR-008):
   /// returns false on a failed/unresolved sequence so the run can continue.
   /// </summary>
-  private async Task<bool> RunOneSequenceAsync(string sequenceId, string rootId, int index, string sessionId, CancellationToken ct) {
+  private async Task<bool> RunOneSequenceAsync(string sequenceId, string rootId, int index, string sessionId, string queueId, CancellationToken ct, string? selfRescheduleOriginActionId = null) {
     try {
       var parentContext = new ExecutionLogContext {
         ParentExecutionId = rootId,
         RootExecutionId = rootId,
         Depth = 1,
-        SequenceIndex = index
+        SequenceIndex = index,
+        // Mark this firing as queue-originated so a self-reschedule action can target this run
+        // (FR-018); also carry the originating action id for attribution of self-reschedule firings.
+        OriginatingQueueId = queueId,
+        SelfRescheduleOriginActionId = selfRescheduleOriginActionId
       };
       var res = await _sequenceExecution.ExecuteAsync(sequenceId, sessionId, parentContext, ct).ConfigureAwait(false);
       return string.Equals(res.Status, "Succeeded", StringComparison.OrdinalIgnoreCase);

--- a/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using GameBot.Domain.Commands.SelfReschedule;
 using GameBot.Domain.Queues;
 
 namespace GameBot.Service.Services.QueueExecution;
@@ -40,7 +42,68 @@ internal sealed class QueueRunHandle {
   /// </summary>
   public ConcurrentDictionary<string, DateTimeOffset> PendingLiveSchedules { get; } =
     new(StringComparer.Ordinal);
+
+  // ── Self-reschedule ephemeral registers (feature 065) ────────────────────────────────────────
+  // All four are in-memory only and discarded with the handle — on normal completion AND on
+  // stop/abort (FR-010, FR-017). Unlike PendingLiveSchedules (most-recent-wins per sequence), these
+  // accumulate so multiple self-reschedules of the same sequence each produce an independent firing.
+
+  /// <summary>Whether this run cycles; lets the coordinator pick the AtQueueStart register (FR-009).</summary>
+  public bool CycleExecution { get; set; }
+
+  /// <summary>OncePerRun firings (and the non-cycling AtQueueStart fallback) drained within the current cycle.</summary>
+  public ConcurrentQueue<SelfRescheduleEntry> PendingOncePerRun { get; } = new();
+
+  /// <summary>AtQueueStart firings (cycling) drained at the top of the next cycle, before once-per-run.</summary>
+  public ConcurrentQueue<SelfRescheduleEntry> PendingNextCycleStart { get; } = new();
+
+  /// <summary>EveryStep registrations, keyed by sequence id so re-registration is idempotent (loop-safe, FR-008).</summary>
+  public ConcurrentDictionary<string, SelfRescheduleEntry> EveryStepInjections { get; } =
+    new(StringComparer.Ordinal);
+
+  private readonly List<SelfRescheduleEntry> _pendingTimerFirings = new();
+  private readonly object _timerLock = new();
+
+  /// <summary>Adds a resolved Timer firing (fires once at/after its <see cref="SelfRescheduleEntry.FireAt"/>).</summary>
+  public void AddTimerFiring(SelfRescheduleEntry entry) {
+    lock (_timerLock) {
+      _pendingTimerFirings.Add(entry);
+    }
+  }
+
+  /// <summary>Removes and returns the Timer firings whose <c>FireAt</c> is at or before <paramref name="now"/>.</summary>
+  public IReadOnlyList<SelfRescheduleEntry> DrainDueTimerFirings(DateTimeOffset now) {
+    lock (_timerLock) {
+      if (_pendingTimerFirings.Count == 0) {
+        return Array.Empty<SelfRescheduleEntry>();
+      }
+      var due = new List<SelfRescheduleEntry>();
+      for (var i = _pendingTimerFirings.Count - 1; i >= 0; i--) {
+        var entry = _pendingTimerFirings[i];
+        if (entry.FireAt is { } fireAt && fireAt <= now) {
+          due.Add(entry);
+          _pendingTimerFirings.RemoveAt(i);
+        }
+      }
+      return due;
+    }
+  }
+
+  /// <summary>True while any Timer firing is still pending (keeps a non-cycling run alive to honor it).</summary>
+  public bool HasPendingTimerFirings {
+    get { lock (_timerLock) { return _pendingTimerFirings.Count > 0; } }
+  }
 }
+
+/// <summary>
+/// One ephemeral, run-scoped self-reschedule firing (feature 065). Never persisted; lives on the
+/// <see cref="QueueRunHandle"/> until it fires or the run ends.
+/// </summary>
+internal sealed record SelfRescheduleEntry(
+  string Id,
+  string SequenceId,
+  SelfRescheduleOption Option,
+  DateTimeOffset? FireAt);
 
 /// <summary>Outcome of a queue run, used to build the terminating execution-log entry.</summary>
 internal sealed record QueueRunResult(

--- a/src/GameBot.Service/Services/QueueExecution/QueueRunRegistry.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueRunRegistry.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// Default <see cref="IQueueRunRegistry"/>: a singleton owning a
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> of active <see cref="QueueRunHandle"/>s keyed by
+/// queue id. Relocated from <c>QueueExecutionService</c>; adds no behavior of its own.
+/// </summary>
+internal sealed class QueueRunRegistry : IQueueRunRegistry {
+  private readonly ConcurrentDictionary<string, QueueRunHandle> _runs =
+    new(StringComparer.Ordinal);
+
+  public bool TryAdd(string queueId, QueueRunHandle handle) => _runs.TryAdd(queueId, handle);
+
+  public bool TryGet(string queueId, out QueueRunHandle handle) {
+    if (_runs.TryGetValue(queueId, out var found)) {
+      handle = found;
+      return true;
+    }
+    handle = null!;
+    return false;
+  }
+
+  public bool Remove(string queueId, out QueueRunHandle handle) {
+    if (_runs.TryRemove(queueId, out var removed)) {
+      handle = removed;
+      return true;
+    }
+    handle = null!;
+    return false;
+  }
+
+  public bool IsRunning(string queueId) => _runs.ContainsKey(queueId);
+}

--- a/src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs
+++ b/src/GameBot.Service/Services/QueueExecution/SelfRescheduleCoordinator.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Globalization;
+using GameBot.Domain.Commands.SelfReschedule;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// Default <see cref="ISelfRescheduleCoordinator"/> (feature 065). Looks up the active run via the
+/// <see cref="IQueueRunRegistry"/> and injects one ephemeral <see cref="SelfRescheduleEntry"/> into
+/// the register matching the chosen option. All wall-clock reads go through the injected
+/// <see cref="TimeProvider"/> so timing is deterministic under test.
+/// </summary>
+internal sealed class SelfRescheduleCoordinator : ISelfRescheduleCoordinator {
+  private readonly IQueueRunRegistry _registry;
+  private readonly TimeProvider _timeProvider;
+
+  public SelfRescheduleCoordinator(
+    IQueueRunRegistry registry,
+    TimeProvider? timeProvider = null) {
+    _registry = registry;
+    _timeProvider = timeProvider ?? TimeProvider.System;
+  }
+
+  public SelfRescheduleResult ScheduleSelf(
+    string queueId,
+    string sequenceId,
+    SelfRescheduleOption option,
+    TimeOnly? timerTimeOfDay,
+    TimeSpan? timerRelativeOffset) {
+    var entryId = Guid.NewGuid().ToString("n");
+
+    if (!_registry.TryGet(queueId, out var handle)) {
+      // Race: the run ended between dispatch and here. Treated as a logged no-op (data-model §5).
+      return new SelfRescheduleResult(SelfRescheduleOutcome.NotRunning, entryId, option, null, "run not active");
+    }
+
+    switch (option) {
+      case SelfRescheduleOption.OncePerRun: {
+        var entry = new SelfRescheduleEntry(entryId, sequenceId, option, null);
+        handle.PendingOncePerRun.Enqueue(entry);
+        return new SelfRescheduleResult(SelfRescheduleOutcome.Scheduled, entryId, option, null, "this cycle");
+      }
+
+      case SelfRescheduleOption.EveryStep: {
+        // Idempotent per sequence: re-registering the same sequence does not stack (loop-safe, FR-008).
+        var entry = new SelfRescheduleEntry(entryId, sequenceId, option, null);
+        handle.EveryStepInjections[sequenceId] = entry;
+        return new SelfRescheduleResult(SelfRescheduleOutcome.Scheduled, entryId, option, null, "after every step");
+      }
+
+      case SelfRescheduleOption.AtQueueStart: {
+        var entry = new SelfRescheduleEntry(entryId, sequenceId, option, null);
+        if (handle.CycleExecution) {
+          handle.PendingNextCycleStart.Enqueue(entry);
+          return new SelfRescheduleResult(SelfRescheduleOutcome.Scheduled, entryId, option, null, "next cycle");
+        }
+        // Non-cycling fallback: fire at the next iteration boundary, i.e. the once-per-run drain.
+        handle.PendingOncePerRun.Enqueue(entry);
+        return new SelfRescheduleResult(SelfRescheduleOutcome.Scheduled, entryId, option, null, "next iteration boundary");
+      }
+
+      case SelfRescheduleOption.Timer: {
+        var fireAt = ResolveTimerFireAt(timerTimeOfDay, timerRelativeOffset);
+        var entry = new SelfRescheduleEntry(entryId, sequenceId, option, fireAt);
+        handle.AddTimerFiring(entry);
+        var timing = fireAt.ToString("u", CultureInfo.InvariantCulture);
+        return new SelfRescheduleResult(SelfRescheduleOutcome.Scheduled, entryId, option, fireAt, timing);
+      }
+
+      default:
+        throw new ArgumentOutOfRangeException(nameof(option), option, "Unknown self-reschedule option.");
+    }
+  }
+
+  /// <summary>
+  /// Resolves a Timer option to an absolute fire instant. A relative offset resolves to
+  /// <c>now + offset</c>; a time-of-day resolves to today at that time, collapsing to <c>now</c>
+  /// when already past so it fires at the next iteration boundary (FR-005/FR-006).
+  /// </summary>
+  private DateTimeOffset ResolveTimerFireAt(TimeOnly? timeOfDay, TimeSpan? relativeOffset) {
+    var now = _timeProvider.GetLocalNow();
+    if (relativeOffset is { } offset) {
+      return now + offset;
+    }
+    if (timeOfDay is { } tod) {
+      var candidate = new DateTimeOffset(
+        now.Year, now.Month, now.Day, tod.Hour, tod.Minute, tod.Second, now.Offset);
+      return candidate < now ? now : candidate;
+    }
+    // Defensive: a Timer with no field should have been rejected by validation; fire next boundary.
+    return now;
+  }
+}

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GameBot.Domain.Actions;
 using GameBot.Domain.Commands;
+using GameBot.Domain.Commands.SelfReschedule;
 using GameBot.Domain.Images;
 using GameBot.Domain.Logging;
 using GameBot.Domain.Services;
 using GameBot.Service.Services.Conditions;
 using GameBot.Service.Services.ExecutionLog;
+using GameBot.Service.Services.QueueExecution;
 
 namespace GameBot.Service.Services.SequenceExecution;
 
@@ -25,6 +28,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private readonly ICommandRepository _commandRepository;
   private readonly ISequenceRepository _sequenceRepository;
   private readonly ICommandExecutor _commandExecutor;
+  private readonly ISelfRescheduleCoordinator _selfRescheduleCoordinator;
 
   public SequenceExecutionService(
     SequenceRunner runner,
@@ -34,7 +38,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     IExecutionLogService executionLogService,
     ICommandRepository commandRepository,
     ISequenceRepository sequenceRepository,
-    ICommandExecutor commandExecutor) {
+    ICommandExecutor commandExecutor,
+    ISelfRescheduleCoordinator selfRescheduleCoordinator) {
     _runner = runner;
     _evalSvc = evalSvc;
     _imageVisibleConditionAdapter = imageVisibleConditionAdapter;
@@ -43,6 +48,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     _commandRepository = commandRepository;
     _sequenceRepository = sequenceRepository;
     _commandExecutor = commandExecutor;
+    _selfRescheduleCoordinator = selfRescheduleCoordinator;
   }
 
   public async Task<SequenceExecutionResult> ExecuteAsync(
@@ -61,6 +67,12 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     var childRootExecutionId = string.IsNullOrWhiteSpace(parentContext?.RootExecutionId) ? rootExecutionId : parentContext!.RootExecutionId!;
     var childDepth = (parentContext?.Depth ?? 0) + 1;
     var childInvocationIndex = 0;
+    // Origin of this firing: the queue run that launched it, propagated through nesting (FR-018).
+    // Non-empty ⇒ a self-reschedule action can schedule into that run; empty ⇒ no-op success (FR-011).
+    var originatingQueueId = parentContext?.OriginatingQueueId;
+    // When this firing was itself produced by a self-reschedule, carry the originating action id so
+    // the extra firing is attributable in the execution log (feature 065, FR-014).
+    var selfRescheduleOriginActionId = parentContext?.SelfRescheduleOriginActionId;
 
     var res = await _runner.ExecuteAsync(
       sequenceId,
@@ -72,7 +84,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
             Depth = childDepth,
             SequenceIndex = ++childInvocationIndex,
             SequenceId = sequenceId,
-            SequenceLabel = startSequenceName
+            SequenceLabel = startSequenceName,
+            OriginatingQueueId = originatingQueueId
           };
           await _commandExecutor.ForceExecuteAsync(sessionId, commandId, childContext, ct).ConfigureAwait(false);
         }
@@ -121,7 +134,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
         }
         return Task.FromResult(false);
       },
-      ct: ct
+      ct: ct,
+      actionDispatcher: (action, token) => Task.FromResult(DispatchSelfReschedule(action, sequenceId, originatingQueueId))
     ).ConfigureAwait(false);
 
     var sequence = await _sequenceRepository.GetAsync(sequenceId).ConfigureAwait(false);
@@ -131,6 +145,11 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     var sequenceStepsByCommandId = flattenedSequenceSteps
       .Where(step => !string.IsNullOrWhiteSpace(step.CommandId))
       .GroupBy(step => step.CommandId, StringComparer.Ordinal)
+      .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+    // feature 065: reschedule-self steps have no commandId; index them by stepId for log enrichment.
+    var sequenceStepsByStepId = flattenedSequenceSteps
+      .Where(step => !string.IsNullOrWhiteSpace(step.StepId))
+      .GroupBy(step => step.StepId, StringComparer.Ordinal)
       .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
     var flowStepsByCommandRef = (sequence?.FlowSteps ?? Array.Empty<FlowStep>())
       .GroupBy(step => string.IsNullOrWhiteSpace(step.PayloadRef) ? step.StepId : step.PayloadRef!, StringComparer.Ordinal)
@@ -151,9 +170,24 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       new(
         "sequence",
         $"Executed commands: {string.Join(",", commandSteps.Select(s => s.CommandId).Take(10))}",
-        new Dictionary<string, object?> { ["executedCount"] = commandSteps.Count },
+        new Dictionary<string, object?> {
+          ["executedCount"] = commandSteps.Count,
+          // feature 065: mark firings produced by a self-reschedule so they are attributable (FR-014).
+          ["selfRescheduleOrigin"] = string.IsNullOrWhiteSpace(selfRescheduleOriginActionId) ? null : true,
+          ["selfRescheduleOriginActionId"] = selfRescheduleOriginActionId
+        },
         "normal")
     };
+    if (!string.IsNullOrWhiteSpace(selfRescheduleOriginActionId)) {
+      detailItems.Add(new ExecutionDetailItem(
+        "note",
+        $"Scheduled by self-reschedule (origin action {selfRescheduleOriginActionId}).",
+        new Dictionary<string, object?> {
+          ["selfRescheduleOrigin"] = true,
+          ["selfRescheduleOriginActionId"] = selfRescheduleOriginActionId
+        },
+        "normal"));
+    }
 
     var stepOrder = 1;
     foreach (var step in res.Steps) {
@@ -189,6 +223,45 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       var actionOutcome = string.IsNullOrWhiteSpace(step.ActionOutcome)
         ? (string.Equals(step.Status, "Skipped", StringComparison.OrdinalIgnoreCase) ? "skipped" : "executed")
         : step.ActionOutcome;
+
+      // feature 065: render a self-reschedule decision as its own log entry (option, resolved timing,
+      // current-run-only, outcome + reason). Outcomes "scheduled"/"noop" are unique to this action.
+      sequenceStepsByStepId.TryGetValue(step.CommandId, out var stepById);
+      var isRescheduleStep =
+        string.Equals(stepById?.Action?.Type, ActionTypes.RescheduleSelf, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(actionOutcome, "scheduled", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(actionOutcome, "noop", StringComparison.OrdinalIgnoreCase);
+      if (isRescheduleStep) {
+        string? option = null;
+        if (stepById?.Action is not null
+            && SelfReschedulePayload.TryRead(stepById.Action, out var reschedulePayload, out _)
+            && reschedulePayload is not null) {
+          option = reschedulePayload.Option.ToString();
+        }
+        detailItems.Add(new ExecutionDetailItem(
+          "step",
+          !string.IsNullOrWhiteSpace(step.Message)
+            ? $"Self-reschedule '{stepLabel}' {actionOutcome}: {step.Message}"
+            : $"Self-reschedule '{stepLabel}' {actionOutcome}.",
+          new Dictionary<string, object?> {
+            ["stepOrder"] = stepOrder++,
+            ["stepType"] = "reschedule-self",
+            ["status"] = step.Status,
+            ["actionOutcome"] = actionOutcome,
+            ["reasonCode"] = actionOutcome,
+            ["option"] = option,
+            ["resolvedTiming"] = step.Message,
+            ["currentRunOnly"] = true,
+            ["message"] = step.Message,
+            ["sequenceId"] = sequenceId,
+            ["sequenceLabel"] = sequenceName,
+            ["stepId"] = stepId,
+            ["stepLabel"] = stepLabel
+          },
+          "normal"));
+        continue;
+      }
+
       var waitDetails = step.WaitForImageDetails;
       var waitConfig = sequenceStep?.WaitForImage;
       var isWaitForImageStep = waitDetails is not null
@@ -273,6 +346,40 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       details: detailItems,
       ct).ConfigureAwait(false);
     return res;
+  }
+
+  /// <summary>
+  /// Dispatches a <c>reschedule-self</c> action (feature 065). When the sequence was not started
+  /// from a queue (<paramref name="originatingQueueId"/> empty), it is a success no-op (FR-011).
+  /// Otherwise it asks the coordinator to inject one ephemeral firing into the originating run and
+  /// records the decision (option + resolved timing) for the execution log (FR-013).
+  /// </summary>
+  private ActionDispatchResult DispatchSelfReschedule(
+      SequenceActionPayload action,
+      string sequenceId,
+      string? originatingQueueId) {
+    if (string.IsNullOrWhiteSpace(originatingQueueId)) {
+      return new ActionDispatchResult("noop", "no originating queue, no reschedule performed");
+    }
+
+    if (!SelfReschedulePayload.TryRead(action, out var payload, out var parseError) || payload is null) {
+      return new ActionDispatchResult("noop", $"self-reschedule not performed: {parseError}");
+    }
+
+    var schedule = _selfRescheduleCoordinator.ScheduleSelf(
+      originatingQueueId!,
+      sequenceId,
+      payload.Option,
+      payload.TimerTimeOfDay,
+      payload.TimerRelativeOffset);
+
+    if (schedule.Outcome == SelfRescheduleOutcome.NotRunning) {
+      return new ActionDispatchResult("noop", "originating queue run no longer active; no reschedule performed");
+    }
+
+    return new ActionDispatchResult(
+      "scheduled",
+      $"rescheduled this sequence (option {schedule.Option}, {schedule.ResolvedTiming}); applies to the current run only");
   }
 
   private static async Task<bool> EvaluateImageConditionAsync(

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -115,25 +115,24 @@ export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
         </div>
       )}
 
-      <label className="loop-block-header__limit-field">
-        Max:{' '}
-        <input
-          type="number"
-          min={1}
-          data-testid="loop-max-iterations"
-          placeholder="∞"
-          value={maxIterations ?? ''}
-          disabled={disabled}
-          onChange={(e) => {
-            const val = parseInt(e.target.value, 10);
-            onMaxIterationsChange?.(isNaN(val) ? undefined : Math.max(1, val));
-          }}
-          style={{ width: '60px' }}
-        />
-      </label>
-
-      {(loopType === 'count' || loopType === 'while') && (
-        <span className="loop-block-header__hint" data-testid="loop-iteration-hint">{'{{iteration}}'}</span>
+      {/* A count loop is bounded by its count; the safety cap (Max) only applies to while/repeat-until. */}
+      {loopType !== 'count' && (
+        <label className="loop-block-header__limit-field">
+          Max:{' '}
+          <input
+            type="number"
+            min={1}
+            data-testid="loop-max-iterations"
+            placeholder="∞"
+            value={maxIterations ?? ''}
+            disabled={disabled}
+            onChange={(e) => {
+              const val = parseInt(e.target.value, 10);
+              onMaxIterationsChange?.(isNaN(val) ? undefined : Math.max(1, val));
+            }}
+            style={{ width: '60px' }}
+          />
+        </label>
       )}
     </div>
   );

--- a/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
+++ b/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
@@ -43,12 +43,14 @@ const testCommands: CommandOption[] = [
 ];
 
 describe('LoopBlockHeader', () => {
-  it('renders count loop header with editable count input and iteration hint', () => {
+  it('renders count loop header with editable count input', () => {
     render(<LoopBlockHeader loopType="count" count={10} />);
     expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('Count');
     const input = screen.getByTestId('loop-count-input') as HTMLInputElement;
     expect(input.value).toBe('10');
-    expect(screen.getByTestId('loop-iteration-hint')).toHaveTextContent('{{iteration}}');
+    // A count loop is bounded by its count: no separate Max field and no {{iteration}} hint.
+    expect(screen.queryByTestId('loop-iteration-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loop-max-iterations')).not.toBeInTheDocument();
   });
 
   it('fires onCountChange when count input is changed', () => {
@@ -68,7 +70,7 @@ describe('LoopBlockHeader', () => {
     expect(screen.getByTestId('loop-type-badge')).toHaveTextContent('While');
     expect(screen.getByTestId('loop-condition-type')).toHaveValue('imageVisible');
     expect(screen.getByTestId('loop-condition-imageId')).toHaveValue('my-img');
-    expect(screen.getByTestId('loop-iteration-hint')).toBeInTheDocument();
+    expect(screen.queryByTestId('loop-iteration-hint')).not.toBeInTheDocument();
   });
 
   it('renders repeatUntil loop header without iteration hint', () => {
@@ -82,9 +84,9 @@ describe('LoopBlockHeader', () => {
     expect(screen.queryByTestId('loop-iteration-hint')).not.toBeInTheDocument();
   });
 
-  it('renders editable max iterations input', () => {
+  it('renders editable max iterations input for while/repeat-until loops', () => {
     const onMaxChange = jest.fn();
-    render(<LoopBlockHeader loopType="count" count={5} maxIterations={100} onMaxIterationsChange={onMaxChange} />);
+    render(<LoopBlockHeader loopType="repeatUntil" condition={{ type: 'imageVisible', imageId: '', minSimilarity: null }} maxIterations={100} onMaxIterationsChange={onMaxChange} />);
     const input = screen.getByTestId('loop-max-iterations') as HTMLInputElement;
     expect(input.value).toBe('100');
     fireEvent.change(input, { target: { value: '50' } });
@@ -134,13 +136,13 @@ describe('LoopBlockHeader', () => {
 
   it('clears max iterations when input is emptied', () => {
     const onMaxChange = jest.fn();
-    render(<LoopBlockHeader loopType="count" count={5} maxIterations={100} onMaxIterationsChange={onMaxChange} />);
+    render(<LoopBlockHeader loopType="repeatUntil" condition={{ type: 'imageVisible', imageId: '', minSimilarity: null }} maxIterations={100} onMaxIterationsChange={onMaxChange} />);
     fireEvent.change(screen.getByTestId('loop-max-iterations'), { target: { value: '' } });
     expect(onMaxChange).toHaveBeenCalledWith(undefined);
   });
 
   it('shows empty max input when maxIterations is not set', () => {
-    render(<LoopBlockHeader loopType="count" count={5} />);
+    render(<LoopBlockHeader loopType="repeatUntil" condition={{ type: 'imageVisible', imageId: '', minSimilarity: null }} />);
     const input = screen.getByTestId('loop-max-iterations') as HTMLInputElement;
     expect(input.value).toBe('');
   });

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -1813,6 +1813,18 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                   Add wait step
                 </button>
               </div>
+              <div className="field" data-testid="edit-add-reschedule-button">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
+                    setDirty(true);
+                  }}
+                  disabled={submitting || loading}
+                >
+                  Add reschedule step
+                </button>
+              </div>
               <div className="field" data-testid="edit-add-loop-buttons">
                 <span>Add loop:</span>{' '}
                 <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -11,7 +11,6 @@ import { SearchableDropdown, SearchableOption } from '../components/SearchableDr
 import type { ReorderableListItem } from '../components/ReorderableList';
 import { SortableSequenceStepList } from '../components/SortableSequenceStepList';
 import { useUnsavedChangesPrompt } from '../hooks/useUnsavedChangesPrompt';
-import { navigateToUnified } from '../lib/navigation';
 import { validatePerStepConditions } from '../lib/validation';
 import { isLinearStepArray, toCommandStepIds, toInterStepDelayRange, toLinearSteps } from '../lib/sequenceMapping';
 import { LoopBlock } from '../components/sequences/LoopBlock';
@@ -1092,30 +1091,6 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
     </div>
   ), [form.steps, submitting, loading]);
 
-  const handleAddTopLevelStep = () => {
-    const id = makeId();
-    const stepId = nextGeneratedStepId(form.steps);
-    const newStep: SequenceStep = {
-      id,
-      stepId,
-      stepType: 'Action',
-      actionType: 'command',
-      commandId: '',
-      commandReference: undefined,
-      waitReferenceImageId: '',
-      waitConfidence: '',
-      waitTimeoutMs: '1000',
-      conditionType: 'none',
-      conditionNegate: false,
-      imageId: '',
-      minSimilarity: '',
-      outcomeStepRef: '',
-      expectedState: 'success',
-    };
-    setForm((prev) => ({ ...prev, steps: [...prev.steps, newStep] }));
-    setDirty(true);
-  };
-
   const createLoopStep = (loopType: 'count' | 'while' | 'repeatUntil'): SequenceStep => {
     const id = makeId();
     const stepId = nextGeneratedStepId(form.steps);
@@ -1476,26 +1451,6 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
           </FormSection>
 
           <FormSection title="Steps" description="Add commands in the order they should run and configure conditions inline." id="sequence-steps">
-            <SearchableDropdown
-              id="sequence-step-dropdown"
-              label="Add command"
-              options={commandOptions}
-              value={pendingStepId}
-              onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
-              disabled={submitting || loading}
-              placeholder="Select a command"
-              onCreateNew={() => navigateToUnified('Commands', { create: true, newTab: true })}
-              createLabel="Create new command"
-            />
-            <div className="field">
-              <button type="button" onClick={() => {
-                if (!pendingStepId) return;
-                const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
-                setForm({ ...form, steps: next });
-                setPendingStepId(undefined);
-                setDirty(true);
-              }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
-            </div>
             <div className="field grid-3">
               <div>
                 <ImageSelectorDropdown
@@ -1529,43 +1484,9 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 />
               </div>
             </div>
-            <div className="field">
-              <button
-                type="button"
-                onClick={() => {
-                  const nextStep = createDefaultWaitStep(nextGeneratedStepId(form.steps));
-                  nextStep.waitReferenceImageId = pendingWaitReferenceImageId.trim();
-                  nextStep.waitConfidence = pendingWaitReferenceImageId.trim() ? pendingWaitConfidence : '';
-                  nextStep.waitTimeoutMs = pendingWaitTimeoutMs || '1000';
-                  setForm((prev) => ({ ...prev, steps: [...prev.steps, nextStep] }));
-                  setPendingWaitReferenceImageId('');
-                  setPendingWaitConfidence('');
-                  setPendingWaitTimeoutMs('1000');
-                  setDirty(true);
-                }}
-                disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
-              >
-                Add wait step
-              </button>
-            </div>
-            <div className="field" data-testid="add-reschedule-button">
-              <button
-                type="button"
-                onClick={() => {
-                  setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
-                  setDirty(true);
-                }}
-                disabled={submitting || loading}
-              >
-                Add reschedule step
-              </button>
-            </div>
-            <div className="field" data-testid="add-loop-buttons">
-              <span>Add loop:</span>{' '}
-              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
-              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
-              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
-            </div>
+
+            <hr className="sequence-steps-separator" />
+
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenterToCursor}
@@ -1586,19 +1507,65 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 emptyMessage="No steps added yet."
               />
             </DndContext>
-            <div className="field">
+
+            <div className="field sequence-inline-row">
+              <SearchableDropdown
+                id="sequence-step-dropdown"
+                label="Add command"
+                options={commandOptions}
+                value={pendingStepId}
+                onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
+                disabled={submitting || loading}
+                placeholder="Select a command"
+              />
+              <button type="button" onClick={() => {
+                if (!pendingStepId) return;
+                const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
+                setForm({ ...form, steps: next });
+                setPendingStepId(undefined);
+                setDirty(true);
+              }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
+            </div>
+            <div className="field sequence-inline-row">
               <button
                 type="button"
-                data-testid="add-top-level-step"
-                onClick={handleAddTopLevelStep}
+                onClick={() => {
+                  const nextStep = createDefaultWaitStep(nextGeneratedStepId(form.steps));
+                  nextStep.waitReferenceImageId = pendingWaitReferenceImageId.trim();
+                  nextStep.waitConfidence = pendingWaitReferenceImageId.trim() ? pendingWaitConfidence : '';
+                  nextStep.waitTimeoutMs = pendingWaitTimeoutMs || '1000';
+                  setForm((prev) => ({ ...prev, steps: [...prev.steps, nextStep] }));
+                  setPendingWaitReferenceImageId('');
+                  setPendingWaitConfidence('');
+                  setPendingWaitTimeoutMs('1000');
+                  setDirty(true);
+                }}
+                disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
+              >
+                Add wait step
+              </button>
+              <button
+                type="button"
+                data-testid="add-reschedule-button"
+                onClick={() => {
+                  setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
+                  setDirty(true);
+                }}
                 disabled={submitting || loading}
               >
-                Add step
+                Add reschedule step
               </button>
+            </div>
+            <div className="field" data-testid="add-loop-buttons">
+              <span>Add loop:</span>{' '}
+              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
+              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
+              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
             </div>
             <div className="form-hint">Steps execute in listed order; drag to reorder within the same level.</div>
           </FormSection>
 
+          <hr className="sequence-steps-separator" />
 
           <FormActions submitting={submitting} onCancel={() => { if (!confirmNavigate()) return; setCreating(false); resetForm(); }}>
             {loading && <span className="form-hint">Loading…</span>}
@@ -1741,26 +1708,6 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
             </FormSection>
 
             <FormSection title="Steps" description="Add commands in the order they should run and configure conditions inline." id="sequence-edit-steps">
-              <SearchableDropdown
-                id="sequence-edit-step-dropdown"
-                label="Add command"
-                options={commandOptions}
-                value={pendingStepId}
-                onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
-                disabled={submitting || loading}
-                placeholder="Select a command"
-                onCreateNew={() => navigateToUnified('Commands', { create: true, newTab: true })}
-                createLabel="Create new command"
-              />
-              <div className="field">
-                <button type="button" onClick={() => {
-                  if (!pendingStepId) return;
-                  const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
-                  setForm({ ...form, steps: next });
-                  setPendingStepId(undefined);
-                  setDirty(true);
-                }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
-              </div>
               <div className="field grid-3">
                 <div>
                   <ImageSelectorDropdown
@@ -1794,43 +1741,9 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                   />
                 </div>
               </div>
-              <div className="field">
-                <button
-                  type="button"
-                  onClick={() => {
-                    const nextStep = createDefaultWaitStep(nextGeneratedStepId(form.steps));
-                    nextStep.waitReferenceImageId = pendingWaitReferenceImageId.trim();
-                    nextStep.waitConfidence = pendingWaitReferenceImageId.trim() ? pendingWaitConfidence : '';
-                    nextStep.waitTimeoutMs = pendingWaitTimeoutMs || '1000';
-                    setForm((prev) => ({ ...prev, steps: [...prev.steps, nextStep] }));
-                    setPendingWaitReferenceImageId('');
-                    setPendingWaitConfidence('');
-                    setPendingWaitTimeoutMs('1000');
-                    setDirty(true);
-                  }}
-                  disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
-                >
-                  Add wait step
-                </button>
-              </div>
-              <div className="field" data-testid="edit-add-reschedule-button">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
-                    setDirty(true);
-                  }}
-                  disabled={submitting || loading}
-                >
-                  Add reschedule step
-                </button>
-              </div>
-              <div className="field" data-testid="edit-add-loop-buttons">
-                <span>Add loop:</span>{' '}
-                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
-                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
-                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
-              </div>
+
+              <hr className="sequence-steps-separator" />
+
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenterToCursor}
@@ -1851,19 +1764,65 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                   emptyMessage="No steps added yet."
                 />
               </DndContext>
-              <div className="field">
+
+              <div className="field sequence-inline-row">
+                <SearchableDropdown
+                  id="sequence-edit-step-dropdown"
+                  label="Add command"
+                  options={commandOptions}
+                  value={pendingStepId}
+                  onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
+                  disabled={submitting || loading}
+                  placeholder="Select a command"
+                />
+                <button type="button" onClick={() => {
+                  if (!pendingStepId) return;
+                  const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
+                  setForm({ ...form, steps: next });
+                  setPendingStepId(undefined);
+                  setDirty(true);
+                }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
+              </div>
+              <div className="field sequence-inline-row">
                 <button
                   type="button"
-                  data-testid="add-top-level-step"
-                  onClick={handleAddTopLevelStep}
+                  onClick={() => {
+                    const nextStep = createDefaultWaitStep(nextGeneratedStepId(form.steps));
+                    nextStep.waitReferenceImageId = pendingWaitReferenceImageId.trim();
+                    nextStep.waitConfidence = pendingWaitReferenceImageId.trim() ? pendingWaitConfidence : '';
+                    nextStep.waitTimeoutMs = pendingWaitTimeoutMs || '1000';
+                    setForm((prev) => ({ ...prev, steps: [...prev.steps, nextStep] }));
+                    setPendingWaitReferenceImageId('');
+                    setPendingWaitConfidence('');
+                    setPendingWaitTimeoutMs('1000');
+                    setDirty(true);
+                  }}
+                  disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
+                >
+                  Add wait step
+                </button>
+                <button
+                  type="button"
+                  data-testid="edit-add-reschedule-button"
+                  onClick={() => {
+                    setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
+                    setDirty(true);
+                  }}
                   disabled={submitting || loading}
                 >
-                  Add step
+                  Add reschedule step
                 </button>
+              </div>
+              <div className="field" data-testid="edit-add-loop-buttons">
+                <span>Add loop:</span>{' '}
+                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
+                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
+                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
               </div>
               <div className="form-hint">Steps execute in listed order; drag to reorder within the same level.</div>
             </FormSection>
 
+            <hr className="sequence-steps-separator" />
 
             <FormActions
               submitting={submitting}

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -628,9 +628,6 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
   const [editingId, setEditingId] = useState<string | undefined>(undefined);
   const [form, setForm] = useState<SequenceFormValue>(emptyForm);
   const [pendingStepId, setPendingStepId] = useState<string | undefined>(undefined);
-  const [pendingWaitReferenceImageId, setPendingWaitReferenceImageId] = useState('');
-  const [pendingWaitConfidence, setPendingWaitConfidence] = useState('');
-  const [pendingWaitTimeoutMs, setPendingWaitTimeoutMs] = useState('1000');
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteMessage, setDeleteMessage] = useState<string | undefined>(undefined);
   const [deleteReferences, setDeleteReferences] = useState<Record<string, Array<{ id: string; name: string }>> | undefined>(undefined);
@@ -778,9 +775,6 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
   const resetForm = () => {
     setForm(emptyForm);
     setPendingStepId(undefined);
-    setPendingWaitReferenceImageId('');
-    setPendingWaitConfidence('');
-    setPendingWaitTimeoutMs('1000');
     setLoadedVersion(1);
     setErrors(undefined);
     setDirty(false);
@@ -1451,42 +1445,6 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
           </FormSection>
 
           <FormSection title="Steps" description="Add commands in the order they should run and configure conditions inline." id="sequence-steps">
-            <div className="field grid-3">
-              <div>
-                <ImageSelectorDropdown
-                  id="sequence-wait-reference"
-                  label="Wait image ID"
-                  value={pendingWaitReferenceImageId}
-                  onChange={(id) => {
-                    setPendingWaitReferenceImageId(id);
-                    if (!id) setPendingWaitConfidence('');
-                  }}
-                />
-              </div>
-              <div>
-                <label htmlFor="sequence-wait-confidence">Wait confidence (0-1)</label>
-                <input
-                  id="sequence-wait-confidence"
-                  inputMode="decimal"
-                  value={pendingWaitConfidence}
-                  onChange={(event) => setPendingWaitConfidence(event.target.value)}
-                  disabled={submitting || loading || !pendingWaitReferenceImageId.trim()}
-                />
-              </div>
-              <div>
-                <label htmlFor="sequence-wait-timeout">Wait timeout (ms)</label>
-                <input
-                  id="sequence-wait-timeout"
-                  inputMode="numeric"
-                  value={pendingWaitTimeoutMs}
-                  onChange={(event) => setPendingWaitTimeoutMs(event.target.value)}
-                  disabled={submitting || loading}
-                />
-              </div>
-            </div>
-
-            <hr className="sequence-steps-separator" />
-
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenterToCursor}
@@ -1508,59 +1466,62 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
               />
             </DndContext>
 
-            <div className="field sequence-inline-row">
-              <SearchableDropdown
-                id="sequence-step-dropdown"
-                label="Add command"
-                options={commandOptions}
-                value={pendingStepId}
-                onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
-                disabled={submitting || loading}
-                placeholder="Select a command"
-              />
-              <button type="button" onClick={() => {
-                if (!pendingStepId) return;
-                const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
-                setForm({ ...form, steps: next });
-                setPendingStepId(undefined);
-                setDirty(true);
-              }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
-            </div>
-            <div className="field sequence-inline-row">
-              <button
-                type="button"
-                onClick={() => {
-                  const nextStep = createDefaultWaitStep(nextGeneratedStepId(form.steps));
-                  nextStep.waitReferenceImageId = pendingWaitReferenceImageId.trim();
-                  nextStep.waitConfidence = pendingWaitReferenceImageId.trim() ? pendingWaitConfidence : '';
-                  nextStep.waitTimeoutMs = pendingWaitTimeoutMs || '1000';
-                  setForm((prev) => ({ ...prev, steps: [...prev.steps, nextStep] }));
-                  setPendingWaitReferenceImageId('');
-                  setPendingWaitConfidence('');
-                  setPendingWaitTimeoutMs('1000');
+            <hr className="sequence-steps-separator" />
+
+            <div className="sequence-add-grid">
+              <div className="sequence-add-col">
+                <div className="sequence-add-col__label">Command</div>
+                <SearchableDropdown
+                  id="sequence-step-dropdown"
+                  label="Add command"
+                  options={commandOptions}
+                  value={pendingStepId}
+                  onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
+                  disabled={submitting || loading}
+                  placeholder="Select a command"
+                />
+                <button type="button" onClick={() => {
+                  if (!pendingStepId) return;
+                  const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
+                  setForm({ ...form, steps: next });
+                  setPendingStepId(undefined);
                   setDirty(true);
-                }}
-                disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
-              >
-                Add wait step
-              </button>
-              <button
-                type="button"
-                data-testid="add-reschedule-button"
-                onClick={() => {
-                  setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
-                  setDirty(true);
-                }}
-                disabled={submitting || loading}
-              >
-                Add reschedule step
-              </button>
-            </div>
-            <div className="field" data-testid="add-loop-buttons">
-              <span>Add loop:</span>{' '}
-              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
-              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
-              <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
+                }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
+              </div>
+              <div className="sequence-add-col">
+                <div className="sequence-add-col__label">Loop</div>
+                <div className="sequence-add-col__buttons" data-testid="add-loop-buttons">
+                  <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>
+                  <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>
+                  <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
+                </div>
+              </div>
+              <div className="sequence-add-col">
+                <div className="sequence-add-col__label">Special steps</div>
+                <div className="sequence-add-col__buttons">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultWaitStep(nextGeneratedStepId(prev.steps))] }));
+                      setDirty(true);
+                    }}
+                    disabled={submitting || loading}
+                  >
+                    Add wait step
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="add-reschedule-button"
+                    onClick={() => {
+                      setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
+                      setDirty(true);
+                    }}
+                    disabled={submitting || loading}
+                  >
+                    Add reschedule step
+                  </button>
+                </div>
+              </div>
             </div>
             <div className="form-hint">Steps execute in listed order; drag to reorder within the same level.</div>
           </FormSection>
@@ -1708,42 +1669,6 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
             </FormSection>
 
             <FormSection title="Steps" description="Add commands in the order they should run and configure conditions inline." id="sequence-edit-steps">
-              <div className="field grid-3">
-                <div>
-                  <ImageSelectorDropdown
-                    id="sequence-edit-wait-reference"
-                    label="Wait image ID"
-                    value={pendingWaitReferenceImageId}
-                    onChange={(id) => {
-                      setPendingWaitReferenceImageId(id);
-                      if (!id) setPendingWaitConfidence('');
-                    }}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="sequence-edit-wait-confidence">Wait confidence (0-1)</label>
-                  <input
-                    id="sequence-edit-wait-confidence"
-                    inputMode="decimal"
-                    value={pendingWaitConfidence}
-                    onChange={(event) => setPendingWaitConfidence(event.target.value)}
-                    disabled={submitting || loading || !pendingWaitReferenceImageId.trim()}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="sequence-edit-wait-timeout">Wait timeout (ms)</label>
-                  <input
-                    id="sequence-edit-wait-timeout"
-                    inputMode="numeric"
-                    value={pendingWaitTimeoutMs}
-                    onChange={(event) => setPendingWaitTimeoutMs(event.target.value)}
-                    disabled={submitting || loading}
-                  />
-                </div>
-              </div>
-
-              <hr className="sequence-steps-separator" />
-
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenterToCursor}
@@ -1765,59 +1690,62 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 />
               </DndContext>
 
-              <div className="field sequence-inline-row">
-                <SearchableDropdown
-                  id="sequence-edit-step-dropdown"
-                  label="Add command"
-                  options={commandOptions}
-                  value={pendingStepId}
-                  onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
-                  disabled={submitting || loading}
-                  placeholder="Select a command"
-                />
-                <button type="button" onClick={() => {
-                  if (!pendingStepId) return;
-                  const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
-                  setForm({ ...form, steps: next });
-                  setPendingStepId(undefined);
-                  setDirty(true);
-                }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
-              </div>
-              <div className="field sequence-inline-row">
-                <button
-                  type="button"
-                  onClick={() => {
-                    const nextStep = createDefaultWaitStep(nextGeneratedStepId(form.steps));
-                    nextStep.waitReferenceImageId = pendingWaitReferenceImageId.trim();
-                    nextStep.waitConfidence = pendingWaitReferenceImageId.trim() ? pendingWaitConfidence : '';
-                    nextStep.waitTimeoutMs = pendingWaitTimeoutMs || '1000';
-                    setForm((prev) => ({ ...prev, steps: [...prev.steps, nextStep] }));
-                    setPendingWaitReferenceImageId('');
-                    setPendingWaitConfidence('');
-                    setPendingWaitTimeoutMs('1000');
+              <hr className="sequence-steps-separator" />
+
+              <div className="sequence-add-grid">
+                <div className="sequence-add-col">
+                  <div className="sequence-add-col__label">Command</div>
+                  <SearchableDropdown
+                    id="sequence-edit-step-dropdown"
+                    label="Add command"
+                    options={commandOptions}
+                    value={pendingStepId}
+                    onChange={(val) => { setPendingStepId(val); setErrors(undefined); }}
+                    disabled={submitting || loading}
+                    placeholder="Select a command"
+                  />
+                  <button type="button" onClick={() => {
+                    if (!pendingStepId) return;
+                    const next = [...form.steps, createDefaultStep(pendingStepId, nextGeneratedStepId(form.steps))];
+                    setForm({ ...form, steps: next });
+                    setPendingStepId(undefined);
                     setDirty(true);
-                  }}
-                  disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
-                >
-                  Add wait step
-                </button>
-                <button
-                  type="button"
-                  data-testid="edit-add-reschedule-button"
-                  onClick={() => {
-                    setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
-                    setDirty(true);
-                  }}
-                  disabled={submitting || loading}
-                >
-                  Add reschedule step
-                </button>
-              </div>
-              <div className="field" data-testid="edit-add-loop-buttons">
-                <span>Add loop:</span>{' '}
-                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>{' '}
-                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>{' '}
-                <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
+                  }} disabled={submitting || loading || !pendingStepId}>Add to steps</button>
+                </div>
+                <div className="sequence-add-col">
+                  <div className="sequence-add-col__label">Loop</div>
+                  <div className="sequence-add-col__buttons" data-testid="edit-add-loop-buttons">
+                    <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('count')] })); setDirty(true); }} disabled={submitting || loading}>Count</button>
+                    <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('while')] })); setDirty(true); }} disabled={submitting || loading}>While</button>
+                    <button type="button" onClick={() => { setForm((prev) => ({ ...prev, steps: [...prev.steps, createLoopStep('repeatUntil')] })); setDirty(true); }} disabled={submitting || loading}>Repeat‑Until</button>
+                  </div>
+                </div>
+                <div className="sequence-add-col">
+                  <div className="sequence-add-col__label">Special steps</div>
+                  <div className="sequence-add-col__buttons">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultWaitStep(nextGeneratedStepId(prev.steps))] }));
+                        setDirty(true);
+                      }}
+                      disabled={submitting || loading}
+                    >
+                      Add wait step
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="edit-add-reschedule-button"
+                      onClick={() => {
+                        setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
+                        setDirty(true);
+                      }}
+                      disabled={submitting || loading}
+                    >
+                      Add reschedule step
+                    </button>
+                  </div>
+                </div>
               </div>
               <div className="form-hint">Steps execute in listed order; drag to reorder within the same level.</div>
             </FormSection>

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -975,7 +975,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
       )}
 
       {step.conditionType === 'imageVisible' && (
-        <>
+        <div className="sequence-step-condition-pair">
           <div className="sequence-step-condition-field sequence-step-condition-field--image-id">
             <ImageSelectorDropdown
               id={`step-image-id-${step.id}`}
@@ -1033,11 +1033,11 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
               disabled={submitting || loading}
             />
           </div>
-        </>
+        </div>
       )}
 
       {step.conditionType === 'commandOutcome' && (
-        <>
+        <div className="sequence-step-condition-pair">
           <div className="sequence-step-condition-field sequence-step-condition-field--step-ref">
             <label htmlFor={`step-step-ref-${step.id}`}>Step Ref</label>
             <select
@@ -1080,7 +1080,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
               <option value="skipped">skipped</option>
             </select>
           </div>
-        </>
+        </div>
       )}
     </div>
   ), [form.steps, submitting, loading]);

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -19,11 +19,13 @@ import type { LoopStepEntry, BreakStepEntry, StepEntry } from '../types/stepEntr
 import type { SequenceLinearStep, LoopConfigDto, SequencePrimitiveActionPayload, SequenceCommandReference } from '../types/sequenceFlow';
 import { ImageSelectorDropdown } from '../components/images/ImageSelectorDropdown';
 
+type RescheduleOption = 'AtQueueStart' | 'OncePerRun' | 'Timer' | 'EveryStep';
+
 type SequenceStep = {
   id: string;
   stepId: string;
   stepType: 'Action' | 'Loop' | 'Break';
-  actionType: 'command' | 'WaitForImage';
+  actionType: 'command' | 'WaitForImage' | 'reschedule-self';
   commandId: string;
   commandReference?: SequenceCommandReference;
   waitReferenceImageId: string;
@@ -36,7 +38,41 @@ type SequenceStep = {
   outcomeStepRef: string;
   expectedState: 'success' | 'failed' | 'skipped';
   loopEntry?: LoopStepEntry;
+  // Self-reschedule action fields (feature 065); only meaningful when actionType === 'reschedule-self'.
+  rescheduleOption?: RescheduleOption;
+  rescheduleTimerMode?: 'relative' | 'timeOfDay';
+  rescheduleTimerRelativeOffset?: string;
+  rescheduleTimerTimeOfDay?: string;
 };
+
+const RESCHEDULE_OPTIONS: ReadonlyArray<{ value: RescheduleOption; label: string }> = [
+  { value: 'AtQueueStart', label: 'At Queue Start' },
+  { value: 'OncePerRun', label: 'Once Per Run' },
+  { value: 'Timer', label: 'Timer' },
+  { value: 'EveryStep', label: 'After Every Step' }
+];
+
+const createDefaultRescheduleStep = (stepId: string): SequenceStep => ({
+  id: makeId(),
+  stepId,
+  stepType: 'Action',
+  actionType: 'reschedule-self',
+  commandId: '',
+  commandReference: undefined,
+  waitReferenceImageId: '',
+  waitConfidence: '',
+  waitTimeoutMs: '1000',
+  conditionType: 'none',
+  conditionNegate: false,
+  imageId: '',
+  minSimilarity: '',
+  outcomeStepRef: '',
+  expectedState: 'success',
+  rescheduleOption: 'OncePerRun',
+  rescheduleTimerMode: 'relative',
+  rescheduleTimerRelativeOffset: '00:10:00',
+  rescheduleTimerTimeOfDay: '12:00'
+});
 
 type SequenceFormValue = {
   name: string;
@@ -302,6 +338,39 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
     }
 
     const primitiveAction = getPrimitiveAction(step);
+    if (primitiveAction?.type === 'reschedule-self') {
+      const payload = primitiveAction.payload ?? {};
+      const option = (typeof payload.option === 'string' ? payload.option : 'OncePerRun') as RescheduleOption;
+      const relative = typeof payload.timerRelativeOffset === 'string' ? payload.timerRelativeOffset : undefined;
+      const timeOfDay = typeof payload.timerTimeOfDay === 'string' ? payload.timerTimeOfDay : undefined;
+      const base = createDefaultRescheduleStep(step.stepId);
+      const rescheduleStep: SequenceStep = {
+        ...base,
+        rescheduleOption: option,
+        rescheduleTimerMode: timeOfDay ? 'timeOfDay' : 'relative',
+        rescheduleTimerRelativeOffset: relative ?? base.rescheduleTimerRelativeOffset,
+        rescheduleTimerTimeOfDay: timeOfDay ? timeOfDay.slice(0, 5) : base.rescheduleTimerTimeOfDay,
+      };
+      if (step.condition?.type === 'imageVisible') {
+        return {
+          ...rescheduleStep,
+          conditionType: 'imageVisible',
+          conditionNegate: step.condition.negate ?? false,
+          imageId: step.condition.imageId,
+          minSimilarity: step.condition.minSimilarity == null ? '' : String(step.condition.minSimilarity),
+        };
+      }
+      if (step.condition?.type === 'commandOutcome') {
+        return {
+          ...rescheduleStep,
+          conditionType: 'commandOutcome',
+          conditionNegate: step.condition.negate ?? false,
+          outcomeStepRef: step.condition.stepRef,
+          expectedState: step.condition.expectedState,
+        };
+      }
+      return rescheduleStep;
+    }
     if (primitiveAction?.type === 'WaitForImage') {
       const detectionTarget = primitiveAction.payload?.detectionTarget as Record<string, unknown> | undefined;
       const confidence = typeof detectionTarget?.confidence === 'number' ? String(detectionTarget.confidence) : '';
@@ -486,6 +555,25 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
         stepId: step.stepId.trim(),
         stepType: 'Break' as const,
         breakCondition: null // top-level breaks are unconditional
+      };
+    }
+
+    if (step.actionType === 'reschedule-self') {
+      const option = step.rescheduleOption ?? 'OncePerRun';
+      const payload: Record<string, unknown> = { option };
+      if (option === 'Timer') {
+        if (step.rescheduleTimerMode === 'timeOfDay') {
+          const t = (step.rescheduleTimerTimeOfDay ?? '').trim();
+          payload.timerTimeOfDay = t.length === 5 ? `${t}:00` : t;
+        } else {
+          payload.timerRelativeOffset = (step.rescheduleTimerRelativeOffset ?? '').trim();
+        }
+      }
+      return {
+        stepId: step.stepId.trim(),
+        stepType: 'Action' as const,
+        primitiveAction: { type: 'reschedule-self', schemaVersion: '1', payload },
+        condition: buildConditionPayload(step)
       };
     }
 
@@ -757,6 +845,91 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         </>
       )}
 
+      {step.stepType === 'Action' && step.actionType === 'reschedule-self' && (
+        <>
+          <div className="sequence-step-condition-field sequence-step-condition-field--reschedule-option">
+            <label htmlFor={`step-reschedule-option-${step.id}`}>Reschedule option</label>
+            <select
+              id={`step-reschedule-option-${step.id}`}
+              value={step.rescheduleOption ?? 'OncePerRun'}
+              onChange={(event) => {
+                const value = event.target.value as RescheduleOption;
+                setForm((prev) => ({
+                  ...prev,
+                  steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, rescheduleOption: value } : candidate)
+                }));
+                setDirty(true);
+              }}
+              disabled={submitting || loading}
+            >
+              {RESCHEDULE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {(step.rescheduleOption ?? 'OncePerRun') === 'Timer' && (
+            <>
+              <div className="sequence-step-condition-field sequence-step-condition-field--reschedule-timer-mode">
+                <label htmlFor={`step-reschedule-timer-mode-${step.id}`}>Timer mode</label>
+                <select
+                  id={`step-reschedule-timer-mode-${step.id}`}
+                  value={step.rescheduleTimerMode ?? 'relative'}
+                  onChange={(event) => {
+                    const value = event.target.value as 'relative' | 'timeOfDay';
+                    setForm((prev) => ({
+                      ...prev,
+                      steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, rescheduleTimerMode: value } : candidate)
+                    }));
+                    setDirty(true);
+                  }}
+                  disabled={submitting || loading}
+                >
+                  <option value="relative">Relative offset</option>
+                  <option value="timeOfDay">Time of day</option>
+                </select>
+              </div>
+
+              {(step.rescheduleTimerMode ?? 'relative') === 'relative' ? (
+                <div className="sequence-step-condition-field sequence-step-condition-field--reschedule-offset">
+                  <label htmlFor={`step-reschedule-offset-${step.id}`}>Relative offset (HH:mm:ss)</label>
+                  <input
+                    id={`step-reschedule-offset-${step.id}`}
+                    value={step.rescheduleTimerRelativeOffset ?? ''}
+                    placeholder="00:10:00"
+                    onChange={(event) => {
+                      setForm((prev) => ({
+                        ...prev,
+                        steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, rescheduleTimerRelativeOffset: event.target.value } : candidate)
+                      }));
+                      setDirty(true);
+                    }}
+                    disabled={submitting || loading}
+                  />
+                </div>
+              ) : (
+                <div className="sequence-step-condition-field sequence-step-condition-field--reschedule-time-of-day">
+                  <label htmlFor={`step-reschedule-time-${step.id}`}>Time of day</label>
+                  <input
+                    id={`step-reschedule-time-${step.id}`}
+                    type="time"
+                    value={step.rescheduleTimerTimeOfDay ?? ''}
+                    onChange={(event) => {
+                      setForm((prev) => ({
+                        ...prev,
+                        steps: prev.steps.map((candidate) => candidate.id === step.id ? { ...candidate, rescheduleTimerTimeOfDay: event.target.value } : candidate)
+                      }));
+                      setDirty(true);
+                    }}
+                    disabled={submitting || loading}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </>
+      )}
+
       <div className="sequence-step-condition-field sequence-step-condition-field--type">
         <label htmlFor={`step-condition-type-${step.id}`}>Condition Type</label>
         <select
@@ -1009,7 +1182,9 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         id: s.id,
         label: s.actionType === 'WaitForImage'
           ? `Wait for image: ${s.waitReferenceImageId.trim() || 'any image'}`
-          : getDisplayCommandLabel(s.commandId, s.commandReference, commandLookup),
+          : s.actionType === 'reschedule-self'
+            ? `Reschedule this sequence (${RESCHEDULE_OPTIONS.find((o) => o.value === (s.rescheduleOption ?? 'OncePerRun'))?.label})`
+            : getDisplayCommandLabel(s.commandId, s.commandReference, commandLookup),
         details: renderStepConditionEditor(s, idx),
       };
     });
@@ -1039,6 +1214,18 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         const parsedTimeout = Number(timeout);
         if (!Number.isInteger(parsedTimeout) || parsedTimeout < 0) {
           next.steps = 'Wait for image timeout must be a non-negative integer';
+          break;
+        }
+      }
+
+      if (step.actionType === 'reschedule-self' && (step.rescheduleOption ?? 'OncePerRun') === 'Timer') {
+        if ((step.rescheduleTimerMode ?? 'relative') === 'timeOfDay') {
+          if (!(step.rescheduleTimerTimeOfDay ?? '').trim()) {
+            next.steps = 'Timer reschedule requires a time of day';
+            break;
+          }
+        } else if (!/^\d{1,2}:\d{2}:\d{2}$/.test((step.rescheduleTimerRelativeOffset ?? '').trim())) {
+          next.steps = 'Timer reschedule requires a relative offset as HH:mm:ss';
           break;
         }
       }
@@ -1359,6 +1546,18 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 disabled={submitting || loading || !pendingWaitTimeoutMs.trim()}
               >
                 Add wait step
+              </button>
+            </div>
+            <div className="field" data-testid="add-reschedule-button">
+              <button
+                type="button"
+                onClick={() => {
+                  setForm((prev) => ({ ...prev, steps: [...prev.steps, createDefaultRescheduleStep(nextGeneratedStepId(prev.steps))] }));
+                  setDirty(true);
+                }}
+                disabled={submitting || loading}
+              >
+                Add reschedule step
               </button>
             </div>
             <div className="field" data-testid="add-loop-buttons">

--- a/src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SequencesPage } from '../SequencesPage';
+import { createSequence, listSequences } from '../../services/sequences';
+import { listCommands } from '../../services/commands';
+
+jest.mock('../../services/sequences');
+jest.mock('../../services/commands');
+
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+const createSequenceMock = createSequence as jest.MockedFunction<typeof createSequence>;
+const listCommandsMock = listCommands as jest.MockedFunction<typeof listCommands>;
+
+describe('SequencesPage self-reschedule action (feature 065)', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    listSequencesMock.mockResolvedValue([] as any);
+    listCommandsMock.mockResolvedValue([{ id: 'cmd-home', name: 'Home' }] as any);
+    createSequenceMock.mockResolvedValue({ id: 'seq-reschedule', name: 'Reschedule', steps: [] } as any);
+  });
+
+  it('T024: authors a reschedule-self action inside an IF branch and serializes it', async () => {
+    render(<SequencesPage />);
+    await waitFor(() => expect(listSequencesMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText('Create Sequence'));
+    fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Reschedule' } });
+
+    // A prior command step to gate against.
+    fireEvent.change(screen.getByLabelText('Add command'), { target: { value: 'cmd-home' } });
+    fireEvent.click(screen.getByText('Add to steps'));
+
+    // The self-reschedule action step.
+    fireEvent.click(screen.getByText('Add reschedule step'));
+
+    // Default option is Once Per Run.
+    expect(screen.getByLabelText('Reschedule option')).toHaveValue('OncePerRun');
+
+    // Place it under an IF: gate on the prior step's outcome.
+    const conditionTypes = screen.getAllByLabelText('Condition Type');
+    fireEvent.change(conditionTypes[1], { target: { value: 'commandOutcome' } });
+    fireEvent.change(screen.getByLabelText('Step Ref'), { target: { value: 'step-1' } });
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(createSequenceMock).toHaveBeenCalledWith(expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            stepId: 'step-2',
+            primitiveAction: expect.objectContaining({
+              type: 'reschedule-self',
+              payload: expect.objectContaining({ option: 'OncePerRun' })
+            }),
+            condition: expect.objectContaining({ type: 'commandOutcome', stepRef: 'step-1' })
+          })
+        ])
+      }));
+    });
+  });
+
+  it('T035: option dropdown offers all four options and shows Timer inputs', async () => {
+    render(<SequencesPage />);
+    await waitFor(() => expect(listSequencesMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText('Create Sequence'));
+    fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Reschedule timer' } });
+    fireEvent.click(screen.getByText('Add reschedule step'));
+
+    const optionSelect = screen.getByLabelText('Reschedule option');
+    const optionLabels = Array.from(optionSelect.querySelectorAll('option')).map((o) => o.textContent);
+    expect(optionLabels).toEqual(['At Queue Start', 'Once Per Run', 'Timer', 'After Every Step']);
+
+    // Timer mode is hidden until Timer is selected.
+    expect(screen.queryByLabelText('Timer mode')).not.toBeInTheDocument();
+
+    fireEvent.change(optionSelect, { target: { value: 'Timer' } });
+    expect(screen.getByLabelText('Timer mode')).toBeInTheDocument();
+    // Default mode is relative offset.
+    expect(screen.getByLabelText('Relative offset (HH:mm:ss)')).toBeInTheDocument();
+
+    // Switching to time-of-day reveals the time input (mirrors the queue-template editor).
+    fireEvent.change(screen.getByLabelText('Timer mode'), { target: { value: 'timeOfDay' } });
+    expect(screen.getByLabelText('Time of day')).toBeInTheDocument();
+  });
+
+  it('T035: Timer relative offset serializes the single timer field', async () => {
+    render(<SequencesPage />);
+    await waitFor(() => expect(listSequencesMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText('Create Sequence'));
+    fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Reschedule timer' } });
+    fireEvent.click(screen.getByText('Add reschedule step'));
+    fireEvent.change(screen.getByLabelText('Reschedule option'), { target: { value: 'Timer' } });
+    fireEvent.change(screen.getByLabelText('Relative offset (HH:mm:ss)'), { target: { value: '00:05:00' } });
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(createSequenceMock).toHaveBeenCalledWith(expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            primitiveAction: expect.objectContaining({
+              type: 'reschedule-self',
+              payload: expect.objectContaining({ option: 'Timer', timerRelativeOffset: '00:05:00' })
+            })
+          })
+        ])
+      }));
+    });
+  });
+});

--- a/src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.reschedule.spec.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { SequencesPage } from '../SequencesPage';
-import { createSequence, listSequences } from '../../services/sequences';
+import { createSequence, getSequence, listSequences } from '../../services/sequences';
 import { listCommands } from '../../services/commands';
 
 jest.mock('../../services/sequences');
 jest.mock('../../services/commands');
 
+jest.mock('../../components/images/ImageSelectorDropdown', () => ({
+  ImageSelectorDropdown: ({ id, label, value, onChange, disabled }: {
+    id?: string; label?: string; value: string; onChange: (v: string) => void; disabled?: boolean;
+  }) => (
+    <>
+      {label && <label htmlFor={id}>{label}</label>}
+      <input id={id} value={value} disabled={disabled} onChange={(e) => onChange(e.target.value)} />
+    </>
+  ),
+}));
+
 const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
 const createSequenceMock = createSequence as jest.MockedFunction<typeof createSequence>;
+const getSequenceMock = getSequence as jest.MockedFunction<typeof getSequence>;
 const listCommandsMock = listCommands as jest.MockedFunction<typeof listCommands>;
 
 describe('SequencesPage self-reschedule action (feature 065)', () => {
@@ -82,6 +94,35 @@ describe('SequencesPage self-reschedule action (feature 065)', () => {
     // Switching to time-of-day reveals the time input (mirrors the queue-template editor).
     fireEvent.change(screen.getByLabelText('Timer mode'), { target: { value: 'timeOfDay' } });
     expect(screen.getByLabelText('Time of day')).toBeInTheDocument();
+  });
+
+  it('edit mode also exposes "Add reschedule step" and round-trips an existing reschedule step', async () => {
+    listSequencesMock.mockResolvedValue([{ id: 'seq-1', name: 'Existing', steps: [] }] as any);
+    getSequenceMock.mockResolvedValue({
+      id: 'seq-1',
+      name: 'Existing',
+      version: 2,
+      steps: [
+        { stepId: 'step-1', label: 'Home', primitiveAction: { type: 'command', schemaVersion: 'v1', payload: { commandId: 'cmd-home' } }, condition: null },
+        {
+          stepId: 'step-2',
+          stepType: 'Action',
+          primitiveAction: { type: 'reschedule-self', schemaVersion: '1', payload: { option: 'Timer', timerRelativeOffset: '00:15:00' } },
+          condition: { type: 'commandOutcome', stepRef: 'step-1', expectedState: 'success' }
+        }
+      ]
+    } as any);
+
+    render(<SequencesPage />);
+    await screen.findByText('Existing');
+    fireEvent.click(screen.getByText('Existing'));
+
+    // Regression: the edit form must offer the reschedule control too (not only the create form).
+    expect(await screen.findByText('Add reschedule step')).toBeInTheDocument();
+
+    // The existing reschedule step loaded its option and timer field back into the editor.
+    expect(screen.getByLabelText('Reschedule option')).toHaveValue('Timer');
+    expect(screen.getByLabelText('Relative offset (HH:mm:ss)')).toHaveValue('00:15:00');
   });
 
   it('T035: Timer relative offset serializes the single timer field', async () => {

--- a/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
@@ -137,10 +137,11 @@ describe('SequencesPage', () => {
 
     fireEvent.click(screen.getByText('Create Sequence'));
     fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Wait Seq' } });
+    // Wait steps are now added first, then configured inline on the step itself.
+    fireEvent.click(screen.getByText('Add wait step'));
     fireEvent.change(screen.getByLabelText('Wait image ID'), { target: { value: 'mail_icon' } });
     fireEvent.change(screen.getByLabelText('Wait confidence (0-1)'), { target: { value: '0.88' } });
     fireEvent.change(screen.getByLabelText('Wait timeout (ms)'), { target: { value: '2400' } });
-    fireEvent.click(screen.getByText('Add wait step'));
 
     createSequenceMock.mockResolvedValue({} as any);
     fireEvent.click(screen.getByText('Save'));

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -132,6 +132,13 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 .edit-form .form-actions { display: flex; gap: var(--gb-space-2); margin-top: var(--gb-space-4); }
 .queue-section-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gb-color-text-muted, #888); white-space: nowrap; }
 
+/* Sequence Steps layout (feature 065 reorg): wait-image area, separators, inline add-rows */
+.sequence-steps-separator { border: none; border-top: 1px solid var(--gb-color-border); margin: var(--gb-space-4) 0; }
+.sequence-inline-row { display: flex; gap: var(--gb-space-3); flex-wrap: wrap; align-items: flex-end; }
+.sequence-inline-row > .searchable-dropdown,
+.sequence-inline-row > div:first-child { flex: 1 1 16rem; min-width: 12rem; }
+.sequence-inline-row button { white-space: nowrap; }
+
 /* Queue sequence entries — keep the ordered list as-is; align the "Add sequence"
    row to list items (default <ol> indentation is 40px) and put the button inline. */
 .queue-entries .queue-entry-add { margin-top: var(--gb-space-2); margin-left: 40px; display: inline-flex; align-items: center; gap: var(--gb-space-2); }

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -132,12 +132,19 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 .edit-form .form-actions { display: flex; gap: var(--gb-space-2); margin-top: var(--gb-space-4); }
 .queue-section-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gb-color-text-muted, #888); white-space: nowrap; }
 
-/* Sequence Steps layout (feature 065 reorg): wait-image area, separators, inline add-rows */
+/* Sequence Steps layout (feature 065 reorg): separators + 3-column add area */
 .sequence-steps-separator { border: none; border-top: 1px solid var(--gb-color-border); margin: var(--gb-space-4) 0; }
-.sequence-inline-row { display: flex; gap: var(--gb-space-3); flex-wrap: wrap; align-items: flex-end; }
-.sequence-inline-row > .searchable-dropdown,
-.sequence-inline-row > div:first-child { flex: 1 1 16rem; min-width: 12rem; }
-.sequence-inline-row button { white-space: nowrap; }
+/* Breathing room after the section title + subtitle, before the steps list */
+#sequence-steps .form-section__description,
+#sequence-edit-steps .form-section__description { margin-bottom: var(--gb-space-4); }
+/* Three left-aligned columns (Command / Loop / Special steps), no separators */
+.sequence-add-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--gb-space-4); align-items: start; }
+.sequence-add-col { display: flex; flex-direction: column; align-items: flex-start; gap: var(--gb-space-2); min-width: 0; }
+.sequence-add-col .searchable-dropdown { width: 100%; }
+.sequence-add-col__label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gb-color-text-muted, #888); }
+.sequence-add-col__buttons { display: flex; flex-direction: column; align-items: flex-start; gap: var(--gb-space-2); }
+/* The dropdown keeps an accessible "Add command" label, but the visible column header is "Command". */
+.sequence-add-col .dropdown-label { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 
 /* Queue sequence entries — keep the ordered list as-is; align the "Add sequence"
    row to list items (default <ol> indentation is 40px) and put the button inline. */

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -146,6 +146,30 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 /* The dropdown keeps an accessible "Add command" label, but the visible column header is "Command". */
 .sequence-add-col .dropdown-label { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 
+/* Compact single-row steps: name + inline condition/dropdown + delete on one line (wraps if needed) */
+.sortable-step-item { align-items: center; }
+.sortable-step-item .reorderable-list__content { display: flex; flex-wrap: wrap; align-items: center; gap: var(--gb-space-2) var(--gb-space-3); flex: 1 1 auto; min-width: 0; }
+.sortable-step-item .reorderable-list__label { flex: 0 0 auto; }
+.sortable-step-item .reorderable-list__details { flex: 1 1 auto; align-items: center; flex-wrap: wrap; overflow-x: visible; }
+/* Condition fields render label-beside-control so a simple step is a single line; they wrap when a condition adds fields. */
+.sortable-step-item .reorderable-list__details .sequence-step-condition-field { flex-direction: row; align-items: center; gap: 6px; flex: 0 0 auto; }
+.sortable-step-item .reorderable-list__details .sequence-step-condition-field label { margin-bottom: 0; white-space: nowrap; }
+
+/* Loop header on one line: "Count × <n>  Remove Loop" (condition loops wrap their fields) */
+.loop-block__header-row { display: flex; align-items: center; flex-wrap: wrap; gap: var(--gb-space-2); }
+.loop-block-header { display: flex; align-items: center; flex-wrap: wrap; gap: var(--gb-space-2); }
+.loop-block-header__badge { font-weight: 600; }
+.loop-block-header__count-field,
+.loop-block-header__limit-field { display: inline-flex; align-items: center; gap: 4px; }
+.loop-block-header__condition-fields { display: flex; align-items: center; flex-wrap: wrap; gap: var(--gb-space-2); }
+
+/* Break rows: header line + wrapped condition fields (≈2–3 lines) */
+.break-step-row__header { display: flex; align-items: center; flex-wrap: wrap; gap: var(--gb-space-2); }
+.break-step-row__badge { font-weight: 600; }
+.break-step-row__condition { display: flex; align-items: flex-end; flex-wrap: wrap; gap: var(--gb-space-2) var(--gb-space-3); margin-top: var(--gb-space-2); }
+.break-step-row__field { display: flex; flex-direction: column; min-width: 0; }
+.break-step-row__field label { display: inline-flex; align-items: center; gap: 4px; }
+
 /* Queue sequence entries — keep the ordered list as-is; align the "Add sequence"
    row to list items (default <ol> indentation is 40px) and put the button inline. */
 .queue-entries .queue-entry-add { margin-top: var(--gb-space-2); margin-left: 40px; display: inline-flex; align-items: center; gap: var(--gb-space-2); }

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -154,6 +154,16 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 /* Condition fields render label-beside-control so a simple step is a single line; they wrap when a condition adds fields. */
 .sortable-step-item .reorderable-list__details .sequence-step-condition-field { flex-direction: row; align-items: center; gap: 6px; flex: 0 0 auto; }
 .sortable-step-item .reorderable-list__details .sequence-step-condition-field label { margin-bottom: 0; white-space: nowrap; }
+/* Keep logical condition pairs together (image id + similarity, step ref + expected state):
+   the pair stays on one line and wraps to the next line as a single unit. */
+.sequence-step-condition-pair { display: flex; align-items: center; gap: var(--gb-space-3); flex: 0 0 auto; }
+
+/* Between-step separators — dashed + muted, to distinguish from the solid top/bottom section separators */
+#sequence-steps .reorderable-list__item:not(:last-child),
+#sequence-edit-steps .reorderable-list__item:not(:last-child) {
+  border-bottom: 1px dashed var(--gb-color-border);
+  padding-bottom: var(--gb-space-2);
+}
 
 /* Loop header on one line: "Count × <n>  Remove Loop" (condition loops wrap their fields) */
 .loop-block__header-row { display: flex; align-items: center; flex-wrap: wrap; gap: var(--gb-space-2); }

--- a/tests/contract/Sequences/SelfRescheduleActionContractTests.cs
+++ b/tests/contract/Sequences/SelfRescheduleActionContractTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.ContractTests.Sequences;
+
+/// <summary>
+/// Feature 065: the <c>reschedule-self</c> action round-trips through the sequence authoring API
+/// (FR-001a) including inside an IF/conditional branch (FR-002), and malformed option/timer
+/// combinations are rejected (validation contract).
+/// </summary>
+public sealed class SelfRescheduleActionContractTests {
+  private static WebApplicationFactory<Program> CreateFactory() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    return new WebApplicationFactory<Program>();
+  }
+
+  private static System.Net.Http.HttpClient AuthedClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  [Fact] // T020 — round-trips unchanged, including under an IF (commandOutcome) condition.
+  public async Task RescheduleSelfActionRoundTripsIncludingUnderACondition() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var createPayload = new {
+      name = "self-reschedule-contract",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "go-home",
+          label = "Go Home",
+          primitiveAction = new { type = "tap", schemaVersion = "v1", payload = new { x = 10, y = 20 } }
+        },
+        new {
+          stepId = "reschedule",
+          label = "Reschedule self",
+          stepType = "Action",
+          primitiveAction = new {
+            type = "reschedule-self",
+            schemaVersion = "1",
+            payload = new { option = "OncePerRun" }
+          },
+          // Placed under an IF: only fires when the prior step succeeded (FR-002).
+          condition = new { type = "commandOutcome", stepRef = "go-home", expectedState = "success" }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var sequenceId = created.GetProperty("id").GetString();
+
+    var getResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    var fetched = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var rescheduleStep = fetched.GetProperty("steps")[1];
+    rescheduleStep.GetProperty("primitiveAction").GetProperty("type").GetString().Should().Be("reschedule-self");
+    rescheduleStep.GetProperty("primitiveAction").GetProperty("payload").GetProperty("option").GetString().Should().Be("OncePerRun");
+    rescheduleStep.GetProperty("condition").GetProperty("type").GetString().Should().Be("commandOutcome");
+  }
+
+  [Fact] // T035 (US2) — Timer with a relative offset round-trips with the single timer field.
+  public async Task TimerRescheduleActionRoundTripsWithRelativeOffset() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var createPayload = new {
+      name = "self-reschedule-timer-contract",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "reschedule",
+          stepType = "Action",
+          primitiveAction = new {
+            type = "reschedule-self",
+            schemaVersion = "1",
+            payload = new { option = "Timer", timerRelativeOffset = "00:10:00" }
+          }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var sequenceId = created.GetProperty("id").GetString();
+
+    var getResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    var fetched = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var payload = fetched.GetProperty("steps")[0].GetProperty("primitiveAction").GetProperty("payload");
+    payload.GetProperty("option").GetString().Should().Be("Timer");
+    payload.GetProperty("timerRelativeOffset").GetString().Should().Be("00:10:00");
+  }
+
+  // ── T034 (US2): validation rejects malformed option/timer combinations ────
+
+  [Theory]
+  [InlineData("Timer", null, null)]                 // Timer with neither field
+  [InlineData("Timer", "14:30:00", "00:10:00")]     // Timer with both fields
+  [InlineData("OncePerRun", null, "00:10:00")]      // timer field on a non-Timer option
+  [InlineData("Timer", null, "-00:10:00")]          // negative offset
+  [InlineData("Bogus", null, null)]                 // unknown option
+  public async Task MalformedRescheduleSelfPayloadsAreRejected(string option, string? timeOfDay, string? relativeOffset) {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    object payload = (timeOfDay, relativeOffset) switch {
+      (not null, not null) => new { option, timerTimeOfDay = timeOfDay, timerRelativeOffset = relativeOffset },
+      (not null, null) => new { option, timerTimeOfDay = timeOfDay },
+      (null, not null) => new { option, timerRelativeOffset = relativeOffset },
+      _ => new { option }
+    };
+
+    var createPayload = new {
+      name = "self-reschedule-invalid",
+      version = 1,
+      steps = new object[] {
+        new { stepId = "reschedule", stepType = "Action",
+          primitiveAction = new { type = "reschedule-self", schemaVersion = "1", payload } }
+      }
+    };
+
+    var response = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+}

--- a/tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs
+++ b/tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Logging;
+using GameBot.Domain.Queues;
+using GameBot.Domain.QueueTemplates;
+using GameBot.Service.Services.ExecutionLog;
+using GameBot.Service.Services.QueueExecution;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Queues;
+
+/// <summary>
+/// Feature 065: end-to-end queue runs that self-reschedule, exercised through the real DI graph
+/// (queue engine → real SequenceExecutionService dispatch → coordinator → run-loop draining).
+/// ADB is stubbed (GAMEBOT_USE_ADB=false); a non-cycling queue gives a deterministic single pass.
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class SelfRescheduleRunIntegrationTests {
+  public SelfRescheduleRunIntegrationTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  // Builds sequence S = [ marker command (always succeeds in stub mode), reschedule-self OncePerRun
+  // gated on the marker's outcome ]. expectedState selects whether the IF branch fires.
+  private static CommandSequence BuildSelfReschedulingSequence(string id, string name, string expectedMarkerState) {
+    var sequence = new CommandSequence { Id = id, Name = name };
+    sequence.SetSteps(new[] {
+      new SequenceStep {
+        Order = 0,
+        StepId = "marker",
+        CommandId = "cmd-marker",
+        StepType = SequenceStepType.Command
+      },
+      new SequenceStep {
+        Order = 1,
+        StepId = "reschedule",
+        StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload {
+          Type = ActionTypes.RescheduleSelf,
+          Parameters = { ["option"] = "OncePerRun" }
+        },
+        Condition = new CommandOutcomeStepCondition { StepRef = "marker", ExpectedState = expectedMarkerState }
+      }
+    });
+    return sequence;
+  }
+
+  private static async Task SeedAsync(
+      IServiceProvider services, CommandSequence sequence, string queueId, bool cycle = false) {
+    await services.GetRequiredService<ISequenceRepository>().CreateAsync(sequence).ConfigureAwait(false);
+
+    var template = new QueueTemplate { Id = $"tpl-{queueId}", Name = $"T-{queueId}" };
+    template.Entries.Add(new QueueTemplateEntry { SequenceId = sequence.Id, ScheduleType = ScheduleType.OncePerRun });
+    await services.GetRequiredService<IQueueTemplateRepository>().CreateAsync(template).ConfigureAwait(false);
+
+    await services.GetRequiredService<IQueueRepository>().CreateAsync(new ExecutionQueue {
+      Id = queueId, Name = $"Q-{queueId}", EmulatorSerial = "emu-offline",
+      CycleExecution = cycle, LinkedTemplateId = template.Id
+    }).ConfigureAwait(false);
+  }
+
+  private static async Task RunToCompletionAsync(IQueueExecutionService engine, string queueId) {
+    (await engine.StartAsync(queueId).ConfigureAwait(false)).Should().Be(QueueStartOutcome.Started);
+    var sw = Stopwatch.StartNew();
+    while (engine.IsRunning(queueId) && sw.ElapsedMilliseconds < 10000) {
+      await Task.Delay(20).ConfigureAwait(false);
+    }
+    engine.IsRunning(queueId).Should().BeFalse();
+  }
+
+  private static async Task<ExecutionLogEntry?> GetQueueRunEntryAsync(IExecutionLogService log, string queueId) {
+    var page = await log.QueryAsync(new ExecutionLogQuery { ObjectType = "queue", RootsOnly = true, PageSize = 100 }).ConfigureAwait(false);
+    return page.Items.FirstOrDefault(e => e.ObjectRef.ObjectId == queueId);
+  }
+
+  [Fact] // T023 (positive) / T023a — an IF-gated reschedule (forced true) fires the sequence again.
+  public async Task IfGatedRescheduleForcedTrueProducesASecondFiring() {
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient(); // force host build
+    var services = app.Services;
+    await SeedAsync(services, BuildSelfReschedulingSequence("seq-true", "Daily", "success"), "q-true").ConfigureAwait(false);
+
+    var engine = services.GetRequiredService<IQueueExecutionService>();
+    await RunToCompletionAsync(engine, "q-true").ConfigureAwait(false);
+
+    var entry = await GetQueueRunEntryAsync(services.GetRequiredService<IExecutionLogService>(), "q-true").ConfigureAwait(false);
+    entry.Should().NotBeNull();
+    entry!.FinalStatus.Should().Be("success");
+    // S once-per-run + one self-reschedule firing = 2 executed (FR-007/FR-016).
+    entry.Summary.Should().Contain("2 sequence(s) executed");
+  }
+
+  [Fact] // T023 (negative) — the IF condition false produces exactly one firing.
+  public async Task IfGatedRescheduleForcedFalseProducesNoExtraFiring() {
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+    var services = app.Services;
+    await SeedAsync(services, BuildSelfReschedulingSequence("seq-false", "Daily", "failed"), "q-false").ConfigureAwait(false);
+
+    var engine = services.GetRequiredService<IQueueExecutionService>();
+    await RunToCompletionAsync(engine, "q-false").ConfigureAwait(false);
+
+    var entry = await GetQueueRunEntryAsync(services.GetRequiredService<IExecutionLogService>(), "q-false").ConfigureAwait(false);
+    entry.Should().NotBeNull();
+    entry!.Summary.Should().Contain("1 sequence(s) executed");
+  }
+
+  [Fact] // T022a — two accepted self-reschedules in one run produce two independent extra firings.
+  public async Task TwoSelfReschedulesInOneRunProduceTwoFirings() {
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+    var services = app.Services;
+
+    // A sequence that reschedules itself twice (two action steps, both forced true).
+    var sequence = new CommandSequence { Id = "seq-twice", Name = "Twice" };
+    sequence.SetSteps(new[] {
+      new SequenceStep { Order = 0, StepId = "marker", CommandId = "cmd-marker", StepType = SequenceStepType.Command },
+      new SequenceStep {
+        Order = 1, StepId = "r1", StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload { Type = ActionTypes.RescheduleSelf, Parameters = { ["option"] = "OncePerRun" } },
+        Condition = new CommandOutcomeStepCondition { StepRef = "marker", ExpectedState = "success" }
+      },
+      new SequenceStep {
+        Order = 2, StepId = "r2", StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload { Type = ActionTypes.RescheduleSelf, Parameters = { ["option"] = "OncePerRun" } },
+        Condition = new CommandOutcomeStepCondition { StepRef = "marker", ExpectedState = "success" }
+      }
+    });
+    await SeedAsync(services, sequence, "q-twice").ConfigureAwait(false);
+
+    var engine = services.GetRequiredService<IQueueExecutionService>();
+    await RunToCompletionAsync(engine, "q-twice").ConfigureAwait(false);
+
+    var entry = await GetQueueRunEntryAsync(services.GetRequiredService<IExecutionLogService>(), "q-twice").ConfigureAwait(false);
+    entry.Should().NotBeNull();
+    // Original firing + two independent reschedules drained in the same cycle = 3 executed.
+    entry!.Summary.Should().Contain("3 sequence(s) executed");
+  }
+
+  [Fact] // T048 — the action entry and the resulting firing are visible and attributable in the logs.
+  public async Task LogsShowRescheduleDecisionAndTaggedFiring() {
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+    var services = app.Services;
+    await SeedAsync(services, BuildSelfReschedulingSequence("seq-obs", "Observable", "success"), "q-obs").ConfigureAwait(false);
+
+    var engine = services.GetRequiredService<IQueueExecutionService>();
+    await RunToCompletionAsync(engine, "q-obs").ConfigureAwait(false);
+
+    var log = services.GetRequiredService<IExecutionLogService>();
+    var page = await log.QueryAsync(new ExecutionLogQuery { ObjectType = "sequence", PageSize = 200 }).ConfigureAwait(false);
+    var firings = page.Items.Where(e => e.ObjectRef.ObjectId == "seq-obs").ToList();
+    firings.Should().HaveCountGreaterThanOrEqualTo(2); // original + the rescheduled firing
+
+    // The reschedule decision entry records the option, resolved timing, current-run-only, scheduled.
+    var decisionDetail = firings
+      .SelectMany(f => f.Details)
+      .FirstOrDefault(d => d.Attributes != null
+        && d.Attributes.TryGetValue("stepType", out var st) && st as string == "reschedule-self");
+    decisionDetail.Should().NotBeNull();
+    (decisionDetail!.Attributes!["actionOutcome"] as string).Should().Be("scheduled");
+    (decisionDetail.Attributes!["option"] as string).Should().Be("OncePerRun");
+    decisionDetail.Attributes!["currentRunOnly"].Should().Be(true);
+
+    // The rescheduled firing is tagged as self-reschedule-originated for attribution (FR-014).
+    var taggedFiring = firings.FirstOrDefault(f =>
+      f.Details.Any(d => d.Attributes != null
+        && d.Attributes.TryGetValue("selfRescheduleOrigin", out var origin) && origin is true));
+    taggedFiring.Should().NotBeNull();
+  }
+}

--- a/tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs
+++ b/tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Logging;
+using GameBot.Service.Services.ExecutionLog;
+using GameBot.Service.Services.QueueExecution;
+using GameBot.Service.Services.SequenceExecution;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Sequences;
+
+/// <summary>
+/// Feature 065 (US3): a sequence containing a self-reschedule action runs correctly outside any
+/// queue — the action is a success no-op, schedules nothing, and the remaining steps still run
+/// (FR-011, FR-012). The standalone execute path never sets an originating queue (FR-011 regression).
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class SelfRescheduleStandaloneIntegrationTests {
+  public SelfRescheduleStandaloneIntegrationTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  [Fact]
+  public async Task StandaloneRunRecordsSuccessNoOpAndSchedulesNothing() {
+    using var app = new WebApplicationFactory<Program>();
+    _ = app.CreateClient();
+    var services = app.Services;
+
+    var sequence = new CommandSequence { Id = "seq-standalone", Name = "Standalone" };
+    sequence.SetSteps(new[] {
+      new SequenceStep {
+        Order = 0,
+        StepId = "reschedule",
+        StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload {
+          Type = ActionTypes.RescheduleSelf,
+          Parameters = { ["option"] = "OncePerRun" }
+        }
+      },
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command }
+    });
+    await services.GetRequiredService<ISequenceRepository>().CreateAsync(sequence).ConfigureAwait(false);
+
+    var execution = services.GetRequiredService<ISequenceExecutionService>();
+    // No parent context ⇒ standalone (not started from a queue), OriginatingQueueId stays unset.
+    var result = await execution.ExecuteAsync("seq-standalone", sessionId: null, parentContext: null).ConfigureAwait(false);
+
+    // The action is a no-op success and the sequence completes normally (the following step still runs).
+    result.Status.Should().Be("Succeeded");
+
+    // Nothing was scheduled anywhere — no queue run exists.
+    services.GetRequiredService<IQueueRunRegistry>().IsRunning("seq-standalone").Should().BeFalse();
+
+    // The execution log records the action as a success no-op with the "not started from a queue" reason.
+    var log = services.GetRequiredService<IExecutionLogService>();
+    var page = await log.QueryAsync(new ExecutionLogQuery { ObjectType = "sequence", RootsOnly = true, PageSize = 100 }).ConfigureAwait(false);
+    var entry = page.Items.FirstOrDefault(e => e.ObjectRef.ObjectId == "seq-standalone");
+    entry.Should().NotBeNull();
+    entry!.FinalStatus.Should().Be("success");
+    var rescheduleDetail = entry.Details.FirstOrDefault(d =>
+      d.Attributes != null
+      && d.Attributes.TryGetValue("stepType", out var st)
+      && st as string == "reschedule-self");
+    rescheduleDetail.Should().NotBeNull();
+    (rescheduleDetail!.Attributes!["actionOutcome"] as string).Should().Be("noop");
+    rescheduleDetail.Message.Should().Contain("no originating queue");
+  }
+}

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using GameBot.Domain.Commands.SelfReschedule;
 using GameBot.Domain.Logging;
 using GameBot.Domain.Queues;
 using GameBot.Domain.QueueTemplates;
@@ -129,11 +130,14 @@ public sealed class QueueExecutionServiceTests {
     public RecordingExecutionLog Log { get; } = new();
     public QueueRuntimeStore Runtime { get; } = new();
     public FakeTimeProvider? Clock { get; }
+    public QueueRunRegistry Registry { get; } = new();
+    public SelfRescheduleCoordinator Coordinator { get; }
     public QueueExecutionService Service { get; }
 
     public Harness(FakeTimeProvider? clock = null) {
       Clock = clock;
-      Service = new QueueExecutionService(Queues, Runtime, Templates, Sequences, Sessions, Log, NullLogger<QueueExecutionService>.Instance, timeProvider: clock);
+      Coordinator = new SelfRescheduleCoordinator(Registry, clock);
+      Service = new QueueExecutionService(Queues, Runtime, Templates, Sequences, Sessions, Log, NullLogger<QueueExecutionService>.Instance, Registry, timeProvider: clock);
     }
 
     public ExecutionQueue AddQueue(string id, IReadOnlyList<string> sequenceIds, bool cycle = false, bool linkTemplate = true) {
@@ -221,7 +225,7 @@ public sealed class QueueExecutionServiceTests {
     var h = new Harness();
     h.AddQueue("q1", new[] { "A" });
     var sessions = new ThrowingDisconnectSessions();
-    var service = new QueueExecutionService(h.Queues, h.Runtime, h.Templates, h.Sequences, sessions, h.Log, NullLogger<QueueExecutionService>.Instance);
+    var service = new QueueExecutionService(h.Queues, h.Runtime, h.Templates, h.Sequences, sessions, h.Log, NullLogger<QueueExecutionService>.Instance, h.Registry);
 
     await service.StartAsync("q1");
     await WaitUntilStoppedAsync(service, "q1");
@@ -962,5 +966,148 @@ public sealed class QueueExecutionServiceTests {
     // Timer fires at the boundary, then OncePerRun steps in order; only the two steps are counted.
     h.Sequences.Executed.Should().Equal("T", "A", "B");
     h.Log.Summary.Should().Contain("2 sequence(s) executed");
+  }
+
+  // ── Feature 065: self-reschedule run-loop draining ───────────────────────
+
+  [Fact] // T022 — OncePerRun reschedule fires before the cycle ends and counts toward executed.
+  public async Task SelfRescheduleOncePerRunFiresWithinRunAndCountsExecuted() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A") }); // non-cycling → deterministic
+    var scheduled = false;
+    h.Sequences.Handler = (id, ct) => {
+      if (id == "A" && !scheduled) {
+        scheduled = true;
+        h.Coordinator.ScheduleSelf("q1", "R", SelfRescheduleOption.OncePerRun, null, null);
+      }
+      return Task.FromResult(FakeSequenceExecution.Success(id));
+    };
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    // A runs, schedules R, then R fires before the cycle ends (FR-007).
+    h.Sequences.Executed.Should().Equal("A", "R");
+    h.Log.Summary.Should().Contain("2 sequence(s) executed"); // both count
+  }
+
+  [Fact] // T022a — two accepted OncePerRun reschedules produce two independent firings.
+  public async Task TwoOncePerRunReschedulesProduceTwoFirings() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A") });
+    var scheduled = false;
+    h.Sequences.Handler = (id, ct) => {
+      if (id == "A" && !scheduled) {
+        scheduled = true;
+        h.Coordinator.ScheduleSelf("q1", "R", SelfRescheduleOption.OncePerRun, null, null);
+        h.Coordinator.ScheduleSelf("q1", "R", SelfRescheduleOption.OncePerRun, null, null);
+      }
+      return Task.FromResult(FakeSequenceExecution.Success(id));
+    };
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Count(id => id == "R").Should().Be(2);
+  }
+
+  [Fact] // T033/T041 — AtQueueStart (cycling) fires at the start of the next cycle.
+  public async Task SelfRescheduleAtQueueStartFiresAtNextCycleStart() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A") }, cycle: true);
+    var scheduled = false;
+    h.Sequences.Handler = async (id, ct) => {
+      await Task.Delay(10, ct);
+      if (id == "A" && !scheduled) {
+        scheduled = true;
+        h.Coordinator.ScheduleSelf("q1", "R", SelfRescheduleOption.AtQueueStart, null, null);
+      }
+      return FakeSequenceExecution.Success(id);
+    };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Sequences.Executed.Contains("R"));
+    await h.Service.StopAsync("q1");
+
+    // R fires at the top of cycle 2, i.e. right after the first A and before the second A.
+    h.Sequences.Executed.Take(2).Should().Equal("A", "R");
+  }
+
+  [Fact] // T032/T040 — EveryStep injection fires after each subsequent step; idempotent (loop-safe).
+  public async Task SelfRescheduleEveryStepFiresAfterEachStepAndIsLoopSafe() {
+    var h = new Harness();
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A") }, cycle: true);
+    var scheduled = false;
+    h.Sequences.Handler = async (id, ct) => {
+      await Task.Delay(10, ct);
+      if (id == "A" && !scheduled) {
+        scheduled = true;
+        h.Coordinator.ScheduleSelf("q1", "R", SelfRescheduleOption.EveryStep, null, null);
+      }
+      return FakeSequenceExecution.Success(id);
+    };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Sequences.Executed.Count(id => id == "R") >= 2);
+    await h.Service.StopAsync("q1");
+
+    // R fires repeatedly (after each A), and the registration never stacked beyond one entry.
+    h.Sequences.Executed.Count(id => id == "R").Should().BeGreaterThanOrEqualTo(2);
+    h.Registry.TryGet("q1", out _).Should().BeFalse(); // run cleaned up
+  }
+
+  [Fact] // T039 — Timer reschedule does not fire before due, then fires once after the offset elapses.
+  public async Task SelfRescheduleTimerFiresOnceAfterOffsetElapses() {
+    var clock = new FakeTimeProvider(FakeStart);
+    var h = new Harness(clock);
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A") }); // non-cycling; stays alive for the timer
+    var scheduled = false;
+    h.Sequences.Handler = (id, ct) => {
+      if (id == "A" && !scheduled) {
+        scheduled = true;
+        h.Coordinator.ScheduleSelf("q1", "R", SelfRescheduleOption.Timer, null, TimeSpan.FromMinutes(10));
+      }
+      return Task.FromResult(FakeSequenceExecution.Success(id));
+    };
+
+    await h.Service.StartAsync("q1");
+    // Wait until the Timer firing is actually registered on the run handle before advancing the
+    // clock — otherwise, under load, "A" (and thus scheduling) could lag the advance and the
+    // resolved FireAt would be computed from the already-advanced clock (ordering race).
+    await WaitForAsync(() => h.Registry.TryGet("q1", out var handle) && handle.HasPendingTimerFirings, 10000);
+    // Not due yet: the run stays alive but R has not fired.
+    h.Service.IsRunning("q1").Should().BeTrue();
+    h.Sequences.Executed.Should().NotContain("R");
+
+    clock.Advance(TimeSpan.FromMinutes(10));
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Count(id => id == "R").Should().Be(1);
+    h.Log.Summary.Should().Contain("2 sequence(s) executed"); // A + R count
+  }
+
+  [Fact] // T049 — a Timer reschedule never due before stop is abandoned; the run is not failed.
+  public async Task SelfRescheduleTimerNeverDueIsAbandonedWithoutFailing() {
+    var clock = new FakeTimeProvider(FakeStart);
+    var h = new Harness(clock);
+    AddQueueWithEntries(h, "q1", new[] { OncePerRun("A") });
+    var scheduled = false;
+    h.Sequences.Handler = (id, ct) => {
+      if (id == "A" && !scheduled) {
+        scheduled = true;
+        h.Coordinator.ScheduleSelf("q1", "R", SelfRescheduleOption.Timer, null, TimeSpan.FromHours(12));
+      }
+      return Task.FromResult(FakeSequenceExecution.Success(id));
+    };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Sequences.Executed.Contains("A"));
+    h.Service.IsRunning("q1").Should().BeTrue(); // stays alive waiting for the 12h timer
+
+    await h.Service.StopAsync("q1"); // stop before the timer becomes due
+
+    h.Sequences.Executed.Should().NotContain("R"); // abandoned, never fired (FR-015)
+    h.Log.FinalStatus.Should().Be("success"); // run not marked failed
+    h.Log.Summary.Should().Contain("stopped manually");
   }
 }

--- a/tests/unit/Queues/QueueRunRegistryTests.cs
+++ b/tests/unit/Queues/QueueRunRegistryTests.cs
@@ -1,0 +1,71 @@
+using System.Threading;
+using FluentAssertions;
+using GameBot.Service.Services.QueueExecution;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Queues;
+
+/// <summary>Feature 065: the extracted active-run registry add/get/remove + per-queue isolation.</summary>
+public sealed class QueueRunRegistryTests {
+  private static QueueRunHandle Handle(string queueId) =>
+    new() { QueueId = queueId, Cts = new CancellationTokenSource() };
+
+  [Fact]
+  public void AddThenGetReturnsTheSameHandle() {
+    var registry = new QueueRunRegistry();
+    var handle = Handle("q1");
+
+    registry.TryAdd("q1", handle).Should().BeTrue();
+    registry.IsRunning("q1").Should().BeTrue();
+    registry.TryGet("q1", out var found).Should().BeTrue();
+    found.Should().BeSameAs(handle);
+  }
+
+  [Fact]
+  public void AddingTwiceForTheSameQueueIsRejected() {
+    var registry = new QueueRunRegistry();
+    registry.TryAdd("q1", Handle("q1")).Should().BeTrue();
+    registry.TryAdd("q1", Handle("q1")).Should().BeFalse();
+  }
+
+  [Fact]
+  public void RemoveReturnsHandleAndClearsRunningState() {
+    var registry = new QueueRunRegistry();
+    var handle = Handle("q1");
+    registry.TryAdd("q1", handle);
+
+    registry.Remove("q1", out var removed).Should().BeTrue();
+    removed.Should().BeSameAs(handle);
+    registry.IsRunning("q1").Should().BeFalse();
+    registry.TryGet("q1", out _).Should().BeFalse();
+  }
+
+  [Fact]
+  public void RunsAreIsolatedPerQueue() {
+    var registry = new QueueRunRegistry();
+    var h1 = Handle("q1");
+    var h2 = Handle("q2");
+    registry.TryAdd("q1", h1);
+    registry.TryAdd("q2", h2);
+
+    registry.TryGet("q1", out var g1).Should().BeTrue();
+    registry.TryGet("q2", out var g2).Should().BeTrue();
+    g1.Should().BeSameAs(h1);
+    g2.Should().BeSameAs(h2);
+
+    // Removing one leaves the other untouched.
+    registry.Remove("q1", out _);
+    registry.IsRunning("q1").Should().BeFalse();
+    registry.IsRunning("q2").Should().BeTrue();
+  }
+
+  [Fact]
+  public void GetOrRemoveOnUnknownQueueReturnsFalse() {
+    var registry = new QueueRunRegistry();
+    registry.TryGet("nope", out _).Should().BeFalse();
+    registry.Remove("nope", out _).Should().BeFalse();
+    registry.IsRunning("nope").Should().BeFalse();
+  }
+}

--- a/tests/unit/Queues/SelfRescheduleCoordinatorTests.cs
+++ b/tests/unit/Queues/SelfRescheduleCoordinatorTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using GameBot.Domain.Commands.SelfReschedule;
+using GameBot.Service.Services.QueueExecution;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Queues;
+
+/// <summary>Feature 065: per-option timing resolution and ephemeral register injection.</summary>
+public sealed class SelfRescheduleCoordinatorTests {
+  private static readonly DateTimeOffset FakeStart = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+  private static (QueueRunRegistry Registry, QueueRunHandle Handle, SelfRescheduleCoordinator Coordinator) Setup(
+      bool cycling = false, FakeTimeProvider? clock = null) {
+    var registry = new QueueRunRegistry();
+    var handle = new QueueRunHandle { QueueId = "q1", Cts = new CancellationTokenSource(), CycleExecution = cycling };
+    registry.TryAdd("q1", handle);
+    var coordinator = new SelfRescheduleCoordinator(registry, clock);
+    return (registry, handle, coordinator);
+  }
+
+  // ── US1 ──────────────────────────────────────────────────────────────────
+
+  [Fact] // T021
+  public void OncePerRunInjectsIntoPendingOncePerRun() {
+    var (_, handle, coordinator) = Setup();
+
+    var result = coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.OncePerRun, null, null);
+
+    result.Outcome.Should().Be(SelfRescheduleOutcome.Scheduled);
+    handle.PendingOncePerRun.Should().ContainSingle();
+    handle.PendingOncePerRun.TryPeek(out var entry).Should().BeTrue();
+    entry!.SequenceId.Should().Be("seq-A");
+    entry.Option.Should().Be(SelfRescheduleOption.OncePerRun);
+    result.EntryId.Should().Be(entry.Id);
+  }
+
+  [Fact] // T021a
+  public void ScheduleAgainstNoActiveRunReturnsNotRunning() {
+    var registry = new QueueRunRegistry();
+    var coordinator = new SelfRescheduleCoordinator(registry, null);
+
+    var result = coordinator.ScheduleSelf("missing", "seq-A", SelfRescheduleOption.OncePerRun, null, null);
+
+    result.Outcome.Should().Be(SelfRescheduleOutcome.NotRunning);
+  }
+
+  [Fact] // T022a (coordinator side): two accepted OncePerRun reschedules accumulate independently.
+  public void TwoOncePerRunReschedulesAccumulate() {
+    var (_, handle, coordinator) = Setup();
+
+    coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.OncePerRun, null, null);
+    coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.OncePerRun, null, null);
+
+    handle.PendingOncePerRun.Should().HaveCount(2);
+  }
+
+  // ── US2: Timer ─────────────────────────────────────────────────────────────
+
+  [Fact] // T030
+  public void TimerRelativeOffsetResolvesNowPlusOffset() {
+    var clock = new FakeTimeProvider(FakeStart);
+    var (_, handle, coordinator) = Setup(clock: clock);
+
+    var result = coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.Timer, null, TimeSpan.FromMinutes(10));
+
+    result.Outcome.Should().Be(SelfRescheduleOutcome.Scheduled);
+    result.FireAt.Should().Be(clock.GetLocalNow() + TimeSpan.FromMinutes(10));
+    handle.HasPendingTimerFirings.Should().BeTrue();
+    handle.DrainDueTimerFirings(clock.GetLocalNow()).Should().BeEmpty(); // not due yet
+    handle.DrainDueTimerFirings(clock.GetLocalNow() + TimeSpan.FromMinutes(10)).Should().ContainSingle();
+  }
+
+  [Fact] // T030 — offset zero fires at the next boundary (immediately due).
+  public void TimerZeroOffsetIsImmediatelyDue() {
+    var clock = new FakeTimeProvider(FakeStart);
+    var (_, handle, coordinator) = Setup(clock: clock);
+
+    coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.Timer, null, TimeSpan.Zero);
+
+    handle.DrainDueTimerFirings(clock.GetLocalNow()).Should().ContainSingle();
+  }
+
+  [Fact] // T031 — time-of-day already past collapses to now (fires next boundary).
+  public void TimerPastTimeOfDayCollapsesToNow() {
+    var clock = new FakeTimeProvider(FakeStart); // local 12:00 (or offset)
+    var (_, handle, coordinator) = Setup(clock: clock);
+    var pastTime = TimeOnly.FromDateTime(clock.GetLocalNow().DateTime).AddHours(-1);
+
+    var result = coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.Timer, pastTime, null);
+
+    result.FireAt.Should().BeOnOrBefore(clock.GetLocalNow());
+    handle.DrainDueTimerFirings(clock.GetLocalNow()).Should().ContainSingle();
+  }
+
+  [Fact] // T031 — future time-of-day fires at that instant, not before.
+  public void TimerFutureTimeOfDayFiresAtThatInstant() {
+    var clock = new FakeTimeProvider(FakeStart);
+    var (_, handle, coordinator) = Setup(clock: clock);
+    var futureTime = TimeOnly.FromDateTime(clock.GetLocalNow().DateTime).AddHours(2);
+
+    var result = coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.Timer, futureTime, null);
+
+    handle.DrainDueTimerFirings(clock.GetLocalNow()).Should().BeEmpty();
+    handle.DrainDueTimerFirings(result.FireAt!.Value).Should().ContainSingle();
+  }
+
+  // ── US2: EveryStep ──────────────────────────────────────────────────────────
+
+  [Fact] // T032 — EveryStep is idempotent per sequence (no unbounded self-chain).
+  public void EveryStepIsIdempotentPerSequence() {
+    var (_, handle, coordinator) = Setup();
+
+    coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.EveryStep, null, null);
+    coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.EveryStep, null, null);
+
+    handle.EveryStepInjections.Should().ContainSingle();
+    handle.EveryStepInjections.ContainsKey("seq-A").Should().BeTrue();
+  }
+
+  // ── US2: AtQueueStart ───────────────────────────────────────────────────────
+
+  [Fact] // T033 — cycling run → next cycle start register.
+  public void AtQueueStartOnCyclingRunGoesToNextCycleStart() {
+    var (_, handle, coordinator) = Setup(cycling: true);
+
+    var result = coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.AtQueueStart, null, null);
+
+    result.Outcome.Should().Be(SelfRescheduleOutcome.Scheduled);
+    handle.PendingNextCycleStart.Should().ContainSingle();
+    handle.PendingOncePerRun.Should().BeEmpty();
+  }
+
+  [Fact] // T033 — non-cycling run → falls back to the once-per-run register (next iteration boundary).
+  public void AtQueueStartOnNonCyclingRunFallsBackToOncePerRun() {
+    var (_, handle, coordinator) = Setup(cycling: false);
+
+    coordinator.ScheduleSelf("q1", "seq-A", SelfRescheduleOption.AtQueueStart, null, null);
+
+    handle.PendingNextCycleStart.Should().BeEmpty();
+    handle.PendingOncePerRun.Should().ContainSingle();
+  }
+}

--- a/tests/unit/Sequences/SelfReschedulePayloadTests.cs
+++ b/tests/unit/Sequences/SelfReschedulePayloadTests.cs
@@ -1,0 +1,73 @@
+using System;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Commands.SelfReschedule;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>Feature 065: typed reading of the <c>reschedule-self</c> action payload.</summary>
+public sealed class SelfReschedulePayloadTests {
+  private static SequenceActionPayload Payload(params (string Key, object? Value)[] pairs) {
+    var p = new SequenceActionPayload { Type = "reschedule-self" };
+    foreach (var (key, value) in pairs) p.Parameters[key] = value;
+    return p;
+  }
+
+  [Theory]
+  [InlineData("AtQueueStart", SelfRescheduleOption.AtQueueStart)]
+  [InlineData("OncePerRun", SelfRescheduleOption.OncePerRun)]
+  [InlineData("Timer", SelfRescheduleOption.Timer)]
+  [InlineData("EveryStep", SelfRescheduleOption.EveryStep)]
+  [InlineData("onceperrun", SelfRescheduleOption.OncePerRun)] // case-insensitive
+  public void ParsesKnownOptions(string wire, SelfRescheduleOption expected) {
+    SelfReschedulePayload.TryRead(Payload(("option", wire)), out var result, out var error).Should().BeTrue();
+    error.Should().BeNull();
+    result!.Option.Should().Be(expected);
+    result.TimerTimeOfDay.Should().BeNull();
+    result.TimerRelativeOffset.Should().BeNull();
+  }
+
+  [Fact]
+  public void ParsesTimerRelativeOffset() {
+    SelfReschedulePayload.TryRead(
+      Payload(("option", "Timer"), ("timerRelativeOffset", "00:10:00")),
+      out var result, out _).Should().BeTrue();
+    result!.Option.Should().Be(SelfRescheduleOption.Timer);
+    result.HasTimerRelativeOffset.Should().BeTrue();
+    result.TimerRelativeOffset.Should().Be(TimeSpan.FromMinutes(10));
+    result.HasTimerTimeOfDay.Should().BeFalse();
+  }
+
+  [Fact]
+  public void ParsesTimerTimeOfDay() {
+    SelfReschedulePayload.TryRead(
+      Payload(("option", "Timer"), ("timerTimeOfDay", "14:30:00")),
+      out var result, out _).Should().BeTrue();
+    result!.HasTimerTimeOfDay.Should().BeTrue();
+    result.TimerTimeOfDay.Should().Be(new TimeOnly(14, 30, 0));
+  }
+
+  [Fact]
+  public void MissingOptionIsRejected() {
+    SelfReschedulePayload.TryRead(Payload(), out var result, out var error).Should().BeFalse();
+    result.Should().BeNull();
+    error.Should().NotBeNullOrWhiteSpace();
+  }
+
+  [Fact]
+  public void UnknownOptionIsRejected() {
+    SelfReschedulePayload.TryRead(Payload(("option", "Bogus")), out _, out var error).Should().BeFalse();
+    error.Should().Contain("Bogus");
+  }
+
+  [Fact]
+  public void MalformedTimerValueIsRejected() {
+    SelfReschedulePayload.TryRead(
+      Payload(("option", "Timer"), ("timerRelativeOffset", "not-a-duration")),
+      out _, out var error).Should().BeFalse();
+    error.Should().NotBeNullOrWhiteSpace();
+  }
+}

--- a/tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerActionDispatchTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using Xunit;
+
+// Test-code analyzer relaxations (permitted by the constitution for test code).
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Feature 065: a <c>reschedule-self</c> action step is dispatched through the injected callback,
+/// its outcome is recorded as the step result, and the sequence continues (FR-012). The dispatch
+/// path performs no command/ADB I/O (SC-006).
+/// </summary>
+public sealed class SequenceRunnerActionDispatchTests {
+  private sealed class StubRepo : ISequenceRepository {
+    private readonly CommandSequence _sequence;
+    public StubRepo(CommandSequence sequence) => _sequence = sequence;
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_sequence);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() => Task.FromResult<IReadOnlyList<CommandSequence>>(new List<CommandSequence> { _sequence });
+    public Task<CommandSequence> CreateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<CommandSequence> UpdateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+  }
+
+  private static CommandSequence BuildSequence() {
+    var sequence = new CommandSequence { Id = "reschedule-seq", Name = "Reschedule Seq" };
+    sequence.SetSteps(new[] {
+      new SequenceStep {
+        Order = 0,
+        StepId = "reschedule",
+        StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload {
+          Type = ActionTypes.RescheduleSelf,
+          Parameters = { ["option"] = "OncePerRun" }
+        }
+      },
+      new SequenceStep {
+        Order = 1,
+        StepId = "after",
+        CommandId = "cmd-after",
+        StepType = SequenceStepType.Command
+      }
+    });
+    return sequence;
+  }
+
+  [Fact]
+  public async Task DispatchesRescheduleActionRecordsOutcomeAndContinues() {
+    var executedCommands = new List<string>();
+    var dispatchedActions = new List<SequenceActionPayload>();
+    var runner = new SequenceRunner(new StubRepo(BuildSequence()));
+
+    var result = await runner.ExecuteAsync(
+      "reschedule-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (action, _) => {
+        dispatchedActions.Add(action);
+        return Task.FromResult(new ActionDispatchResult("scheduled", "rescheduled (OncePerRun)"));
+      },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    // The dispatcher was invoked once with the reschedule-self payload.
+    dispatchedActions.Should().ContainSingle();
+    dispatchedActions[0].Type.Should().Be(ActionTypes.RescheduleSelf);
+    // The action recorded a step with the returned outcome.
+    result.Steps.Should().Contain(s => s.ActionOutcome == "scheduled" && s.Message == "rescheduled (OncePerRun)");
+    // The sequence continued: the following command step still ran...
+    executedCommands.Should().Contain("cmd-after");
+    // ...and the dispatch path performed NO command I/O for the action itself (SC-006).
+    executedCommands.Should().NotContain(string.Empty);
+    executedCommands.Should().NotContain("reschedule");
+  }
+
+  [Fact] // T044 — a no-op dispatch result (e.g. not started from a queue) is success + non-terminating.
+  public async Task NoOpDispatchResultIsRecordedAsSuccessAndContinues() {
+    var executedCommands = new List<string>();
+    var runner = new SequenceRunner(new StubRepo(BuildSequence()));
+
+    var result = await runner.ExecuteAsync(
+      "reschedule-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (_, _) => Task.FromResult(new ActionDispatchResult("noop", "no originating queue, no reschedule performed")),
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    result.Steps.Should().Contain(s => s.ActionOutcome == "noop");
+    executedCommands.Should().Contain("cmd-after"); // sequence continued
+  }
+
+  [Fact]
+  public async Task WithoutDispatcherRescheduleActionIsANonTerminatingNoOp() {
+    var executedCommands = new List<string>();
+    var runner = new SequenceRunner(new StubRepo(BuildSequence()));
+
+    // No dispatcher supplied (e.g. a path that doesn't wire one): must not throw or early-stop.
+    var result = await runner.ExecuteAsync(
+      "reschedule-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    executedCommands.Should().Contain("cmd-after");
+  }
+}


### PR DESCRIPTION
## Summary

Adds an authorable **self-reschedule sequence action** (`reschedule-self`). When a sequence reaches this action during a **queue-driven run**, it schedules **one additional firing of the same sequence into the current run** using any of the four schedule options — **At Queue Start / Once Per Run / Timer (relative or time-of-day) / After Every Step**. It's placeable under the sequence's IF/conditional flow, applies to the **current run only** (never persisted), is reflected in the execution logs, and is a **success no-op** when the sequence was not started from a queue.

Implements spec `065-sequence-self-reschedule` (US1–US4) end to end.

## How it works

- **Origin propagation** — `ExecutionLogContext` gains `OriginatingQueueId`, set by the queue run and propagated through nesting (FR-018). Empty ⇒ standalone ⇒ no-op success.
- **DI-cycle break** — active-run state is extracted into a singleton `IQueueRunRegistry`; a narrow `ISelfRescheduleCoordinator` injects an ephemeral, run-scoped firing without re-forming the `SequenceExecutionService ↔ QueueExecutionService` cycle.
- **Ephemeral registers** — `QueueRunHandle` gains per-option registers; the run loop drains each at its matching boundary (once-per-run within the cycle, next-cycle-start, resolved timer instants, after-every-step). Unfired entries are discarded with the run handle (FR-015/FR-017); timing uses the injected `TimeProvider`.
- **Runner dispatch** — `SequenceRunner` gains an optional `actionDispatcher` callback so it stays web/queue-agnostic; the action never terminates the sequence (FR-012).
- **Web UI** — the sequence editor gains `reschedule-self` as a third action type with all four options and Timer inputs, authorable under IF branches. (Plus several layout refinements to the Steps editor requested during review.)

## Testing

- Backend `dotnet test`: **Unit 516 · Contract 83 · Integration 287** — all green.
- Web UI: `vite build` + **Jest 91 suites / 527 tests** — all green (the real web-ui gate; lint/`tsc` have pre-existing failures).
- Coverage ≥ targets for touched areas; new unit/contract/integration + Jest specs cover every option, the IF-gated second firing, standalone no-op-success, origin propagation, and log observability.

## Docs

- `docs/architecture.md` (domain model + capability map), spec `Status: Implemented`, `specs/STATUS.md` row, and a performance note in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)