### PR TITLE
Break step success/failure execution statuses (066)

### DIFF
--- a/.claude/skills/speckit-pipeline/SKILL.md
+++ b/.claude/skills/speckit-pipeline/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: "speckit-pipeline"
+description: "Orchestrate the full spec-kit pipeline end to end autonomously: specify -> clarify -> plan -> tasks -> analyze -> fix -> compact -> commit -> implement -> commit -> wait for CI -> open PR, without stopping for manual review."
+argument-hint: "Describe the feature to build (forwarded to /speckit-specify)"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "local"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Treat the input above as the **feature description**. It is required for a fresh
+run and is forwarded verbatim to `/speckit-specify`. If it is empty, assume the
+spec already exists on the current branch and start from step 2 (clarify).
+
+## Goal
+
+Drive the complete spec-kit flow for one feature by invoking the existing
+speckit skills in order, in this same conversation, so their context carries
+forward. Run **fully autonomously** — the user is not reviewing anything
+manually. Do not pause for confirmation, questions, or gates. Only a hard
+failure (see Halting rules) stops the run.
+
+## Pipeline (run in order)
+
+1. **`/speckit-specify`** — pass `$ARGUMENTS` as the feature description.
+   Skip only if the input is empty and a spec already exists for the branch.
+2. **`/speckit-clarify`** — this step would normally ask the user targeted
+   questions. Since there is no manual review, **do not pause**: answer each
+   question yourself by choosing the most reasonable option given the spec and
+   codebase, record the chosen answers and a one-line rationale in the spec (as
+   clarify would), and continue.
+3. **`/speckit-plan`** — generate the design artifacts.
+4. **`/speckit-tasks`** — generate `tasks.md`.
+5. **`/speckit-analyze`** — cross-artifact consistency check.
+6. **Fix all issues** — resolve **every** finding `analyze` reported, at all
+   severities, by editing the relevant spec / plan / tasks artifacts. Then
+   **re-run `/speckit-analyze`** and repeat this fix step until analyze reports
+   no remaining issues (cap at 3 rounds; if issues persist after 3 rounds, note
+   the residual findings and continue anyway — do not stop).
+7. **Compact memory** — now that the design artifacts are finalized and clean,
+   run `/compact` to compress the conversation context. The spec / plan / tasks
+   files on disk are the source of truth from here on, so the detailed
+   back-and-forth from earlier steps no longer needs to stay in context; this
+   frees room for the implementation phase. Continue immediately afterward.
+8. **Commit** — run `/speckit-git-commit` to commit the spec, plan, tasks, and
+   fixes before any implementation. This creates a clean checkpoint separating
+   the design artifacts from the implementation.
+9. **`/speckit-implement`** — execute the tasks.
+10. **Commit the implementation** — run `/speckit-git-commit` again to commit all
+    changes produced by `implement`.
+11. **Push and wait for CI** — push the branch to `origin`, then wait for the
+    GitHub Actions CI runs to finish. **This can take several minutes; keep
+    waiting, do not give up early.** Concretely:
+    - Push: `git push -u origin HEAD`
+    - Watch the run for the current commit to completion, e.g.
+      `gh run watch $(gh run list --branch "$(git branch --show-current)" --limit 1 --json databaseId --jq '.[0].databaseId') --exit-status`
+      (`--exit-status` makes it return non-zero if CI fails). If the run has not
+      registered yet, poll `gh run list --branch <branch>` until it appears,
+      then watch it. Multiple workflows may trigger (see `.github/workflows/`);
+      wait for **all** of them.
+12. **Create the PR — only if CI passed** — if every CI run succeeded, open a
+    pull request into `master` with `gh pr create --base master --fill` (title
+    and body from the commits; expand the body with a short summary and the spec
+    directory). Report the PR URL.
+
+## Halting rules
+
+Stop **only** if a step throws a hard error or its required inputs are missing
+(e.g. no spec/plan on the branch, a script exits non-zero, git refuses the
+commit, `git push` is rejected). Report the error and where it stopped. Do
+**not** stop for consistency findings, clarify questions, or anything that
+would normally need human judgment — resolve those autonomously and keep going.
+
+**CI failure is a hard stop for the PR step only:** if any CI run fails, do
+**not** open the PR. Report the failing workflow and a short diagnosis (pull the
+failed job log with `gh run view <id> --log-failed`). You may attempt an
+autonomous fix and re-push once; if CI still fails, stop and report without
+creating the PR.
+
+## Between steps
+
+After each step, print a one-line status:
+
+```
+[pipeline] <step> - done (or: skipped / auto-resolved / FAILED: <reason>)
+```
+
+## On completion
+
+Print a final summary: which steps ran, which were skipped, the clarify
+answers you chose, the analyze findings you fixed, the two commit SHAs (design
++ implementation), the CI outcome (which workflows ran and their conclusions),
+the PR URL (or the reason no PR was opened), and the branch / spec directory
+the work landed in.

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/065-sequence-self-reschedule"
+  "feature_directory": "specs/066-break-step-status"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file.
   - New configuration parameter `GAMEBOT_TAP_JITTER_RADIUS_PX` (default `5`): `0` disables jitter entirely (pixel-exact input); negative/invalid values fall back to the default. Follows the standard precedence (default → saved config file → environment variable), appears in the generic UI Configuration variables list, and is documented in `ENVIRONMENT.md`.
   - Execution logs and step outcomes now report both the pre-jitter target and the post-jitter executed coordinates: tap details read "Tap targeted (X,Y), executed at (X',Y')" and step outcome payloads gain additive `executedPoint`, `targetSwipe`, and `executedSwipe` fields alongside the existing `resolvedPoint`.
 
+### Changed
+- Break step success/failure execution statuses (066-break-step-status)
+  - A break that **does not fire** (its condition evaluated false) now shows a distinct, neutral **"No break"** state in the execution logs instead of the old `Skipped` label — clearly signalling that the loop simply continued, and never the alarming red "Failed".
+  - A break whose condition **cannot be evaluated** (a runtime error) is now treated exactly like a false condition — a non-influential "No break" — so execution continues and the run no longer fails. This reverses the previous behavior where a break-condition error aborted the run. The same guarantee applies to a loop-level `breakOn` condition on a while block, whose evaluation errors are now guarded.
+  - A break that **fires** is reported as a success (fixing a latent miscolor where a fired break could fall through to the red "failure" styling). A non-firing break never marks the enclosing loop, sequence, or run as failed and is excluded from failure counts. No change to break authoring, break firing behavior, or the persisted log format — only the reported *outcome* of a break changes.
+
 ## [0.7.0] - 2026-06-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/065-sequence-self-reschedule/plan.md
+at specs/066-break-step-status/plan.md
 <!-- SPECKIT END -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ For the *history* of how the system got here — one folder per feature, point-i
 history; this file is the current-state source of truth. When the two disagree, this file wins and
 the relevant spec should be marked superseded.
 
-_Last reviewed: 2026-06-22._
+_Last reviewed: 2026-07-01._
 
 ## What GameBot is
 
@@ -86,6 +86,25 @@ not survive a service restart; queue *configuration* and templates are persisted
   runtime per-component logging level control, jitter/retry/delay parameters.
 - **Packaging**: standalone Windows installer (EXE/MSI) with semantic-version upgrade flow
   (build auto-versioning, downgrade prohibition).
+
+### Break & loop execution and the execution-log status vocabulary
+
+Loops (count / while / repeat-until step-loops, and while/repeat-until blocks) may end early via a
+**break** — either a discrete break step in the loop body (`SequenceStepType.Break`) or a loop-level
+`breakOn` condition on a while block. A break's *own* outcome (feature 066) is reported with a
+canonical two-token vocabulary (`GameBot.Domain.Services.BreakOutcomes`), carried in the existing
+`StepResult.ActionOutcome`:
+
+- `break` — the break **fired** (unconditional, or its condition/`breakOn` evaluated true). A
+  **success**; the loop ends at that point.
+- `no_break` — the break **did not fire** (condition false, or the condition/`breakOn` could not be
+  evaluated). A distinct, neutral **"No break"** — never `Skipped`, never the red `Failed`. Execution
+  continues unchanged and the run's health is not affected: a break-condition (or `breakOn`)
+  evaluation error is guarded and treated as `no_break`, so it never fails the run.
+
+`ExecutionLogService.MapStepStatus` maps these to node statuses (`break → success`,
+`no_break → no_break`); the web-ui renders `no_break` as a neutral "No break" badge distinct from
+`failure` and `skipped`.
 
 ## REST API surface
 

--- a/specs/066-break-step-status/checklists/requirements.md
+++ b/specs/066-break-step-status/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Break Step Success/Failure Execution Statuses
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Clarification resolved (2026-07-01): a break-condition **evaluation error** is treated as a non-influential "no break" failure (same as a false condition), continuing execution and not failing the run. Captured in FR-002a and the Edge Cases section.
+- All checklist items pass; spec is ready for `/speckit-plan`.

--- a/specs/066-break-step-status/contracts/break-step-outcome.md
+++ b/specs/066-break-step-status/contracts/break-step-outcome.md
@@ -1,0 +1,47 @@
+# Contract: Break Step Outcome Vocabulary & Non-Influence
+
+This feature adds **no HTTP endpoint** and no request/response shape change. The "contract" here
+is the internal outcome vocabulary and the invariants that Domain, Service, and web-ui must agree
+on and that tests assert against.
+
+## Outcome tokens (carried in `actionOutcome`)
+
+| Token | Meaning | Emitted when |
+|-------|---------|--------------|
+| `break` | The break fired (loop ended). A **success**. | Unconditional break; conditional break whose condition evaluated true; loop-level `breakOn` that evaluated true (block end-status `"true"`). |
+| `no_break` | The break did not fire. A distinct, neutral **"No break"** — NOT a failure, NOT skipped. | Conditional break whose condition evaluated false; conditional break whose condition could not be evaluated (runtime error); loop-level `breakOn` treated as false (including guarded errors). |
+
+The old `Skipped` status + `continue` outcome for a non-firing conditional break is **removed**
+(FR-003). The old `Failed` + `result.Fail()` path for a break-condition evaluation error is
+**removed** (FR-002a).
+
+## Node-status mapping (`ExecutionLogService.MapStepStatus`)
+
+| `actionOutcome` | Node status |
+|-----------------|-------------|
+| `break` | `success` |
+| `no_break` | `no_break` (new, neutral) |
+
+`ExecutionTreeNodeStatus` (web-ui) is extended with `'no_break'`, rendered as a distinct neutral
+badge, visually separate from `failure` (red) and `skipped`.
+
+## Invariants (MUST hold — asserted by tests)
+
+1. A `no_break` outcome keeps `StepResult.Status = "Succeeded"` and never triggers
+   `SequenceExecutionResult.Fail(...)`.
+2. A run whose only non-success break outcomes are `no_break` has `FinalStatus = Succeeded`
+   (success), and its loop/sequence nodes are not `failure`.
+3. A `no_break` outcome does not early-stop the iteration, skip subsequent body steps, or skip
+   remaining iterations (flow identical to today's condition-false path).
+4. Both `break` and `no_break` outcomes retain the condition detail (`conditionType`,
+   `conditionResult`, and a human-readable `message`).
+5. A break-condition evaluation error — for the loop-body break step **and** the loop-level
+   `breakOn` — is recorded as `no_break` and never throws out to fail the run.
+6. `no_break` outcomes are excluded from failure counts / health summaries / failure alerts.
+
+## Out of scope (explicitly unchanged)
+
+- Break authoring (`BreakStepRow`, sequence editor) — no change.
+- Break *firing* behavior (which iteration/loop ends when a break fires) — no change.
+- Persisted execution-log entry format — no field added or removed; only the `actionOutcome`
+  values carried for break steps change.

--- a/specs/066-break-step-status/data-model.md
+++ b/specs/066-break-step-status/data-model.md
@@ -1,0 +1,80 @@
+# Phase 1 Data Model: Break Step Success/Failure Execution Statuses
+
+This feature adds **no persisted schema**. It defines a small outcome vocabulary and a
+status-mapping that flow through existing in-memory result types and the execution-log
+projection. Below are the conceptual entities, the values that change, and the mapping.
+
+## Entities
+
+### Break step (existing — `SequenceStep`, `StepType = Break`)
+
+A step inside a loop body that optionally carries a `BreakCondition`.
+
+- Fires when unconditional (`BreakCondition == null`) or when its condition evaluates true.
+- Does not fire when the condition evaluates false or cannot be evaluated.
+- No structural change to the entity; only its recorded **outcome** changes.
+
+### Loop-level break condition (existing — while-block `breakOn`)
+
+A condition attached to a while-style block, evaluated at `breakOn-start` and `breakOn-mid`.
+
+- Fires (ends the block) when it evaluates true → block `Status = "true"`.
+- Does not fire when false; an evaluation error is now treated as false (guarded).
+- No structural change; only its error handling and the success/no-break interpretation change.
+
+### Break step outcome (new vocabulary over existing fields)
+
+Recorded per break evaluation on the existing `StepResult` fields (Domain) and carried through to
+the execution-log projection. **No new field is introduced.**
+
+| Concept | `StepResult.Status` | `StepResult.ActionOutcome` | `StepResult.ConditionResult` | `StepResult.Message` |
+|---------|---------------------|----------------------------|------------------------------|----------------------|
+| Fired (unconditional) | `Succeeded` | `break` | `true` | "Unconditional break triggered" |
+| Fired (condition true) | `Succeeded` | `break` | `true` | "Break triggered: {detail} evaluated to true" |
+| No break (condition false) | `Succeeded` | `no_break` | `false` | "No break: {detail} evaluated to false" |
+| No break (eval error) | `Succeeded` | `no_break` | `error` | "No break: {detail} could not be evaluated ({error})" |
+
+Notes:
+- `Status` is `Succeeded` in every case (a break is never a real failure), which keeps the
+  enclosing loop/sequence/run out of `Failed` (FR-004/FR-005).
+- The distinct neutral appearance is produced entirely by the `no_break` **outcome token**, not
+  by `Status`.
+- `ConditionResult` / `Message` retain the evaluation detail for both outcomes (FR-007).
+
+## Outcome token → node status mapping
+
+`ExecutionLogService.MapStepStatus(step.Outcome)` gains two cases:
+
+| Outcome token | Node status (tree/grid) | Rendering |
+|---------------|-------------------------|-----------|
+| `break` | `success` | existing success styling (fixes today's fall-through to `failure`) |
+| `no_break` | `no_break` (NEW) | distinct **neutral** "No break" badge — not red `failure`, not `skipped` |
+
+web-ui type change: `ExecutionTreeNodeStatus = ExecutionStatus | 'skipped' | 'not_executed' | 'no_break'`.
+
+## State transitions (per break evaluation, one loop iteration)
+
+```text
+                     ┌─ unconditional ──────────────► FIRED  (break, success) ─► end iteration/loop
+break step reached ──┤
+                     └─ conditional ─┬─ eval true ──► FIRED  (break, success) ─► end iteration/loop
+                                     ├─ eval false ─► NO BREAK (no_break) ─────► continue (next body step / iteration)
+                                     └─ eval error ─► NO BREAK (no_break) ─────► continue (next body step / iteration)   ← reversed from today (was Fail + stop)
+
+loop-level breakOn ──┬─ eval true ──► FIRED  (block Status "true", success) ─► end block
+                     ├─ eval false ─► NO BREAK ─────────────────────────────► continue (no discrete record)
+                     └─ eval error ─► NO BREAK (guarded, treated as false) ──► continue   ← previously threw / failed run
+```
+
+## Non-influence invariants (validation rules the tests assert)
+
+- **INV-1 (FR-004/FR-005)**: A `no_break` outcome never sets `SequenceExecutionResult.Status` to
+  `Failed` and never marks the enclosing loop or any ancestor as failed. Run `FinalStatus` stays
+  `Succeeded` when the only non-success break outcomes are `no_break`.
+- **INV-2 (FR-006)**: A `no_break` outcome does not early-stop, skip subsequent body steps, or
+  skip remaining iterations — execution flow is identical to today's condition-false path.
+- **INV-3 (FR-008)**: A `no_break` outcome maps to node status `no_break` (never `failure`) and is
+  excluded from failure counts/alerts.
+- **INV-4 (FR-003)**: A non-firing conditional break is never recorded as `Skipped`.
+- **INV-5 (FR-002a / FR-010)**: A break-condition evaluation error (loop-body break step or
+  loop-level `breakOn`) is treated as `no_break` and never throws out to fail the run.

--- a/specs/066-break-step-status/plan.md
+++ b/specs/066-break-step-status/plan.md
@@ -1,0 +1,184 @@
+# Implementation Plan: Break Step Success/Failure Execution Statuses
+
+**Branch**: `066-break-step-status` | **Date**: 2026-07-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/066-break-step-status/spec.md`
+
+## Summary
+
+Redefine how a break's own outcome is reported in the execution log, for **both** break
+mechanisms — the discrete break step inside a loop body (`SequenceStepType.Break`) and the
+loop-level break condition (`breakOn`) on a while-style block — and guarantee that a break
+which does **not** fire never influences run health.
+
+Concretely:
+
+- A break that **fires** (condition true, or an unconditional "Always break") is a **success**.
+- A break that **does not fire** (condition false) is a distinct, neutral **"No break"** outcome
+  — not the red "Failed" indicator, and no longer the old `Skipped` representation.
+- A break condition that **cannot be evaluated** (runtime error) is treated exactly like a false
+  condition: a non-influential "No break" outcome; execution continues and the run is **not**
+  failed. This reverses today's behavior where the break-condition catch calls `result.Fail()`
+  and stops the run.
+- A "No break" outcome never marks the enclosing loop, sequence/run, or any ancestor as failed,
+  never alters execution flow, and never contributes to failure counts/alerts.
+
+Technical approach — a thin vertical slice through the existing three layers, additive except
+for the two behavior reversals (error → no-break; false → "No break" instead of `Skipped`):
+
+1. **Domain (`SequenceRunner`).** Introduce a single canonical outcome vocabulary for breaks:
+   `break` (fired) and `no_break` (did not fire, whether false or eval-error). In
+   `ExecuteLoopBodyAsync`, the condition-false branch records `no_break` instead of
+   `Skipped`/`continue`, and the condition-error `catch` records `no_break` and continues
+   instead of calling `Fail()` + early-stop. In `ExecuteWhileBlockAsync`, wrap each `breakOn`
+   evaluation in a guard that treats an exception as `false` (no break) so a broken breakOn
+   condition can no longer throw out and fail the run; the block's existing `"true"` end-status
+   continues to represent "break fired" (success).
+
+2. **Service (`ExecutionLogService` mapping).** Map the break outcomes to node statuses so the
+   tree/grid render correctly: `break` → `success`, `no_break` → a new neutral `no_break` node
+   status (distinct from `failure` and from `skipped`). This also fixes a latent miscolor where
+   `MapStepStatus("break")` currently falls through to `failure`.
+
+3. **UI (web-ui).** Extend `ExecutionTreeNodeStatus` with `no_break`, render it as a distinct,
+   neutral "No break" badge/label in the execution-log grid (`executionLogGrid.ts` /
+   `ExecutionLogs.tsx` + CSS), separate from the red failed styling.
+
+No new endpoints, no schema/persistence changes, no new dependencies. Authoring
+(`BreakStepRow`) is unchanged — this is purely about how the *outcome* of a break is reported and
+how it (does not) propagate.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 9 (`GameBot.Domain` + `GameBot.Service`); TypeScript + React 18
+(web UI, Vite + Jest).
+**Primary Dependencies**: ASP.NET Core Minimal API, Microsoft.Extensions.Logging; web UI: React,
+existing execution-log grid/tree components and `executionLogsApi` client. No new packages.
+**Storage**: None added. Break outcomes flow through the existing in-memory `StepResult`
+(`Status`, `ActionOutcome`, `ConditionResult`, `Message`) → `ExecutionDetailItem` →
+`ExecutionStepOutcome` projection. No persisted-log format field is added or removed; only the
+*values* carried in the existing `actionOutcome`/`status` attributes change for break steps.
+**Testing**: xUnit + coverlet (backend unit/contract/integration); Jest + React Testing Library
+(web UI). `vite build` + `jest` is the real web-ui green gate — lint / `tsc --noEmit` have
+pre-existing failures (see memory), so they are not the gate.
+**Target Platform**: Windows desktop service (ASP.NET Core host serving the static web UI).
+**Project Type**: Web application (C# backend + React SPA) — existing
+`GameBot.Domain` / `GameBot.Service` / `src/web-ui` / `tests` layout.
+**Performance Goals**: No new cost. The condition-false / error branches already run today; this
+changes only the recorded outcome value. `breakOn` guarding adds a `try/catch` around an
+evaluation that already happens. Well within the conditional-step p95 ≤ 200 ms budget; no I/O, no
+ADB round-trip added.
+**Constraints**: MUST NOT influence run health (FR-004–FR-008): a `no_break` outcome must keep
+`SequenceExecutionResult.Status` = `Succeeded` (no `Fail()` call on the break path), map to a
+non-`failure` node status, and stay out of failure counts. MUST NOT alter execution flow
+(FR-006): the condition-false and error branches continue exactly as the false branch does today
+(fall through to the next body step / next iteration). MUST apply to every loop construct hosting
+breaks (FR-009) and to the loop-level `breakOn` (FR-010). Distinct neutral "No break" indicator,
+never reusing `failure` styling (Clarification 2026-07-01).
+**Scale/Scope**: Operator scale. ~3 branches changed in `SequenceRunner` (loop-body false,
+loop-body error, `breakOn` guard), 1–2 mapping lines in `ExecutionLogService`, 1 UI status token
++ label/CSS, and ~10–16 new/updated tests (unit + web-ui). One existing test
+(`CountLoopBreakConditionThrowsLoopFails`) is rewritten to assert the new no-fail behavior.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation
+progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality Discipline | PASS (plan) | Small, localized, mostly additive edits along existing break/loop code paths. One shared constant set for the break outcome tokens (`break` / `no_break`) avoids magic strings. CamelCase methods (e.g. a `RecordNoBreak` helper, `TryEvaluateBreakOn`). No new dependencies; removes the `Skipped`/`continue` special-case and the `Fail()`-on-error branch (net dead-path reduction). Public members keep XML docs. |
+| II. Testing Standards | PASS (plan) | Bug-fix-style TDD: the reversed behaviors get failing-first tests. Unit (`SequenceRunnerLoopTests`): fired→success/`break`; condition-false→`no_break` (not `Skipped`) + loop continues + run `Succeeded`; **condition-error→`no_break` + loop continues + run `Succeeded`** (rewrites `CountLoopBreakConditionThrowsLoopFails`); unconditional→success; nested-loop non-influence; `breakOn` fired→block `true`, `breakOn` error→no-throw/continue. Mapping unit test: `no_break`→neutral node status, `break`→success. Web-ui Jest: grid renders distinct "No break" badge, run row stays non-failed. Coverage ≥80% line / ≥70% branch for touched areas. |
+| III. User Experience Consistency | PASS | Introduces one clearly-labelled neutral "No break" state, consistent with the existing status vocabulary/chips; does not reuse the alarming red "Failed" for normal loop iterations; error messages retain the condition detail (FR-007). No breaking change to authoring or API. |
+| IV. Performance Requirements | PASS | No added I/O or polling; only the recorded outcome value changes on branches that already execute. `breakOn` `try/catch` is negligible. Perf note included below. |
+| V. Living Documentation | PASS (plan) | `docs/architecture.md` break/loop-execution and execution-log status vocabulary updated (refreshed "Last reviewed" date) in the implementation PR. This spec's `Status` and `specs/STATUS.md` updated on completion. No earlier spec is superseded — this refines the break behavior introduced in 014/034/042 without replacing them; those specs' `Status` lines get an "iterated by 066" note if warranted. |
+| Quality Gates – DoD | PASS (plan) | No underscores in method names (the `no_break` token is a data value, not a method); behavior pinned in `contracts/` + `quickstart.md`; changelog entry for the user-visible log change; web-ui validated with `vite build` + `jest`. |
+
+No violations → Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/066-break-step-status/
+├── spec.md              # Feature specification (clarified, 3 Q&A)
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (outcome vocabulary + status mapping)
+├── quickstart.md        # Phase 1 output (manual verification)
+├── contracts/
+│   └── break-step-outcome.md   # Break outcome tokens + node-status mapping + non-influence rules
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+No OpenAPI fragment: the feature adds **no new HTTP endpoint** and no request/response shape
+change. The contract doc instead pins the internal outcome-token → node-status mapping and the
+non-influence invariants that tests assert against.
+
+### Source Code (repository root)
+
+```text
+src/
+├── GameBot.Domain/
+│   └── Services/
+│       └── SequenceRunner.cs
+│           # ExecuteLoopBodyAsync: condition-false branch -> record `no_break` (was Skipped/continue)
+│           # ExecuteLoopBodyAsync: condition-error catch  -> record `no_break` + continue (was Fail()+earlyStop)
+│           # DescribeBreakCondition message retained on both branches (FR-007)
+│           # ExecuteWhileBlockAsync: guard breakOn evaluation (breakOn-start & breakOn-mid) so an
+│           #   evaluation error is treated as false (no break); block `"true"` still = break fired
+│           # (optional) small BreakOutcomes constants: "break" / "no_break"
+└── GameBot.Service/
+    └── Services/
+        └── ExecutionLog/
+            └── ExecutionLogService.cs
+                # MapStepStatus: "break" -> "success"; "no_break" -> "no_break" (new neutral node status)
+        (SequenceExecutionService.cs: the actionOutcome for break steps now flows as
+         "break"/"no_break"; verify the flat detail-item mapping passes them through unchanged —
+         no Skipped special-casing needed for break)
+
+src/web-ui/src/
+├── services/
+│   └── executionLogsApi.ts          # ExecutionTreeNodeStatus += 'no_break'
+├── pages/
+│   ├── executionLogGrid.ts          # surface 'no_break' status value for the grid row
+│   ├── ExecutionLogs.tsx            # label/aria for the 'no_break' status cell
+│   └── ExecutionLogs.css (or execution-logs styles)  # distinct neutral badge for [data-status="no_break"]
+└── (StatusChip.tsx unchanged — session/run chip; a run with only no_break breaks stays Succeeded)
+
+tests/
+├── unit/
+│   └── Sequences/
+│       └── SequenceRunnerLoopTests.cs
+│           # rewrite CountLoopBreakConditionThrowsLoopFails -> ...ErrorRecordedAsNoBreakLoopContinues
+│           # update CountLoopConditionalBreakNeverTriggered... to assert `no_break` (not Skipped) + run Succeeded
+│           # add fired->success/`break`; nested-loop non-influence; run-level Status Succeeded
+│       └── SequenceRunnerWhileBreakOnTests.cs (new or existing while tests)
+│           # breakOn fired -> block "true"; breakOn evaluation error -> no throw, loop continues, not failed
+├── unit/ (Service)
+│   └── ExecutionLog/ExecutionLogServiceMapStepStatusTests.cs (or existing projection test)
+│           # "break" -> success, "no_break" -> no_break
+└── (web-ui Jest colocated __tests__/)
+    └── executionLogGrid + ExecutionLogs: renders distinct "No break" badge; run row not failed
+```
+
+**Structure Decision**: All changes fit the existing four-project layout; no new files are
+strictly required beyond tests and a small optional constants holder. The core behavior lives in
+`SequenceRunner` (Domain); the display correctness lives in `ExecutionLogService` (Service) and
+the grid (web-ui). Keeping a single canonical `break` / `no_break` outcome vocabulary shared by
+both the loop-body break step and the (block-level) `breakOn` end-state avoids divergent status
+strings across the two mechanisms.
+
+## Complexity Tracking
+
+No constitution violations. The two behavior reversals (error→no-break, false→`no_break` instead
+of `Skipped`) are simplifications of existing branches, not added complexity.
+
+## Performance note (implementation, Principle IV)
+
+This change does not add I/O, polling, or ADB round-trips. The condition-false and
+condition-error branches already execute today; only the recorded outcome value changes. The
+`breakOn` guard wraps an evaluation that already runs in a `try/catch`, which is negligible. No
+hot-path regression is possible; no benchmark required.

--- a/specs/066-break-step-status/quickstart.md
+++ b/specs/066-break-step-status/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart / Manual Verification: Break Step Success/Failure Statuses
+
+Prerequisites: backend service running and the web UI served, with an emulator/session available
+(or use the unit tests below for a no-device check).
+
+## Automated check (fastest, no device)
+
+```powershell
+# Backend — break/loop behavior + mapping
+dotnet test "C:\src\GameBot\GameBot.sln" --filter "FullyQualifiedName~SequenceRunnerLoopTests|FullyQualifiedName~MapStepStatus"
+
+# web-ui — real green gate (lint/tsc have pre-existing failures; do NOT gate on them)
+npm --prefix "C:\src\GameBot\src\web-ui" run build
+npm --prefix "C:\src\GameBot\src\web-ui" test
+```
+
+Expected: break tests show fired→success, condition-false→`no_break` (not `Skipped`),
+condition-error→`no_break` + loop continues + run `Succeeded`; the rewritten error test no longer
+asserts a failed loop. web-ui tests render a distinct "No break" badge.
+
+## Manual UI walkthrough
+
+1. **Author a loop with a conditional break** in the sequence editor: a count loop with a body
+   step followed by a Break step whose condition is `imageVisible(imageId=...)` for an image that
+   is currently NOT on screen.
+2. **Run the sequence** and open its entry in **Execution Logs**.
+3. **Expand the loop.** For each iteration where the image was absent, the break step row shows a
+   distinct neutral **"No break"** badge — **not** a red "Failed", and **not** "Skipped".
+   - Verify the body step still ran every iteration and the loop ran to its full count
+     (FR-006).
+   - Verify the loop row and the overall run row are **Succeeded** (green), not failed
+     (FR-004/FR-005).
+4. **Make the break fire**: arrange for the image to be visible so the condition becomes true (or
+   use an unconditional "Always break"). Re-run.
+   - The break step row shows a **success**; the loop ends at that iteration (break fired).
+5. **Break condition error path** (FR-002a): configure a break condition that cannot be evaluated
+   (e.g. a missing/invalid image reference). Re-run.
+   - The break step row shows **"No break"** (with the error detail in its message), the loop
+     continues, and the run is **Succeeded** — it does **not** abort the sequence.
+6. **Loop-level `breakOn`** (FR-010): for a while-style loop using a `breakOn` condition, confirm
+   that a `breakOn` which never becomes true lets the loop run normally and the run stays
+   Succeeded, and that a `breakOn` whose condition errors does not abort the run.
+
+## What to confirm against the spec
+
+- SC-001: fired→success, non-firing→"No break"; no `Skipped` for break steps anywhere.
+- SC-002: loop + run report success when the break never fires.
+- SC-003: same number of iterations / same actions as before the change.
+- SC-004: run failure counts/alerts show zero contribution from non-firing breaks.

--- a/specs/066-break-step-status/research.md
+++ b/specs/066-break-step-status/research.md
@@ -1,0 +1,93 @@
+# Phase 0 Research: Break Step Success/Failure Execution Statuses
+
+All Technical Context items were resolvable from the existing codebase; there were no external
+NEEDS CLARIFICATION unknowns. The decisions below record how the current system behaves and the
+chosen approach for each requirement.
+
+## Decision 1 — Canonical break outcome vocabulary: `break` / `no_break`
+
+- **Decision**: Represent a break's own outcome with two tokens carried in the existing
+  `StepResult.ActionOutcome` (and the persisted `actionOutcome` attribute): `break` when the
+  break fires, `no_break` when it does not (whether the condition was false or could not be
+  evaluated). `StepResult.Status` stays `Succeeded` for both (it is not a failure); the neutral
+  "No break" appearance is driven by the outcome token, not by a `Failed`/`Skipped` status.
+- **Rationale**: `ActionOutcome` already drives the node status (`MapStepStatus(step.Outcome)` in
+  `ExecutionLogService`) and the flat detail-item messages in `SequenceExecutionService`. Using a
+  single dedicated token keeps both break mechanisms consistent and avoids overloading `Skipped`
+  (which means "step not run") or `Failed` (which means a real failure). Keeping `Status`
+  `Succeeded` guarantees the sequence/run is not marked failed (FR-004/FR-005) since
+  `SequenceExecutionResult.Status` only becomes `Failed` via an explicit `Fail()` call.
+- **Alternatives considered**:
+  - *Reuse `Skipped`/`continue` (today's behavior)*: rejected — the spec explicitly removes the
+    `Skipped` representation (FR-003) and it conflates "did not break" with "did not run".
+  - *Use `Status = "Failed"` for no-break (literal success/failure framing)*: rejected by the
+    2026-07-01 clarification in favor of a distinct neutral badge; a `Failed` status would also
+    risk influencing failure counts and tree rollups.
+
+## Decision 2 — Condition-error is a non-influential `no_break` (behavior reversal)
+
+- **Decision**: In `ExecuteLoopBodyAsync`, the `catch` around break-condition evaluation records a
+  `no_break` outcome (retaining the error detail in the message per FR-007) and continues the
+  loop, instead of calling `result.Fail()` and returning `earlyStop = true`.
+- **Rationale**: FR-002a — an unevaluable condition is treated exactly like a false condition. The
+  clarification chose "Treat error as 'no break'", so no break-step outcome may influence the run.
+- **Current code**: `SequenceRunner.cs` lines ~994–1002 (the `catch` block) call `result.Fail(...)`
+  and return `(true, false, stepsExecuted)`. This is the branch being reversed.
+- **Alternatives considered**: keep failing the run on error (rejected by clarification);
+  distinct error indicator that does not fail the run (rejected by clarification in favor of a
+  single "No break" state — the error detail still lives in the message).
+
+## Decision 3 — Loop-level `breakOn`: guard evaluation, keep block-level granularity
+
+- **Decision**: In `ExecuteWhileBlockAsync`, wrap each `breakOn` evaluation (both the
+  `breakOn-start` and `breakOn-mid` checks) so an exception is treated as `false` (no break). A
+  `breakOn` that evaluates true continues to end the block with `Status = "true"` (= break fired /
+  success). Do **not** emit a discrete per-evaluation "No break" record for each false `breakOn`
+  check.
+- **Rationale**: FR-010 requires the success / no-break semantics and non-influence guarantees to
+  apply to the loop-level break condition, and FR-002a's error handling to apply there too. Today
+  `breakOn` is evaluated without a `try/catch` (lines ~1254 and ~1294), so a broken condition
+  throws out of the block and fails the run — guarding it implements the error requirement. The
+  spec's edge case explicitly leaves per-evaluation granularity to planning and only forbids
+  influence on run status; a `breakOn` that stays false already just continues (it never sets
+  `Failed`), so no extra record is needed and per-check "No break" rows would be log spam.
+- **Alternatives considered**: emit a `no_break` detail item on every false `breakOn` check
+  (rejected — noisy, and the block result already conveys the end reason); leave `breakOn`
+  unguarded (rejected — violates FR-010's error handling).
+
+## Decision 4 — Node-status mapping: add `success` for `break`, new neutral `no_break`
+
+- **Decision**: Extend `ExecutionLogService.MapStepStatus` so `"break" → "success"` and
+  `"no_break" → "no_break"` (a new neutral node status). Add `no_break` to the web-ui
+  `ExecutionTreeNodeStatus` union and render it as a distinct neutral badge (not the `failure`
+  styling, not `skipped`).
+- **Rationale**: The tree/grid node status is derived from the outcome token via `MapStepStatus`.
+  `"break"` is currently unmapped and falls through to `"failure"`, so even a *fired* break is
+  mis-colored today — this fixes it. `no_break` needs its own bucket to render the distinct
+  neutral indicator required by the clarification.
+- **Alternatives considered**: map `no_break → skipped` and reuse the existing skipped styling
+  (rejected — the clarification asked for a *distinct* "No break" indicator, and "skipped" carries
+  the wrong meaning); map `break → true`-style success only at block level (insufficient for the
+  discrete break step which renders as a step node).
+
+## Decision 5 — Failure counts / health summaries (FR-008)
+
+- **Decision**: No dedicated exclusion logic is required. Because `no_break` outcomes keep
+  `StepResult.Status = "Succeeded"`, map to the neutral `no_break` node status (not `failure`),
+  and never trigger `result.Fail()`, they are inherently excluded from any run-level failure
+  count/alert that keys on a `Failed` status or `failure` node status.
+- **Rationale**: Verified that the run's `FinalStatus` is the persisted
+  `SequenceExecutionResult.Status` (not a child rollup), and metrics/health key on failure
+  status — none of which `no_break` sets.
+- **Alternatives considered**: add explicit filtering (rejected as unnecessary given the status
+  values chosen).
+
+## Testing approach
+
+- **Backend**: extend `SequenceRunnerLoopTests` (fired/false/error/unconditional/nested) and add
+  `breakOn` guard coverage; the existing `CountLoopBreakConditionThrowsLoopFails` is rewritten to
+  assert continue + `Succeeded`. Add a focused `MapStepStatus` unit test for `break`/`no_break`.
+  Fake evaluators drive true/false/throw deterministically (no ADB, <1s).
+- **web-ui**: Jest tests assert the grid renders a distinct "No break" badge for a `no_break`
+  node and that a run whose only "failures" are breaks renders as non-failed. Gate on
+  `vite build` + `jest`.

--- a/specs/066-break-step-status/spec.md
+++ b/specs/066-break-step-status/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Break Step Success/Failure Execution Statuses
+
+**Feature Branch**: `066-break-step-status`  
+**Created**: 2026-07-01  
+**Status**: Draft  
+**Input**: User description: "adjusting success/failure execution statuses of break steps. Break step can be success of failure in itself, depending whether the condition is true or false, but the "failed" break step means there is NO break, so failed break step must not influence the execution."
+
+## Overview
+
+Loops can be broken in two ways: a discrete **break step** placed inside the loop body, and a
+loop-level **break condition** attached to a while-style loop (evaluated before/between
+iterations). In both cases the break either fires (ending the loop) or does not fire (the loop
+continues). Today the execution log represents a break step that did **not** fire as `Skipped`,
+which does not clearly communicate that the break was evaluated and simply chose not to break;
+the loop-level break condition, meanwhile, has no explicit success/"no break" representation at
+all.
+
+This feature redefines how a break's own outcome is reported, for both the discrete break step
+and the loop-level break condition:
+
+- A break that **fires** (its condition is true, or an unconditional "Always break" step) is a
+  **success** — it did its job and broke the loop.
+- A break that **does not fire** (its condition is false) "failed to break" — but this is surfaced
+  as a distinct, neutral **"No break"** outcome, never the red "Failed" status used for genuine
+  failures.
+
+The critical invariant is that a non-firing break is *local to the break*: it must **not**
+influence the execution — it must not mark the loop or the sequence/run as failed, and it must not
+stop, skip, or otherwise alter the flow of subsequent steps or iterations.
+
+To keep normal loop iterations from looking alarming, a non-firing break is shown with its
+own distinct, neutral **"No break"** indicator in the execution log — visually separate from
+a genuine red "Failed" result — rather than reusing the failure indicator used for real
+failing steps.
+
+## Clarifications
+
+### Session 2026-07-01
+
+- Q: When a break step's condition cannot be evaluated at runtime (a genuine error, not simply "false"), how should it behave? → A: Treat the error exactly like a false condition — a non-influential "no break" outcome; continue execution and do not fail the run.
+- Q: How should a non-firing break step ("no break") be shown in the execution log? → A: Use a distinct, neutral "No break" badge, visually separate from a genuine red "Failed" indicator.
+- Q: Which "break" mechanism does this feature cover? → A: Both — the discrete break step in a loop body AND the loop-level break condition (`breakOn`) on a while-style loop.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Break step reflects whether it broke (Priority: P1)
+
+A sequence author reviewing an execution log wants each break step to show, at a glance,
+whether it actually broke the loop. A break step that fired should read as a success; a
+break step whose condition was false should read as a distinct "No break" outcome.
+
+**Why this priority**: This is the core observable change. Without it, authors cannot tell
+from the log whether a break fired, which is the whole purpose of the feature.
+
+**Independent Test**: Author a loop containing a single conditional break step. Run it once
+with the condition satisfied and once with the condition not satisfied. Confirm the break
+step is reported as a success in the first run and as a "No break" outcome in the second.
+
+**Acceptance Scenarios**:
+
+1. **Given** a loop with a conditional break, **When** the break condition evaluates to true, **Then** the break step is recorded as a success, the loop iteration ends (break fires), and the condition detail is retained in the log.
+2. **Given** a loop with a conditional break, **When** the break condition evaluates to false, **Then** the break step is recorded with the distinct "No break" outcome, and the loop continues to the next step/iteration.
+3. **Given** a loop with an unconditional ("Always break") step, **When** the step is reached, **Then** the break step is recorded as a success and the loop iteration ends.
+
+---
+
+### User Story 2 - A non-firing break never taints the run (Priority: P1)
+
+When a break step does not fire, the user expects the loop and the overall sequence/run to
+be evaluated purely on the merits of the real work — the non-firing break must never turn a
+healthy run red or halt it.
+
+**Why this priority**: A conditional break that stays false across many iterations is the
+normal, expected path. If each "no break" counted as a real failure, virtually every looped
+sequence would be misreported as failing, making run status meaningless.
+
+**Independent Test**: Author a loop that iterates several times with the break condition
+false until a separate exit condition ends the loop. Confirm the loop and the sequence/run
+both report success even though the break step reported "No break" on every iteration.
+
+**Acceptance Scenarios**:
+
+1. **Given** a loop whose break condition is false on every iteration, **When** the loop completes via its normal exit/iteration limit, **Then** the loop status is not failed solely because of the non-firing break.
+2. **Given** a sequence containing such a loop and no other failing steps, **When** the sequence completes, **Then** the overall run status is success.
+3. **Given** a non-firing break step, **When** it is evaluated, **Then** all subsequent steps in the same iteration and all remaining iterations run exactly as they would have before this change (no early stop, no skipped work caused by the break's "No break" outcome).
+4. **Given** a run summary that counts failed steps or raises alerts on failures, **When** a break step reports "no break," **Then** that outcome is excluded from those failure counts/alerts.
+
+---
+
+### Edge Cases
+
+- **Break condition cannot be evaluated (runtime error):** A genuine error while evaluating a break condition (e.g., a malformed or unresolvable condition) is treated exactly like a condition that evaluates to false — the break step is recorded as a non-firing "no break" failure, execution continues, and the run is not marked failed. This changes today's behavior, where an evaluation error fails the whole sequence.
+- **Unconditional break:** Has no false path, so it can only ever be a success; it has no failure representation.
+- **Break inside nested loops:** The non-influence guarantee applies to the immediately enclosing loop and every ancestor loop/sequence — a non-firing break must not fail any level of the hierarchy.
+- **Break as the last step of an iteration vs. followed by more body steps:** In both cases a non-firing break must allow normal continuation (next body step, then next iteration).
+- **Loop-level break condition evaluated multiple times per iteration:** A while-style break condition may be checked more than once per iteration (e.g., before and mid-iteration). Every false/error check is a non-influential "No break" outcome; the eventual true check is the break success that ends the loop. The exact granularity of how these repeated "No break" checks are surfaced in the log is left to planning, but none of them may influence the run status.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When a break step fires (its condition evaluates to true, or it is unconditional), the system MUST record the break step's own status as a **success** and end the current loop iteration (break behavior unchanged).
+- **FR-002**: When a conditional break step's condition evaluates to false, the system MUST record the break step's own outcome as a non-firing **"No break"** result. This outcome MUST be presented with a distinct, neutral "No break" indicator that is visually separate from the "Failed" indicator used for genuinely failing steps.
+- **FR-002a**: When a conditional break step's condition cannot be evaluated because of a runtime error, the system MUST treat it as a non-firing "No break" outcome per FR-002 — recording the outcome (with the error detail retained per FR-007), continuing execution, and NOT marking the loop, sequence, or run as failed. This supersedes the prior behavior of failing the whole sequence on a break-condition evaluation error.
+- **FR-003**: The system MUST no longer represent a non-firing conditional break as `Skipped`; the "No break" outcome defined in FR-002 replaces it.
+- **FR-004**: A break step recorded with the "No break" outcome per FR-002 MUST NOT cause the enclosing loop to be marked failed.
+- **FR-005**: A break step recorded with the "No break" outcome per FR-002 MUST NOT cause the enclosing sequence/run (or any ancestor loop) to be marked failed.
+- **FR-006**: A break step recorded with the "No break" outcome per FR-002 MUST NOT stop, skip, or otherwise alter the execution of subsequent steps in the current iteration or of any remaining iterations.
+- **FR-007**: The system MUST retain, for both the success and "No break" outcomes, the descriptive detail of the evaluation (condition type, evaluated result, and a human-readable message) so authors can understand why the break did or did not fire.
+- **FR-008**: A non-firing break step's "No break" outcome MUST be excluded from any run-level failure counts, health summaries, or failure-triggered alerts.
+- **FR-009**: The change MUST apply consistently across every loop construct that supports break steps (fixed-count, conditional/while, and any other loop variants that host break steps).
+- **FR-010**: The success / "No break" semantics and the non-influence guarantees (FR-004 through FR-008, and the FR-002a error handling) MUST also apply to a loop-level break condition (a while-style loop's break-on condition): when it evaluates true the loop ends and this is represented as a break success. While it evaluates false — or cannot be evaluated — the loop MUST continue, and this MUST never mark the loop, sequence, or run as failed. Representation of the loop-level break condition is at the loop/block level (the loop's ended-by-break outcome); individual false evaluations need not be recorded as separate log entries, but none of them may influence run status.
+
+### Key Entities *(include if feature involves data)*
+
+- **Break step**: A step within a loop body that optionally carries a condition. It fires (breaks the loop) when unconditional or when its condition is true; otherwise it does not fire.
+- **Loop-level break condition**: A condition attached to a while-style loop (evaluated before/between iterations) that ends the loop when it becomes true. It has the same fire / "No break" outcome vocabulary as a break step, but belongs to the loop rather than being a body step.
+- **Break step outcome**: The recorded result of evaluating a break step for one iteration — a **success** when the break fired, or a distinct **"No break"** result when a conditional break did not fire (whether the condition was false or could not be evaluated) — along with retained condition detail.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In 100% of runs, a break step that fires is reported as a success and a conditional break step that does not fire is reported with the distinct neutral "No break" indicator (never the genuine "Failed" indicator, and never the old `Skipped` representation).
+- **SC-002**: A loop that runs to completion with a break condition that is false on every iteration reports the loop and the overall run as successful in 100% of such runs (assuming no other failing work).
+- **SC-003**: Enabling this change produces zero difference in the sequence of actions performed and the number of iterations executed compared with the prior behavior for the same inputs (execution flow is unchanged).
+- **SC-004**: Run-level failure counts and failure alerts show zero contributions from non-firing break steps.
+
+## Assumptions
+
+- A break that fires reuses the execution log's existing "success" indicator; a non-firing break uses a new distinct, neutral "No break" indicator rather than the existing "Failed" indicator (per Clarifications, 2026-07-01).
+- The existing break-firing behavior (which iteration/loop ends when a break fires) is unchanged; only the *reporting* of the break step's own outcome and the *non-influence* guarantee for non-firing breaks are in scope.
+- Unconditional ("Always break") steps are always successes and need no failure representation.
+- The overall run is still marked failed by genuinely failing real steps; this feature only ensures a *non-firing break* is not one of those causes.

--- a/specs/066-break-step-status/spec.md
+++ b/specs/066-break-step-status/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `066-break-step-status`  
 **Created**: 2026-07-01  
-**Status**: Draft  
+**Status**: Implemented  
 **Input**: User description: "adjusting success/failure execution statuses of break steps. Break step can be success of failure in itself, depending whether the condition is true or false, but the "failed" break step means there is NO break, so failed break step must not influence the execution."
 
 ## Overview

--- a/specs/066-break-step-status/tasks.md
+++ b/specs/066-break-step-status/tasks.md
@@ -1,0 +1,169 @@
+---
+description: "Task list for Break Step Success/Failure Execution Statuses"
+---
+
+# Tasks: Break Step Success/Failure Execution Statuses
+
+**Input**: Design documents from `/specs/066-break-step-status/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/break-step-outcome.md, quickstart.md
+
+**Tests**: INCLUDED. The Constitution (Testing Standards) and the two behavior reversals in this
+feature (error → no-break; false → `no_break` instead of `Skipped`) require failing-first tests
+that reproduce/pin the new behavior before the code changes.
+
+**Organization**: Tasks are grouped by the two P1 user stories from spec.md. Both stories touch
+the same file (`SequenceRunner.cs`) in adjacent branches, so US1 and US2 are sequenced (not run in
+parallel by different people on that file); tasks in different files are marked [P].
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 or US2 (Setup / Foundational / Polish carry no story label)
+
+## Path Conventions
+
+Web application, existing four-project layout: `src/GameBot.Domain/`, `src/GameBot.Service/`,
+`src/web-ui/src/`, and `tests/` at repo root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a known-green baseline before changing behavior (release-blocker gate).
+
+- [ ] T001 Establish baseline: run `dotnet test "C:\src\GameBot\GameBot.sln" --filter "FullyQualifiedName~SequenceRunnerLoopTests|FullyQualifiedName~ExecutionLog"` and `npm --prefix "C:\src\GameBot\src\web-ui" run build` + `npm --prefix "C:\src\GameBot\src\web-ui" test`; record that they pass (or note the pre-existing lint/`tsc` failures are excluded from the gate per project memory).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The single canonical break outcome vocabulary shared by BOTH break mechanisms and by the display mapping.
+
+**⚠️ CRITICAL**: Both user stories depend on these tokens existing.
+
+- [ ] T002 Add canonical break outcome tokens `break` and `no_break` as a small internal/public static holder in `src/GameBot.Domain/Services/SequenceRunner.cs` (e.g. a `BreakOutcomes` static class alongside the runner) so the loop-body break step, the loop-level `breakOn` end-state, and `GameBot.Service` mapping all reference one source of truth instead of magic strings.
+
+**Checkpoint**: Outcome tokens available — user story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Break reflects whether it broke (Priority: P1) 🎯 MVP
+
+**Goal**: Each break's own outcome reads as a **success** when it fired and as a distinct neutral **"No break"** when a conditional break did not fire — never `Skipped`, never red `Failed`.
+
+**Independent Test**: Author a loop with one conditional break; run once with the condition satisfied and once not. The break step shows `break`/success in the first run and a distinct "No break" badge in the second (verified via unit + web-ui tests, and the manual walkthrough in quickstart.md).
+
+### Tests for User Story 1 (write first, ensure they FAIL) ⚠️
+
+- [ ] T003 [P] [US1] Unit test: conditional break with condition TRUE records `StepResult.Status="Succeeded"`, `ActionOutcome="break"`, `ConditionResult="true"`, and ends the iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [ ] T004 [P] [US1] Unit test: conditional break with condition FALSE records `ActionOutcome="no_break"` (asserts it is NOT `Skipped`/`continue`) and the loop continues to the next iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [ ] T005 [P] [US1] Unit test: unconditional ("Always break") step records `ActionOutcome="break"` success and ends the iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [ ] T006 [P] [US1] Unit test: `ExecutionLogService.MapStepStatus` maps `"break" → "success"` and `"no_break" → "no_break"` — in `tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs` (new file, alongside the existing `tests/unit/ExecutionLogs/` suite)
+- [ ] T007 [P] [US1] web-ui Jest test: the execution-log grid renders a distinct neutral "No break" badge for a node whose status is `no_break` (asserts it is not the red `failure` styling and not `skipped`) — colocated in `src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx` (new file)
+- [ ] T026 [P] [US1] Unit test for FR-009 (loop-construct consistency): a break step hosted in a **while / do-while** step-loop (not a count loop) yields the same `break`/`no_break` outcomes as the count-loop cases, confirming the shared `ExecuteLoopBodyAsync` path applies uniformly — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] In `ExecuteLoopBodyAsync` condition-FALSE branch, record the outcome as `no_break` (`Status="Succeeded"`, `ActionOutcome=no_break`, `ConditionResult="false"`, message retained per FR-007) instead of `Status="Skipped"`/`ActionOutcome="continue"`, keeping the fall-through to the next body step / iteration unchanged — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 1013-1017)
+- [ ] T009 [US1] In the fired branches of `ExecuteLoopBodyAsync` (unconditional and condition-true), confirm/normalize `ActionOutcome=break` and `Status="Succeeded"` using the `BreakOutcomes` tokens — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 978-1010)
+- [ ] T010 [US1] Extend `ExecutionLogService.MapStepStatus`: add cases `"break" => "success"` and `"no_break" => "no_break"` (fixes the current fall-through of `"break"` to `"failure"`) — in `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` (~lines 475-482)
+- [ ] T011 [US1] Verify the flat detail-item mapping in `SequenceExecutionService` passes `break`/`no_break` through unchanged (the `Skipped→"skipped"` fallback at ~lines 223-225 does not apply because break steps set `ActionOutcome` explicitly); adjust only if a break step would otherwise be mislabeled — in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [ ] T012 [P] [US1] Extend `ExecutionTreeNodeStatus` with `'no_break'` — in `src/web-ui/src/services/executionLogsApi.ts` (line ~36)
+- [ ] T013 [US1] Render the `no_break` status in the log grid: surface the value in `src/web-ui/src/pages/executionLogGrid.ts`, give it a readable label/aria in `src/web-ui/src/pages/ExecutionLogs.tsx` (status cell, ~line 56), and add a distinct **neutral** badge style for the `execution-logs-row[data-status="no_break"]` / `execution-logs-cell-status` selectors in `src/web-ui/src/styles.css` (do not reuse the `failure`/red styling)
+
+**Checkpoint**: A fired break shows success; a non-firing conditional break shows a distinct "No break" badge. MVP is demoable.
+
+---
+
+## Phase 4: User Story 2 - A non-firing break never taints the run (Priority: P1)
+
+**Goal**: A break that does not fire (condition false, or condition/`breakOn` evaluation error) never marks the loop, sequence/run, or any ancestor as failed, never alters flow, and is excluded from failure counts — for both the discrete break step and the loop-level `breakOn`.
+
+**Independent Test**: Run a loop that iterates several times with the break condition false (and one with a condition that errors) until a separate exit ends it; the loop and run report Succeeded and every iteration's work still ran (verified via unit + web-ui tests and quickstart.md).
+
+### Tests for User Story 2 (write first, ensure they FAIL) ⚠️
+
+- [ ] T014 [P] [US2] Rewrite `CountLoopBreakConditionThrowsLoopFails` → `CountLoopBreakConditionErrorRecordedAsNoBreakLoopContinues`: a break condition that throws is recorded as `no_break`, the loop continues, and the run/loop `Status` is `Succeeded` (asserts `result.Fail()` is NOT called) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs` (~line 434)
+- [ ] T015 [P] [US2] Update `CountLoopConditionalBreakNeverTriggeredLoopRunsToCompletion` to also assert the run `Status="Succeeded"` and that each non-firing break is `no_break` (not `Skipped`) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs` (~line 374)
+- [ ] T016 [P] [US2] Unit test: nested loops — a `no_break` on an inner break does not mark the inner loop, outer loop, or sequence as failed (run `Status="Succeeded"`) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [ ] T017 [P] [US2] Unit test for the loop-level `breakOn`: a `breakOn` whose evaluation throws does not propagate/fail the run and the loop continues; a `breakOn` that evaluates true ends the block with `Status="true"` — in `tests/unit/Sequences/SequenceRunnerWhileBreakOnTests.cs` (new file)
+- [ ] T018 [P] [US2] web-ui Jest test: a run whose only non-success break outcomes are `no_break` renders the run/loop row as Succeeded (not failed) — colocated in `src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx`
+
+### Implementation for User Story 2
+
+- [ ] T019 [US2] In the `ExecuteLoopBodyAsync` break-condition `catch`, record `no_break` (`Status="Succeeded"`, `ConditionResult="error"`, message includes the condition detail + error per FR-007) and return `(false, false, stepsExecuted)` to continue the loop — remove the `result.Fail(...)` call and the `earlyStop=true` return — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 994-1002)
+- [ ] T020 [US2] Guard the loop-level `breakOn` evaluations: wrap the `breakOn-start` (~line 1254) and `breakOn-mid` (~line 1294) `conditionEvaluator` calls in `ExecuteWhileBlockAsync` so an exception is treated as `false` (no break) rather than propagating out and failing the run; a true result still ends the block with `Status="true"` — in `src/GameBot.Domain/Services/SequenceRunner.cs`
+- [ ] T021 [US2] Confirm FR-008: `no_break` outcomes are excluded from failure counts/health/alerts (they key on `Failed` status / `failure` node status, which `no_break` never sets). Add/extend an assertion covering this and change code only if a counter would otherwise include `no_break` — in `tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs` (and `src/GameBot.Service/Endpoints/MetricsEndpoints.cs` only if a change is actually needed)
+
+**Checkpoint**: Non-firing breaks (false + error) and unguarded `breakOn` errors leave the run green and the flow intact, across both break mechanisms.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [ ] T022 [P] Update `docs/architecture.md`: break/loop execution behavior and the execution-log status vocabulary (add `break`/`no_break`), and refresh the "Last reviewed" date (Constitution Principle V)
+- [ ] T023 [P] Add a `CHANGELOG.md` entry for the user-visible change (non-firing breaks now show a neutral "No break" state instead of `Skipped`, and a break-condition error no longer fails the run)
+- [ ] T024 Update `specs/066-break-step-status/spec.md` `Status` line to Implemented and reconcile `specs/STATUS.md`; add an "iterated by 066" note to the `Status` of the earlier break/loop specs (014, 034, 042) if their described behavior is now changed (Constitution Principle V)
+- [ ] T025 Run `specs/066-break-step-status/quickstart.md` validation end-to-end (backend `dotnet test` filters + `vite build` + `jest`, then the manual UI walkthrough)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately.
+- **Foundational (Phase 2 / T002)**: depends on Setup; BLOCKS both stories.
+- **User Story 1 (Phase 3)**: depends on T002. MVP.
+- **User Story 2 (Phase 4)**: depends on T002; also depends on US1's T008/T009/T010 because it edits adjacent branches of the same `SequenceRunner.cs`/mapping and reuses the `no_break` rendering — do US1 first, then US2.
+- **Polish (Phase 5)**: depends on US1 + US2 complete.
+
+### Within Each User Story
+
+- Write the story's tests (they FAIL) before its implementation.
+- Domain outcome recording (T008/T009, T019/T020) before Service mapping consumption (T010) before web-ui rendering (T012/T013) — but tests come first.
+
+### Parallel Opportunities
+
+- **US1 tests**: T003, T004, T005, T006, T007, T026 are all [P] (independent files / independent assertions).
+- **US2 tests**: T014, T015, T016, T017, T018 are all [P].
+- **Cross-file impl within US1**: T012 (web-ui type) is [P] against the Domain/Service tasks.
+- **Polish**: T022 and T023 are [P].
+- US1 and US2 implementation are **not** parallel on `SequenceRunner.cs` (same file, adjacent branches).
+
+---
+
+## Parallel Example: User Story 1 tests
+
+```bash
+# Launch the US1 failing-first tests together:
+Task: "Unit test conditional break TRUE → break/success in tests/unit/Sequences/SequenceRunnerLoopTests.cs"
+Task: "Unit test conditional break FALSE → no_break (not Skipped) in tests/unit/Sequences/SequenceRunnerLoopTests.cs"
+Task: "Unit test unconditional break → break/success in tests/unit/Sequences/SequenceRunnerLoopTests.cs"
+Task: "Unit test MapStepStatus break→success, no_break→no_break in tests/unit/ExecutionLog/ExecutionLogServiceMapStepStatusTests.cs"
+Task: "web-ui Jest: grid renders distinct No break badge in src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (T002) → 3. Phase 3 US1 → **STOP & VALIDATE**: a fired break reads as success and a non-firing conditional break reads as a distinct "No break" (no `Skipped`). Demoable.
+
+### Incremental Delivery
+
+1. Setup + Foundational → tokens ready.
+2. US1 → representation correct (MVP).
+3. US2 → non-influence + error/`breakOn` guarantees layered on the same paths.
+4. Polish → docs, changelog, status lines, quickstart validation.
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on an incomplete task.
+- Both user stories are P1 and tightly coupled through `SequenceRunner.cs`; sequence US1 → US2 to avoid same-file conflicts.
+- The two behavior reversals (error → `no_break`; false → `no_break` not `Skipped`) MUST have failing-first tests (T004, T014) per the Constitution.
+- Commit after each task or logical group; do not mark a phase complete on a red build/test (release-blocker gate).

--- a/specs/066-break-step-status/tasks.md
+++ b/specs/066-break-step-status/tasks.md
@@ -31,7 +31,7 @@ Web application, existing four-project layout: `src/GameBot.Domain/`, `src/GameB
 
 **Purpose**: Establish a known-green baseline before changing behavior (release-blocker gate).
 
-- [ ] T001 Establish baseline: run `dotnet test "C:\src\GameBot\GameBot.sln" --filter "FullyQualifiedName~SequenceRunnerLoopTests|FullyQualifiedName~ExecutionLog"` and `npm --prefix "C:\src\GameBot\src\web-ui" run build` + `npm --prefix "C:\src\GameBot\src\web-ui" test`; record that they pass (or note the pre-existing lint/`tsc` failures are excluded from the gate per project memory).
+- [X] T001 Establish baseline: run `dotnet test "C:\src\GameBot\GameBot.sln" --filter "FullyQualifiedName~SequenceRunnerLoopTests|FullyQualifiedName~ExecutionLog"` and `npm --prefix "C:\src\GameBot\src\web-ui" run build` + `npm --prefix "C:\src\GameBot\src\web-ui" test`; record that they pass (or note the pre-existing lint/`tsc` failures are excluded from the gate per project memory).
 
 ---
 
@@ -41,7 +41,7 @@ Web application, existing four-project layout: `src/GameBot.Domain/`, `src/GameB
 
 **⚠️ CRITICAL**: Both user stories depend on these tokens existing.
 
-- [ ] T002 Add canonical break outcome tokens `break` and `no_break` as a small internal/public static holder in `src/GameBot.Domain/Services/SequenceRunner.cs` (e.g. a `BreakOutcomes` static class alongside the runner) so the loop-body break step, the loop-level `breakOn` end-state, and `GameBot.Service` mapping all reference one source of truth instead of magic strings.
+- [X] T002 Add canonical break outcome tokens `break` and `no_break` as a small internal/public static holder in `src/GameBot.Domain/Services/SequenceRunner.cs` (e.g. a `BreakOutcomes` static class alongside the runner) so the loop-body break step, the loop-level `breakOn` end-state, and `GameBot.Service` mapping all reference one source of truth instead of magic strings.
 
 **Checkpoint**: Outcome tokens available — user story work can begin.
 
@@ -55,21 +55,21 @@ Web application, existing four-project layout: `src/GameBot.Domain/`, `src/GameB
 
 ### Tests for User Story 1 (write first, ensure they FAIL) ⚠️
 
-- [ ] T003 [P] [US1] Unit test: conditional break with condition TRUE records `StepResult.Status="Succeeded"`, `ActionOutcome="break"`, `ConditionResult="true"`, and ends the iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
-- [ ] T004 [P] [US1] Unit test: conditional break with condition FALSE records `ActionOutcome="no_break"` (asserts it is NOT `Skipped`/`continue`) and the loop continues to the next iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
-- [ ] T005 [P] [US1] Unit test: unconditional ("Always break") step records `ActionOutcome="break"` success and ends the iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
-- [ ] T006 [P] [US1] Unit test: `ExecutionLogService.MapStepStatus` maps `"break" → "success"` and `"no_break" → "no_break"` — in `tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs` (new file, alongside the existing `tests/unit/ExecutionLogs/` suite)
-- [ ] T007 [P] [US1] web-ui Jest test: the execution-log grid renders a distinct neutral "No break" badge for a node whose status is `no_break` (asserts it is not the red `failure` styling and not `skipped`) — colocated in `src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx` (new file)
-- [ ] T026 [P] [US1] Unit test for FR-009 (loop-construct consistency): a break step hosted in a **while / do-while** step-loop (not a count loop) yields the same `break`/`no_break` outcomes as the count-loop cases, confirming the shared `ExecuteLoopBodyAsync` path applies uniformly — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [X] T003 [P] [US1] Unit test: conditional break with condition TRUE records `StepResult.Status="Succeeded"`, `ActionOutcome="break"`, `ConditionResult="true"`, and ends the iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [X] T004 [P] [US1] Unit test: conditional break with condition FALSE records `ActionOutcome="no_break"` (asserts it is NOT `Skipped`/`continue`) and the loop continues to the next iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [X] T005 [P] [US1] Unit test: unconditional ("Always break") step records `ActionOutcome="break"` success and ends the iteration — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [X] T006 [P] [US1] Unit test: `ExecutionLogService.MapStepStatus` maps `"break" → "success"` and `"no_break" → "no_break"` — in `tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs` (new file, alongside the existing `tests/unit/ExecutionLogs/` suite)
+- [X] T007 [P] [US1] web-ui Jest test: the execution-log grid renders a distinct neutral "No break" badge for a node whose status is `no_break` (asserts it is not the red `failure` styling and not `skipped`) — colocated in `src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx` (new file)
+- [X] T026 [P] [US1] Unit test for FR-009 (loop-construct consistency): a break step hosted in a **while / do-while** step-loop (not a count loop) yields the same `break`/`no_break` outcomes as the count-loop cases, confirming the shared `ExecuteLoopBodyAsync` path applies uniformly — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T008 [US1] In `ExecuteLoopBodyAsync` condition-FALSE branch, record the outcome as `no_break` (`Status="Succeeded"`, `ActionOutcome=no_break`, `ConditionResult="false"`, message retained per FR-007) instead of `Status="Skipped"`/`ActionOutcome="continue"`, keeping the fall-through to the next body step / iteration unchanged — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 1013-1017)
-- [ ] T009 [US1] In the fired branches of `ExecuteLoopBodyAsync` (unconditional and condition-true), confirm/normalize `ActionOutcome=break` and `Status="Succeeded"` using the `BreakOutcomes` tokens — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 978-1010)
-- [ ] T010 [US1] Extend `ExecutionLogService.MapStepStatus`: add cases `"break" => "success"` and `"no_break" => "no_break"` (fixes the current fall-through of `"break"` to `"failure"`) — in `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` (~lines 475-482)
-- [ ] T011 [US1] Verify the flat detail-item mapping in `SequenceExecutionService` passes `break`/`no_break` through unchanged (the `Skipped→"skipped"` fallback at ~lines 223-225 does not apply because break steps set `ActionOutcome` explicitly); adjust only if a break step would otherwise be mislabeled — in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
-- [ ] T012 [P] [US1] Extend `ExecutionTreeNodeStatus` with `'no_break'` — in `src/web-ui/src/services/executionLogsApi.ts` (line ~36)
-- [ ] T013 [US1] Render the `no_break` status in the log grid: surface the value in `src/web-ui/src/pages/executionLogGrid.ts`, give it a readable label/aria in `src/web-ui/src/pages/ExecutionLogs.tsx` (status cell, ~line 56), and add a distinct **neutral** badge style for the `execution-logs-row[data-status="no_break"]` / `execution-logs-cell-status` selectors in `src/web-ui/src/styles.css` (do not reuse the `failure`/red styling)
+- [X] T008 [US1] In `ExecuteLoopBodyAsync` condition-FALSE branch, record the outcome as `no_break` (`Status="Succeeded"`, `ActionOutcome=no_break`, `ConditionResult="false"`, message retained per FR-007) instead of `Status="Skipped"`/`ActionOutcome="continue"`, keeping the fall-through to the next body step / iteration unchanged — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 1013-1017)
+- [X] T009 [US1] In the fired branches of `ExecuteLoopBodyAsync` (unconditional and condition-true), confirm/normalize `ActionOutcome=break` and `Status="Succeeded"` using the `BreakOutcomes` tokens — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 978-1010)
+- [X] T010 [US1] Extend `ExecutionLogService.MapStepStatus`: add cases `"break" => "success"` and `"no_break" => "no_break"` (fixes the current fall-through of `"break"` to `"failure"`) — in `src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs` (~lines 475-482)
+- [X] T011 [US1] Verify the flat detail-item mapping in `SequenceExecutionService` passes `break`/`no_break` through unchanged (the `Skipped→"skipped"` fallback at ~lines 223-225 does not apply because break steps set `ActionOutcome` explicitly); adjust only if a break step would otherwise be mislabeled — in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [X] T012 [P] [US1] Extend `ExecutionTreeNodeStatus` with `'no_break'` — in `src/web-ui/src/services/executionLogsApi.ts` (line ~36)
+- [X] T013 [US1] Render the `no_break` status in the log grid: surface the value in `src/web-ui/src/pages/executionLogGrid.ts`, give it a readable label/aria in `src/web-ui/src/pages/ExecutionLogs.tsx` (status cell, ~line 56), and add a distinct **neutral** badge style for the `execution-logs-row[data-status="no_break"]` / `execution-logs-cell-status` selectors in `src/web-ui/src/styles.css` (do not reuse the `failure`/red styling)
 
 **Checkpoint**: A fired break shows success; a non-firing conditional break shows a distinct "No break" badge. MVP is demoable.
 
@@ -83,17 +83,17 @@ Web application, existing four-project layout: `src/GameBot.Domain/`, `src/GameB
 
 ### Tests for User Story 2 (write first, ensure they FAIL) ⚠️
 
-- [ ] T014 [P] [US2] Rewrite `CountLoopBreakConditionThrowsLoopFails` → `CountLoopBreakConditionErrorRecordedAsNoBreakLoopContinues`: a break condition that throws is recorded as `no_break`, the loop continues, and the run/loop `Status` is `Succeeded` (asserts `result.Fail()` is NOT called) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs` (~line 434)
-- [ ] T015 [P] [US2] Update `CountLoopConditionalBreakNeverTriggeredLoopRunsToCompletion` to also assert the run `Status="Succeeded"` and that each non-firing break is `no_break` (not `Skipped`) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs` (~line 374)
-- [ ] T016 [P] [US2] Unit test: nested loops — a `no_break` on an inner break does not mark the inner loop, outer loop, or sequence as failed (run `Status="Succeeded"`) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
-- [ ] T017 [P] [US2] Unit test for the loop-level `breakOn`: a `breakOn` whose evaluation throws does not propagate/fail the run and the loop continues; a `breakOn` that evaluates true ends the block with `Status="true"` — in `tests/unit/Sequences/SequenceRunnerWhileBreakOnTests.cs` (new file)
-- [ ] T018 [P] [US2] web-ui Jest test: a run whose only non-success break outcomes are `no_break` renders the run/loop row as Succeeded (not failed) — colocated in `src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx`
+- [X] T014 [P] [US2] Rewrite `CountLoopBreakConditionThrowsLoopFails` → `CountLoopBreakConditionErrorRecordedAsNoBreakLoopContinues`: a break condition that throws is recorded as `no_break`, the loop continues, and the run/loop `Status` is `Succeeded` (asserts `result.Fail()` is NOT called) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs` (~line 434)
+- [X] T015 [P] [US2] Update `CountLoopConditionalBreakNeverTriggeredLoopRunsToCompletion` to also assert the run `Status="Succeeded"` and that each non-firing break is `no_break` (not `Skipped`) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs` (~line 374)
+- [X] T016 [P] [US2] Unit test: nested loops — a `no_break` on an inner break does not mark the inner loop, outer loop, or sequence as failed (run `Status="Succeeded"`) — in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`
+- [X] T017 [P] [US2] Unit test for the loop-level `breakOn`: a `breakOn` whose evaluation throws does not propagate/fail the run and the loop continues; a `breakOn` that evaluates true ends the block with `Status="true"` — in `tests/unit/Sequences/SequenceRunnerWhileBreakOnTests.cs` (new file)
+- [X] T018 [P] [US2] web-ui Jest test: a run whose only non-success break outcomes are `no_break` renders the run/loop row as Succeeded (not failed) — colocated in `src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx`
 
 ### Implementation for User Story 2
 
-- [ ] T019 [US2] In the `ExecuteLoopBodyAsync` break-condition `catch`, record `no_break` (`Status="Succeeded"`, `ConditionResult="error"`, message includes the condition detail + error per FR-007) and return `(false, false, stepsExecuted)` to continue the loop — remove the `result.Fail(...)` call and the `earlyStop=true` return — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 994-1002)
-- [ ] T020 [US2] Guard the loop-level `breakOn` evaluations: wrap the `breakOn-start` (~line 1254) and `breakOn-mid` (~line 1294) `conditionEvaluator` calls in `ExecuteWhileBlockAsync` so an exception is treated as `false` (no break) rather than propagating out and failing the run; a true result still ends the block with `Status="true"` — in `src/GameBot.Domain/Services/SequenceRunner.cs`
-- [ ] T021 [US2] Confirm FR-008: `no_break` outcomes are excluded from failure counts/health/alerts (they key on `Failed` status / `failure` node status, which `no_break` never sets). Add/extend an assertion covering this and change code only if a counter would otherwise include `no_break` — in `tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs` (and `src/GameBot.Service/Endpoints/MetricsEndpoints.cs` only if a change is actually needed)
+- [X] T019 [US2] In the `ExecuteLoopBodyAsync` break-condition `catch`, record `no_break` (`Status="Succeeded"`, `ConditionResult="error"`, message includes the condition detail + error per FR-007) and return `(false, false, stepsExecuted)` to continue the loop — remove the `result.Fail(...)` call and the `earlyStop=true` return — in `src/GameBot.Domain/Services/SequenceRunner.cs` (~lines 994-1002)
+- [X] T020 [US2] Guard the loop-level `breakOn` evaluations: wrap the `breakOn-start` (~line 1254) and `breakOn-mid` (~line 1294) `conditionEvaluator` calls in `ExecuteWhileBlockAsync` so an exception is treated as `false` (no break) rather than propagating out and failing the run; a true result still ends the block with `Status="true"` — in `src/GameBot.Domain/Services/SequenceRunner.cs`
+- [X] T021 [US2] Confirm FR-008: `no_break` outcomes are excluded from failure counts/health/alerts (they key on `Failed` status / `failure` node status, which `no_break` never sets). Add/extend an assertion covering this and change code only if a counter would otherwise include `no_break` — in `tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs` (and `src/GameBot.Service/Endpoints/MetricsEndpoints.cs` only if a change is actually needed)
 
 **Checkpoint**: Non-firing breaks (false + error) and unguarded `breakOn` errors leave the run green and the flow intact, across both break mechanisms.
 
@@ -101,10 +101,10 @@ Web application, existing four-project layout: `src/GameBot.Domain/`, `src/GameB
 
 ## Phase 5: Polish & Cross-Cutting Concerns
 
-- [ ] T022 [P] Update `docs/architecture.md`: break/loop execution behavior and the execution-log status vocabulary (add `break`/`no_break`), and refresh the "Last reviewed" date (Constitution Principle V)
-- [ ] T023 [P] Add a `CHANGELOG.md` entry for the user-visible change (non-firing breaks now show a neutral "No break" state instead of `Skipped`, and a break-condition error no longer fails the run)
-- [ ] T024 Update `specs/066-break-step-status/spec.md` `Status` line to Implemented and reconcile `specs/STATUS.md`; add an "iterated by 066" note to the `Status` of the earlier break/loop specs (014, 034, 042) if their described behavior is now changed (Constitution Principle V)
-- [ ] T025 Run `specs/066-break-step-status/quickstart.md` validation end-to-end (backend `dotnet test` filters + `vite build` + `jest`, then the manual UI walkthrough)
+- [X] T022 [P] Update `docs/architecture.md`: break/loop execution behavior and the execution-log status vocabulary (add `break`/`no_break`), and refresh the "Last reviewed" date (Constitution Principle V)
+- [X] T023 [P] Add a `CHANGELOG.md` entry for the user-visible change (non-firing breaks now show a neutral "No break" state instead of `Skipped`, and a break-condition error no longer fails the run)
+- [X] T024 Update `specs/066-break-step-status/spec.md` `Status` line to Implemented and reconcile `specs/STATUS.md`; add an "iterated by 066" note to the `Status` of the earlier break/loop specs (014, 034, 042) if their described behavior is now changed (Constitution Principle V)
+- [X] T025 Run `specs/066-break-step-status/quickstart.md` validation end-to-end (backend `dotnet test` filters + `vite build` + `jest`, then the manual UI walkthrough)
 
 ---
 

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -69,7 +69,7 @@ Status vocabulary:
 | 031 | Visual Conditional Sequence Logic | Superseded by 032, 033 |
 | 032 | Per-Step Optional Conditions | Implemented |
 | 033 | Conditional Sequence Steps (Minimal) | Implemented |
-| 034 | Command Loop Structures | Implemented |
+| 034 | Command Loop Structures | Implemented (iterated by 066) |
 | 035 | Background Screenshot Service | Implemented |
 | 036 | UI Configuration Editor | Implemented |
 | 037 | Tap Wait-and-Retry Before Execution | Implemented |
@@ -77,7 +77,7 @@ Status vocabulary:
 | 039 | Primitive Actions Data Model Refactor | Implemented (removed the Action data model) |
 | 040 | Wait for Image Primitive Action | Implemented |
 | 041 | Preserve Sequence Step Command Names | Implemented |
-| 042 | Sequence Loop Step Management | Implemented |
+| 042 | Sequence Loop Step Management | Implemented (iterated by 066) |
 | 043 | Reorder Spec Folders | Meta (housekeeping) |
 | 044 | Drag and Drop for Command Steps | Implemented |
 | 045 | Image Selector Dropdown | Implemented |
@@ -101,6 +101,7 @@ Status vocabulary:
 | 063 | Execution Logs Reflect What Was Actually Executed | Implemented (iterated by 050) — renumbered from 049 |
 | 064 | Command Editor Rework | Implemented (iterated by 054) — renumbered from 053 |
 | 065 | Sequence Self-Rescheduling into the Originating Queue Run | Implemented |
+| 066 | Break Step Success/Failure Execution Statuses | Implemented |
 
 ## Numbering notes
 

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -14,6 +14,23 @@ using GameBot.Domain.Utils;
 
 namespace GameBot.Domain.Services {
   /// <summary>
+  /// Canonical break-outcome vocabulary (feature 066) shared by both break mechanisms —
+  /// the loop-body break step (<see cref="SequenceStepType.Break"/>) and the loop-level
+  /// <c>breakOn</c> end-state — and by the <c>GameBot.Service</c> execution-log mapping,
+  /// so no layer relies on magic strings.
+  /// </summary>
+  public static class BreakOutcomes {
+    /// <summary>The break fired (loop ended). Rendered as a success.</summary>
+    public const string Break = "break";
+
+    /// <summary>
+    /// The break did not fire (condition false, or condition/breakOn could not be evaluated).
+    /// A distinct, neutral "No break" — never a failure, never <c>Skipped</c>.
+    /// </summary>
+    public const string NoBreak = "no_break";
+  }
+
+  /// <summary>
   /// Minimal runner that executes a sequence by iterating steps and applying delays.
   /// Detection gating and retries will be added in later phases.
   /// </summary>
@@ -950,7 +967,8 @@ namespace GameBot.Domain.Services {
     /// <summary>
     /// Executes the body steps for one loop iteration.  Returns
     /// (<c>earlyStop</c>, <c>breakTriggered</c>, <c>stepsExecuted</c>).
-    /// A break step with a condition-evaluator error sets earlyStop=true.
+    /// A break step whose condition cannot be evaluated is recorded as a neutral "No break"
+    /// (feature 066, FR-002a) and the loop continues — it does not set earlyStop.
     /// </summary>
     private async Task<(bool EarlyStop, bool BreakTriggered, int StepCount)> ExecuteLoopBodyAsync(
         IReadOnlyList<SequenceStep> bodySteps,
@@ -974,11 +992,11 @@ namespace GameBot.Domain.Services {
           var brkKey = string.IsNullOrWhiteSpace(step.StepId) ? "break" : step.StepId;
 
           if (step.BreakCondition is null) {
-            // Unconditional break
+            // Unconditional break — fired.
             result.AddStep(brkKey, 0, "Succeeded",
                 conditionType: "unconditional",
                 conditionResult: "true",
-                actionOutcome: "break",
+                actionOutcome: BreakOutcomes.Break,
                 message: "Unconditional break triggered");
             return (false, true, stepsExecuted);
           }
@@ -987,34 +1005,42 @@ namespace GameBot.Domain.Services {
 
           // Conditional break
           bool breakCond;
+          var evalError = false;
           try {
             breakCond = await EvaluateLoopConditionAsync(
                 step.BreakCondition, conditionEvaluator, stepOutcomes, ct).ConfigureAwait(false);
           }
-          catch {
-            result.AddStep(brkKey, 0, "Failed",
+          catch (Exception ex) {
+            // FR-002a: a break-condition evaluation error is treated exactly like a false
+            // condition — a neutral "No break". The loop continues and the run is not failed.
+            evalError = true;
+            breakCond = false;
+            result.AddStep(brkKey, 0, "Succeeded",
                 conditionType: condDesc.Type,
                 conditionResult: "error",
-                actionOutcome: "failed",
-                message: $"Break step '{brkKey}' condition evaluation failed ({condDesc.Detail}).");
-            result.Fail($"Break step '{brkKey}' condition evaluation failed.");
-            return (true, false, stepsExecuted);
+                actionOutcome: BreakOutcomes.NoBreak,
+                message: $"No break: {condDesc.Detail} could not be evaluated ({ex.Message})");
           }
 
           if (breakCond) {
+            // Conditional break — fired.
             result.AddStep(brkKey, 0, "Succeeded",
                 conditionType: condDesc.Type,
                 conditionResult: "true",
-                actionOutcome: "break",
+                actionOutcome: BreakOutcomes.Break,
                 message: $"Break triggered: {condDesc.Detail} evaluated to true");
             return (false, true, stepsExecuted);
           }
 
-          result.AddStep(brkKey, 0, "Skipped",
-              conditionType: condDesc.Type,
-              conditionResult: "false",
-              actionOutcome: "continue",
-              message: $"Break skipped: {condDesc.Detail} evaluated to false");
+          if (!evalError) {
+            // Conditional break — did not fire. A neutral "No break" (never Skipped), the loop
+            // continues, and the run is not influenced (feature 066, FR-003/FR-006).
+            result.AddStep(brkKey, 0, "Succeeded",
+                conditionType: condDesc.Type,
+                conditionResult: "false",
+                actionOutcome: BreakOutcomes.NoBreak,
+                message: $"No break: {condDesc.Detail} evaluated to false");
+          }
 
           if (bodyIndex < orderedBodySteps.Count - 1) {
             var delayMs = SampleInterStepDelay(interStepDelayRange);
@@ -1251,7 +1277,9 @@ namespace GameBot.Domain.Services {
       while (true) {
         ct.ThrowIfCancellationRequested();
         if (breakOn != null && conditionEvaluator != null) {
-          var brStart = await conditionEvaluator(breakOn, ct).ConfigureAwait(false);
+          // FR-010: guard the breakOn evaluation — an error is treated as false (no break) rather
+          // than propagating out and failing the run.
+          var brStart = await TryEvaluateBreakOnAsync(conditionEvaluator, breakOn, ct).ConfigureAwait(false);
           evals++;
           if (_logger != null) LogBlockEvaluation(_logger, "while", "breakOn-start", brStart, null);
           if (brStart) {
@@ -1291,7 +1319,8 @@ namespace GameBot.Domain.Services {
               }
             }
             if (breakOn != null && conditionEvaluator != null) {
-              var brMid = await conditionEvaluator(breakOn, ct).ConfigureAwait(false);
+              // FR-010: guard the breakOn evaluation — an error is treated as false (no break).
+              var brMid = await TryEvaluateBreakOnAsync(conditionEvaluator, breakOn, ct).ConfigureAwait(false);
               evals++;
               if (_logger != null) LogBlockEvaluation(_logger, "while", "breakOn-mid", brMid, null);
               if (brMid) {
@@ -1333,6 +1362,26 @@ namespace GameBot.Domain.Services {
           return;
         }
         await Task.Delay(cadenceMs, ct).ConfigureAwait(false);
+      }
+    }
+
+    /// <summary>
+    /// Evaluates a loop-level <c>breakOn</c> condition, treating an evaluation error as
+    /// <c>false</c> (no break) per feature 066 (FR-010) so a broken condition can never throw
+    /// out of the block and fail the run.  Cancellation is not swallowed.
+    /// </summary>
+    private static async Task<bool> TryEvaluateBreakOnAsync(
+        Func<Condition, CancellationToken, Task<bool>> conditionEvaluator,
+        Condition breakOn,
+        CancellationToken ct) {
+      try {
+        return await conditionEvaluator(breakOn, ct).ConfigureAwait(false);
+      }
+      catch (OperationCanceledException) {
+        throw;
+      }
+      catch {
+        return false;
       }
     }
 

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -472,9 +472,10 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       _ => "step"
     };
 
-  private static string MapStepStatus(string? outcome)
+  internal static string MapStepStatus(string? outcome)
     => (outcome ?? string.Empty).ToLowerInvariant() switch {
-      "executed" or "success" or "image_detected" or "true" => "success",
+      "executed" or "success" or "image_detected" or "true" or "break" => "success",
+      "no_break" => "no_break",
       "skipped" => "skipped",
       "not_executed" => "not_executed",
       "running" => "running",

--- a/src/web-ui/src/pages/ExecutionLogs.tsx
+++ b/src/web-ui/src/pages/ExecutionLogs.tsx
@@ -8,7 +8,7 @@ import {
   getExecutionSubtree,
   listExecutionLogs
 } from '../services/executionLogsApi';
-import { GridRow, projectEntryRow, projectNodeRow } from './executionLogGrid';
+import { GridRow, projectEntryRow, projectNodeRow, statusLabel } from './executionLogGrid';
 
 const PAGE_SIZE = 50;
 const POLL_INTERVAL_MS = 2000;
@@ -53,7 +53,7 @@ const GridRowView: React.FC<{ row: GridRow; expanded: boolean; onToggle: () => v
       {row.name}
     </td>
     <td className="execution-logs-cell-type">{row.type}</td>
-    <td className="execution-logs-cell-status">{row.status}</td>
+    <td className="execution-logs-cell-status" aria-label={statusLabel(row.status)}>{statusLabel(row.status)}</td>
     <td className="execution-logs-cell-info">{row.info}</td>
   </tr>
 );

--- a/src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx
+++ b/src/web-ui/src/pages/__tests__/ExecutionLogs.noBreak.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { ExecutionLogsPage } from '../ExecutionLogs';
+import {
+  ExecutionSubtreeResponseDto,
+  getExecutionSubtree,
+  listExecutionLogs
+} from '../../services/executionLogsApi';
+
+jest.mock('../../services/executionLogsApi');
+
+const listExecutionLogsMock = listExecutionLogs as jest.MockedFunction<typeof listExecutionLogs>;
+const getExecutionSubtreeMock = getExecutionSubtree as jest.MockedFunction<typeof getExecutionSubtree>;
+
+// A run whose loop contains a break that never fired: its only non-success break outcome is
+// no_break. The run/loop themselves stay success (FR-004/FR-005).
+const sequenceItem = {
+  id: 'seq-exec-1',
+  timestampUtc: new Date('2026-07-01T10:00:00.000Z').toISOString(),
+  executionType: 'sequence' as const,
+  finalStatus: 'success' as const,
+  childCount: 1,
+  objectRef: { objectType: 'sequence', objectId: 'seq-1', displayNameSnapshot: 'Loop Sequence' },
+  summary: "Sequence 'Loop Sequence' success."
+};
+
+const sequenceSubtree: ExecutionSubtreeResponseDto = {
+  executionId: 'seq-exec-1',
+  finalStatus: 'success',
+  root: {
+    nodeKind: 'sequence',
+    executionId: 'seq-exec-1',
+    order: 0,
+    label: 'Loop Sequence',
+    status: 'success',
+    children: [
+      {
+        nodeKind: 'loop',
+        order: 1,
+        label: 'Farm loop',
+        status: 'success',
+        children: [
+          { nodeKind: 'step', order: 1, label: 'Break check', status: 'no_break', children: [] }
+        ]
+      }
+    ]
+  }
+};
+
+const rowOf = (name: string) => screen.getByText(name).closest('tr') as HTMLElement;
+const expand = (name: string) =>
+  fireEvent.click(within(rowOf(name)).getByRole('button', { name: 'Expand sub-elements' }));
+
+describe('ExecutionLogs no_break rendering', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    listExecutionLogsMock.mockResolvedValue({ items: [sequenceItem], nextPageToken: undefined });
+    getExecutionSubtreeMock.mockResolvedValue(sequenceSubtree);
+  });
+
+  // T007 (US1): the grid renders a distinct neutral "No break" badge for a no_break node.
+  it('renders a distinct neutral "No break" badge, not failure or skipped', async () => {
+    render(<ExecutionLogsPage />);
+    await screen.findByText('Loop Sequence');
+
+    expand('Loop Sequence');
+    await waitFor(() => expect(getExecutionSubtreeMock).toHaveBeenCalledWith('seq-exec-1'));
+    await screen.findByText('Farm loop');
+    expand('Farm loop');
+
+    const breakRow = await screen.findByText('No break');
+    const row = breakRow.closest('tr') as HTMLElement;
+
+    // Distinct neutral status, carried on the row for styling — not red failure, not skipped.
+    expect(row.getAttribute('data-status')).toBe('no_break');
+    expect(row.getAttribute('data-status')).not.toBe('failure');
+    expect(row.getAttribute('data-status')).not.toBe('skipped');
+
+    // Readable label rather than the raw token.
+    expect(within(row).getByText('No break')).toBeInTheDocument();
+  });
+
+  // T018 (US2): a run whose only non-success break outcome is no_break renders as Succeeded.
+  it('keeps the run/loop rows non-failed when the only break outcome is no_break', async () => {
+    render(<ExecutionLogsPage />);
+    await screen.findByText('Loop Sequence');
+
+    // Run row stays success.
+    expect(rowOf('Loop Sequence').getAttribute('data-status')).toBe('success');
+
+    expand('Loop Sequence');
+    await waitFor(() => expect(getExecutionSubtreeMock).toHaveBeenCalledWith('seq-exec-1'));
+
+    // Loop row stays success (not marked failure by the non-firing break).
+    const loopRow = (await screen.findByText('Farm loop')).closest('tr') as HTMLElement;
+    expect(loopRow.getAttribute('data-status')).toBe('success');
+    expect(loopRow.getAttribute('data-status')).not.toBe('failure');
+  });
+});

--- a/src/web-ui/src/pages/executionLogGrid.ts
+++ b/src/web-ui/src/pages/executionLogGrid.ts
@@ -33,6 +33,11 @@ const NODE_TYPE_LABELS: Record<ExecutionTreeNodeKind, string> = {
 export const typeLabel = (nodeKind: string): string =>
   NODE_TYPE_LABELS[nodeKind as ExecutionTreeNodeKind] ?? nodeKind;
 
+// Human-readable label for a status token. Most statuses read fine as-is; the
+// neutral break outcome 'no_break' (feature 066) gets a friendlier "No break".
+export const statusLabel = (status: string): string =>
+  status === 'no_break' ? 'No break' : status;
+
 export const formatExitCondition = (exitCondition?: string): string => {
   switch (exitCondition) {
     case 'image_detected':

--- a/src/web-ui/src/services/executionLogsApi.ts
+++ b/src/web-ui/src/services/executionLogsApi.ts
@@ -33,7 +33,7 @@ export type ExecutionTreeNodeKind =
   | 'wait'
   | 'tap';
 
-export type ExecutionTreeNodeStatus = ExecutionStatus | 'skipped' | 'not_executed';
+export type ExecutionTreeNodeStatus = ExecutionStatus | 'skipped' | 'not_executed' | 'no_break';
 
 export type ExecutionTreeNodeDto = {
   nodeKind: ExecutionTreeNodeKind;

--- a/src/web-ui/src/styles.css
+++ b/src/web-ui/src/styles.css
@@ -73,6 +73,19 @@ pre.json { background: var(--gb-color-surface-alt); border: 1px solid var(--gb-c
 .execution-logs-cell-timestamp, .execution-logs-cell-type, .execution-logs-cell-status { white-space: nowrap; }
 .execution-logs-cell-name { min-width: 12rem; }
 .execution-logs-cell-info { min-width: 18rem; color: var(--gb-color-muted); }
+/* Feature 066: a break that did not fire is a distinct, neutral "No break" — never the alarming
+   red failure styling, never "skipped". A calm slate badge marks it as a normal, non-failing state. */
+.execution-logs-row[data-status="no_break"] .execution-logs-cell-status {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 8px;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 700;
+	letter-spacing: 0.03em;
+	background: #f1f5f9;
+	color: #64748b;
+}
 
 /* Mobile: single-column layout with full-width controls */
 @media (max-width: 480px) {

--- a/tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using GameBot.Service.Services.ExecutionLog;
+using Xunit;
+
+namespace GameBot.UnitTests.ExecutionLogs;
+
+/// <summary>
+/// Feature 066: the execution-log step-status mapping must render break outcomes correctly —
+/// a fired break as a success, a non-firing break as a distinct neutral "no_break" node status
+/// (never the red "failure", never "skipped"), and it must keep no_break out of failure counts.
+/// </summary>
+public sealed class ExecutionLogServiceMapStepStatusTests {
+  [Fact] // T006 (US1)
+  public void MapsBreakOutcomeToSuccess() {
+    ExecutionLogService.MapStepStatus("break").Should().Be("success");
+  }
+
+  [Fact] // T006 (US1)
+  public void MapsNoBreakOutcomeToNeutralNoBreak() {
+    var status = ExecutionLogService.MapStepStatus("no_break");
+    status.Should().Be("no_break");
+    status.Should().NotBe("failure");
+    status.Should().NotBe("skipped");
+  }
+
+  [Fact] // T021 (US2) — FR-008: no_break is not a failure and so contributes nothing to failure counts.
+  public void NoBreakIsNotCountedAsFailure() {
+    // Failure counts/health/alerts key on the "failure" node status; no_break must never map to it.
+    ExecutionLogService.MapStepStatus("no_break").Should().NotBe("failure");
+  }
+}

--- a/tests/unit/Sequences/SequenceRunnerLoopTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerLoopTests.cs
@@ -397,8 +397,14 @@ public sealed class SequenceRunnerLoopTests {
         id => { executed.Add(id); return Task.CompletedTask; },
         conditionEvaluator: (_, _) => Task.FromResult(false));
 
-    result.Status.Should().Be("Succeeded");
+    result.Status.Should().Be("Succeeded"); // T015 (US2): the non-firing break never taints the run
     executed.Should().HaveCount(5);
+
+    // T015 (US2): each non-firing break is a neutral no_break, never Skipped.
+    var breaks = result.Steps.Where(s => s.CommandId == "break").ToList();
+    breaks.Should().HaveCount(5);
+    breaks.Should().OnlyContain(s => s.ActionOutcome == "no_break");
+    breaks.Should().NotContain(s => s.Status == "Skipped");
   }
 
   [Fact]
@@ -430,32 +436,171 @@ public sealed class SequenceRunnerLoopTests {
     executed.Should().HaveCount(1);
   }
 
-  [Fact]
-  public async Task CountLoopBreakConditionThrowsLoopFails() {
+  [Fact] // T014 (US2) — reverses the old fail-on-error behavior (feature 066, FR-002a).
+  public async Task CountLoopBreakConditionErrorRecordedAsNoBreakLoopContinues() {
     var executed = new List<string>();
-    var loopStep = new SequenceStep {
-      Order = 0,
-      StepId = "loop",
-      StepType = SequenceStepType.Loop,
-      Loop = new CountLoopConfig { Count = 10 },
-      Body = new List<SequenceStep>
-        {
-                ActionBodyStep(0, "inner"),
-                new SequenceStep
-                {
-                    Order = 1,
-                    StepId = "break",
-                    StepType = SequenceStepType.Break,
-                    BreakCondition = new ImageVisibleStepCondition { ImageId = "img" }
-                }
-            }
-    };
+    var loopStep = CountLoopWithBreak(new ImageVisibleStepCondition { ImageId = "img" }, count: 4);
 
     var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
     var result = await runner.ExecuteAsync("s",
         id => { executed.Add(id); return Task.CompletedTask; },
         conditionEvaluator: (_, _) => throw new InvalidOperationException("eval error"));
 
-    result.Status.Should().Be("Failed");
+    // The break condition erroring is a neutral "no break": the loop runs to completion and the
+    // run stays Succeeded (result.Fail is never called).
+    result.Status.Should().Be("Succeeded");
+    executed.Should().HaveCount(4);
+
+    var breaks = result.Steps.Where(s => s.CommandId == "break").ToList();
+    breaks.Should().HaveCount(4);
+    breaks.Should().OnlyContain(s => s.ActionOutcome == "no_break");
+    breaks.Should().OnlyContain(s => s.ConditionResult == "error");
+    breaks.Should().NotContain(s => s.Status == "Failed");
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Feature 066: break outcome vocabulary (break / no_break)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  private static SequenceStep BreakBodyStep(int order, SequenceStepCondition? condition, string stepId = "break")
+      => new() {
+        Order = order,
+        StepId = stepId,
+        StepType = SequenceStepType.Break,
+        BreakCondition = condition
+      };
+
+  private static SequenceStep CountLoopWithBreak(SequenceStepCondition? breakCondition, int count) =>
+      new() {
+        Order = 0,
+        StepId = "loop",
+        StepType = SequenceStepType.Loop,
+        Loop = new CountLoopConfig { Count = count },
+        Body = new List<SequenceStep> { ActionBodyStep(0, "inner"), BreakBodyStep(1, breakCondition) }
+      };
+
+  [Fact] // T003 (US1)
+  public async Task ConditionalBreakConditionTrueRecordsBreakSuccessAndEndsIteration() {
+    var executed = new List<string>();
+    var loopStep = CountLoopWithBreak(new ImageVisibleStepCondition { ImageId = "img" }, count: 5);
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        id => { executed.Add(id); return Task.CompletedTask; },
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    result.Status.Should().Be("Succeeded");
+    executed.Should().HaveCount(1); // break fired on first iteration → loop ends
+
+    var brk = result.Steps.Single(s => s.CommandId == "break");
+    brk.Status.Should().Be("Succeeded");
+    brk.ActionOutcome.Should().Be("break");
+    brk.ConditionResult.Should().Be("true");
+  }
+
+  [Fact] // T004 (US1)
+  public async Task ConditionalBreakConditionFalseRecordsNoBreakAndLoopContinues() {
+    var executed = new List<string>();
+    var loopStep = CountLoopWithBreak(new ImageVisibleStepCondition { ImageId = "img" }, count: 3);
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        id => { executed.Add(id); return Task.CompletedTask; },
+        conditionEvaluator: (_, _) => Task.FromResult(false));
+
+    result.Status.Should().Be("Succeeded");
+    executed.Should().HaveCount(3); // never breaks → loop runs to completion
+
+    var breaks = result.Steps.Where(s => s.CommandId == "break").ToList();
+    breaks.Should().HaveCount(3);
+    breaks.Should().OnlyContain(s => s.ActionOutcome == "no_break");
+    breaks.Should().OnlyContain(s => s.ConditionResult == "false");
+    breaks.Should().NotContain(s => s.Status == "Skipped");
+    breaks.Should().NotContain(s => s.ActionOutcome == "continue");
+  }
+
+  [Fact] // T005 (US1)
+  public async Task UnconditionalBreakRecordsBreakSuccessAndEndsIteration() {
+    var executed = new List<string>();
+    var loopStep = CountLoopWithBreak(breakCondition: null, count: 10);
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        id => { executed.Add(id); return Task.CompletedTask; });
+
+    result.Status.Should().Be("Succeeded");
+    executed.Should().HaveCount(1);
+
+    var brk = result.Steps.Single(s => s.CommandId == "break");
+    brk.Status.Should().Be("Succeeded");
+    brk.ActionOutcome.Should().Be("break");
+  }
+
+  [Fact] // T026 (US1) — FR-009: a break in a while step-loop yields the same break/no_break outcomes
+  public async Task BreakInWhileStepLoopYieldsSameBreakAndNoBreakOutcomes() {
+    var executed = new List<string>();
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new WhileLoopConfig { Condition = new ImageVisibleStepCondition { ImageId = "loop" } },
+      Body = new List<SequenceStep> {
+        ActionBodyStep(0, "inner"),
+        BreakBodyStep(1, new ImageVisibleStepCondition { ImageId = "brk" })
+      }
+    };
+
+    var brkChecks = 0;
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        id => { executed.Add(id); return Task.CompletedTask; },
+        conditionEvaluator: (cond, _) => {
+          // While condition ("loop") stays true; break condition ("brk") fires on 2nd check.
+          if (cond.TargetId == "brk") return Task.FromResult(++brkChecks >= 2);
+          return Task.FromResult(true);
+        });
+
+    result.Status.Should().Be("Succeeded");
+
+    var breaks = result.Steps.Where(s => s.CommandId == "break").ToList();
+    breaks.Should().HaveCount(2);
+    breaks[0].ActionOutcome.Should().Be("no_break");
+    breaks[0].Status.Should().Be("Succeeded");
+    breaks[1].ActionOutcome.Should().Be("break");
+    breaks[1].Status.Should().Be("Succeeded");
+  }
+
+  [Fact] // T016 (US2) — a no_break on an inner break taints neither the inner loop, outer loop, nor run.
+  public async Task NestedLoopInnerNoBreakDoesNotFailAnyAncestor() {
+    var executed = new List<string>();
+    var innerLoop = new SequenceStep {
+      Order = 1,
+      StepId = "inner-loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new CountLoopConfig { Count = 2 },
+      Body = new List<SequenceStep> {
+        ActionBodyStep(0, "inner"),
+        BreakBodyStep(1, new ImageVisibleStepCondition { ImageId = "img" })
+      }
+    };
+    var outerLoop = new SequenceStep {
+      Order = 0,
+      StepId = "outer-loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new CountLoopConfig { Count = 3 },
+      Body = new List<SequenceStep> { innerLoop }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { outerLoop })));
+    var result = await runner.ExecuteAsync("s",
+        id => { executed.Add(id); return Task.CompletedTask; },
+        conditionEvaluator: (_, _) => Task.FromResult(false)); // break never fires
+
+    result.Status.Should().Be("Succeeded");
+    executed.Should().HaveCount(6); // 3 outer × 2 inner iterations
+
+    var breaks = result.Steps.Where(s => s.CommandId == "break").ToList();
+    breaks.Should().OnlyContain(s => s.ActionOutcome == "no_break");
+    result.Steps.Where(s => s.LoopIterations is not null).Should().OnlyContain(s => s.Status != "Failed");
   }
 }

--- a/tests/unit/Sequences/SequenceRunnerWhileBreakOnTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerWhileBreakOnTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using Xunit;
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Feature 066 (US2 / FR-010): the loop-level <c>breakOn</c> on a while block must behave like the
+/// discrete break step — a <c>breakOn</c> that evaluates true ends the block (success), and a
+/// <c>breakOn</c> whose evaluation throws is treated as "no break" (guarded) and never propagates
+/// out to fail the run.
+/// </summary>
+public sealed class SequenceRunnerWhileBreakOnTests {
+  private sealed class StubRepo : ISequenceRepository {
+    private readonly CommandSequence _seq;
+    public StubRepo(CommandSequence seq) { _seq = seq; }
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_seq);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() =>
+        Task.FromResult<IReadOnlyList<CommandSequence>>(new List<CommandSequence> { _seq }.AsReadOnly());
+    public Task<CommandSequence> CreateAsync(CommandSequence s) => Task.FromResult(s);
+    public Task<CommandSequence> UpdateAsync(CommandSequence s) => Task.FromResult(s);
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+  }
+
+  private static CommandSequence WhileWithBreakOn(string id) {
+    var seq = new CommandSequence { Id = id, Name = id };
+    var json = "{\"type\":\"while\",\"timeoutMs\":1000,\"cadenceMs\":0," +
+               "\"condition\":{\"source\":\"trigger\",\"targetId\":\"main\",\"mode\":\"Present\"}," +
+               "\"breakOn\":{\"source\":\"trigger\",\"targetId\":\"break\",\"mode\":\"Present\"}," +
+               "\"steps\":[{\"order\":1,\"commandId\":\"c1\"}]}";
+    seq.SetBlocks(new object[] { JsonDocument.Parse(json).RootElement });
+    return seq;
+  }
+
+  [Fact] // T017 (US2) — breakOn evaluation error is guarded: no throw, loop continues, run Succeeded.
+  public async Task WhileBreakOnEvaluationErrorIsGuardedAndRunSucceeds() {
+    var seq = WhileWithBreakOn("wh-breakon-error");
+    var mainChecks = 0;
+
+    var runner = new SequenceRunner(new StubRepo(seq));
+    var res = await runner.ExecuteAsync("wh-breakon-error", _ => Task.CompletedTask,
+        conditionEvaluator: (cond, _) => {
+          if (cond.TargetId == "break") throw new InvalidOperationException("breakOn eval error");
+          // main stays true for two iterations then ends the loop normally.
+          if (cond.TargetId == "main") return Task.FromResult(++mainChecks <= 2);
+          return Task.FromResult(false);
+        },
+        ct: CancellationToken.None);
+
+    res.Status.Should().Be("Succeeded");
+    res.Blocks.Should().HaveCount(1);
+    res.Blocks[0].Status.Should().NotBe("Failed");
+  }
+
+  [Fact] // T017 (US2) — breakOn that evaluates true ends the block with Status "true" (fired).
+  public async Task WhileBreakOnTrueEndsBlockWithTrueStatus() {
+    var seq = WhileWithBreakOn("wh-breakon-true");
+
+    var runner = new SequenceRunner(new StubRepo(seq));
+    var res = await runner.ExecuteAsync("wh-breakon-true", _ => Task.CompletedTask,
+        conditionEvaluator: (cond, _) => {
+          if (cond.TargetId == "main") return Task.FromResult(true);
+          if (cond.TargetId == "break") return Task.FromResult(true); // fires at breakOn-start
+          return Task.FromResult(false);
+        },
+        ct: CancellationToken.None);
+
+    res.Status.Should().Be("Succeeded");
+    res.Blocks.Should().ContainSingle();
+    res.Blocks[0].Status.Should().Be("true");
+  }
+}


### PR DESCRIPTION
## Summary

Redefine how a break's own outcome is reported in the execution log — for **both** break mechanisms (the discrete break step and the loop-level `breakOn`) — and guarantee a break that does **not** fire never influences run health.

- A break that **fires** (condition true, or unconditional) is a **success**.
- A break that **does not fire** (condition false) is a distinct, neutral **"No break"** — no longer the old `Skipped` label, never the red "Failed".
- A break condition that **cannot be evaluated** (runtime error) is treated exactly like a false condition: a non-influential "No break"; execution continues and the run is **not** failed (reverses the previous `Fail()`+stop behavior). The same guard applies to a while-block `breakOn`.
- A "No break" outcome never marks the loop, sequence/run, or any ancestor as failed, never alters flow, and is excluded from failure counts.

## Changes

- **Domain** (`SequenceRunner`): canonical `BreakOutcomes` (`break`/`no_break`); condition-false → `no_break`; condition-error → `no_break` + continue; `breakOn` evaluations guarded via `TryEvaluateBreakOnAsync`.
- **Service** (`ExecutionLogService.MapStepStatus`): `break → success`, `no_break → no_break` (fixes a latent fall-through of `break` to `failure`).
- **Web UI**: `ExecutionTreeNodeStatus += 'no_break'`; neutral "No break" badge distinct from `failure`/`skipped`.
- **Docs**: `architecture.md`, `CHANGELOG.md`, spec Status → Implemented, `STATUS.md` (034/042 iterated by 066).

## Testing

- Backend: filtered suites green (65 unit + 24 integration + 11 contract). Failing-first confirmed for the two reversed behaviors before implementation.
- Web UI: `vite build` ✓ and full Jest suite **529 passed / 92 suites** (the real green gate; lint/`tsc` excluded per project convention).
- Quickstart automated no-device path fully green. The manual UI walkthrough requires a live emulator and was not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)