### PR TITLE
Fix screenshot clone race and surface condition-eval errors

### DIFF
--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -472,7 +472,7 @@ namespace GameBot.Domain.Services {
             ConfidenceThreshold = imageCondition.MinSimilarity
           }, ct).ConfigureAwait(false);
         }
-        catch {
+        catch (Exception ex) {
           result.AddStep(
               step.CommandId,
               0,
@@ -480,8 +480,8 @@ namespace GameBot.Domain.Services {
               conditionType: "imageVisible",
               conditionResult: "error",
               actionOutcome: "failed",
-              message: $"Step '{stepKey}' condition evaluation failed");
-          result.Fail($"Step '{stepKey}' condition evaluation failed");
+              message: $"Step '{stepKey}' condition evaluation failed: {ex.Message}");
+          result.Fail($"Step '{stepKey}' condition evaluation failed: {ex.Message}");
           if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "failed";
           return true;
         }
@@ -910,9 +910,9 @@ namespace GameBot.Domain.Services {
           condResult = await EvaluateLoopConditionAsync(
               cfg.Condition, conditionEvaluator, stepOutcomes, ct).ConfigureAwait(false);
         }
-        catch {
-          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' condition evaluation failed.");
-          result.Fail($"Loop '{stepKey}' condition evaluation failed.");
+        catch (Exception ex) {
+          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' condition evaluation failed: {ex.Message}");
+          result.Fail($"Loop '{stepKey}' condition evaluation failed: {ex.Message}");
           stepOutcomes[stepKey] = "failed";
           return true;
         }
@@ -1018,9 +1018,9 @@ namespace GameBot.Domain.Services {
           exitCond = await EvaluateLoopConditionAsync(
               cfg.Condition, conditionEvaluator, stepOutcomes, ct).ConfigureAwait(false);
         }
-        catch {
-          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exit condition evaluation failed.");
-          result.Fail($"Loop '{stepKey}' exit condition evaluation failed.");
+        catch (Exception ex) {
+          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exit condition evaluation failed: {ex.Message}");
+          result.Fail($"Loop '{stepKey}' exit condition evaluation failed: {ex.Message}");
           stepOutcomes[stepKey] = "failed";
           return true;
         }
@@ -1072,13 +1072,13 @@ namespace GameBot.Domain.Services {
         condResult = await EvaluateLoopConditionAsync(
             step.If.Condition, conditionEvaluator, stepOutcomes, ct).ConfigureAwait(false);
       }
-      catch {
+      catch (Exception ex) {
         result.AddStep(stepKey, 0, "Failed",
             conditionType: condDesc.Type,
             conditionResult: "error",
             actionOutcome: "failed",
-            message: $"If '{stepKey}' condition evaluation failed.");
-        result.Fail($"If '{stepKey}' condition evaluation failed.");
+            message: $"If '{stepKey}' condition evaluation failed: {ex.Message}");
+        result.Fail($"If '{stepKey}' condition evaluation failed: {ex.Message}");
         stepOutcomes[stepKey] = "failed";
         return (true, false);
       }
@@ -1398,9 +1398,9 @@ namespace GameBot.Domain.Services {
       try {
         takeIf = await conditionEvaluator(cond, ct).ConfigureAwait(false);
       }
-      catch {
+      catch (Exception ex) {
         result.AddBlock(new BlockResult { BlockType = "ifElse", Iterations = 0, DurationMs = 0, Status = "Failed" });
-        result.Fail("ifElse condition evaluation failed");
+        result.Fail($"ifElse condition evaluation failed: {ex.Message}");
         if (_logger != null) LogBlockEnd(_logger, "ifElse", "Failed", 0, 0, null);
         return;
       }

--- a/src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs
+++ b/src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using System.IO;
 using System.Runtime.Versioning;
 using GameBot.Domain.Sessions;
 using GameBot.Domain.Triggers.Evaluators;
@@ -28,7 +29,11 @@ public sealed class BackgroundCaptureScreenSource : IScreenSource {
     var frame = _captureService.GetCachedFrame(sess.Id);
     if (frame is null) return null;
 
-    // Return a clone so the caller can dispose it independently
-    return new Bitmap(frame.Bitmap);
+    // Decode from the immutable PNG snapshot instead of cloning frame.Bitmap:
+    // the capture loop disposes the cached Bitmap when it swaps in a new frame,
+    // and reading a GDI+ Bitmap concurrently with its disposal throws.
+    using var ms = new MemoryStream(frame.PngBytes, writable: false);
+    using var tmp = new Bitmap(ms);
+    return new Bitmap(tmp); // detach from stream so the caller can dispose it independently
   }
 }

--- a/tests/unit/BackgroundCaptureScreenSourceTests.cs
+++ b/tests/unit/BackgroundCaptureScreenSourceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -50,6 +51,26 @@ public sealed class BackgroundCaptureScreenSourceTests : IDisposable {
     bitmap!.Width.Should().BeGreaterThan(0);
     bitmap.Height.Should().BeGreaterThan(0);
     bitmap.Dispose();
+  }
+
+  [Fact]
+  public async Task ConcurrentGetLatestScreenshotWhileFramesSwapDoesNotThrow() {
+    _sessions.AddSession("sess-1", "game-1", "device-1", SessionStatus.Running);
+    _captureService.StartCapture("sess-1", "device-1");
+    await Task.Delay(200);
+
+    // Regression: cloning frame.Bitmap while the capture loop disposed it threw
+    // InvalidOperationException/ArgumentException; decoding from PngBytes must not.
+    using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+    var readers = Enumerable.Range(0, 4).Select(_ => Task.Run(() => {
+      while (!stop.IsCancellationRequested) {
+        using var bmp = _source.GetLatestScreenshot();
+        if (bmp is not null) bmp.Width.Should().BeGreaterThan(0);
+      }
+    })).ToArray();
+
+    var whenAll = () => Task.WhenAll(readers);
+    await whenAll.Should().NotThrowAsync();
   }
 
   [Fact]


### PR DESCRIPTION
## Summary

Fixes an intermittent "condition evaluation failed" abort observed in queue runs (2026-07-08T20:30Z, step `close-popup-1` of sequence `13cca15e15f4438a8009930167adb9d3`) where the same imageVisible condition passed fine in standalone runs.

- **Race fix**: `BackgroundCaptureScreenSource.GetLatestScreenshot` cloned the cached frame with `new Bitmap(frame.Bitmap)` while `SessionCaptureLoop` could concurrently swap the frame and dispose that Bitmap. GDI+ bitmaps are not thread-safe, so the clone intermittently threw `InvalidOperationException`/`ArgumentException`. The method now decodes a fresh Bitmap from the immutable `CachedFrame.PngBytes` snapshot instead of touching the shared Bitmap — no locking needed, and callers still get an independently disposable copy.
- **Diagnosability**: the five `SequenceRunner` catch sites that logged a bare "condition evaluation failed" (per-step imageVisible, while-loop condition, repeat-until exit condition, if-step condition, ifElse block) now include `ex.Message` in both the step log entry and the sequence failure reason.
- **Regression test**: `ConcurrentGetLatestScreenshotWhileFramesSwapDoesNotThrow` hammers `GetLatestScreenshot` from four threads while the capture loop swaps frames every 50 ms.

Deliberately unchanged: an evaluation exception still fails the sequence (behavior pinned by `ConditionEvaluationErrorStopsSequence`). Making that skippable/configurable is left as a follow-up.

## Test plan

- [x] `dotnet build GameBot.sln` — clean
- [x] `dotnet test tests/unit` filtered to capture-source and sequence-condition tests — 65/65 passed, including the new concurrency regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
