### PR TITLE
Dispatch primitive tap/swipe/key sequence steps to the session input pipeline

### DIFF
--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -427,6 +427,7 @@ namespace GameBot.Domain.Services {
             result,
             sequenceId,
             _config.LoopMaxIterations,
+            actionDispatcher,
             ct).ConfigureAwait(false);
       }
 
@@ -442,6 +443,7 @@ namespace GameBot.Domain.Services {
             result,
             sequenceId,
             EmptyIterContext,
+            actionDispatcher,
             ct).ConfigureAwait(false);
         return ifEarlyStop;
       }
@@ -594,6 +596,44 @@ namespace GameBot.Domain.Services {
         return false;
       }
 
+      // ── Primitive input action dispatch (tap / swipe / key) ───────────────
+      // Dispatched through the injected callback to the session input pipeline. A failed
+      // dispatch fails the step and stops the sequence — a primitive step must never report
+      // success when no input reached the device. Without a dispatcher the step falls through
+      // to the command path (callers that execute primitives via executeCommandAsync).
+      if (step.StepType == SequenceStepType.Action
+          && actionDispatcher is not null
+          && IsPrimitiveInputAction(step.Action)) {
+        var inputDispatch = await actionDispatcher(step.Action!, ct).ConfigureAwait(false);
+        if (string.Equals(inputDispatch.Outcome, "failed", StringComparison.OrdinalIgnoreCase)) {
+          var reason = !string.IsNullOrWhiteSpace(inputDispatch.Message)
+              ? inputDispatch.Message
+              : $"step '{stepKey}' {step.Action!.Type} dispatch failed";
+          result.AddStep(
+              stepKey,
+              appliedDelay,
+              "Failed",
+              conditionType: step.Condition is null ? null : step.Condition.Type,
+              conditionResult: step.Condition is null ? null : "true",
+              actionOutcome: "failed",
+              message: reason);
+          result.Fail(reason);
+          if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "failed";
+          return true;
+        }
+
+        result.AddStep(
+            stepKey,
+            appliedDelay,
+            "Succeeded",
+            conditionType: step.Condition is null ? null : step.Condition.Type,
+            conditionResult: step.Condition is null ? null : "true",
+            actionOutcome: inputDispatch.Outcome,
+            message: inputDispatch.Message);
+        if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "success";
+        return false;
+      }
+
       if (_logger != null) LogCommandStart(_logger, step.CommandId, null);
       var cmdStart = DateTimeOffset.UtcNow;
       try {
@@ -624,6 +664,12 @@ namespace GameBot.Domain.Services {
       if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "success";
       if (_logger != null) LogCommandEnd(_logger, step.CommandId, durationMs, null);
       return false;
+    }
+
+    private static bool IsPrimitiveInputAction(SequenceActionPayload? action) {
+      return string.Equals(action?.Type, ActionTypes.Tap, StringComparison.OrdinalIgnoreCase)
+          || string.Equals(action?.Type, ActionTypes.Swipe, StringComparison.OrdinalIgnoreCase)
+          || string.Equals(action?.Type, ActionTypes.Key, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsWaitForImageStep(SequenceStep step) {
@@ -757,6 +803,7 @@ namespace GameBot.Domain.Services {
         SequenceExecutionResult result,
         string sequenceId,
         int globalMaxIterations,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher,
         CancellationToken ct) {
       var stepKey = !string.IsNullOrWhiteSpace(step.StepId) ? step.StepId : $"loop@{step.Order}";
       var maxIterations = step.Loop?.MaxIterations ?? globalMaxIterations;
@@ -765,17 +812,17 @@ namespace GameBot.Domain.Services {
         case CountLoopConfig countCfg:
           return await ExecuteCountLoopAsync(step, stepKey, countCfg,
               executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-              stepOutcomes, result, sequenceId, ct).ConfigureAwait(false);
+              stepOutcomes, result, sequenceId, actionDispatcher, ct).ConfigureAwait(false);
 
         case WhileLoopConfig whileCfg:
           return await ExecuteWhileLoopAsync(step, stepKey, whileCfg, maxIterations,
               executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-              stepOutcomes, result, sequenceId, ct).ConfigureAwait(false);
+              stepOutcomes, result, sequenceId, actionDispatcher, ct).ConfigureAwait(false);
 
         case RepeatUntilLoopConfig ruCfg:
           return await ExecuteRepeatUntilLoopAsync(step, stepKey, ruCfg, maxIterations,
               executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-              stepOutcomes, result, sequenceId, ct).ConfigureAwait(false);
+              stepOutcomes, result, sequenceId, actionDispatcher, ct).ConfigureAwait(false);
 
         default:
           result.AddStep(stepKey, 0, "Failed", message: $"Loop step '{stepKey}' has missing or unknown loop configuration.");
@@ -797,6 +844,7 @@ namespace GameBot.Domain.Services {
         Dictionary<string, string> stepOutcomes,
         SequenceExecutionResult result,
         string sequenceId,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher,
         CancellationToken ct) {
       var iterResults = new List<LoopIterResult>();
       var priorIterationExecutedSteps = false;
@@ -814,7 +862,7 @@ namespace GameBot.Domain.Services {
         var iterCtx = ImmutableIterContext(i + 1);
         var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
             step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-            stepOutcomes, result, sequenceId, iterCtx, ct).ConfigureAwait(false);
+            stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
         iterResults.Add(new LoopIterResult { IterationIndex = i + 1, BreakTriggered = breakTriggered, StepCount = stepCount });
         priorIterationExecutedSteps = stepCount > 0;
@@ -845,6 +893,7 @@ namespace GameBot.Domain.Services {
         Dictionary<string, string> stepOutcomes,
         SequenceExecutionResult result,
         string sequenceId,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher,
         CancellationToken ct) {
       var iterResults = new List<LoopIterResult>();
       var iterations = 0;
@@ -890,7 +939,7 @@ namespace GameBot.Domain.Services {
         var iterCtx = ImmutableIterContext(iterations);
         var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
             step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-            stepOutcomes, result, sequenceId, iterCtx, ct).ConfigureAwait(false);
+            stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
         iterResults.Add(new LoopIterResult { IterationIndex = iterations, BreakTriggered = breakTriggered, StepCount = stepCount });
         priorIterationExecutedSteps = stepCount > 0;
@@ -921,6 +970,7 @@ namespace GameBot.Domain.Services {
         Dictionary<string, string> stepOutcomes,
         SequenceExecutionResult result,
         string sequenceId,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher,
         CancellationToken ct) {
       var iterResults = new List<LoopIterResult>();
       var iterations = 0;
@@ -940,7 +990,7 @@ namespace GameBot.Domain.Services {
         var iterCtx = ImmutableIterContext(iterations);
         var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
             step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-            stepOutcomes, result, sequenceId, iterCtx, ct).ConfigureAwait(false);
+            stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
         iterResults.Add(new LoopIterResult { IterationIndex = iterations, BreakTriggered = breakTriggered, StepCount = stepCount });
         priorIterationExecutedSteps = stepCount > 0;
@@ -1001,6 +1051,7 @@ namespace GameBot.Domain.Services {
         SequenceExecutionResult result,
         string sequenceId,
         IReadOnlyDictionary<string, string> iterContext,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher,
         CancellationToken ct) {
       var stepKey = !string.IsNullOrWhiteSpace(step.StepId) ? step.StepId : $"if@{step.Order}";
 
@@ -1049,7 +1100,7 @@ namespace GameBot.Domain.Services {
 
       var (earlyStop, breakTriggered, _) = await ExecuteLoopBodyAsync(
           branch, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-          stepOutcomes, result, sequenceId, iterContext, ct).ConfigureAwait(false);
+          stepOutcomes, result, sequenceId, iterContext, actionDispatcher, ct).ConfigureAwait(false);
 
       if (earlyStop) {
         stepOutcomes[stepKey] = "failed";
@@ -1076,6 +1127,7 @@ namespace GameBot.Domain.Services {
         SequenceExecutionResult result,
         string sequenceId,
         IReadOnlyDictionary<string, string> iterContext,
+        Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher,
         CancellationToken ct) {
       var stepsExecuted = 0;
       var orderedBodySteps = bodySteps.OrderBy(s => s.Order).ToList();
@@ -1151,7 +1203,7 @@ namespace GameBot.Domain.Services {
           // {{iteration}} substitution, and a break inside a branch exits the enclosing loop.
           var (ifEarlyStop, ifBreakTriggered) = await ExecuteIfStepAsync(
               step, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
-              stepOutcomes, result, sequenceId, iterContext, ct).ConfigureAwait(false);
+              stepOutcomes, result, sequenceId, iterContext, actionDispatcher, ct).ConfigureAwait(false);
           stepsExecuted++;
 
           if (ifEarlyStop) return (true, false, stepsExecuted);
@@ -1177,7 +1229,7 @@ namespace GameBot.Domain.Services {
             stepOutcomes,
             result,
             sequenceId,
-            actionDispatcher: null,
+            actionDispatcher,
             ct).ConfigureAwait(false);
         stepsExecuted++;
 

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GameBot.Domain.Actions;
@@ -9,9 +11,11 @@ using GameBot.Domain.Commands.SelfReschedule;
 using GameBot.Domain.Images;
 using GameBot.Domain.Logging;
 using GameBot.Domain.Services;
+using GameBot.Emulator.Session;
 using GameBot.Service.Services.Conditions;
 using GameBot.Service.Services.ExecutionLog;
 using GameBot.Service.Services.QueueExecution;
+using EmulatorInputAction = GameBot.Emulator.Session.InputAction;
 
 namespace GameBot.Service.Services.SequenceExecution;
 
@@ -29,6 +33,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private readonly ISequenceRepository _sequenceRepository;
   private readonly ICommandExecutor _commandExecutor;
   private readonly ISelfRescheduleCoordinator _selfRescheduleCoordinator;
+  private readonly ISessionManager _sessionManager;
 
   public SequenceExecutionService(
     SequenceRunner runner,
@@ -39,7 +44,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     ICommandRepository commandRepository,
     ISequenceRepository sequenceRepository,
     ICommandExecutor commandExecutor,
-    ISelfRescheduleCoordinator selfRescheduleCoordinator) {
+    ISelfRescheduleCoordinator selfRescheduleCoordinator,
+    ISessionManager sessionManager) {
     _runner = runner;
     _evalSvc = evalSvc;
     _imageVisibleConditionAdapter = imageVisibleConditionAdapter;
@@ -49,6 +55,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     _sequenceRepository = sequenceRepository;
     _commandExecutor = commandExecutor;
     _selfRescheduleCoordinator = selfRescheduleCoordinator;
+    _sessionManager = sessionManager;
   }
 
   public async Task<SequenceExecutionResult> ExecuteAsync(
@@ -96,8 +103,11 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
           throw new InvalidOperationException($"No session available for command '{commandId}'. Start a session or pass a sessionId.");
         }
         catch (KeyNotFoundException) {
-          // Command not found in repository — step uses a primitive action type (e.g. tap)
-          // or references a non-existent command; treat as completed.
+          // Command not found in repository. Primitive input steps (tap/swipe/key) no longer
+          // reach this path — they are dispatched to the session input pipeline via the
+          // action dispatcher below. This swallow remains only for action types without a
+          // dispatch implementation (connect-to-game, ensure-game-running) and for dangling
+          // command references; treat as completed.
         }
       },
       gateEvaluator: (step, token) => {
@@ -135,7 +145,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
         return Task.FromResult(false);
       },
       ct: ct,
-      actionDispatcher: (action, token) => Task.FromResult(DispatchSelfReschedule(action, sequenceId, originatingQueueId))
+      actionDispatcher: (action, token) => DispatchActionAsync(action, sequenceId, originatingQueueId, sessionId, token)
     ).ConfigureAwait(false);
 
     var sequence = await _sequenceRepository.GetAsync(sequenceId).ConfigureAwait(false);
@@ -410,6 +420,145 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     return new ActionDispatchResult(
       "scheduled",
       $"rescheduled this sequence (option {schedule.Option}, {schedule.ResolvedTiming}); applies to the current run only");
+  }
+
+  /// <summary>
+  /// Routes a non-command sequence action to its handler: <c>reschedule-self</c> to the
+  /// coordinator (feature 065), primitive inputs (tap/swipe/key) to the session input pipeline.
+  /// </summary>
+  private Task<ActionDispatchResult> DispatchActionAsync(
+      SequenceActionPayload action,
+      string sequenceId,
+      string? originatingQueueId,
+      string? sessionId,
+      CancellationToken ct) {
+    if (string.Equals(action.Type, ActionTypes.RescheduleSelf, StringComparison.OrdinalIgnoreCase)) {
+      return Task.FromResult(DispatchSelfReschedule(action, sequenceId, originatingQueueId));
+    }
+
+    return DispatchPrimitiveInputAsync(action, sessionId, ct);
+  }
+
+  /// <summary>
+  /// Sends a primitive tap/swipe/key sequence step to the emulator session input pipeline.
+  /// Returns a <c>failed</c> outcome — which fails the step and the sequence — when the payload
+  /// is incomplete, no running session can be resolved, or the device rejects the input.
+  /// </summary>
+  private async Task<ActionDispatchResult> DispatchPrimitiveInputAsync(
+      SequenceActionPayload action,
+      string? sessionId,
+      CancellationToken ct) {
+    if (!TryBuildInputAction(action, out var input, out var error)) {
+      return new ActionDispatchResult("failed", error);
+    }
+
+    var resolvedSessionId = sessionId;
+    if (string.IsNullOrWhiteSpace(resolvedSessionId)) {
+      var runningSessions = _sessionManager.ListSessions()
+        .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
+        .ToList();
+      if (runningSessions.Count != 1) {
+        return new ActionDispatchResult(
+          "failed",
+          $"no session available for '{action.Type}' step; start a session or pass a sessionId");
+      }
+      resolvedSessionId = runningSessions[0].Id;
+    }
+
+    var accepted = await _sessionManager.SendInputsAsync(resolvedSessionId!, new[] { input! }, ct).ConfigureAwait(false);
+    if (accepted == 0) {
+      return new ActionDispatchResult(
+        "failed",
+        $"'{action.Type}' input was not accepted by session '{resolvedSessionId}'");
+    }
+
+    // Describe after sending: the session manager applies tap-point jitter by mutating the
+    // args in place, so the message reflects the coordinates actually sent to the device.
+    return new ActionDispatchResult("executed", DescribeInput(input!));
+  }
+
+  private static bool TryBuildInputAction(SequenceActionPayload action, out EmulatorInputAction? input, out string? error) {
+    input = null;
+    error = null;
+
+    if (string.Equals(action.Type, ActionTypes.Tap, StringComparison.OrdinalIgnoreCase)) {
+      if (!TryGetInt(action.Parameters, "x", out var x) || !TryGetInt(action.Parameters, "y", out var y)) {
+        error = "tap step requires numeric 'x' and 'y' parameters";
+        return false;
+      }
+      input = new EmulatorInputAction("tap", new Dictionary<string, object> { ["x"] = x, ["y"] = y });
+      return true;
+    }
+
+    if (string.Equals(action.Type, ActionTypes.Swipe, StringComparison.OrdinalIgnoreCase)) {
+      if (!TryGetInt(action.Parameters, "x1", out var x1) || !TryGetInt(action.Parameters, "y1", out var y1)
+          || !TryGetInt(action.Parameters, "x2", out var x2) || !TryGetInt(action.Parameters, "y2", out var y2)) {
+        error = "swipe step requires numeric 'x1', 'y1', 'x2' and 'y2' parameters";
+        return false;
+      }
+      var swipeArgs = new Dictionary<string, object> { ["x1"] = x1, ["y1"] = y1, ["x2"] = x2, ["y2"] = y2 };
+      var durationMs = TryGetInt(action.Parameters, "durationMs", out var duration) ? duration : (int?)null;
+      input = new EmulatorInputAction("swipe", swipeArgs, null, durationMs);
+      return true;
+    }
+
+    if (string.Equals(action.Type, ActionTypes.Key, StringComparison.OrdinalIgnoreCase)) {
+      if (TryGetInt(action.Parameters, "keyCode", out var keyCode)) {
+        input = new EmulatorInputAction("key", new Dictionary<string, object> { ["keyCode"] = keyCode });
+        return true;
+      }
+      if (TryGetString(action.Parameters, "key", out var key)) {
+        input = new EmulatorInputAction("key", new Dictionary<string, object> { ["key"] = key! });
+        return true;
+      }
+      error = "key step requires a 'key' or 'keyCode' parameter";
+      return false;
+    }
+
+    error = $"action type '{action.Type}' has no input dispatch";
+    return false;
+  }
+
+  // Parameters arrive as JsonElement from persisted sequences, as CLR primitives from in-process
+  // callers, and as strings after {{iteration}} template substitution in loop bodies.
+  private static bool TryGetInt(Dictionary<string, object?> parameters, string key, out int value) {
+    value = 0;
+    if (!parameters.TryGetValue(key, out var raw) || raw is null) return false;
+    switch (raw) {
+      case JsonElement je when je.ValueKind == JsonValueKind.Number:
+        return je.TryGetInt32(out value);
+      case JsonElement je when je.ValueKind == JsonValueKind.String:
+        return int.TryParse(je.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+      case JsonElement:
+        return false;
+      case string s:
+        return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+      default:
+        try {
+          value = Convert.ToInt32(raw, CultureInfo.InvariantCulture);
+          return true;
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException) {
+          return false;
+        }
+    }
+  }
+
+  private static bool TryGetString(Dictionary<string, object?> parameters, string key, out string? value) {
+    value = null;
+    if (!parameters.TryGetValue(key, out var raw) || raw is null) return false;
+    value = raw is JsonElement je
+      ? (je.ValueKind == JsonValueKind.String ? je.GetString() : je.ToString())
+      : raw.ToString();
+    return !string.IsNullOrWhiteSpace(value);
+  }
+
+  private static string DescribeInput(EmulatorInputAction input) {
+    return input.Type switch {
+      "tap" => $"tap({input.Args["x"]},{input.Args["y"]}) sent to emulator",
+      "swipe" => $"swipe({input.Args["x1"]},{input.Args["y1"]} -> {input.Args["x2"]},{input.Args["y2"]}) sent to emulator",
+      _ => "key input sent to emulator"
+    };
   }
 
   private static async Task<bool> EvaluateImageConditionAsync(

--- a/tests/integration/Sequences/EmptyStateExecuteSequenceIntegrationTests.cs
+++ b/tests/integration/Sequences/EmptyStateExecuteSequenceIntegrationTests.cs
@@ -10,8 +10,11 @@ using Xunit;
 namespace GameBot.IntegrationTests.Sequences;
 
 public sealed class EmptyStateExecuteSequenceIntegrationTests {
+  // A primitive tap step must reach the emulator to succeed. With no session running the
+  // execute call still returns 200 with the run result, but the run fails on the first tap
+  // step instead of fake-reporting every step as executed.
   [Fact]
-  public async Task FirstSequenceExecuteSucceedsFromEmptyRepository() {
+  public async Task FirstSequenceExecuteWithoutSessionFailsFastFromEmptyRepository() {
     TestEnvironment.PrepareCleanDataDir();
     Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
 
@@ -56,7 +59,10 @@ public sealed class EmptyStateExecuteSequenceIntegrationTests {
     executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     var execution = await executeResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
 
-    execution.GetProperty("status").GetString().Should().Be("Succeeded");
-    execution.GetProperty("steps").GetArrayLength().Should().Be(3);
+    execution.GetProperty("status").GetString().Should().Be("Failed");
+    var steps = execution.GetProperty("steps");
+    steps.GetArrayLength().Should().Be(1); // the run stops at the first undeliverable tap
+    steps[0].GetProperty("status").GetString().Should().Be("Failed");
+    steps[0].GetProperty("message").GetString().Should().Contain("no session available");
   }
 }

--- a/tests/unit/Sequences/SequenceRunnerPrimitiveInputDispatchTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerPrimitiveInputDispatchTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using Xunit;
+
+// Test-code analyzer relaxations (permitted by the constitution for test code).
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Primitive input action steps (tap/swipe/key) are dispatched through the injected callback
+/// to the session input pipeline instead of falling through to the command path, where a
+/// missing command was previously swallowed and the step reported a silent fake success.
+/// A failed dispatch fails the step and stops the sequence.
+/// </summary>
+public sealed class SequenceRunnerPrimitiveInputDispatchTests {
+  private sealed class StubRepo : ISequenceRepository {
+    private readonly CommandSequence _sequence;
+    public StubRepo(CommandSequence sequence) => _sequence = sequence;
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_sequence);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() => Task.FromResult<IReadOnlyList<CommandSequence>>(new List<CommandSequence> { _sequence });
+    public Task<CommandSequence> CreateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<CommandSequence> UpdateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+  }
+
+  private static SequenceStep PrimitiveStep(int order, string stepId, string actionType, params (string Key, object Value)[] parameters) {
+    var payload = new SequenceActionPayload { Type = actionType };
+    foreach (var (key, value) in parameters) payload.Parameters[key] = value;
+    return new SequenceStep {
+      Order = order,
+      StepId = stepId,
+      // The API maps primitive steps with CommandId = StepId; replicate that so the tests
+      // prove the dispatcher wins over the (dangling) command fallback.
+      CommandId = stepId,
+      StepType = SequenceStepType.Action,
+      Action = payload
+    };
+  }
+
+  private static CommandSequence Sequence(params SequenceStep[] steps) {
+    var sequence = new CommandSequence { Id = "primitive-seq", Name = "Primitive Seq" };
+    sequence.SetSteps(steps);
+    return sequence;
+  }
+
+  [Fact]
+  public async Task TapStepIsDispatchedAndRecordedWithDispatchOutcome() {
+    var executedCommands = new List<string>();
+    var dispatched = new List<SequenceActionPayload>();
+    var sequence = Sequence(
+      PrimitiveStep(0, "tap-step", ActionTypes.Tap, ("x", 100), ("y", 200)),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "primitive-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (action, _) => {
+        dispatched.Add(action);
+        return Task.FromResult(new ActionDispatchResult("executed", "tap(100,200) sent to emulator"));
+      },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    dispatched.Should().ContainSingle();
+    dispatched[0].Type.Should().Be(ActionTypes.Tap);
+    dispatched[0].Parameters["x"].Should().Be(100);
+    result.Steps.Should().Contain(s => s.CommandId == "tap-step" && s.ActionOutcome == "executed" && s.Message == "tap(100,200) sent to emulator");
+    // The tap step performed no command I/O; the following command step still ran.
+    executedCommands.Should().Equal("cmd-after");
+  }
+
+  [Fact]
+  public async Task FailedDispatchFailsTheStepAndStopsTheSequence() {
+    var executedCommands = new List<string>();
+    var sequence = Sequence(
+      PrimitiveStep(0, "key-step", ActionTypes.Key, ("key", "BACK")),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "primitive-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (_, _) => Task.FromResult(new ActionDispatchResult("failed", "no session available for 'key' step; start a session or pass a sessionId")),
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Failed");
+    result.Steps.Should().Contain(s => s.CommandId == "key-step" && s.Status == "Failed" && s.ActionOutcome == "failed");
+    executedCommands.Should().BeEmpty(); // sequence stopped before the next step
+  }
+
+  [Fact]
+  public async Task PrimitiveStepInsideLoopBodyIsDispatchedPerIteration() {
+    var dispatched = new List<SequenceActionPayload>();
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new CountLoopConfig { Count = 3 },
+      Body = new List<SequenceStep> { PrimitiveStep(0, "tap-in-loop", ActionTypes.Tap, ("x", 10), ("y", 20)) }
+    };
+    var runner = new SequenceRunner(new StubRepo(Sequence(loopStep)));
+
+    var result = await runner.ExecuteAsync(
+      "primitive-seq",
+      _ => Task.CompletedTask,
+      actionDispatcher: (action, _) => {
+        dispatched.Add(action);
+        return Task.FromResult(new ActionDispatchResult("executed", null));
+      },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    dispatched.Should().HaveCount(3);
+  }
+
+  [Fact]
+  public async Task WithoutDispatcherPrimitiveStepFallsThroughToCommandPath() {
+    // Callers that supply no dispatcher (unit-test harnesses) keep the legacy behavior of
+    // executing the step through executeCommandAsync.
+    var executedCommands = new List<string>();
+    var runner = new SequenceRunner(new StubRepo(Sequence(PrimitiveStep(0, "tap-step", ActionTypes.Tap, ("x", 1), ("y", 2)))));
+
+    var result = await runner.ExecuteAsync(
+      "primitive-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    executedCommands.Should().Equal("tap-step");
+  }
+}


### PR DESCRIPTION
﻿## Summary

Sequence steps with primitive actions of type `tap`, `swipe`, or `key` were silently skipped during execution but reported as **Succeeded/executed**: the runner fell through to the command path with a `CommandId` equal to the StepId, the repository lookup threw `KeyNotFoundException`, and the execution service swallowed it as "completed". No input ever reached the emulator.

This PR implements real dispatch of those steps to the session input pipeline. When the input cannot be delivered (no running session, incomplete payload, device rejected the input), the step and the sequence now fail loudly instead of fake-succeeding.

## Changes

- **SequenceRunner** (`GameBot.Domain`): `tap`/`swipe`/`key` action steps are routed through the injected `actionDispatcher` (same mechanism as `reschedule-self`); a `failed` dispatch records the step as Failed and stops the run. The dispatcher is now plumbed through the loop and if executors (previously hardcoded `actionDispatcher: null`), so primitives dispatch inside loop bodies and if branches, once per iteration. Delays, gates, and per-step conditions still apply before dispatch. Callers that supply no dispatcher keep the legacy fall-through.
- **SequenceExecutionService** (`GameBot.Service`): injects `ISessionManager` and translates primitive payloads into emulator `InputAction`s, reusing the existing pipeline (tap-point jitter, ADB retries, stub mode). Parameters are accepted as `JsonElement` (persisted sequences), CLR primitives (in-process), or strings (`{{iteration}}` substitution). Session resolution matches the command path: explicit `sessionId`, else the single running session, else a failed step with a clear message.
- **Tests**: new unit tests for the dispatch behavior (dispatch payload, failure stops the run, per-iteration dispatch in loops, legacy no-dispatcher fall-through). The empty-state execute integration test codified the fake success (3 tap steps "Succeeded" with no session); it now asserts the run fails fast on the first undeliverable tap.

## Out of scope

`connect-to-game` and `ensure-game-running` action steps (and dangling command references) still fake-succeed via the now-narrowed exception swallow; being addressed separately.

## Test plan

- `dotnet test tests/unit` — 560 passed
- `dotnet test tests/integration` — 287 passed
- `dotnet test tests/contract` — 88 passed

Repro from the report: POST /api/sequences with a tap step, then POST /api/sequences/{id}/execute. With a running session the tap reaches the emulator and the log reports the executed coordinates; without one the step reports Failed with "no session available for 'tap' step; start a session or pass a sessionId".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
