### PR TITLE
Add OCR-parsed dynamic offset to reschedule-self (068)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/067-sequence-if-conditions"
+  "feature_directory": "specs/068-reschedule-ocr-offset"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/067-sequence-if-conditions/plan.md
+at specs/068-reschedule-ocr-offset/plan.md
 <!-- SPECKIT END -->

--- a/specs/068-reschedule-ocr-offset/checklists/requirements.md
+++ b/specs/068-reschedule-ocr-offset/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: OCR-Parsed Dynamic Reschedule Offset
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec references existing internal seams (OCR engine, reschedule resolution) only as context/assumptions, not as required implementation. Concrete design (field names, files, tests) is deferred to plan.md.
+- Feature extends 065 (sequence self-reschedule); no [NEEDS CLARIFICATION] markers required — scope, fallback, and bounds behavior were confirmed with the requester.

--- a/specs/068-reschedule-ocr-offset/plan.md
+++ b/specs/068-reschedule-ocr-offset/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: OCR-Parsed Dynamic Reschedule Offset
+
+**Branch**: `068-reschedule-ocr-offset` | **Date**: 2026-07-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/068-reschedule-ocr-offset/spec.md`
+
+## Summary
+
+Extend the `reschedule-self` action (feature 065) so a Timer reschedule can derive its relative offset at runtime by OCR-reading an on-screen countdown timer, instead of only a static offset. Driving case: PNS Radio Quiz self-pacing off its growing cooldown. Failures fall back to a required static offset; parsed values are bounds-checked; the offset source is recorded in the execution log.
+
+## Technical Context
+
+**Language/Version**: C# / .NET (existing solution)
+**Primary dependencies**: existing OCR (`ITextOcr` via `DynamicTextOcr` → `TesseractProcessOcr`/`EnvTextOcr`), existing self-reschedule (`ISelfRescheduleCoordinator`), existing emulator screen-capture used for image-match detection.
+**Storage**: N/A (payload stored in the existing sequence action dictionary; no schema migration).
+**Testing**: xUnit — mirror feature 065's `SelfReschedulePayloadTests`, `SelfRescheduleRunIntegrationTests`, `SelfRescheduleActionContractTests`.
+**Project Type**: existing multi-project solution (Domain + Service + web-ui).
+**Constraints**: MUST NOT change behavior when OCR-offset is absent (FR-008). MUST never fail the step or skip the reschedule on OCR error (FR-005). Bounds-clamp bad reads (FR-006).
+**Scale/Scope**: single action type; ~4 production files + parser + tests.
+
+## Constitution Check
+
+- **Additive & backward-compatible**: new payload fields optional; absent → identical behavior (FR-008). PASS.
+- **TDD**: tests authored before/with implementation. PASS (Phase 2).
+- **Separation of concerns**: pure parse/validation in Domain; screen capture + OCR + scheduling side-effects in Service. PASS.
+- **Deterministic tests**: OCR + screen capture behind interfaces so dispatch tests use fakes; time via existing `TimeProvider`. PASS.
+
+No violations; no Complexity Tracking needed.
+
+## Design
+
+### Data model (see data-model.md)
+
+Add an optional **OCR-offset spec** to the `reschedule-self` payload, valid only with `option=Timer`. Nested object under key `ocrOffset` in the action `parameters`:
+
+```
+"ocrOffset": {
+  "region":   { "x": int, "y": int, "width": int, "height": int },  // captured-screen pixels
+  "fallback": "HH:mm:ss",     // REQUIRED static offset used on any failure
+  "min":      "HH:mm:ss",     // optional, default 00:00:01
+  "max":      "HH:mm:ss"      // optional, default 24:00:00
+}
+```
+
+Existing `timerRelativeOffset` / `timerTimeOfDay` remain. When `ocrOffset` is present it takes precedence for computing the offset, with `fallback` as the safety net; `timerRelativeOffset` need not be set.
+
+### Duration parsing (Domain, pure)
+
+New pure helper `CooldownDurationParser.TryParse(string ocrText, out TimeSpan value)`:
+- Extract the first `HH:mm:ss` or `mm:ss` token from noisy OCR text via a tolerant regex (digits + colons; ignore surrounding non-`[0-9:]`; optional whitespace).
+- 3 groups → `h:m:s`; 2 groups → `m:s`.
+- Normalize safe OCR digit confusions (e.g. `O`→`0`) before matching.
+- Return false on no match / non-numeric / overflow.
+
+### Payload reader/validation (Domain)
+
+- `SelfReschedulePayload`: add nullable typed `OcrOffset` (`Region`, `Fallback`, `Min`, `Max`) + `HasOcrOffset`; parse in `TryRead` (parse-level errors on malformed region/durations).
+- `ActionPayloadValidationService`: cross-field rules — `ocrOffset` only with `option=Timer`; `region` present with positive width/height; `fallback` present/parseable; `min < max`; clear messages (mirror existing reschedule validation). Keep `SequenceStepValidationService` + `FileSequenceRepository.ValidateActionPayloads` consistent (same allow-list pattern as prior action-payload changes).
+
+### Dispatch resolution (Service — the only behavioral change)
+
+In `SequenceExecutionService.DispatchSelfReschedule` (make it receive `sessionId`; `DispatchActionAsync` already has it):
+1. If `payload.HasOcrOffset`:
+   - Capture the current emulator frame for `sessionId` (reuse the screen-capture service image-match detection already uses).
+   - Crop `region`, `ITextOcr.Recognize`, `CooldownDurationParser.TryParse`.
+   - parsed AND within `[min,max]` → `effectiveOffset = parsed`, source `ocr`; else `effectiveOffset = fallback`, source `fallback` (+ reason: no-capture / ocr-empty / parse-failed / out-of-bounds).
+   - `ScheduleSelf(..., timerTimeOfDay: null, timerRelativeOffset: effectiveOffset)`.
+   - Encode source + recognized text + duration into `ActionDispatchResult.Message` (execution log, FR-007).
+2. Else: unchanged path.
+
+Introduce a small `IOcrOffsetResolver` (Service) wrapping screen-capture + OCR + parser so dispatch stays testable with fakes; Tesseract/screen wiring stays in composition root.
+
+### Phase 0 — research (research.md)
+
+Confirm during implementation (low risk): exact screen-capture service/method to get a frame by `sessionId` in the Service layer + the crop pattern in `TextMatchEvaluator`; OCR PSM suitability for a short digits/colons timer (config, not code).
+
+### Phase 1 — contracts/quickstart
+
+No external HTTP contract change (action `parameters` is a free-form dict already accepted). Add an example payload + `quickstart.md` showing a Radio-Quiz-style `reschedule-self` with `ocrOffset`.
+
+## Phase 2 — Test plan (write first)
+
+- **Domain unit**: `SelfReschedulePayload` parses `ocrOffset` (valid + malformed); `ActionPayloadValidationService` accepts valid, rejects non-Timer option / missing region / non-positive region / missing fallback / min≥max.
+- **Domain unit (parser)**: `mm:ss`, `hh:mm:ss`, noisy text, `O`→`0`, zero, garbage, overflow.
+- **Service/integration**: fake OCR good timer → next firing `now + parsed`, source `ocr`; fake OCR empty/garbage → `now + fallback`, source `fallback`; out-of-bounds → fallback; absent ocrOffset → unchanged (regression).
+- **Contract**: action payload round-trips `ocrOffset`.
+
+## Progress Tracking
+
+- [x] Spec written & validated
+- [x] Plan written
+- [ ] data-model.md, quickstart.md
+- [ ] tasks.md (via `/speckit-tasks`)
+- [ ] Implementation (TDD) + green build/tests

--- a/specs/068-reschedule-ocr-offset/plan.md
+++ b/specs/068-reschedule-ocr-offset/plan.md
@@ -88,6 +88,31 @@ No external HTTP contract change (action `parameters` is a free-form dict alread
 
 - [x] Spec written & validated
 - [x] Plan written
-- [ ] data-model.md, quickstart.md
-- [ ] tasks.md (via `/speckit-tasks`)
-- [ ] Implementation (TDD) + green build/tests
+- [~] data-model.md, quickstart.md — folded into this plan's Design section; not authored as separate files (payload shape + parser semantics captured above)
+- [x] tasks.md (implemented directly following plan.md; see tasks.md for the task list)
+- [x] Implementation (TDD) + green build/tests
+
+### Implementation notes (2026-07-14)
+
+Done, TDD-first. `dotnet build GameBot.sln` clean (0 warnings/errors); tests: Unit 605, Contract 91,
+Integration 287 — all pass.
+
+Files added (production):
+- `src/GameBot.Domain/Commands/SelfReschedule/CooldownDurationParser.cs` — pure tolerant duration parser.
+- `src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOcrOffset.cs` — typed spec + `OcrOffsetRegion`.
+- `src/GameBot.Service/Services/SequenceExecution/IOcrOffsetResolver.cs` — resolver interface + `OcrOffsetResolution` + `OcrOffsetSource`.
+- `src/GameBot.Service/Services/SequenceExecution/OcrOffsetResolver.cs` — real Windows resolver (capture→crop→OCR→parse→bounds).
+- `src/GameBot.Service/Services/SequenceExecution/StaticFallbackOcrOffsetResolver.cs` — always-fallback resolver for non-Windows / ADB-disabled hosts.
+- `src/GameBot.Service/Services/SequenceExecution/ISessionFrameSource.cs` + `BackgroundCaptureSessionFrameSource.cs` — per-session frame capture seam.
+
+Files changed (production):
+- `SelfReschedulePayload.cs` — parse nullable `OcrOffset` (+`HasOcrOffset`) via a JsonElement/dict `NestedReader`.
+- `SequenceStepValidationService.cs` — ocrOffset cross-field rules (Timer-only, positive region, min<max, fallback bounds); Timer+ocrOffset no longer requires a static timer field.
+- `SequenceExecutionService.cs` — `DispatchSelfReschedule` takes `sessionId`; OCR path resolves the offset and encodes source/text/duration into the log message (FR-007).
+- `GameBotServiceSetup.cs` — DI wiring: real resolver on Windows+ADB, static fallback otherwise.
+
+Deviation from plan: the plan named `ActionPayloadValidationService` for cross-field rules, but the
+real reschedule-self payload validation lives in `SequenceStepValidationService.ValidateRescheduleSelfPayload`
+(that is the path the authoring API and `FileSequenceRepository` reach). Rules were added there.
+`FileSequenceRepository.ValidateActionPayloads` already accepts `reschedule-self` by action-type
+allow-list and does no deep field validation, so no change was needed there.

--- a/specs/068-reschedule-ocr-offset/spec.md
+++ b/specs/068-reschedule-ocr-offset/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: OCR-Parsed Dynamic Reschedule Offset
+
+**Feature Branch**: `068-reschedule-ocr-offset`
+**Created**: 2026-07-13
+**Status**: Draft
+**Input**: User description: "Add an OCR-parsed dynamic relative offset to the `reschedule-self` sequence action (extends feature 065), so a self-rescheduling sequence can read an on-screen countdown timer and reschedule itself by that duration."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Self-pace off a live on-screen countdown (Priority: P1)
+
+A daily automation performs an action that starts a variable cooldown displayed on screen as a countdown timer (the driving case: answering the PNS Radio Quiz, whose cooldown grows with each answer). Immediately after acting, the same screen shows the new cooldown (e.g. `00:05:42`). The sequence's final step reschedules itself to fire again after exactly that displayed duration, so the next run lands right when the next action is available — without polling and without hard-coding an interval that would be wrong as the cooldown changes.
+
+**Why this priority**: This is the core capability and the only reason the feature exists. Without it, self-rescheduling sequences must use a fixed interval, which is either wasteful (too frequent) or laggy (too infrequent) whenever the real interval is dynamic.
+
+**Independent Test**: Configure a `reschedule-self` (Timer) step with an OCR-offset region pointing at a known countdown timer, run the sequence, and verify the next firing is scheduled at approximately `now + <displayed duration>`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence whose `reschedule-self` step is configured to read its offset from a screen region, **When** that region legibly shows `00:05:42`, **Then** the next firing is scheduled at approximately `now + 5m42s` and the execution log records that the OCR-parsed value was used.
+2. **Given** the same step, **When** the region shows `01:20` (mm:ss form), **Then** the next firing is scheduled at approximately `now + 1m20s`.
+3. **Given** the same step, **When** the region shows a value surrounded by OCR noise (e.g. leading/trailing non-digit characters), **Then** the duration is still extracted and used.
+
+### User Story 2 - Never stall when the timer can't be read (Priority: P1)
+
+The automation runs unattended for days. Occasionally OCR fails — the region is momentarily blank, the timer is absent (the control shows a button instead of a countdown), or recognition returns garbage. The sequence must still reschedule itself using a required static fallback offset, so the self-rescheduling chain never dies and never spins in a tight loop.
+
+**Why this priority**: A self-rescheduling task that stops rescheduling silently breaks the whole automation until a human notices. Robust fallback is as important as the happy path.
+
+**Independent Test**: Point the OCR-offset region at an area with no readable duration, run the sequence, and verify it still reschedules using the configured fallback offset and logs that the fallback was used.
+
+**Acceptance Scenarios**:
+
+1. **Given** an OCR-offset step with a fallback of `00:06:00`, **When** the region yields no parseable duration, **Then** the next firing is scheduled at `now + 6m` and the log records that the fallback was used (with the reason).
+2. **Given** an OCR-offset step, **When** OCR raises an error or returns empty text, **Then** the reschedule still occurs via fallback (the step does not fail the sequence or skip the reschedule).
+
+### User Story 3 - Reject implausible reads (Priority: P2)
+
+A misread could yield an absurd duration (e.g. an extra digit → hours instead of minutes, or `00:00:00`). Using such a value directly would either park the sequence far in the future or make it fire immediately in a hot loop. Parsed durations outside a sane, configurable range are treated as a failed parse and fall back to the static offset.
+
+**Why this priority**: Prevents rare OCR errors from causing pathological scheduling; important for safety but secondary to the happy path and basic fallback.
+
+**Independent Test**: Feed the parser a value below the minimum (e.g. `00:00:00`) and above the maximum (e.g. `99:59:59`) and verify both fall back to the static offset.
+
+**Acceptance Scenarios**:
+
+1. **Given** a min bound of 1 second, **When** the region reads `00:00:00`, **Then** the parsed value is rejected and the fallback offset is used.
+2. **Given** a max bound of 24 hours, **When** the region reads a duration exceeding it, **Then** the parsed value is rejected and the fallback offset is used.
+
+### Edge Cases
+
+- Timer already elapsed / control shows an actionable button instead of a countdown → no parseable duration → fallback (kept short so the sequence retries soon).
+- Recognized text has digit-confusable characters (e.g. `O`/`0`, `l`/`1`) → tolerated where feasible; otherwise fallback.
+- Region coordinates fall partly/entirely outside the captured frame, or the capture is unavailable → fallback.
+- Parsed `00:00:00` (zero) → below minimum → fallback.
+- A `reschedule-self` step configured for OCR-offset but with a non-Timer option, or missing the required region or fallback → rejected at validation time with a clear message.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `reschedule-self` action (option = Timer) MUST support deriving its relative offset by reading text from a caller-specified region of the current emulator screen at execution time, instead of using only a static offset.
+- **FR-002**: The OCR-offset configuration MUST specify the screen region to read, expressed as x, y, width, height in the same captured-screen pixel space used by image-match detection.
+- **FR-003**: The system MUST parse the recognized text into a duration, supporting at least `mm:ss` and `hh:mm:ss` countdown formats and tolerating surrounding non-duration characters (OCR noise).
+- **FR-004**: On a successful, in-bounds parse, the next firing MUST be scheduled at `now + parsed duration`, reusing the existing Timer relative-offset resolution.
+- **FR-005**: An OCR-offset configuration MUST include a required static fallback offset. If OCR fails, returns empty, or the text cannot be parsed into a plausible duration, the system MUST reschedule using the fallback offset rather than failing the step or skipping the reschedule.
+- **FR-006**: The parsed duration MUST be validated against configurable minimum and maximum bounds; a value outside the bounds MUST be treated as a failed parse and fall back to the static offset.
+- **FR-007**: The execution log MUST record which offset source was used for each reschedule (OCR-parsed vs. fallback); on the OCR path it MUST include the recognized text and the resulting duration, and on the fallback path the reason.
+- **FR-008**: When no OCR-offset is configured, `reschedule-self` MUST behave exactly as today for all options (AtQueueStart, OncePerRun, EveryStep, Timer with static `timerRelativeOffset` / `timerTimeOfDay`).
+- **FR-009**: Payload validation MUST reject an OCR-offset configuration that is missing the region or the fallback offset, has a non-positive region size, or is combined with a non-Timer option, returning a clear, human-readable error.
+
+### Key Entities *(include if feature involves data)*
+
+- **OCR-offset spec**: an optional part of a `reschedule-self` Timer payload describing how to derive the offset at runtime. Attributes: the screen region (x, y, width, height); the expected duration format(s); a required static fallback offset (duration); optional minimum and maximum plausible-duration bounds (with sensible defaults).
+- **Reschedule outcome (log detail)**: the recorded result of a reschedule — the offset source (OCR vs. fallback), the effective duration used, and, where relevant, the recognized text and/or fallback reason.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When the configured region legibly shows a `mm:ss` or `hh:mm:ss` duration, the next firing is scheduled within 2 seconds of `now + that duration`.
+- **SC-002**: When the region yields no parseable in-bounds duration, the sequence still reschedules 100% of the time, using the configured fallback offset (no dropped reschedules, no tight loops).
+- **SC-003**: A parsed duration outside the configured `[min, max]` window never determines the next firing — it is always replaced by the fallback.
+- **SC-004**: Every reschedule via this feature produces an execution-log entry that unambiguously states whether the OCR value or the fallback was used.
+- **SC-005**: Sequences that do not configure an OCR-offset exhibit no behavioral change versus the prior release (verified by existing self-reschedule tests continuing to pass).
+
+## Assumptions
+
+- The target timer text is legible to the existing OCR engine at the specified region; recognition tuning (e.g. page-segmentation settings) is handled by existing OCR configuration and is out of scope here.
+- Region coordinates are provided in the captured-screen pixel space already used by image cropping/detection.
+- Default plausibility bounds are reasonable for game cooldown timers (minimum on the order of 1 second, maximum on the order of 24 hours) and are configurable per step where needed.
+- The driving Radio Quiz workflow supplies the timer region; authoring the specific Radio Quiz sequence/queue entry is a separate task and not part of this feature.
+
+## Non-Goals
+
+- No general variable/expression system for sequences; this is scoped to the `reschedule-self` offset only.
+- No changes to the other `reschedule-self` options or to `timerTimeOfDay`.
+- Not building the Radio Quiz correct-answer bank (tracked separately).

--- a/specs/068-reschedule-ocr-offset/tasks.md
+++ b/specs/068-reschedule-ocr-offset/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: OCR-Parsed Dynamic Reschedule Offset (068)
+
+Implemented TDD-first following plan.md. All tasks complete; `dotnet build GameBot.sln` clean,
+tests green (Unit 605 / Contract 91 / Integration 287).
+
+## Phase 1 — Domain (pure)
+
+- [x] T001 Test: `CooldownDurationParserTests` — hh:mm:ss, mm:ss, noisy text, O→0 / l→1, zero, garbage, overflow, first-token.
+- [x] T002 Impl: `CooldownDurationParser.TryParse(string, out TimeSpan)` — tolerant regex + digit normalization + checked overflow guard.
+- [x] T003 Test: `SelfReschedulePayloadTests` ocrOffset cases — defaults, explicit bounds, missing region, missing/malformed fallback, absent-unchanged.
+- [x] T004 Impl: `SelfRescheduleOcrOffset` + `OcrOffsetRegion`; `SelfReschedulePayload` parses nullable `OcrOffset` (+`HasOcrOffset`) from JsonElement or dict.
+
+## Phase 2 — Validation
+
+- [x] T005 Test: `OcrOffsetValidationTests` — valid Timer passes; non-Timer rejected; non-positive region; min≥max; missing fallback; Timer+ocrOffset needs no static field.
+- [x] T006 Impl: `SequenceStepValidationService.ValidateRescheduleSelfPayload` — ocrOffset cross-field rules; relax static-timer-field requirement when ocrOffset present.
+
+## Phase 3 — Service (behavioral change)
+
+- [x] T007 Test: `OcrOffsetResolverTests` — good read → ocr; empty/garbage/zero/above-max/no-capture/no-session/ocr-error/off-frame → fallback with reason; mm:ss read.
+- [x] T008 Impl: `IOcrOffsetResolver` / `OcrOffsetResolution` / `OcrOffsetSource`; `OcrOffsetResolver` (capture→crop→OCR→parse→bounds, never throws); `StaticFallbackOcrOffsetResolver`; `ISessionFrameSource` + `BackgroundCaptureSessionFrameSource`.
+- [x] T009 Impl: `SequenceExecutionService.DispatchSelfReschedule` receives `sessionId`, runs the OCR path when `HasOcrOffset` + Timer, schedules with the effective offset, and encodes source/text/duration into the log message (FR-007).
+- [x] T010 Impl: DI wiring in `GameBotServiceSetup` — real resolver on Windows+ADB, static fallback otherwise (keeps the ADB-disabled test graph buildable).
+
+## Phase 4 — Contract & regression
+
+- [x] T011 Test: `SelfRescheduleActionContractTests` — ocrOffset round-trips; non-Timer ocrOffset rejected (400); missing fallback rejected (400).
+- [x] T012 Regression (FR-008): existing feature-065 payload / contract / integration tests pass unchanged with ocrOffset absent.

--- a/src/GameBot.Domain/Commands/SelfReschedule/CooldownDurationParser.cs
+++ b/src/GameBot.Domain/Commands/SelfReschedule/CooldownDurationParser.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace GameBot.Domain.Commands.SelfReschedule;
+
+/// <summary>
+/// Pure helper (feature 068) that extracts a countdown duration from noisy OCR text. Supports
+/// <c>hh:mm:ss</c> and <c>mm:ss</c> forms, tolerates surrounding non-duration characters, and
+/// normalizes a few safe OCR digit confusions (e.g. <c>O</c>→<c>0</c>). Returns <c>false</c> when
+/// no duration token is present or a numeric component overflows.
+/// </summary>
+public static class CooldownDurationParser {
+  // First token of the form  d+:dd(:dd)?  anywhere in the text. Hours are unbounded so an absurd
+  // read is caught by the overflow guard below (rather than silently truncated); minutes/seconds
+  // are 1-2 digits. Two colon groups => h:m:s, one => m:s.
+  private static readonly Regex DurationToken = new(
+    @"(\d+)\s*:\s*(\d{1,2})(?:\s*:\s*(\d{1,2}))?",
+    RegexOptions.CultureInvariant | RegexOptions.Compiled,
+    TimeSpan.FromMilliseconds(200));
+
+  /// <summary>
+  /// Attempts to parse the first countdown duration found in <paramref name="ocrText"/>.
+  /// </summary>
+  public static bool TryParse(string? ocrText, out TimeSpan value) {
+    value = default;
+    if (string.IsNullOrWhiteSpace(ocrText)) {
+      return false;
+    }
+
+    var normalized = NormalizeDigits(ocrText);
+    var match = DurationToken.Match(normalized);
+    if (!match.Success) {
+      return false;
+    }
+
+    var hasHours = match.Groups[3].Success;
+    // h:m:s when three groups matched; otherwise the two groups are m:s.
+    var firstText = match.Groups[1].Value;
+    var secondText = match.Groups[2].Value;
+    var thirdText = hasHours ? match.Groups[3].Value : null;
+
+    long hours, minutes, seconds;
+    if (hasHours) {
+      if (!TryParseComponent(firstText, out hours)
+          || !TryParseComponent(secondText, out minutes)
+          || !TryParseComponent(thirdText!, out seconds)) {
+        return false;
+      }
+    }
+    else {
+      hours = 0;
+      if (!TryParseComponent(firstText, out minutes)
+          || !TryParseComponent(secondText, out seconds)) {
+        return false;
+      }
+    }
+
+    try {
+      // Use a checked total-seconds computation so an implausible read fails rather than wrapping.
+      var totalSeconds = checked((hours * 3600L) + (minutes * 60L) + seconds);
+      value = TimeSpan.FromSeconds(totalSeconds);
+      return true;
+    }
+    catch (OverflowException) {
+      return false;
+    }
+  }
+
+  private static bool TryParseComponent(string text, out long value) =>
+    long.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+
+  // Replaces the common OCR letter/digit confusions that appear inside timer glyphs. Only affects
+  // the extracted numeric token because the regex still requires digits + colons around them.
+  private static string NormalizeDigits(string text) {
+    Span<char> buffer = text.Length <= 256 ? stackalloc char[text.Length] : new char[text.Length];
+    for (var i = 0; i < text.Length; i++) {
+      buffer[i] = text[i] switch {
+        'O' or 'o' => '0',
+        'l' or 'I' or '|' => '1',
+        _ => text[i]
+      };
+    }
+    return new string(buffer);
+  }
+}

--- a/src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOcrOffset.cs
+++ b/src/GameBot.Domain/Commands/SelfReschedule/SelfRescheduleOcrOffset.cs
@@ -1,0 +1,24 @@
+namespace GameBot.Domain.Commands.SelfReschedule;
+
+/// <summary>
+/// Typed view of the optional <c>ocrOffset</c> spec on a <c>reschedule-self</c> Timer payload
+/// (feature 068). Describes how to derive the Timer relative offset at runtime by OCR-reading an
+/// on-screen countdown timer, with a required static <see cref="Fallback"/> used on any failure and
+/// plausibility bounds (<see cref="Min"/>/<see cref="Max"/>) that reject implausible reads.
+/// </summary>
+public sealed class SelfRescheduleOcrOffset {
+  /// <summary>Screen region to read, in the captured-screen pixel space used by image detection.</summary>
+  public required OcrOffsetRegion Region { get; init; }
+
+  /// <summary>Required static offset used when OCR fails, is empty, or is out of bounds.</summary>
+  public required System.TimeSpan Fallback { get; init; }
+
+  /// <summary>Lower plausibility bound; a parsed value below this falls back (default 00:00:01).</summary>
+  public required System.TimeSpan Min { get; init; }
+
+  /// <summary>Upper plausibility bound; a parsed value above this falls back (default 24:00:00).</summary>
+  public required System.TimeSpan Max { get; init; }
+}
+
+/// <summary>Captured-screen pixel rectangle for an <see cref="SelfRescheduleOcrOffset"/> read.</summary>
+public readonly record struct OcrOffsetRegion(int X, int Y, int Width, int Height);

--- a/src/GameBot.Domain/Commands/SelfReschedule/SelfReschedulePayload.cs
+++ b/src/GameBot.Domain/Commands/SelfReschedule/SelfReschedulePayload.cs
@@ -8,9 +8,10 @@ namespace GameBot.Domain.Commands.SelfReschedule;
 /// <summary>
 /// Thin typed reader over a <see cref="SequenceActionPayload"/> of type
 /// <c>reschedule-self</c> (feature 065). The dictionary remains the storage; this view parses
-/// <c>option</c>, <c>timerTimeOfDay</c>, and <c>timerRelativeOffset</c>. Cross-field validation
-/// (mutual exclusivity, ranges) lives in <c>ActionPayloadValidationService</c>; this reader only
-/// surfaces parse-level errors (unknown option, malformed timer string).
+/// <c>option</c>, <c>timerTimeOfDay</c>, <c>timerRelativeOffset</c>, and the optional
+/// <c>ocrOffset</c> spec (feature 068). Cross-field validation (mutual exclusivity, ranges) lives in
+/// <c>SequenceStepValidationService.ValidateRescheduleSelfPayload</c>; this reader only surfaces
+/// parse-level errors (unknown option, malformed timer/region/duration).
 /// </summary>
 public sealed class SelfReschedulePayload {
   /// <summary>Wire key for the chosen schedule option.</summary>
@@ -19,6 +20,13 @@ public sealed class SelfReschedulePayload {
   public const string TimerTimeOfDayKey = "timerTimeOfDay";
   /// <summary>Wire key for the Timer relative-offset value (HH:mm:ss).</summary>
   public const string TimerRelativeOffsetKey = "timerRelativeOffset";
+  /// <summary>Wire key for the optional OCR-offset spec (feature 068).</summary>
+  public const string OcrOffsetKey = "ocrOffset";
+
+  /// <summary>Default lower bound for a parsed OCR duration when <c>min</c> is omitted.</summary>
+  public static readonly TimeSpan DefaultOcrMin = TimeSpan.FromSeconds(1);
+  /// <summary>Default upper bound for a parsed OCR duration when <c>max</c> is omitted.</summary>
+  public static readonly TimeSpan DefaultOcrMax = TimeSpan.FromHours(24);
 
   /// <summary>The chosen schedule option.</summary>
   public required SelfRescheduleOption Option { get; init; }
@@ -34,6 +42,12 @@ public sealed class SelfReschedulePayload {
 
   /// <summary>True when a relative offset was supplied (regardless of option).</summary>
   public bool HasTimerRelativeOffset { get; init; }
+
+  /// <summary>The OCR-offset spec (feature 068), when configured; otherwise null.</summary>
+  public SelfRescheduleOcrOffset? OcrOffset { get; init; }
+
+  /// <summary>True when an <c>ocrOffset</c> spec was supplied.</summary>
+  public bool HasOcrOffset => OcrOffset is not null;
 
   /// <summary>
   /// Attempts to read a <c>reschedule-self</c> payload. Returns <c>false</c> with a human-readable
@@ -74,15 +88,199 @@ public sealed class SelfReschedulePayload {
       relativeOffset = parsedRelative;
     }
 
+    SelfRescheduleOcrOffset? ocrOffset = null;
+    if (TryGetIgnoreCase(payload.Parameters, OcrOffsetKey, out var rawOcrOffset) && rawOcrOffset is not null
+        && !IsJsonNull(rawOcrOffset)) {
+      if (!TryReadOcrOffset(rawOcrOffset, out ocrOffset, out error)) {
+        return false;
+      }
+    }
+
     result = new SelfReschedulePayload {
       Option = option,
       TimerTimeOfDay = timeOfDay,
       TimerRelativeOffset = relativeOffset,
       HasTimerTimeOfDay = hasTimeOfDay,
-      HasTimerRelativeOffset = hasRelative
+      HasTimerRelativeOffset = hasRelative,
+      OcrOffset = ocrOffset
     };
     return true;
   }
+
+  private static bool IsJsonNull(object value) =>
+    value is JsonElement je && je.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined;
+
+  // Parses the nested ocrOffset object. Structural problems (not an object, missing/malformed
+  // region, missing/malformed fallback/min/max) are parse-level errors surfaced here; cross-field
+  // business rules (option must be Timer, positive region, min < max) live in the validation service.
+  private static bool TryReadOcrOffset(object raw, out SelfRescheduleOcrOffset? result, out string? error) {
+    result = null;
+    error = null;
+
+    if (!TryReadNested(raw, out var reader)) {
+      error = "ocrOffset must be an object";
+      return false;
+    }
+
+    if (!reader.TryGetChild("region", out var regionReader)) {
+      error = "ocrOffset.region is required";
+      return false;
+    }
+
+    if (!regionReader.TryGetInt("x", out var x)
+        || !regionReader.TryGetInt("y", out var y)
+        || !regionReader.TryGetInt("width", out var width)
+        || !regionReader.TryGetInt("height", out var height)) {
+      error = "ocrOffset.region requires numeric x, y, width and height";
+      return false;
+    }
+
+    if (!reader.TryGetString("fallback", out var fallbackRaw) || string.IsNullOrWhiteSpace(fallbackRaw)) {
+      error = "ocrOffset.fallback is required";
+      return false;
+    }
+    if (!TimeSpan.TryParse(fallbackRaw, CultureInfo.InvariantCulture, out var fallback)) {
+      error = $"ocrOffset.fallback '{fallbackRaw}' is not a valid HH:mm:ss duration";
+      return false;
+    }
+
+    var min = DefaultOcrMin;
+    if (reader.TryGetString("min", out var minRaw) && !string.IsNullOrWhiteSpace(minRaw)) {
+      if (!TimeSpan.TryParse(minRaw, CultureInfo.InvariantCulture, out min)) {
+        error = $"ocrOffset.min '{minRaw}' is not a valid HH:mm:ss duration";
+        return false;
+      }
+    }
+
+    var max = DefaultOcrMax;
+    if (reader.TryGetString("max", out var maxRaw) && !string.IsNullOrWhiteSpace(maxRaw)) {
+      if (!TimeSpan.TryParse(maxRaw, CultureInfo.InvariantCulture, out max)) {
+        error = $"ocrOffset.max '{maxRaw}' is not a valid HH:mm:ss duration";
+        return false;
+      }
+    }
+
+    result = new SelfRescheduleOcrOffset {
+      Region = new OcrOffsetRegion(x, y, width, height),
+      Fallback = fallback,
+      Min = min,
+      Max = max
+    };
+    return true;
+  }
+
+  // ocrOffset arrives either as a JsonElement (persisted / API) or a plain dictionary (in-process
+  // authoring). NestedReader normalizes both so parsing is written once.
+  private readonly struct NestedReader {
+    private readonly JsonElement? _json;
+    private readonly IReadOnlyDictionary<string, object?>? _dict;
+
+    private NestedReader(JsonElement? json, IReadOnlyDictionary<string, object?>? dict) {
+      _json = json;
+      _dict = dict;
+    }
+
+    public static bool TryCreate(object raw, out NestedReader reader) {
+      switch (raw) {
+        case JsonElement je when je.ValueKind == JsonValueKind.Object:
+          reader = new NestedReader(je, null);
+          return true;
+        case IReadOnlyDictionary<string, object?> rod:
+          reader = new NestedReader(null, rod);
+          return true;
+        case IDictionary<string, object?> d:
+          reader = new NestedReader(null, new Dictionary<string, object?>(d, StringComparer.OrdinalIgnoreCase));
+          return true;
+        default:
+          reader = default;
+          return false;
+      }
+    }
+
+    public bool TryGetChild(string key, out NestedReader child) {
+      if (TryGetRaw(key, out var value) && value is not null && TryReadNested(value, out child)) {
+        return true;
+      }
+      child = default;
+      return false;
+    }
+
+    public bool TryGetString(string key, out string? value) {
+      value = null;
+      if (!TryGetRaw(key, out var raw) || raw is null) {
+        return false;
+      }
+      switch (raw) {
+        case string s:
+          value = s;
+          return true;
+        case JsonElement je when je.ValueKind == JsonValueKind.String:
+          value = je.GetString();
+          return true;
+        case JsonElement je when je.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined:
+          return false;
+        default:
+          value = raw.ToString();
+          return value is not null;
+      }
+    }
+
+    public bool TryGetInt(string key, out int value) {
+      value = 0;
+      if (!TryGetRaw(key, out var raw) || raw is null) {
+        return false;
+      }
+      switch (raw) {
+        case int i:
+          value = i;
+          return true;
+        case long l when l is >= int.MinValue and <= int.MaxValue:
+          value = (int)l;
+          return true;
+        case double dbl when dbl is >= int.MinValue and <= int.MaxValue:
+          value = (int)dbl;
+          return true;
+        case JsonElement je when je.ValueKind == JsonValueKind.Number && je.TryGetInt32(out var ji):
+          value = ji;
+          return true;
+        case JsonElement je when je.ValueKind == JsonValueKind.String:
+          return int.TryParse(je.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        case string s:
+          return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        default:
+          return false;
+      }
+    }
+
+    private bool TryGetRaw(string key, out object? value) {
+      if (_dict is not null) {
+        if (_dict.TryGetValue(key, out value)) {
+          return true;
+        }
+        foreach (var pair in _dict) {
+          if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase)) {
+            value = pair.Value;
+            return true;
+          }
+        }
+        value = null;
+        return false;
+      }
+
+      if (_json is { } je) {
+        foreach (var prop in je.EnumerateObject()) {
+          if (string.Equals(prop.Name, key, StringComparison.OrdinalIgnoreCase)) {
+            value = prop.Value;
+            return true;
+          }
+        }
+      }
+      value = null;
+      return false;
+    }
+  }
+
+  private static bool TryReadNested(object raw, out NestedReader reader) => NestedReader.TryCreate(raw, out reader);
 
   private static string? ReadString(IReadOnlyDictionary<string, object?> parameters, string key) {
     TryReadString(parameters, key, out var value);

--- a/src/GameBot.Domain/Services/SequenceStepValidationService.cs
+++ b/src/GameBot.Domain/Services/SequenceStepValidationService.cs
@@ -293,7 +293,12 @@ public sealed class SequenceStepValidationService {
     }
 
     if (payload.Option == SelfRescheduleOption.Timer) {
-      if (payload.HasTimerTimeOfDay && payload.HasTimerRelativeOffset) {
+      if (payload.HasOcrOffset) {
+        // feature 068: the ocrOffset spec supplies the offset at runtime (with a required static
+        // fallback), so the static timerTimeOfDay/timerRelativeOffset fields are optional here.
+        ValidateOcrOffset(payload.OcrOffset!, stepLabel, errors);
+      }
+      else if (payload.HasTimerTimeOfDay && payload.HasTimerRelativeOffset) {
         errors.Add($"Step '{stepLabel}' reschedule-self Timer requires exactly one of timerTimeOfDay or timerRelativeOffset, not both.");
       }
       else if (!payload.HasTimerTimeOfDay && !payload.HasTimerRelativeOffset) {
@@ -306,6 +311,28 @@ public sealed class SequenceStepValidationService {
     }
     else if (payload.HasTimerTimeOfDay || payload.HasTimerRelativeOffset) {
       errors.Add($"Step '{stepLabel}' reschedule-self timer fields are only valid when option is Timer.");
+    }
+    else if (payload.HasOcrOffset) {
+      errors.Add($"Step '{stepLabel}' reschedule-self ocrOffset is only valid when option is Timer.");
+    }
+  }
+
+  // feature 068: cross-field rules for an ocrOffset spec (region present positive; min < max). The
+  // fallback presence/format is enforced at parse time in SelfReschedulePayload.TryRead.
+  private static void ValidateOcrOffset(
+      SelfRescheduleOcrOffset ocrOffset,
+      string stepLabel,
+      List<string> errors) {
+    if (ocrOffset.Region.Width <= 0 || ocrOffset.Region.Height <= 0) {
+      errors.Add($"Step '{stepLabel}' reschedule-self ocrOffset.region must have positive width and height.");
+    }
+
+    if (ocrOffset.Min >= ocrOffset.Max) {
+      errors.Add($"Step '{stepLabel}' reschedule-self ocrOffset.min must be less than ocrOffset.max.");
+    }
+
+    if (ocrOffset.Fallback < TimeSpan.Zero || ocrOffset.Fallback > MaxRescheduleOffset) {
+      errors.Add($"Step '{stepLabel}' reschedule-self ocrOffset.fallback must be between 00:00:00 and 24:00:00.");
     }
   }
 

--- a/src/GameBot.Service/GameBotServiceSetup.cs
+++ b/src/GameBot.Service/GameBotServiceSetup.cs
@@ -256,12 +256,27 @@ internal static class GameBotServiceSetup {
     builder.Services.AddSingleton<CaptureSessionStore>();
     builder.Services.AddSingleton<ImageCropper>();
     builder.Services.AddSingleton<IImageReferenceRepository>(sp => new TriggerImageReferenceRepository(sp.GetRequiredService<ITriggerRepository>()));
+    var useAdbForOcrOffset =
+      !string.Equals(Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB"), "false", StringComparison.OrdinalIgnoreCase);
     if (OperatingSystem.IsWindows()) {
       RegisterWindowsScreenCapture(builder);
       builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Triggers.Evaluators.ImageMatchEvaluator>();
       // Text match evaluator (OCR): dynamic backend selection based on refreshed configuration
       builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.ITextOcr, GameBot.Service.Services.DynamicTextOcr>();
       builder.Services.AddSingleton<ITriggerEvaluator, GameBot.Domain.Triggers.Evaluators.TextMatchEvaluator>();
+    }
+    // feature 068: OCR-offset resolver for reschedule-self. The real resolver needs the background
+    // capture service (ADB) + OCR; when either is unavailable (non-Windows or ADB-disabled test
+    // hosts) fall back to a static resolver so a self-rescheduling sequence still reschedules.
+    if (OperatingSystem.IsWindows() && useAdbForOcrOffset) {
+      builder.Services.AddSingleton<GameBot.Service.Services.SequenceExecution.ISessionFrameSource,
+        GameBot.Service.Services.SequenceExecution.BackgroundCaptureSessionFrameSource>();
+      builder.Services.AddSingleton<GameBot.Service.Services.SequenceExecution.IOcrOffsetResolver,
+        GameBot.Service.Services.SequenceExecution.OcrOffsetResolver>();
+    }
+    else {
+      builder.Services.AddSingleton<GameBot.Service.Services.SequenceExecution.IOcrOffsetResolver,
+        GameBot.Service.Services.SequenceExecution.StaticFallbackOcrOffsetResolver>();
     }
     // Register template matcher (no endpoint yet; foundational only in Phase 2)
     builder.Services.AddSingleton<GameBot.Domain.Vision.ITemplateMatcher, GameBot.Domain.Vision.TemplateMatcher>();

--- a/src/GameBot.Service/Services/SequenceExecution/BackgroundCaptureSessionFrameSource.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/BackgroundCaptureSessionFrameSource.cs
@@ -1,0 +1,35 @@
+using System.Drawing;
+using System.IO;
+using System.Runtime.Versioning;
+using GameBot.Emulator.Session;
+
+namespace GameBot.Service.Services.SequenceExecution;
+
+/// <summary>
+/// <see cref="ISessionFrameSource"/> backed by the <see cref="BackgroundScreenCaptureService"/>
+/// cache (feature 068). Decodes the immutable PNG snapshot rather than cloning the cached Bitmap,
+/// which the capture loop disposes when it swaps in a new frame.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class BackgroundCaptureSessionFrameSource : ISessionFrameSource {
+  private readonly BackgroundScreenCaptureService _captureService;
+
+  public BackgroundCaptureSessionFrameSource(BackgroundScreenCaptureService captureService) {
+    _captureService = captureService;
+  }
+
+  public Bitmap? Capture(string sessionId) {
+    if (string.IsNullOrWhiteSpace(sessionId)) {
+      return null;
+    }
+
+    var frame = _captureService.GetCachedFrame(sessionId);
+    if (frame is null) {
+      return null;
+    }
+
+    using var ms = new MemoryStream(frame.PngBytes, writable: false);
+    using var tmp = new Bitmap(ms);
+    return new Bitmap(tmp); // detach from the stream so the caller can dispose independently
+  }
+}

--- a/src/GameBot.Service/Services/SequenceExecution/IOcrOffsetResolver.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/IOcrOffsetResolver.cs
@@ -1,0 +1,33 @@
+using GameBot.Domain.Commands.SelfReschedule;
+
+namespace GameBot.Service.Services.SequenceExecution;
+
+/// <summary>Offset-source labels recorded in the execution log (feature 068, FR-007).</summary>
+internal static class OcrOffsetSource {
+  public const string Ocr = "ocr";
+  public const string Fallback = "fallback";
+}
+
+/// <summary>
+/// Outcome of resolving a <c>reschedule-self</c> Timer offset from an on-screen countdown
+/// (feature 068). <see cref="EffectiveOffset"/> is always usable — on any failure it is the
+/// spec's static fallback and <see cref="Source"/> is <see cref="OcrOffsetSource.Fallback"/>.
+/// </summary>
+/// <param name="EffectiveOffset">The offset the reschedule should use.</param>
+/// <param name="Source">Either <c>ocr</c> or <c>fallback</c>.</param>
+/// <param name="RecognizedText">The OCR text read, when a capture/OCR was attempted.</param>
+/// <param name="Reason">On the fallback path, why the OCR value was not used.</param>
+internal sealed record OcrOffsetResolution(
+  System.TimeSpan EffectiveOffset,
+  string Source,
+  string? RecognizedText,
+  string? Reason);
+
+/// <summary>
+/// Resolves an <see cref="SelfRescheduleOcrOffset"/> to an effective Timer offset by capturing the
+/// session frame, cropping the region, OCR-reading it, parsing a duration, and bounds-checking it.
+/// Never throws — every failure path yields the static fallback (FR-005).
+/// </summary>
+internal interface IOcrOffsetResolver {
+  OcrOffsetResolution Resolve(string? sessionId, SelfRescheduleOcrOffset spec);
+}

--- a/src/GameBot.Service/Services/SequenceExecution/ISessionFrameSource.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/ISessionFrameSource.cs
@@ -1,0 +1,12 @@
+using System.Drawing;
+
+namespace GameBot.Service.Services.SequenceExecution;
+
+/// <summary>
+/// Captures the latest emulator frame for a specific session (feature 068). Abstracts the
+/// background capture cache so <see cref="OcrOffsetResolver"/> stays unit-testable with a fake.
+/// </summary>
+internal interface ISessionFrameSource {
+  /// <summary>Returns a detached copy of the latest frame, or null when none is available.</summary>
+  Bitmap? Capture(string sessionId);
+}

--- a/src/GameBot.Service/Services/SequenceExecution/OcrOffsetResolver.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/OcrOffsetResolver.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.Versioning;
+using GameBot.Domain.Commands.SelfReschedule;
+using GameBot.Domain.Triggers.Evaluators;
+
+namespace GameBot.Service.Services.SequenceExecution;
+
+/// <summary>
+/// Real <see cref="IOcrOffsetResolver"/> (feature 068): captures the session frame, crops the
+/// configured region, OCR-reads it, parses a duration, and bounds-checks it. Any failure — no
+/// session, no capture, region off-frame, OCR error/empty, unparseable, or out of bounds — yields
+/// the spec's static fallback with a reason (FR-005/FR-006); it never throws.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class OcrOffsetResolver : IOcrOffsetResolver {
+  private readonly ISessionFrameSource _frameSource;
+  private readonly ITextOcr _ocr;
+
+  public OcrOffsetResolver(ISessionFrameSource frameSource, ITextOcr ocr) {
+    _frameSource = frameSource;
+    _ocr = ocr;
+  }
+
+  public OcrOffsetResolution Resolve(string? sessionId, SelfRescheduleOcrOffset spec) {
+    ArgumentNullException.ThrowIfNull(spec);
+
+    if (string.IsNullOrWhiteSpace(sessionId)) {
+      return Fallback(spec, "no-session", null);
+    }
+
+    Bitmap? frame = null;
+    Bitmap? cropped = null;
+    try {
+      frame = _frameSource.Capture(sessionId);
+      if (frame is null) {
+        return Fallback(spec, "no-capture", null);
+      }
+
+      cropped = CropRegion(frame, spec.Region);
+      if (cropped is null) {
+        return Fallback(spec, "region-invalid", null);
+      }
+
+      var text = _ocr.Recognize(cropped).Text;
+      if (string.IsNullOrWhiteSpace(text)) {
+        return Fallback(spec, "ocr-empty", text ?? string.Empty);
+      }
+
+      if (!CooldownDurationParser.TryParse(text, out var parsed)) {
+        return Fallback(spec, "parse-failed", text);
+      }
+
+      if (parsed < spec.Min || parsed > spec.Max) {
+        return Fallback(spec, "out-of-bounds", text);
+      }
+
+      return new OcrOffsetResolution(parsed, OcrOffsetSource.Ocr, text, null);
+    }
+    catch (Exception) {
+      // FR-005: OCR/capture faults must never fail the step — always reschedule via fallback.
+      return Fallback(spec, "ocr-error", null);
+    }
+    finally {
+      cropped?.Dispose();
+      frame?.Dispose();
+    }
+  }
+
+  private static OcrOffsetResolution Fallback(SelfRescheduleOcrOffset spec, string reason, string? text) =>
+    new(spec.Fallback, OcrOffsetSource.Fallback, text, reason);
+
+  // Crops the region in absolute captured-screen pixel space (FR-002). Clamps to the frame; returns
+  // null when the region starts entirely outside the frame or has non-positive size.
+  private static Bitmap? CropRegion(Bitmap frame, OcrOffsetRegion region) {
+    if (region.Width <= 0 || region.Height <= 0) {
+      return null;
+    }
+    if (region.X >= frame.Width || region.Y >= frame.Height) {
+      return null;
+    }
+
+    var rx = Math.Clamp(region.X, 0, frame.Width - 1);
+    var ry = Math.Clamp(region.Y, 0, frame.Height - 1);
+    var rw = Math.Clamp(region.Width, 1, frame.Width - rx);
+    var rh = Math.Clamp(region.Height, 1, frame.Height - ry);
+
+    try {
+      var dest = new Bitmap(rw, rh, PixelFormat.Format24bppRgb);
+      using var g = Graphics.FromImage(dest);
+      g.DrawImage(frame, new Rectangle(0, 0, rw, rh), new Rectangle(rx, ry, rw, rh), GraphicsUnit.Pixel);
+      return dest;
+    }
+    catch (Exception ex) when (ex is ArgumentException or OutOfMemoryException) {
+      return null;
+    }
+  }
+}

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -37,6 +37,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private readonly ISessionManager _sessionManager;
   private readonly IEnsureGameRunningActionHandler _ensureGameRunning;
   private readonly ISessionService _sessionService;
+  private readonly IOcrOffsetResolver _ocrOffsetResolver;
 
   public SequenceExecutionService(
     SequenceRunner runner,
@@ -50,7 +51,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     ISelfRescheduleCoordinator selfRescheduleCoordinator,
     ISessionManager sessionManager,
     IEnsureGameRunningActionHandler ensureGameRunning,
-    ISessionService sessionService) {
+    ISessionService sessionService,
+    IOcrOffsetResolver ocrOffsetResolver) {
     _runner = runner;
     _evalSvc = evalSvc;
     _imageVisibleConditionAdapter = imageVisibleConditionAdapter;
@@ -63,6 +65,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     _sessionManager = sessionManager;
     _ensureGameRunning = ensureGameRunning;
     _sessionService = sessionService;
+    _ocrOffsetResolver = ocrOffsetResolver;
   }
 
   public async Task<SequenceExecutionResult> ExecuteAsync(
@@ -407,7 +410,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private ActionDispatchResult DispatchSelfReschedule(
       SequenceActionPayload action,
       string sequenceId,
-      string? originatingQueueId) {
+      string? originatingQueueId,
+      string? sessionId) {
     if (string.IsNullOrWhiteSpace(originatingQueueId)) {
       return new ActionDispatchResult("noop", "no originating queue, no reschedule performed");
     }
@@ -416,21 +420,50 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       return new ActionDispatchResult("noop", $"self-reschedule not performed: {parseError}");
     }
 
+    // feature 068: when an ocrOffset spec is present (Timer), derive the relative offset at runtime
+    // by OCR-reading the on-screen countdown, falling back to the static offset on any failure.
+    var timerTimeOfDay = payload.TimerTimeOfDay;
+    var timerRelativeOffset = payload.TimerRelativeOffset;
+    OcrOffsetResolution? ocrResolution = null;
+    if (payload.HasOcrOffset && payload.Option == SelfRescheduleOption.Timer) {
+      ocrResolution = _ocrOffsetResolver.Resolve(sessionId, payload.OcrOffset!);
+      timerTimeOfDay = null;
+      timerRelativeOffset = ocrResolution.EffectiveOffset;
+    }
+
     var schedule = _selfRescheduleCoordinator.ScheduleSelf(
       originatingQueueId!,
       sequenceId,
       payload.Option,
-      payload.TimerTimeOfDay,
-      payload.TimerRelativeOffset);
+      timerTimeOfDay,
+      timerRelativeOffset);
 
     if (schedule.Outcome == SelfRescheduleOutcome.NotRunning) {
       return new ActionDispatchResult("noop", "originating queue run no longer active; no reschedule performed");
     }
 
-    return new ActionDispatchResult(
-      "scheduled",
-      $"rescheduled this sequence (option {schedule.Option}, {schedule.ResolvedTiming}); applies to the current run only");
+    var message = ocrResolution is null
+      ? $"rescheduled this sequence (option {schedule.Option}, {schedule.ResolvedTiming}); applies to the current run only"
+      : $"rescheduled this sequence (option {schedule.Option}, {schedule.ResolvedTiming}); {DescribeOcrOffset(ocrResolution)}; applies to the current run only";
+
+    return new ActionDispatchResult("scheduled", message);
   }
+
+  // feature 068: renders the offset-source detail for the execution log (FR-007).
+  // internal for unit testing the log-message content (SC-004).
+  internal static string DescribeOcrOffset(OcrOffsetResolution resolution) {
+    if (string.Equals(resolution.Source, OcrOffsetSource.Ocr, StringComparison.Ordinal)) {
+      return $"offset source ocr (read '{resolution.RecognizedText}' -> {FormatOffset(resolution.EffectiveOffset)})";
+    }
+
+    var readSuffix = string.IsNullOrEmpty(resolution.RecognizedText)
+      ? string.Empty
+      : $", read '{resolution.RecognizedText}'";
+    return $"offset source fallback (reason {resolution.Reason}{readSuffix}, using {FormatOffset(resolution.EffectiveOffset)})";
+  }
+
+  private static string FormatOffset(TimeSpan offset) =>
+    offset.ToString("c", CultureInfo.InvariantCulture);
 
   /// <summary>
   /// Routes a non-command sequence action to its handler: <c>reschedule-self</c> to the
@@ -445,7 +478,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       string? sessionId,
       CancellationToken ct) {
     if (string.Equals(action.Type, ActionTypes.RescheduleSelf, StringComparison.OrdinalIgnoreCase)) {
-      return Task.FromResult(DispatchSelfReschedule(action, sequenceId, originatingQueueId));
+      return Task.FromResult(DispatchSelfReschedule(action, sequenceId, originatingQueueId, sessionId));
     }
 
     if (string.Equals(action.Type, ActionTypes.ConnectToGame, StringComparison.OrdinalIgnoreCase)) {

--- a/src/GameBot.Service/Services/SequenceExecution/StaticFallbackOcrOffsetResolver.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/StaticFallbackOcrOffsetResolver.cs
@@ -1,0 +1,15 @@
+using GameBot.Domain.Commands.SelfReschedule;
+
+namespace GameBot.Service.Services.SequenceExecution;
+
+/// <summary>
+/// <see cref="IOcrOffsetResolver"/> used when screen capture / OCR are unavailable (non-Windows or
+/// ADB-disabled test hosts): always returns the spec's static fallback so a self-rescheduling
+/// sequence still reschedules (FR-005) instead of failing DI graph construction.
+/// </summary>
+internal sealed class StaticFallbackOcrOffsetResolver : IOcrOffsetResolver {
+  public OcrOffsetResolution Resolve(string? sessionId, SelfRescheduleOcrOffset spec) {
+    System.ArgumentNullException.ThrowIfNull(spec);
+    return new OcrOffsetResolution(spec.Fallback, OcrOffsetSource.Fallback, null, "ocr-unavailable");
+  }
+}

--- a/tests/contract/Sequences/SelfRescheduleActionContractTests.cs
+++ b/tests/contract/Sequences/SelfRescheduleActionContractTests.cs
@@ -102,6 +102,110 @@ public sealed class SelfRescheduleActionContractTests {
     payload.GetProperty("timerRelativeOffset").GetString().Should().Be("00:10:00");
   }
 
+  // ── feature 068: ocrOffset round-trip + validation ────────────────────────
+
+  [Fact]
+  public async Task TimerRescheduleWithOcrOffsetRoundTrips() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var createPayload = new {
+      name = "self-reschedule-ocr-contract",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "reschedule",
+          stepType = "Action",
+          primitiveAction = new {
+            type = "reschedule-self",
+            schemaVersion = "1",
+            payload = new {
+              option = "Timer",
+              ocrOffset = new {
+                region = new { x = 10, y = 20, width = 120, height = 40 },
+                fallback = "00:06:00",
+                min = "00:00:05",
+                max = "01:00:00"
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var sequenceId = created.GetProperty("id").GetString();
+
+    var getResponse = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}", UriKind.Relative)).ConfigureAwait(false);
+    var fetched = await getResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    var payload = fetched.GetProperty("steps")[0].GetProperty("primitiveAction").GetProperty("payload");
+    payload.GetProperty("option").GetString().Should().Be("Timer");
+    var ocr = payload.GetProperty("ocrOffset");
+    ocr.GetProperty("region").GetProperty("width").GetInt32().Should().Be(120);
+    ocr.GetProperty("fallback").GetString().Should().Be("00:06:00");
+  }
+
+  [Fact]
+  public async Task OcrOffsetOnNonTimerOptionIsRejected() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var createPayload = new {
+      name = "self-reschedule-ocr-invalid",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "reschedule",
+          stepType = "Action",
+          primitiveAction = new {
+            type = "reschedule-self",
+            schemaVersion = "1",
+            payload = new {
+              option = "OncePerRun",
+              ocrOffset = new {
+                region = new { x = 10, y = 20, width = 120, height = 40 },
+                fallback = "00:06:00"
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var response = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
+  [Fact]
+  public async Task OcrOffsetMissingFallbackIsRejected() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var createPayload = new {
+      name = "self-reschedule-ocr-nofallback",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "reschedule",
+          stepType = "Action",
+          primitiveAction = new {
+            type = "reschedule-self",
+            schemaVersion = "1",
+            payload = new {
+              option = "Timer",
+              ocrOffset = new { region = new { x = 10, y = 20, width = 120, height = 40 } }
+            }
+          }
+        }
+      }
+    };
+
+    var response = await client.PostAsJsonAsync("/api/sequences", createPayload).ConfigureAwait(false);
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+  }
+
   // ── T034 (US2): validation rejects malformed option/timer combinations ────
 
   [Theory]

--- a/tests/unit/Sequences/CooldownDurationParserTests.cs
+++ b/tests/unit/Sequences/CooldownDurationParserTests.cs
@@ -1,0 +1,78 @@
+using System;
+using FluentAssertions;
+using GameBot.Domain.Commands.SelfReschedule;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>Feature 068: tolerant extraction of a countdown duration from noisy OCR text.</summary>
+public sealed class CooldownDurationParserTests {
+  [Fact]
+  public void ParsesHhMmSs() {
+    CooldownDurationParser.TryParse("00:05:42", out var value).Should().BeTrue();
+    value.Should().Be(new TimeSpan(0, 5, 42));
+  }
+
+  [Fact]
+  public void ParsesMmSs() {
+    CooldownDurationParser.TryParse("01:20", out var value).Should().BeTrue();
+    value.Should().Be(new TimeSpan(0, 1, 20));
+  }
+
+  [Fact]
+  public void ParsesHoursForm() {
+    CooldownDurationParser.TryParse("02:30:15", out var value).Should().BeTrue();
+    value.Should().Be(new TimeSpan(2, 30, 15));
+  }
+
+  [Theory]
+  [InlineData("Next in 00:05:42 remaining")]
+  [InlineData("  \n00:05:42\t")]
+  [InlineData("[[00:05:42]]")]
+  public void ExtractsFromSurroundingNoise(string text) {
+    CooldownDurationParser.TryParse(text, out var value).Should().BeTrue();
+    value.Should().Be(new TimeSpan(0, 5, 42));
+  }
+
+  [Fact]
+  public void NormalizesDigitConfusions() {
+    // 'O' -> '0', 'l'/'I'/'|' -> '1'
+    CooldownDurationParser.TryParse("OO:O5:42", out var oValue).Should().BeTrue();
+    oValue.Should().Be(new TimeSpan(0, 5, 42));
+
+    CooldownDurationParser.TryParse("Ol:2O", out var lValue).Should().BeTrue();
+    lValue.Should().Be(new TimeSpan(0, 1, 20));
+  }
+
+  [Fact]
+  public void ParsesZeroAsSuccess() {
+    // Zero is a valid parse; bounds-checking (not the parser) rejects it downstream.
+    CooldownDurationParser.TryParse("00:00:00", out var value).Should().BeTrue();
+    value.Should().Be(TimeSpan.Zero);
+  }
+
+  [Theory]
+  [InlineData("")]
+  [InlineData("   ")]
+  [InlineData(null)]
+  [InlineData("no timer here")]
+  [InlineData("Attack")]
+  [InlineData("12")]
+  public void ReturnsFalseOnGarbage(string? text) {
+    CooldownDurationParser.TryParse(text, out var value).Should().BeFalse();
+    value.Should().Be(TimeSpan.Zero);
+  }
+
+  [Fact]
+  public void ReturnsFalseOnOverflow() {
+    CooldownDurationParser.TryParse("999999999999999999999:00:00", out _).Should().BeFalse();
+  }
+
+  [Fact]
+  public void TakesTheFirstDurationToken() {
+    CooldownDurationParser.TryParse("first 00:01:00 then 00:09:00", out var value).Should().BeTrue();
+    value.Should().Be(new TimeSpan(0, 1, 0));
+  }
+}

--- a/tests/unit/Sequences/OcrOffsetMessageTests.cs
+++ b/tests/unit/Sequences/OcrOffsetMessageTests.cs
@@ -1,0 +1,44 @@
+using System;
+using FluentAssertions;
+using GameBot.Service.Services.SequenceExecution;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Feature 068: the reschedule decision message (written to the execution log, FR-007/SC-004) must
+/// unambiguously state whether the OCR-parsed value or the static fallback was used, with the read
+/// text / reason and the resulting offset.
+/// </summary>
+public sealed class OcrOffsetMessageTests {
+  [Fact]
+  public void OcrSourceMessageIncludesRecognizedTextAndDuration() {
+    var msg = SequenceExecutionService.DescribeOcrOffset(
+      new OcrOffsetResolution(new TimeSpan(0, 5, 42), OcrOffsetSource.Ocr, "00:05:42", null));
+
+    msg.Should().Contain("offset source ocr");
+    msg.Should().Contain("00:05:42");
+  }
+
+  [Fact]
+  public void FallbackSourceMessageIncludesReasonAndOffset() {
+    var msg = SequenceExecutionService.DescribeOcrOffset(
+      new OcrOffsetResolution(new TimeSpan(0, 6, 0), OcrOffsetSource.Fallback, null, "ocr-unavailable"));
+
+    msg.Should().Contain("offset source fallback");
+    msg.Should().Contain("ocr-unavailable");
+    msg.Should().Contain("00:06:00");
+  }
+
+  [Fact]
+  public void FallbackWithRecognizedTextAlsoReportsWhatWasRead() {
+    var msg = SequenceExecutionService.DescribeOcrOffset(
+      new OcrOffsetResolution(new TimeSpan(0, 6, 0), OcrOffsetSource.Fallback, "no timer", "parse-failed"));
+
+    msg.Should().Contain("offset source fallback");
+    msg.Should().Contain("parse-failed");
+    msg.Should().Contain("no timer");
+  }
+}

--- a/tests/unit/Sequences/OcrOffsetResolverTests.cs
+++ b/tests/unit/Sequences/OcrOffsetResolverTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Drawing;
+using FluentAssertions;
+using GameBot.Domain.Commands.SelfReschedule;
+using GameBot.Domain.Triggers.Evaluators;
+using GameBot.Service.Services.SequenceExecution;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Feature 068: the OCR-offset resolver's decision logic (capture → crop → OCR → parse →
+/// bounds-check → source), exercised deterministically with a fake frame source and fake OCR.
+/// </summary>
+public sealed class OcrOffsetResolverTests {
+  private sealed class FakeFrameSource : ISessionFrameSource {
+    private readonly int _width;
+    private readonly int _height;
+    private readonly bool _returnNull;
+    public FakeFrameSource(int width = 200, int height = 100, bool returnNull = false) {
+      _width = width; _height = height; _returnNull = returnNull;
+    }
+    public Bitmap? Capture(string sessionId) => _returnNull ? null : new Bitmap(_width, _height);
+  }
+
+  private sealed class FakeOcr : ITextOcr {
+    private readonly string _text;
+    private readonly bool _throw;
+    public FakeOcr(string text, bool @throw = false) { _text = text; _throw = @throw; }
+    public OcrResult Recognize(Bitmap image) =>
+      _throw ? throw new InvalidOperationException("ocr boom") : new OcrResult(_text, 0.99);
+    public OcrResult Recognize(Bitmap image, string? language) => Recognize(image);
+  }
+
+  private static SelfRescheduleOcrOffset Spec(
+      TimeSpan? min = null, TimeSpan? max = null, TimeSpan? fallback = null,
+      int x = 0, int y = 0, int w = 120, int h = 40) =>
+    new() {
+      Region = new OcrOffsetRegion(x, y, w, h),
+      Fallback = fallback ?? TimeSpan.FromMinutes(6),
+      Min = min ?? TimeSpan.FromSeconds(1),
+      Max = max ?? TimeSpan.FromHours(24)
+    };
+
+  private static OcrOffsetResolver Resolver(ISessionFrameSource frames, ITextOcr ocr) =>
+    new(frames, ocr);
+
+  [Fact]
+  public void GoodTimerReadUsesOcrOffset() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("00:05:42")).Resolve("sess", Spec());
+    res.Source.Should().Be(OcrOffsetSource.Ocr);
+    res.EffectiveOffset.Should().Be(new TimeSpan(0, 5, 42));
+    res.RecognizedText.Should().Be("00:05:42");
+    res.Reason.Should().BeNull();
+  }
+
+  [Fact]
+  public void EmptyOcrFallsBack() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("   ")).Resolve("sess", Spec());
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.EffectiveOffset.Should().Be(TimeSpan.FromMinutes(6));
+    res.Reason.Should().Be("ocr-empty");
+  }
+
+  [Fact]
+  public void GarbageOcrFallsBack() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("no timer")).Resolve("sess", Spec());
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.Reason.Should().Be("parse-failed");
+    res.RecognizedText.Should().Be("no timer");
+  }
+
+  [Fact]
+  public void ZeroReadIsBelowMinAndFallsBack() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("00:00:00")).Resolve("sess", Spec());
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.Reason.Should().Be("out-of-bounds");
+  }
+
+  [Fact]
+  public void AboveMaxFallsBack() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("23:00:00"))
+      .Resolve("sess", Spec(max: TimeSpan.FromHours(1)));
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.Reason.Should().Be("out-of-bounds");
+  }
+
+  [Fact]
+  public void NoCaptureFallsBack() {
+    var res = Resolver(new FakeFrameSource(returnNull: true), new FakeOcr("00:05:42")).Resolve("sess", Spec());
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.Reason.Should().Be("no-capture");
+  }
+
+  [Fact]
+  public void NoSessionFallsBack() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("00:05:42")).Resolve(null, Spec());
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.Reason.Should().Be("no-session");
+  }
+
+  [Fact]
+  public void OcrErrorFallsBackWithoutThrowing() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("x", @throw: true)).Resolve("sess", Spec());
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.Reason.Should().Be("ocr-error");
+  }
+
+  [Fact]
+  public void RegionEntirelyOffFrameFallsBack() {
+    // Frame is 200x100; region starts at x=500 which is off-frame.
+    var res = Resolver(new FakeFrameSource(200, 100), new FakeOcr("00:05:42"))
+      .Resolve("sess", Spec(x: 500, y: 10, w: 50, h: 20));
+    res.Source.Should().Be(OcrOffsetSource.Fallback);
+    res.Reason.Should().Be("region-invalid");
+  }
+
+  [Fact]
+  public void MmSsReadUsesOcrOffset() {
+    var res = Resolver(new FakeFrameSource(), new FakeOcr("01:20")).Resolve("sess", Spec());
+    res.Source.Should().Be(OcrOffsetSource.Ocr);
+    res.EffectiveOffset.Should().Be(new TimeSpan(0, 1, 20));
+  }
+}

--- a/tests/unit/Sequences/OcrOffsetValidationTests.cs
+++ b/tests/unit/Sequences/OcrOffsetValidationTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>Feature 068: cross-field validation of the ocrOffset spec on reschedule-self.</summary>
+public sealed class OcrOffsetValidationTests {
+  private static readonly SequenceStepValidationService Validator = new();
+
+  private static Dictionary<string, object?> Region(int x, int y, int w, int h) =>
+    new() { ["x"] = x, ["y"] = y, ["width"] = w, ["height"] = h };
+
+  private static IReadOnlyList<string> ValidateReschedule(string option, Dictionary<string, object?> ocrOffset) {
+    var step = new SequenceStep {
+      Order = 0,
+      StepId = "reschedule",
+      StepType = SequenceStepType.Action,
+      Action = new SequenceActionPayload {
+        Type = ActionTypes.RescheduleSelf,
+        Parameters = { ["option"] = option, ["ocrOffset"] = ocrOffset }
+      }
+    };
+    return Validator.Validate(new[] { step });
+  }
+
+  [Fact]
+  public void ValidTimerOcrOffsetPasses() {
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(10, 20, 120, 40),
+      ["fallback"] = "00:06:00"
+    };
+    ValidateReschedule("Timer", ocr).Should().BeEmpty();
+  }
+
+  [Fact]
+  public void OcrOffsetOnNonTimerOptionIsRejected() {
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(10, 20, 120, 40),
+      ["fallback"] = "00:06:00"
+    };
+    ValidateReschedule("OncePerRun", ocr)
+      .Should().ContainSingle(e => e.Contains("ocrOffset is only valid when option is Timer"));
+  }
+
+  [Fact]
+  public void NonPositiveRegionIsRejected() {
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(10, 20, 0, 40),
+      ["fallback"] = "00:06:00"
+    };
+    ValidateReschedule("Timer", ocr)
+      .Should().Contain(e => e.Contains("positive width and height"));
+  }
+
+  [Fact]
+  public void MinNotLessThanMaxIsRejected() {
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(10, 20, 120, 40),
+      ["fallback"] = "00:06:00",
+      ["min"] = "01:00:00",
+      ["max"] = "00:30:00"
+    };
+    ValidateReschedule("Timer", ocr)
+      .Should().Contain(e => e.Contains("min must be less than ocrOffset.max"));
+  }
+
+  [Fact]
+  public void MissingFallbackIsRejected() {
+    var ocr = new Dictionary<string, object?> { ["region"] = Region(10, 20, 120, 40) };
+    ValidateReschedule("Timer", ocr)
+      .Should().Contain(e => e.Contains("fallback"));
+  }
+
+  [Fact]
+  public void TimerWithOcrOffsetDoesNotRequireStaticTimerFields() {
+    // Regression guard: the static "Timer requires timerTimeOfDay or timerRelativeOffset" rule
+    // must not fire when ocrOffset supplies the offset.
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(10, 20, 120, 40),
+      ["fallback"] = "00:06:00"
+    };
+    ValidateReschedule("Timer", ocr).Should().NotContain(e => e.Contains("requires a timerTimeOfDay"));
+  }
+}

--- a/tests/unit/Sequences/SelfReschedulePayloadTests.cs
+++ b/tests/unit/Sequences/SelfReschedulePayloadTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using GameBot.Domain.Commands;
 using GameBot.Domain.Commands.SelfReschedule;
@@ -69,5 +70,75 @@ public sealed class SelfReschedulePayloadTests {
       Payload(("option", "Timer"), ("timerRelativeOffset", "not-a-duration")),
       out _, out var error).Should().BeFalse();
     error.Should().NotBeNullOrWhiteSpace();
+  }
+
+  // ── feature 068: ocrOffset parsing ─────────────────────────────────────────
+
+  private static Dictionary<string, object?> Region(int x, int y, int w, int h) =>
+    new() { ["x"] = x, ["y"] = y, ["width"] = w, ["height"] = h };
+
+  [Fact]
+  public void AbsentOcrOffsetLeavesPayloadUnchanged() {
+    SelfReschedulePayload.TryRead(Payload(("option", "Timer"), ("timerRelativeOffset", "00:10:00")),
+      out var result, out _).Should().BeTrue();
+    result!.HasOcrOffset.Should().BeFalse();
+    result.OcrOffset.Should().BeNull();
+  }
+
+  [Fact]
+  public void ParsesOcrOffsetWithDefaults() {
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(10, 20, 120, 40),
+      ["fallback"] = "00:06:00"
+    };
+    SelfReschedulePayload.TryRead(Payload(("option", "Timer"), ("ocrOffset", ocr)),
+      out var result, out var error).Should().BeTrue();
+    error.Should().BeNull();
+    result!.HasOcrOffset.Should().BeTrue();
+    result.OcrOffset!.Region.Should().Be(new OcrOffsetRegion(10, 20, 120, 40));
+    result.OcrOffset.Fallback.Should().Be(TimeSpan.FromMinutes(6));
+    result.OcrOffset.Min.Should().Be(TimeSpan.FromSeconds(1));
+    result.OcrOffset.Max.Should().Be(TimeSpan.FromHours(24));
+  }
+
+  [Fact]
+  public void ParsesOcrOffsetWithExplicitBounds() {
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(1, 2, 3, 4),
+      ["fallback"] = "00:06:00",
+      ["min"] = "00:00:05",
+      ["max"] = "01:00:00"
+    };
+    SelfReschedulePayload.TryRead(Payload(("option", "Timer"), ("ocrOffset", ocr)),
+      out var result, out _).Should().BeTrue();
+    result!.OcrOffset!.Min.Should().Be(TimeSpan.FromSeconds(5));
+    result.OcrOffset.Max.Should().Be(TimeSpan.FromHours(1));
+  }
+
+  [Fact]
+  public void OcrOffsetMissingRegionIsRejected() {
+    var ocr = new Dictionary<string, object?> { ["fallback"] = "00:06:00" };
+    SelfReschedulePayload.TryRead(Payload(("option", "Timer"), ("ocrOffset", ocr)),
+      out _, out var error).Should().BeFalse();
+    error.Should().Contain("region");
+  }
+
+  [Fact]
+  public void OcrOffsetMissingFallbackIsRejected() {
+    var ocr = new Dictionary<string, object?> { ["region"] = Region(1, 2, 3, 4) };
+    SelfReschedulePayload.TryRead(Payload(("option", "Timer"), ("ocrOffset", ocr)),
+      out _, out var error).Should().BeFalse();
+    error.Should().Contain("fallback");
+  }
+
+  [Fact]
+  public void OcrOffsetMalformedFallbackIsRejected() {
+    var ocr = new Dictionary<string, object?> {
+      ["region"] = Region(1, 2, 3, 4),
+      ["fallback"] = "not-a-duration"
+    };
+    SelfReschedulePayload.TryRead(Payload(("option", "Timer"), ("ocrOffset", ocr)),
+      out _, out var error).Should().BeFalse();
+    error.Should().Contain("fallback");
   }
 }


### PR DESCRIPTION
## Summary

Extends the `reschedule-self` Timer action (feature 065) so a self-rescheduling sequence can derive its relative offset at runtime by **OCR-reading an on-screen countdown timer**, instead of only a fixed offset.

Driving case: the PNS **Radio Quiz** cooldown grows with each answer and is shown as a live countdown in the Radio building — the automation answers, reads the new cooldown, and reschedules itself to fire exactly when the next quiz is ready.

Spec-driven: see `specs/068-reschedule-ocr-offset/` (spec + plan + tasks).

## Behavior

A `reschedule-self` (option `Timer`) payload gains an optional `ocrOffset`:

```json
ocrOffset: {
  region:   { x: 0, y: 860, width: 180, height: 40 },
  fallback: 00:06:00,
  min: 00:00:01,
  max: 24:00:00
}
```

At dispatch it captures the session frame, crops `region`, OCRs it, parses an `hh:mm:ss`/`mm:ss` countdown, bounds-checks it, and reschedules `now + parsed`. **Any failure** (no capture, empty/garbage OCR, unparseable, out of bounds) falls back to the required static `fallback` — the step never fails and the reschedule is never skipped. The execution log records which source was used (`ocr` vs `fallback` + reason + read text).

## Key points

- **Backward-compatible**: absent `ocrOffset` → behavior byte-for-byte unchanged for all options (existing 065 tests pass unchanged).
- **Domain (pure)**: `CooldownDurationParser` (tolerant, `O`→`0`/`l`→`1`, checked overflow), `SelfRescheduleOcrOffset`, payload parsing + `SequenceStepValidationService` cross-field rules.
- **Service**: `IOcrOffsetResolver` / `OcrOffsetResolver` (never throws) + `StaticFallbackOcrOffsetResolver` for non-Windows/ADB-disabled hosts; `ISessionFrameSource` capture seam; `DispatchSelfReschedule` OCR path + FR-007 logging.

## Testing

- `dotnet build GameBot.sln` clean (0 warnings / 0 errors).
- Unit + contract + integration suites green.
- Coverage: parser (all forms/noise/overflow), payload parse (defaults + malformed), validation (all rules), resolver (all 10 branches), and the decision-message source rendering (FR-007/SC-004).
- No Timer-dispatch integration test: a self-rescheduling Timer intentionally keeps a non-cycling run alive and re-arms each firing (perpetual by design), so a completion-based integration test is infeasible; the offset-flow glue is trivial and the resolver's parsed offset is fully unit-tested.

## Out of scope

- Authoring the actual Radio Quiz sequence/queue entry that uses `ocrOffset`.
- Radio Quiz correct-answer bank (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)