### PR TITLE
Populate queue runtime entries from linked template on start

### DIFF
--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -97,8 +97,20 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
       return QueueStartOutcome.AlreadyRunning;
     }
 
+    // Resolve the linked template once and materialize its entries into the runtime store so the
+    // entries shown by GET match what the run executes. The run reuses this same snapshot; the
+    // display layer instead reads the runtime store, and auto-load on display is suppressed once
+    // the queue is Running (see QueuesEndpoints.MaybeAutoLoadAsync). Without this, a queue started
+    // before it was ever displayed reports zero entries despite a populated linked template.
+    var template = string.IsNullOrEmpty(queue.LinkedTemplateId)
+      ? null
+      : await _templates.GetAsync(queue.LinkedTemplateId).ConfigureAwait(false);
+    if (template is not null) {
+      _runtime.SetEntries(queueId, template.Entries.Select(e => e.SequenceId));
+    }
+
     _runtime.SetStatus(queueId, QueueExecutionStatus.Running);
-    handle.RunTask = Task.Run(() => RunAsync(queue, handle, cts.Token), CancellationToken.None);
+    handle.RunTask = Task.Run(() => RunAsync(queue, template, handle, cts.Token), CancellationToken.None);
     return QueueStartOutcome.Started;
   }
 
@@ -118,7 +130,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     }
   }
 
-  private async Task RunAsync(ExecutionQueue queue, QueueRunHandle handle, CancellationToken ct) {
+  private async Task RunAsync(ExecutionQueue queue, QueueTemplate? template, QueueRunHandle handle, CancellationToken ct) {
     var rootId = await _log.LogQueueStartAsync(queue.Id, queue.Name, CancellationToken.None).ConfigureAwait(false);
     handle.RootExecutionId = rootId;
 
@@ -130,10 +142,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     string? sessionId = null;
 
     try {
-      // 1. Load the linked template server-side (FR-002).
-      var template = string.IsNullOrEmpty(queue.LinkedTemplateId)
-        ? null
-        : await _templates.GetAsync(queue.LinkedTemplateId).ConfigureAwait(false);
+      // 1. Template was resolved once by StartAsync (FR-002) and reused here for the whole run.
       if (template is null) {
         reason = QueueStopReason.Failure;
         failureReason = "no template to run (the queue has no linked template, or it could not be resolved)";

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -179,6 +179,24 @@ public sealed class QueueExecutionServiceTests {
     h.Sequences.Executed.Should().Equal("A", "B", "C");
   }
 
+  [Fact] // Regression: a started queue's runtime entries mirror its linked template so GET (and the UI) show them
+  public async Task StartMaterializesLinkedTemplateEntriesIntoRuntimeStore() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A", "B", "C" });
+    // Block the first sequence so the queue stays running while we inspect its runtime entries.
+    h.Sequences.Handler = async (id, ct) => {
+      if (id == "A") { await Task.Delay(Timeout.Infinite, ct); }
+      return FakeSequenceExecution.Success(id);
+    };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Sequences.Executed.Count >= 1);
+
+    h.Runtime.GetEntries("q1").Select(e => e.SequenceId).Should().Equal("A", "B", "C");
+
+    await h.Service.StopAsync("q1");
+  }
+
   [Fact] // T013
   public async Task CompletedFullRunWritesOneSuccessEntryAndDisconnects() {
     var h = new Harness();


### PR DESCRIPTION
## Problem

A queue started before it was ever displayed showed **zero entries** in the UI/API despite a fully populated linked template (e.g. the live `PNS Daily 5558` queue: `Running`, `entryCount: 0`, but its template has 15 entries).

Root cause: `StartAsync` only flipped the runtime status to `Running` (via `SetStatus`, which creates an empty runtime-state entry) and never materialized the template's entries into the runtime store. The run engine loaded the template into its own private copy inside `RunAsync`, so **execution was correct** — but `GET /queues/{id}` (and the UI) read the runtime store, and `MaybeAutoLoadAsync` suppresses auto-load once the queue is `Running`. Net effect: the display store stayed empty forever while the queue happily ran all its sequences.

## Fix

- Resolve the linked template **once** in `StartAsync` and `SetEntries` into the runtime store before flipping to `Running`, so the display store matches what's executing.
- Pass that same snapshot into `RunAsync`, removing the redundant per-run repository read. The display store and the run now share a single source of truth.

## Tests

- New unit test `StartMaterializesLinkedTemplateEntriesIntoRuntimeStore` (blocks the first sequence to keep the queue running, asserts `GetEntries` mirrors the template order).
- Unit 53/53, queue integration 75/75, queue contract 11/11 — all green. `CycleExecutionRepeatsWithoutReloadingTemplate` still passes (template still loaded exactly once).

## Note

Already-running queues won't retroactively fix themselves (their runtime state predates the fix); a stop/start or service restart repopulates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)