### PR TITLE
fix(sequences): dispatch connect-to-game/ensure-game-running steps and fail loudly on dangling command refs

### DIFF
--- a/src/GameBot.Domain/Commands/FileSequenceRepository.cs
+++ b/src/GameBot.Domain/Commands/FileSequenceRepository.cs
@@ -107,6 +107,7 @@ namespace GameBot.Domain.Commands {
                 ActionTypes.Swipe,
                 ActionTypes.Key,
                 ActionTypes.ConnectToGame,
+                ActionTypes.EnsureGameRunning,
                 ActionTypes.WaitForImage,
                 ActionTypes.RescheduleSelf
             };

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -596,14 +596,15 @@ namespace GameBot.Domain.Services {
         return false;
       }
 
-      // ── Primitive input action dispatch (tap / swipe / key) ───────────────
-      // Dispatched through the injected callback to the session input pipeline. A failed
+      // ── Primitive action dispatch (tap / swipe / key / connect-to-game /
+      //    ensure-game-running) ──────────────────────────────────────────────
+      // Dispatched through the injected callback to the session/game pipeline. A failed
       // dispatch fails the step and stops the sequence — a primitive step must never report
-      // success when no input reached the device. Without a dispatcher the step falls through
+      // success when nothing reached the device. Without a dispatcher the step falls through
       // to the command path (callers that execute primitives via executeCommandAsync).
       if (step.StepType == SequenceStepType.Action
           && actionDispatcher is not null
-          && IsPrimitiveInputAction(step.Action)) {
+          && IsDispatchedPrimitiveAction(step.Action)) {
         var inputDispatch = await actionDispatcher(step.Action!, ct).ConfigureAwait(false);
         if (string.Equals(inputDispatch.Outcome, "failed", StringComparison.OrdinalIgnoreCase)) {
           var reason = !string.IsNullOrWhiteSpace(inputDispatch.Message)
@@ -666,10 +667,12 @@ namespace GameBot.Domain.Services {
       return false;
     }
 
-    private static bool IsPrimitiveInputAction(SequenceActionPayload? action) {
+    private static bool IsDispatchedPrimitiveAction(SequenceActionPayload? action) {
       return string.Equals(action?.Type, ActionTypes.Tap, StringComparison.OrdinalIgnoreCase)
           || string.Equals(action?.Type, ActionTypes.Swipe, StringComparison.OrdinalIgnoreCase)
-          || string.Equals(action?.Type, ActionTypes.Key, StringComparison.OrdinalIgnoreCase);
+          || string.Equals(action?.Type, ActionTypes.Key, StringComparison.OrdinalIgnoreCase)
+          || string.Equals(action?.Type, ActionTypes.ConnectToGame, StringComparison.OrdinalIgnoreCase)
+          || string.Equals(action?.Type, ActionTypes.EnsureGameRunning, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsWaitForImageStep(SequenceStep step) {

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -13,6 +13,7 @@ using GameBot.Domain.Logging;
 using GameBot.Domain.Services;
 using GameBot.Emulator.Session;
 using GameBot.Service.Services.Conditions;
+using GameBot.Service.Services.EnsureGameRunning;
 using GameBot.Service.Services.ExecutionLog;
 using GameBot.Service.Services.QueueExecution;
 using EmulatorInputAction = GameBot.Emulator.Session.InputAction;
@@ -34,6 +35,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private readonly ICommandExecutor _commandExecutor;
   private readonly ISelfRescheduleCoordinator _selfRescheduleCoordinator;
   private readonly ISessionManager _sessionManager;
+  private readonly IEnsureGameRunningActionHandler _ensureGameRunning;
+  private readonly ISessionService _sessionService;
 
   public SequenceExecutionService(
     SequenceRunner runner,
@@ -45,7 +48,9 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     ISequenceRepository sequenceRepository,
     ICommandExecutor commandExecutor,
     ISelfRescheduleCoordinator selfRescheduleCoordinator,
-    ISessionManager sessionManager) {
+    ISessionManager sessionManager,
+    IEnsureGameRunningActionHandler ensureGameRunning,
+    ISessionService sessionService) {
     _runner = runner;
     _evalSvc = evalSvc;
     _imageVisibleConditionAdapter = imageVisibleConditionAdapter;
@@ -56,6 +61,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     _commandExecutor = commandExecutor;
     _selfRescheduleCoordinator = selfRescheduleCoordinator;
     _sessionManager = sessionManager;
+    _ensureGameRunning = ensureGameRunning;
+    _sessionService = sessionService;
   }
 
   public async Task<SequenceExecutionResult> ExecuteAsync(
@@ -102,12 +109,15 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
         catch (InvalidOperationException ex) when (ex.Message == "missing_session_context") {
           throw new InvalidOperationException($"No session available for command '{commandId}'. Start a session or pass a sessionId.");
         }
-        catch (KeyNotFoundException) {
-          // Command not found in repository. Primitive input steps (tap/swipe/key) no longer
-          // reach this path — they are dispatched to the session input pipeline via the
-          // action dispatcher below. This swallow remains only for action types without a
-          // dispatch implementation (connect-to-game, ensure-game-running) and for dangling
-          // command references; treat as completed.
+        catch (KeyNotFoundException ex) {
+          // Primitive action steps (tap/swipe/key/connect-to-game/ensure-game-running) never
+          // reach this path — they are dispatched via the action dispatcher below. What lands
+          // here is a dangling reference (missing command or session); it must fail the step
+          // loudly instead of reporting a fake success.
+          var reason = ex.Message == "Command not found"
+            ? $"Command '{commandId}' was not found; the sequence step references a missing command."
+            : $"Command '{commandId}' could not be executed: {ex.Message}.";
+          throw new InvalidOperationException(reason);
         }
       },
       gateEvaluator: (step, token) => {
@@ -424,7 +434,9 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
 
   /// <summary>
   /// Routes a non-command sequence action to its handler: <c>reschedule-self</c> to the
-  /// coordinator (feature 065), primitive inputs (tap/swipe/key) to the session input pipeline.
+  /// coordinator (feature 065), <c>connect-to-game</c> to the session service,
+  /// <c>ensure-game-running</c> to its action handler, and primitive inputs (tap/swipe/key)
+  /// to the session input pipeline.
   /// </summary>
   private Task<ActionDispatchResult> DispatchActionAsync(
       SequenceActionPayload action,
@@ -436,7 +448,71 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       return Task.FromResult(DispatchSelfReschedule(action, sequenceId, originatingQueueId));
     }
 
+    if (string.Equals(action.Type, ActionTypes.ConnectToGame, StringComparison.OrdinalIgnoreCase)) {
+      return Task.FromResult(DispatchConnectToGame(action));
+    }
+
+    if (string.Equals(action.Type, ActionTypes.EnsureGameRunning, StringComparison.OrdinalIgnoreCase)) {
+      return DispatchEnsureGameRunningAsync(sessionId, ct);
+    }
+
     return DispatchPrimitiveInputAsync(action, sessionId, ct);
+  }
+
+  /// <summary>
+  /// Handles a <c>connect-to-game</c> sequence step by starting (or restarting) a session for
+  /// the game/device named in the step parameters — the same operation as the
+  /// <c>/api/sessions/start</c> endpoint. Returns a <c>failed</c> outcome — which fails the
+  /// step and the sequence — when parameters are missing or the session cannot be started.
+  /// </summary>
+  private ActionDispatchResult DispatchConnectToGame(SequenceActionPayload action) {
+    if (!TryGetString(action.Parameters, "gameId", out var gameId)
+        || !TryGetString(action.Parameters, "adbSerial", out var adbSerial)) {
+      return new ActionDispatchResult(
+        "failed",
+        "connect-to-game step requires 'gameId' and 'adbSerial' parameters");
+    }
+
+    try {
+      var started = _sessionService.StartSession(gameId!, adbSerial!);
+      return new ActionDispatchResult(
+        "executed",
+        $"connected to game '{gameId}' on device '{adbSerial}' (session {started.SessionId})");
+    }
+    catch (Exception ex) when (ex is InvalidOperationException or KeyNotFoundException or ArgumentException) {
+      return new ActionDispatchResult(
+        "failed",
+        $"connect-to-game failed for game '{gameId}' on device '{adbSerial}': {ex.Message}");
+    }
+  }
+
+  /// <summary>
+  /// Handles an <c>ensure-game-running</c> sequence step through the same handler the command
+  /// executor uses for its command-step equivalent. Success means the linked game is the
+  /// foreground app; anything else (game not running — a launch is attempted, missing
+  /// context/config, unsupported platform) is a <c>failed</c> outcome that fails the step
+  /// and stops the sequence.
+  /// </summary>
+  private async Task<ActionDispatchResult> DispatchEnsureGameRunningAsync(
+      string? sessionId,
+      CancellationToken ct) {
+    var resolvedSessionId = sessionId;
+    if (string.IsNullOrWhiteSpace(resolvedSessionId)) {
+      var runningSessions = _sessionManager.ListSessions()
+        .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
+        .ToList();
+      if (runningSessions.Count != 1) {
+        return new ActionDispatchResult(
+          "failed",
+          "no session available for 'ensure-game-running' step; start a session or pass a sessionId");
+      }
+      resolvedSessionId = runningSessions[0].Id;
+    }
+
+    var result = await _ensureGameRunning.ExecuteAsync(resolvedSessionId!, ct).ConfigureAwait(false);
+    return result.IsSuccess
+      ? new ActionDispatchResult("executed", "game is running in the foreground (game_running)")
+      : new ActionDispatchResult("failed", $"ensure-game-running failed: {result.ReasonCode}");
   }
 
   /// <summary>

--- a/tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs
+++ b/tests/integration/Queues/SelfRescheduleRunIntegrationTests.cs
@@ -29,17 +29,22 @@ public sealed class SelfRescheduleRunIntegrationTests {
     TestEnvironment.PrepareCleanDataDir();
   }
 
-  // Builds sequence S = [ marker command (always succeeds in stub mode), reschedule-self OncePerRun
+  // Builds sequence S = [ marker step (always succeeds), reschedule-self OncePerRun
   // gated on the marker's outcome ]. expectedState selects whether the IF branch fires.
+  // The marker is a wait-for-image step with no detection target and a zero timeout — an
+  // infrastructure-free step that records a "success" outcome. (It used to be a dangling
+  // command reference, which now fails the run loudly instead of fake-succeeding.)
+  private static SequenceStep MarkerStep() => new() {
+    Order = 0,
+    StepId = "marker",
+    StepType = SequenceStepType.Action,
+    WaitForImage = new WaitForImageConfig { TimeoutMs = 0 }
+  };
+
   private static CommandSequence BuildSelfReschedulingSequence(string id, string name, string expectedMarkerState) {
     var sequence = new CommandSequence { Id = id, Name = name };
     sequence.SetSteps(new[] {
-      new SequenceStep {
-        Order = 0,
-        StepId = "marker",
-        CommandId = "cmd-marker",
-        StepType = SequenceStepType.Command
-      },
+      MarkerStep(),
       new SequenceStep {
         Order = 1,
         StepId = "reschedule",
@@ -123,7 +128,7 @@ public sealed class SelfRescheduleRunIntegrationTests {
     // A sequence that reschedules itself twice (two action steps, both forced true).
     var sequence = new CommandSequence { Id = "seq-twice", Name = "Twice" };
     sequence.SetSteps(new[] {
-      new SequenceStep { Order = 0, StepId = "marker", CommandId = "cmd-marker", StepType = SequenceStepType.Command },
+      MarkerStep(),
       new SequenceStep {
         Order = 1, StepId = "r1", StepType = SequenceStepType.Action,
         Action = new SequenceActionPayload { Type = ActionTypes.RescheduleSelf, Parameters = { ["option"] = "OncePerRun" } },

--- a/tests/integration/Sequences/FixedDelayTests.cs
+++ b/tests/integration/Sequences/FixedDelayTests.cs
@@ -8,8 +8,12 @@ namespace GameBot.IntegrationTests.Sequences {
   public class FixedDelayTests {
     public FixedDelayTests() { }
 
+    // The /api/sequences authoring shape only accepts string command ids; object-shaped step
+    // entries ({ order, commandId, delayMs }) are silently dropped, so the created sequence has
+    // no steps and executing it succeeds trivially. This test pins that contract. (It used to
+    // assert "Succeeded" believing the steps ran with delays — they never existed.)
     [Fact]
-    public async Task SequenceFixedDelayExecutesInOrderAndRespectsDelay() {
+    public async Task ObjectShapedStepsAreDroppedByAuthoringShapeAndExecuteSucceedsWithNoSteps() {
       Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
       Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
       using var app = new WebApplicationFactory<Program>();
@@ -30,25 +34,16 @@ namespace GameBot.IntegrationTests.Sequences {
       var created = await createResp.Content.ReadFromJsonAsync<SequenceDto>();
       Assert.NotNull(created);
 
-      var start = DateTimeOffset.UtcNow;
       var execUri = new Uri(client.BaseAddress!, $"/api/sequences/{created!.id}/execute");
       var execResp = await client.PostAsync(execUri, content: null);
       execResp.EnsureSuccessStatusCode();
       var res = await execResp.Content.ReadFromJsonAsync<ExecuteResultDto>();
-      var end = DateTimeOffset.UtcNow;
 
       Assert.NotNull(res);
       Assert.Equal("Succeeded", res!.status);
       Assert.Equal(created!.id, res.sequenceId);
-      // Minimal stub returns steps data; count may vary in current implementation
       Assert.NotNull(res.steps);
-
-      // Duration should be at least the sum of applied delays (with tolerance)
-      var appliedTotal = 0;
-      foreach (var s in res.steps) {
-        appliedTotal += s.appliedDelayMs;
-      }
-      // Skip strict timing assertions to avoid flakiness; server applied delays are implementation-defined at this phase
+      Assert.Empty(res.steps);
     }
 
     private sealed class SequenceDto {

--- a/tests/integration/Sequences/GatingIntegrationTests.cs
+++ b/tests/integration/Sequences/GatingIntegrationTests.cs
@@ -1,17 +1,26 @@
+using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
 using GameBot.Domain.Commands;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace GameBot.IntegrationTests.Sequences {
   public class GatingIntegrationTests {
-    private readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+    // Gate steps cannot be authored through the /api/sequences create endpoint (its authoring
+    // shape only accepts string command ids), so the sequences are seeded directly into the
+    // repository. Previously these tests posted a domain-shaped payload whose steps were
+    // silently dropped and then executed a non-existent sequence id — asserting nothing.
+    private static async Task SeedAsync(IServiceProvider services, CommandSequence sequence) {
+      await services.GetRequiredService<ISequenceRepository>().CreateAsync(sequence).ConfigureAwait(false);
+    }
 
     [Fact]
     public async Task ExecuteSequenceFailsOnTimeoutGate() {
+      TestEnvironment.PrepareCleanDataDir();
       Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
       using var app = new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>();
       var client = app.CreateClient();
@@ -25,19 +34,20 @@ namespace GameBot.IntegrationTests.Sequences {
       {
                 new SequenceStep { Order = 1, CommandId = "cmd-1", TimeoutMs = 200, Gate = new GateConfig { TargetId = "never", Condition = GateCondition.Present } }
             });
-
-      var createResp = await client.PostAsJsonAsync("/api/sequences", seq, _json);
+      await SeedAsync(app.Services, seq);
 
       using var empty = new StringContent("");
       var execResp = await client.PostAsync(new Uri($"/api/sequences/{seq.Id}/execute", UriKind.Relative), empty);
       execResp.StatusCode.Should().Be(HttpStatusCode.OK);
-      var res = await execResp.Content.ReadFromJsonAsync<GameBot.Domain.Services.SequenceExecutionResult>(_json);
-      res.Should().NotBeNull();
-      res!.Status.Should().Match(s => s == "Failed" || s == "Succeeded");
+      var res = await execResp.Content.ReadFromJsonAsync<JsonElement>();
+      // The "never" gate cannot pass; the 200ms timeout elapses and fails the run before the
+      // command step is attempted.
+      res.GetProperty("status").GetString().Should().Be("Failed");
     }
 
     [Fact]
-    public async Task ExecuteSequenceSucceedsOnPassingGate() {
+    public async Task ExecuteSequencePassesGateAndProceedsToTheStep() {
+      TestEnvironment.PrepareCleanDataDir();
       Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
       using var app = new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>();
       var client = app.CreateClient();
@@ -51,15 +61,20 @@ namespace GameBot.IntegrationTests.Sequences {
       {
                 new SequenceStep { Order = 1, CommandId = "cmd-1", TimeoutMs = 500, Gate = new GateConfig { TargetId = "always", Condition = GateCondition.Present } }
             });
-
-      var createResp = await client.PostAsJsonAsync("/api/sequences", seq, _json);
+      await SeedAsync(app.Services, seq);
 
       using var empty2 = new StringContent("");
       var execResp = await client.PostAsync(new Uri($"/api/sequences/{seq.Id}/execute", UriKind.Relative), empty2);
       execResp.StatusCode.Should().Be(HttpStatusCode.OK);
-      var res = await execResp.Content.ReadFromJsonAsync<GameBot.Domain.Services.SequenceExecutionResult>(_json);
-      res.Should().NotBeNull();
-      res!.Status.Should().Be("Succeeded");
+      var res = await execResp.Content.ReadFromJsonAsync<JsonElement>();
+      // The gate passed and execution reached the command step. "cmd-1" does not exist, and a
+      // dangling command reference now fails the step loudly instead of fake-succeeding, so the
+      // run fails at the command — not with a "Gating timeout reached" message.
+      res.GetProperty("status").GetString().Should().Be("Failed");
+      var messages = res.GetProperty("steps").EnumerateArray()
+        .Select(s => s.TryGetProperty("message", out var m) ? m.GetString() : null)
+        .ToList();
+      messages.Should().Contain(m => m != null && m.Contains("cmd-1") && m.Contains("not found"));
     }
   }
 }

--- a/tests/integration/Sequences/LegacySequenceCompatibilityIntegrationTests.cs
+++ b/tests/integration/Sequences/LegacySequenceCompatibilityIntegrationTests.cs
@@ -45,10 +45,14 @@ public sealed class LegacySequenceCompatibilityIntegrationTests {
     steps[0].Should().Be("cmd-legacy-a");
     steps[1].Should().Be("cmd-legacy-b");
 
+    // Executing still works through the legacy shape, but the referenced commands do not
+    // exist — a dangling command reference now fails the run loudly (at the first step)
+    // instead of fake-reporting every step as executed.
     var executeResponse = await client.PostAsync(new Uri($"/api/sequences/{sequenceId}/execute", UriKind.Relative), null).ConfigureAwait(false);
     executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     var execution = await executeResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
-    execution.GetProperty("status").GetString().Should().Be("Succeeded");
-    execution.GetProperty("steps").GetArrayLength().Should().Be(2);
+    execution.GetProperty("status").GetString().Should().Be("Failed");
+    execution.GetProperty("steps").GetArrayLength().Should().Be(1);
+    execution.GetProperty("steps")[0].GetProperty("message").GetString().Should().Contain("cmd-legacy-a");
   }
 }

--- a/tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs
+++ b/tests/integration/Sequences/SelfRescheduleStandaloneIntegrationTests.cs
@@ -44,7 +44,15 @@ public sealed class SelfRescheduleStandaloneIntegrationTests {
           Parameters = { ["option"] = "OncePerRun" }
         }
       },
-      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command }
+      // A wait-for-image step with no detection target and a zero timeout: an
+      // infrastructure-free step that genuinely succeeds, proving the sequence continued
+      // past the reschedule action. (A dangling command reference would now fail the run.)
+      new SequenceStep {
+        Order = 1,
+        StepId = "after",
+        StepType = SequenceStepType.Action,
+        WaitForImage = new WaitForImageConfig { TimeoutMs = 0 }
+      }
     });
     await services.GetRequiredService<ISequenceRepository>().CreateAsync(sequence).ConfigureAwait(false);
 

--- a/tests/integration/Sequences/WaitForImageSequenceExecutionIntegrationTests.cs
+++ b/tests/integration/Sequences/WaitForImageSequenceExecutionIntegrationTests.cs
@@ -64,11 +64,14 @@ public sealed class WaitForImageSequenceExecutionIntegrationTests : IDisposable 
     executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     var execution = await executeResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
 
-    execution.GetProperty("status").GetString().Should().Be("Succeeded");
+    // The wait step completed and the sequence continued to the next step. That step
+    // references a command that does not exist, which now fails loudly instead of
+    // fake-reporting "executed".
+    execution.GetProperty("status").GetString().Should().Be("Failed");
     var steps = execution.GetProperty("steps");
     steps.GetArrayLength().Should().Be(2);
     steps[0].GetProperty("actionOutcome").GetString().Should().Be("image_detected");
-    steps[1].GetProperty("actionOutcome").GetString().Should().Be("executed");
+    steps[1].GetProperty("actionOutcome").GetString().Should().Be("failed");
   }
 
   [Fact]
@@ -85,10 +88,12 @@ public sealed class WaitForImageSequenceExecutionIntegrationTests : IDisposable 
     executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     var execution = await executeResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
 
-    execution.GetProperty("status").GetString().Should().Be("Succeeded");
+    // Continuation past the wait step is proven by the second step being attempted; it fails
+    // honestly because its command reference does not exist.
+    execution.GetProperty("status").GetString().Should().Be("Failed");
     var steps = execution.GetProperty("steps");
     steps[0].GetProperty("actionOutcome").GetString().Should().Be("timeout_elapsed");
-    steps[1].GetProperty("actionOutcome").GetString().Should().Be("executed");
+    steps[1].GetProperty("actionOutcome").GetString().Should().Be("failed");
   }
 
   [Fact]
@@ -109,10 +114,12 @@ public sealed class WaitForImageSequenceExecutionIntegrationTests : IDisposable 
     executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     var execution = await executeResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
 
-    execution.GetProperty("status").GetString().Should().Be("Succeeded");
+    // Continuation past the wait step is proven by the second step being attempted; it fails
+    // honestly because its command reference does not exist.
+    execution.GetProperty("status").GetString().Should().Be("Failed");
     var steps = execution.GetProperty("steps");
     steps[0].GetProperty("actionOutcome").GetString().Should().Be("image_unavailable");
-    steps[1].GetProperty("actionOutcome").GetString().Should().Be("executed");
+    steps[1].GetProperty("actionOutcome").GetString().Should().Be("failed");
   }
 
   private static async Task<string> CreateSequenceAsync(HttpClient client, object waitPayload) {

--- a/tests/unit/Sequences/SequenceRunnerGameActionDispatchTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerGameActionDispatchTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using Xunit;
+
+// Test-code analyzer relaxations (permitted by the constitution for test code).
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// connect-to-game and ensure-game-running action steps are dispatched through the injected
+/// callback instead of falling through to the command path, where the (dangling) command
+/// reference was previously swallowed and the step reported a silent fake success.
+/// A failed dispatch fails the step and stops the sequence.
+/// </summary>
+public sealed class SequenceRunnerGameActionDispatchTests {
+  private sealed class StubRepo : ISequenceRepository {
+    private readonly CommandSequence _sequence;
+    public StubRepo(CommandSequence sequence) => _sequence = sequence;
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_sequence);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() => Task.FromResult<IReadOnlyList<CommandSequence>>(new List<CommandSequence> { _sequence });
+    public Task<CommandSequence> CreateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<CommandSequence> UpdateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+  }
+
+  private static SequenceStep ActionStep(int order, string stepId, string actionType, params (string Key, object Value)[] parameters) {
+    var payload = new SequenceActionPayload { Type = actionType };
+    foreach (var (key, value) in parameters) payload.Parameters[key] = value;
+    return new SequenceStep {
+      Order = order,
+      StepId = stepId,
+      // The API maps primitive steps with CommandId = StepId; replicate that so the tests
+      // prove the dispatcher wins over the (dangling) command fallback.
+      CommandId = stepId,
+      StepType = SequenceStepType.Action,
+      Action = payload
+    };
+  }
+
+  private static CommandSequence Sequence(params SequenceStep[] steps) {
+    var sequence = new CommandSequence { Id = "game-action-seq", Name = "Game Action Seq" };
+    sequence.SetSteps(steps);
+    return sequence;
+  }
+
+  [Fact]
+  public async Task EnsureGameRunningStepIsDispatchedAndRecordedWithDispatchOutcome() {
+    var executedCommands = new List<string>();
+    var dispatched = new List<SequenceActionPayload>();
+    var sequence = Sequence(
+      ActionStep(0, "ensure-step", ActionTypes.EnsureGameRunning),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "game-action-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (action, _) => {
+        dispatched.Add(action);
+        return Task.FromResult(new ActionDispatchResult("executed", "game is running in the foreground (game_running)"));
+      },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    dispatched.Should().ContainSingle();
+    dispatched[0].Type.Should().Be(ActionTypes.EnsureGameRunning);
+    result.Steps.Should().Contain(s => s.CommandId == "ensure-step" && s.ActionOutcome == "executed" && s.Message == "game is running in the foreground (game_running)");
+    // The action step performed no command I/O; the following command step still ran.
+    executedCommands.Should().Equal("cmd-after");
+  }
+
+  [Fact]
+  public async Task ConnectToGameStepIsDispatchedAndRecordedWithDispatchOutcome() {
+    var executedCommands = new List<string>();
+    var dispatched = new List<SequenceActionPayload>();
+    var sequence = Sequence(
+      ActionStep(0, "connect-step", ActionTypes.ConnectToGame, ("gameId", "game-1"), ("adbSerial", "emulator-5554")),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "game-action-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (action, _) => {
+        dispatched.Add(action);
+        return Task.FromResult(new ActionDispatchResult("executed", "connected to game 'game-1' on device 'emulator-5554' (session s-1)"));
+      },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    dispatched.Should().ContainSingle();
+    dispatched[0].Type.Should().Be(ActionTypes.ConnectToGame);
+    dispatched[0].Parameters["gameId"].Should().Be("game-1");
+    result.Steps.Should().Contain(s => s.CommandId == "connect-step" && s.ActionOutcome == "executed");
+    executedCommands.Should().Equal("cmd-after");
+  }
+
+  [Fact]
+  public async Task FailedEnsureGameRunningDispatchFailsTheStepAndStopsTheSequence() {
+    var executedCommands = new List<string>();
+    var sequence = Sequence(
+      ActionStep(0, "ensure-step", ActionTypes.EnsureGameRunning),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "game-action-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (_, _) => Task.FromResult(new ActionDispatchResult("failed", "ensure-game-running failed: game_not_running")),
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Failed");
+    result.Steps.Should().Contain(s => s.CommandId == "ensure-step" && s.Status == "Failed" && s.ActionOutcome == "failed");
+    executedCommands.Should().BeEmpty(); // sequence stopped before the next step
+  }
+
+  [Fact]
+  public async Task FailedConnectToGameDispatchFailsTheStepAndStopsTheSequence() {
+    var executedCommands = new List<string>();
+    var sequence = Sequence(
+      ActionStep(0, "connect-step", ActionTypes.ConnectToGame),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "game-action-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (_, _) => Task.FromResult(new ActionDispatchResult("failed", "connect-to-game step requires 'gameId' and 'adbSerial' parameters")),
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Failed");
+    result.Steps.Should().Contain(s => s.CommandId == "connect-step" && s.Status == "Failed" && s.ActionOutcome == "failed");
+    executedCommands.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task WithoutDispatcherGameActionStepFallsThroughToCommandPath() {
+    // Callers that supply no dispatcher (unit-test harnesses) keep the legacy behavior of
+    // executing the step through executeCommandAsync.
+    var executedCommands = new List<string>();
+    var runner = new SequenceRunner(new StubRepo(Sequence(ActionStep(0, "ensure-step", ActionTypes.EnsureGameRunning))));
+
+    var result = await runner.ExecuteAsync(
+      "game-action-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    executedCommands.Should().Equal("ensure-step");
+  }
+}


### PR DESCRIPTION
## Problem

Sequence steps with primitive action types `connect-to-game` and `ensure-game-running` — and steps referencing non-existent command ids — reported **Succeeded/executed without doing anything**. They fell through to the command path, where the missing command's `KeyNotFoundException` was silently swallowed in `SequenceExecutionService`'s `executeCommandAsync` callback. The tap/swipe/key equivalent of this bug was already fixed by dispatching through the `actionDispatcher` callback; this PR closes the remaining fake-success paths.

## Changes

- **SequenceRunner**: the primitive action dispatch branch (previously tap/swipe/key) now also covers `connect-to-game` and `ensure-game-running`. A failed dispatch fails the step and stops the sequence. Loop/if bodies are covered since all nested steps route through `ExecuteSingleStepAsync`.
- **SequenceExecutionService**:
  - `ensure-game-running` dispatches through `IEnsureGameRunningActionHandler` (the same handler `CommandExecutor` uses for the command-step equivalent). Success = game is the foreground app; otherwise a launch is attempted and the step fails with the reason code.
  - `connect-to-game` dispatches through `ISessionService.StartSession(gameId, adbSerial)` — the same operation as `POST /api/sessions/start`. Missing parameters or start errors fail the step.
  - The `KeyNotFoundException` swallow is gone: dangling command references now fail the step loudly with `Command 'x' was not found; the sequence step references a missing command.`
- **FileSequenceRepository**: `ensure-game-running` added to the sequence action-type allow-list (`SequenceStepValidationService` already accepted it via `PrimitiveActionTypes.All`).

## Test updates

- New `SequenceRunnerGameActionDispatchTests` (5 tests) following the existing primitive-input dispatch test patterns.
- Tests that pinned the fake success now assert the honest failure (`WaitForImageSequenceExecutionIntegrationTests`, `LegacySequenceCompatibilityIntegrationTests`).
- Self-reschedule tests replace the dangling `cmd-marker` ("always succeeds in stub mode") with a zero-timeout `WaitForImage` step that genuinely records a `success` outcome, preserving each test's FR intent.
- `GatingIntegrationTests` now seed the repository directly: they previously posted a domain-shaped payload whose steps the create endpoint drops (and executed a **non-existent** sequence id), passing only because `SequenceExecutionResult` deserializes with private setters. They now actually exercise gate pass/timeout.
- `FixedDelayTests` repurposed to pin the real authoring contract: object-shaped step entries are dropped, so the sequence executes with zero steps.

## Verification

Full suite green: 88 contract, 565 unit, 287 integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
