### PR TITLE
Set installer release version to 1.0.0

### DIFF
--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
-  "major": "0",
-  "minor": "10",
+  "major": "1",
+  "minor": "0",
   "patch": "0",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-06-10T00:00:00Z"
+  "updatedAtUtc": "2026-07-10T00:00:00Z"
 }


### PR DESCRIPTION
## Why

Declare the current state as the first stable release: **1.0.0**.

## What

- Bump the maintainer-controlled version override (installer/versioning/version.override.json) from 0.10.0 to 1.0.0, per the process in VERSIONING.md. The fourth (Build) component stays CI-managed via ci-build-counter.json.

## Verification

- Resolve-InstallerVersion -BuildContext local resolves to 1.0.0.x.
- The release-installer workflow runs on this PR (installer/** path filter) and builds the artifact with the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)