### PR TITLE
Add go-to-home-screen action (069)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/068-reschedule-ocr-offset"
+  "feature_directory": "specs/069-go-home-screen"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/068-reschedule-ocr-offset/plan.md
+at specs/069-go-home-screen/plan.md
 <!-- SPECKIT END -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ For the *history* of how the system got here — one folder per feature, point-i
 history; this file is the current-state source of truth. When the two disagree, this file wins and
 the relevant spec should be marked superseded.
 
-_Last reviewed: 2026-07-06._
+_Last reviewed: 2026-07-17._
 
 ## What GameBot is
 
@@ -41,9 +41,14 @@ not survive a service restart; queue *configuration* and templates are persisted
 - **Command** — an ordered list of **steps**. Steps are **primitive actions** plus control
   structures (loops, per-step conditions). A command may carry a vestigial `TriggerId`.
 - **Primitive Action** — the unit of input/effect. Current variants: **Tap**, **Swipe**,
-  **Key**, **Wait for Image**, **Connect to Game**, **Ensure Game Running**. (These replaced the
-  old first-class "Action" object — see *Legacy/removed* below.) Taps/swipes resolve coordinates
-  from image detection + offset, with wait-and-retry and tap-point jitter applied automatically.
+  **Key**, **Wait for Image**, **Connect to Game**, **Ensure Game Running**, **Go to Home Screen**.
+  (These replaced the old first-class "Action" object — see *Legacy/removed* below.) Taps/swipes
+  resolve coordinates from image detection + offset, with wait-and-retry and tap-point jitter
+  applied automatically. **Go to Home Screen** (`go-to-home-screen`, feature 069) is a parameterless
+  action that presses Android HOME (keycode 3) so the device returns to its home/main screen,
+  leaving the game running in the background — the leave-game counterpart to Connect to Game. It is
+  usable both as a sequence action (dispatched through the session input pipeline) and a command
+  step, and degrades to a stub success on non-Windows/non-ADB sessions.
 - **Sequence** — an ordered list of steps that run **commands**, with random inter-step delays,
   conditional steps, loop/flow blocks (`SequenceFlowGraph`, `Blocks/`), and **if blocks**
   (`SequenceStepType.If`, feature 067): a condition (same model as while-loop conditions —

--- a/specs/069-go-home-screen/checklists/requirements.md
+++ b/specs/069-go-home-screen/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Go To Home Screen Action
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Behavior was clarified up front with the user: HOME-only (press HOME, leave game running), exposed the same way as the existing connect-to-game action. No open [NEEDS CLARIFICATION] markers.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/069-go-home-screen/contracts/go-to-home-screen-action.md
+++ b/specs/069-go-home-screen/contracts/go-to-home-screen-action.md
@@ -1,0 +1,73 @@
+# Contract: Go To Home Screen Action
+
+The action is exposed through the same JSON-authored surfaces as the other primitive/parameterless
+actions. There is no new HTTP endpoint; the contract is the JSON shape accepted by the existing
+sequence and command APIs, plus the dispatch outcome.
+
+## 1. As a sequence step (action payload)
+
+Persisted/accepted inside a sequence step's `action`:
+
+```json
+{
+  "stepId": "leave-game",
+  "action": {
+    "type": "go-to-home-screen",
+    "parameters": {}
+  }
+}
+```
+
+- `type` MUST be `"go-to-home-screen"`. In any polymorphic step object the `type` property MUST come
+  first (the service JSON deserializer requires the discriminator before other fields).
+- `parameters` MUST be empty (`{}`) or omitted. Extra parameters are ignored; none are required.
+- Validation: accepted by `SequenceStepValidationService`, `ActionPayloadValidationService`, and the
+  `FileSequenceRepository` persistence guard. A sequence containing only this step is valid.
+
+### Dispatch outcome
+
+| Condition | Outcome | Step result |
+|---|---|---|
+| HOME key accepted by session (real ADB or stub) | `executed` | Succeeded |
+| No running session resolvable / input rejected | `failed` | Failed, sequence stops |
+
+## 2. As a command step
+
+Accepted by `POST /api/commands` (and update) inside `steps[]`:
+
+```json
+{
+  "type": "GoToHomeScreen",
+  "order": 0
+}
+```
+
+- `type` MUST be `"GoToHomeScreen"` (the `CommandStepTypeDto` enum name).
+- No config object is required (parallels `EnsureGameRunning`). `ValidateStep` returns no error for
+  this type.
+- Execution: `CommandExecutor` sends `KEYCODE_HOME` and reports a step outcome of `executed` on
+  success (stub success on non-Windows).
+
+## 3. Authoring UI (web-ui)
+
+- `ActionTypeSelector` offers a **"Go to Home Screen"** option (value `GoToHomeScreen`) alongside
+  the existing actions.
+- Selecting it shows a parameterless confirmation panel (mirrors `EnsureGameRunningPanel`): a short
+  description and Add/Cancel, no input fields.
+
+## 4. Automation tool (MCP)
+
+- No schema change (command/sequence tools accept free-form JSON). The `create_command` /
+  `create_sequence` tool descriptions list `GoToHomeScreen` among the available primitive step
+  types so the model can author it.
+
+## Graceful degradation (FR-007)
+
+On a non-Windows host or a non-ADB (stub) session the action completes successfully without
+contacting a device and never throws — identical to how `ensure-game-running` / `key` inputs behave
+in the same conditions.
+
+## Backward compatibility
+
+Purely additive. Existing sequences, commands, `connect-to-game`, and `ensure-game-running` behave
+exactly as before. No persisted data requires migration.

--- a/specs/069-go-home-screen/data-model.md
+++ b/specs/069-go-home-screen/data-model.md
@@ -1,0 +1,68 @@
+# Phase 1 Data Model: Go To Home Screen Action
+
+This feature is additive and introduces no persisted schema changes beyond one new enum member and
+one new action-type string. No migration is required (existing sequences/commands are unaffected).
+
+## Action type identity
+
+| Concept | Value |
+|---|---|
+| Canonical action-type key | `go-to-home-screen` |
+| `ActionTypes` constant | `ActionTypes.GoToHomeScreen` |
+| `PrimitiveActionTypes` constant | `PrimitiveActionTypes.GoToHomeScreen` (added to `PrimitiveActionTypes.All`) |
+| Command step enum member | `CommandStepType.GoToHomeScreen` / `CommandStepTypeDto.GoToHomeScreen` |
+| Web-ui selector member | `PrimitiveActionType` union value `'GoToHomeScreen'` |
+| Device operation | Android key event `KEYCODE_HOME` (keycode `3`) |
+| Author-supplied parameters | none (parameterless) |
+
+## Entities
+
+### PrimitiveGoToHomeScreenAction (new)
+
+A parameterless variant of `PrimitiveActionBase`, mirroring `PrimitiveEnsureGameRunningAction`.
+
+```csharp
+public sealed class PrimitiveGoToHomeScreenAction : PrimitiveActionBase {
+  public PrimitiveGoToHomeScreenAction() : base(PrimitiveActionTypes.GoToHomeScreen) { }
+}
+```
+
+- **Fields**: none beyond the inherited `Type` / `SchemaVersion`.
+- **Validation rules**: type must equal `go-to-home-screen`; no payload fields to validate
+  (`PrimitiveActionValidationService` requires no new `case`).
+
+### CommandStep (extended)
+
+`CommandStepType` gains a `GoToHomeScreen` member. A `GoToHomeScreen` command step carries no
+config object (like `EnsureGameRunning`): `PrimitiveTap`/`WaitForImage`/`KeyInput`/`Swipe` all null,
+`TargetId` empty.
+
+### SequenceActionPayload (unchanged shape)
+
+When used as a sequence step, the action is persisted as the existing
+`SequenceActionPayload { Type = "go-to-home-screen", Parameters = {} }`. No new payload shape.
+
+## Outcome vocabulary
+
+| Outcome | Meaning |
+|---|---|
+| `executed` | The HOME key event was accepted by the session (real device or stub). Step succeeds. |
+| `failed` | No running session could be resolved, or the device rejected the input. Step fails and the sequence stops (consistent with other primitive actions). |
+
+## Allow-list touch points (must all recognize `go-to-home-screen`)
+
+| Location | Mechanism | Update |
+|---|---|---|
+| `SequenceStepValidationService` | `AllowedPrimitiveActionTypes = PrimitiveActionTypes.All` | automatic |
+| `PrimitiveActionValidationService` | `SupportedActionTypes = PrimitiveActionTypes.All` | automatic |
+| `ActionPayloadValidationService` | `PrimitiveActionTypes.All` + `RescheduleSelf` | automatic |
+| `FileSequenceRepository.ValidateActionPayloads` | **hard-coded set** | **explicit add required** |
+| `SequenceRunner.IsDispatchedPrimitiveAction` | explicit type checks | **explicit add required** |
+| `SequenceExecutionService.DispatchActionAsync` | explicit routing | **explicit add required** |
+| `CommandExecutor.ExecuteOneStepAsync` | explicit `switch`/`if` on step type | **explicit add required** |
+| `CommandsEndpoints` DTO<->domain maps | explicit `switch` | **explicit add required** |
+
+## State transitions
+
+None. The action is stateless: invoke → HOME key event → outcome. It does not create, mutate, or
+destroy sessions, games, queues, or persisted entities.

--- a/specs/069-go-home-screen/plan.md
+++ b/specs/069-go-home-screen/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Go To Home Screen Action
+
+**Branch**: `069-go-home-screen` | **Date**: 2026-07-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/069-go-home-screen/spec.md`
+
+## Summary
+
+Add a new parameterless action type, `go-to-home-screen`, that returns the Android device to its
+home/main screen by sending the hardware HOME key (Android `KEYCODE_HOME` = 3), leaving the game
+running in the background. It is the leave-game counterpart to `connect-to-game` and is wired
+through exactly the same surfaces the existing `ensure-game-running` action uses (the closest
+analogue — a parameterless device action wired as both a sequence action and a command step): the
+action-type constants, the primitive-action validation/allow-lists, the sequence-runner dispatch
+gate, the sequence-execution dispatcher, the command-step executor, the command DTO/enum mapping,
+plus web-ui authoring and MCP tool-description parity.
+
+The device operation reuses the existing session input pipeline (`SendInputsAsync` with a `key`
+action of `keyCode = 3`), which already retries on Windows/ADB and returns a stub success on
+non-Windows or non-ADB sessions — giving the graceful degradation the spec requires (FR-007)
+without new ADB plumbing.
+
+## Technical Context
+
+**Language/Version**: C# / .NET (net8.0) backend; TypeScript + React (Vite) web-ui; TypeScript MCP server
+**Primary Dependencies**: ASP.NET Minimal APIs + MVC controllers, System.Text.Json; React 18 / Vite / Jest; `@modelcontextprotocol/sdk` + zod
+**Storage**: File-based repositories (sequences/commands persisted as JSON under the data dir); no schema migration needed (additive enum/const)
+**Testing**: xUnit (`tests/unit`, `tests/integration`, `tests/contract`); Jest + Testing Library (web-ui); `vite build` + `jest` is the real web-ui green gate
+**Target Platform**: Windows host driving Android emulators via ADB; degrades to stub on non-Windows
+**Project Type**: Web service + companion web-ui + MCP server (multi-surface single repo)
+**Performance Goals**: Action dispatch adds one ADB `input keyevent` (<1s typical); no hot-path impact
+**Constraints**: CamelCase method names only (no underscores); functions ≈<50 LOC; ≥80% line / ≥70% branch coverage on touched areas; `docs/architecture.md` + `specs/STATUS.md` updated for the new capability
+**Scale/Scope**: One new action type across ~7 backend files + ~3 web-ui files + MCP description text, with mirrored tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+- **I. Code Quality Discipline**: PASS — additive change mirroring an established action (`ensure-game-running`); no dead code; CamelCase; parameterless action needs no new config types. New public members get XML doc comments.
+- **II. Testing Standards**: PASS — unit tests for validation allow-lists, runner dispatch gate, sequence dispatcher (sends HOME key), command-step executor, and repository payload validation; web-ui component tests for the selector/panel. Deterministic and isolated (session input is faked/stubbed).
+- **III. UX Consistency**: PASS — action naming and behavior follow the existing `ensure-game-running` conventions (kebab-case action key, parameterless authoring panel, neutral outcome reporting).
+- **IV. Performance**: PASS — a single key event per invocation; no measurable regression; no hot path touched.
+- **V. Living Documentation**: PASS (planned) — `docs/architecture.md` capability/API surface updated with the new action; `specs/069-go-home-screen/spec.md` carries a `Status` line and `specs/STATUS.md` is updated; no earlier spec is superseded.
+
+No violations → Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/069-go-home-screen/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── go-to-home-screen-action.md
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/GameBot.Domain/Actions/
+├── ActionTypes.cs                 # + GoToHomeScreen = "go-to-home-screen"
+├── PrimitiveActionTypes.cs        # + GoToHomeScreen const + add to All (auto-covers 3 allow-lists)
+├── PrimitiveActionVariants.cs     # + PrimitiveGoToHomeScreenAction (parameterless)
+└── PrimitiveActionValidationService.cs  # (no new case required — parameterless)
+
+src/GameBot.Domain/Commands/
+├── CommandStep.cs                 # + CommandStepType.GoToHomeScreen
+└── FileSequenceRepository.cs      # + ActionTypes.GoToHomeScreen in supportedActionTypes set
+
+src/GameBot.Domain/Services/
+└── SequenceRunner.cs              # + GoToHomeScreen in IsDispatchedPrimitiveAction
+
+src/GameBot.Service/Services/
+├── SequenceExecution/SequenceExecutionService.cs  # + DispatchGoToHomeScreenAsync → key(HOME)
+└── CommandExecutor.cs             # + CommandStepType.GoToHomeScreen branch → key(HOME)
+
+src/GameBot.Service/
+├── Models/Commands.cs             # + CommandStepTypeDto.GoToHomeScreen
+└── Endpoints/CommandsEndpoints.cs # + DTO<->domain mapping + ValidateStep no-op case
+
+src/mcp-server/src/tools/
+└── commands.ts                    # description text: add GoToHomeScreen to the primitive list
+
+src/web-ui/src/components/commands/
+├── ActionTypeSelector.tsx         # + 'GoToHomeScreen' union member + <option>
+├── GoToHomeScreenPanel.tsx        # NEW parameterless panel (mirrors EnsureGameRunningPanel)
+└── CommandForm.tsx                # wire the new action type into add-step flow
+
+tests/unit/…                       # validation, runner gate, dispatcher, command executor, repo
+tests/integration/…                # sequence-with-go-home end-to-end (stub session)
+src/web-ui/src/components/commands/__tests__/…  # selector + panel + form tests
+```
+
+**Structure Decision**: Existing multi-surface layout is reused unchanged. The feature is purely
+additive — one new action type threaded through the same files that already carry
+`ensure-game-running`. No new projects, endpoints, or persistence formats are introduced.
+
+## Design Decisions
+
+1. **Device mechanism = HOME key via the session pipeline, not a new ADB handler.**
+   `SessionManager.SendInputsAsync` already maps a `key` action (`keyCode`/`key`) to
+   `adb shell input keyevent`, already retries per `AppConfig`, and already returns a stub success
+   on non-Windows/non-ADB sessions. Sending `keyCode = 3` (HOME) reuses all of that and satisfies
+   graceful degradation (FR-007) with zero new ADB code. `KeyNameMap["HOME"] = 3` already exists.
+
+2. **Parity model = `ensure-game-running`, not the `/api/sessions/start` endpoint.**
+   `connect-to-game` also drives a session-lifecycle endpoint because it *starts* a session with a
+   game/device payload. `go-to-home-screen` is parameterless and starts nothing, so the honest
+   "same as connect-to-game" reading is *first-class action parity across authoring/validation/
+   dispatch/tooling*, which `ensure-game-running` already exemplifies. No new session endpoint.
+
+3. **Allow-list coverage via `PrimitiveActionTypes.All`.** Three validators
+   (`SequenceStepValidationService`, `PrimitiveActionValidationService`,
+   `ActionPayloadValidationService`) derive their supported set from `PrimitiveActionTypes.All`, so
+   adding the const there covers them automatically. **`FileSequenceRepository.ValidateActionPayloads`
+   keeps its own hard-coded set** and MUST be updated separately, or persisting a sequence that uses
+   the action 500s.
+
+4. **Dual surface (sequence action + command step).** Mirrors `ensure-game-running` exactly so the
+   action is usable in both sequences (dispatched via `actionDispatcher`) and standalone commands
+   (executed via `CommandExecutor`), and appears in the web-ui `ActionTypeSelector`.
+
+## Complexity Tracking
+
+No constitution violations — no entries required.

--- a/specs/069-go-home-screen/quickstart.md
+++ b/specs/069-go-home-screen/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Go To Home Screen Action
+
+## What it does
+
+Adds a `go-to-home-screen` action that presses the Android HOME button so the device returns to its
+main/home screen, leaving the game running in the background. It is the leave-game counterpart to
+`connect-to-game`, wired like `ensure-game-running`.
+
+## Use it in a sequence
+
+Add a step whose action is:
+
+```json
+{ "stepId": "leave-game", "action": { "type": "go-to-home-screen", "parameters": {} } }
+```
+
+Run the sequence against a running session — the device returns to the home screen; re-entering the
+game resumes it (the process was not killed).
+
+## Use it in a command
+
+```json
+{ "name": "Go Home", "steps": [ { "type": "GoToHomeScreen", "order": 0 } ] }
+```
+
+## Use it in the web-ui
+
+Command editor → **Action type** → **Go to Home Screen** → **Add**. No fields to fill in.
+
+## Build & test (real green gate)
+
+Backend:
+
+```powershell
+& dotnet build "C:\src\GameBot\GameBot.sln"
+& dotnet test  "C:\src\GameBot\GameBot.sln"
+```
+
+Web-ui (lint/tsc have pre-existing failures — use build + jest as the gate):
+
+```powershell
+& npm --prefix "C:\src\GameBot\src\web-ui" run build
+& npm --prefix "C:\src\GameBot\src\web-ui" test -- --watchAll=false
+```
+
+## Key files (see plan.md for the full list)
+
+- `src/GameBot.Domain/Actions/ActionTypes.cs`, `PrimitiveActionTypes.cs`, `PrimitiveActionVariants.cs`
+- `src/GameBot.Domain/Commands/CommandStep.cs`, `FileSequenceRepository.cs`
+- `src/GameBot.Domain/Services/SequenceRunner.cs`
+- `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`, `CommandExecutor.cs`
+- `src/GameBot.Service/Models/Commands.cs`, `Endpoints/CommandsEndpoints.cs`
+- `src/web-ui/src/components/commands/ActionTypeSelector.tsx`, `GoToHomeScreenPanel.tsx`, `CommandForm.tsx`
+- `src/mcp-server/src/tools/commands.ts`
+
+## Gotchas
+
+- **Two allow-lists**: `PrimitiveActionTypes.All` covers three service validators automatically, but
+  `FileSequenceRepository.ValidateActionPayloads` has its own hard-coded set — update it too or
+  saving a sequence with the action returns HTTP 500.
+- **Type-first JSON**: in polymorphic step objects the `type` property must be first.
+- **HOME keycode 3** is already in `SessionManager.KeyNameMap`; no new ADB code is needed.

--- a/specs/069-go-home-screen/research.md
+++ b/specs/069-go-home-screen/research.md
@@ -1,0 +1,79 @@
+# Phase 0 Research: Go To Home Screen Action
+
+## Decision 1 — How to reach the device home screen
+
+**Decision**: Send an Android `KEYCODE_HOME` (keycode `3`) key event through the existing session
+input pipeline (`ISessionManager.SendInputsAsync` with a `key` action carrying `keyCode = 3`).
+
+**Rationale**:
+- `SessionManager.SendInputsAsync` already implements the `key` branch: it maps `keyCode` (or a
+  symbolic `key` name via `KeyNameMap`) to `adb shell input keyevent <code>`, with configurable
+  retries (`AppConfig.AdbRetries`/`AdbRetryDelayMs`).
+- `KeyNameMap` already contains `["HOME"] = 3`.
+- In non-Windows or non-ADB (stub) sessions the same method returns success without touching a
+  device, which is exactly the graceful-degradation behavior FR-007 requires.
+- HOME (not force-stop) matches the clarified behavior: the game keeps running in the background.
+
+**Alternatives considered**:
+- *New `IAdbGameOperations.PressHomeAsync` + dedicated handler (mirroring `ensure-game-running`'s
+  `EnsureGameRunningActionHandler`)*: rejected — adds ADB plumbing, a new interface method, DI
+  wiring, and platform guards that the session pipeline already provides. More code, same result.
+- *`am force-stop <package>` and/or a launcher intent*: rejected — that closes/kills the game,
+  contradicting the clarified "leave it running in the background" requirement.
+- *Reuse the generic `key` action with `keyCode: 3` directly (no new action type)*: rejected — the
+  user explicitly wants a first-class action "same as connect-to-game", discoverable in the
+  authoring surfaces, not a raw keycode authors must memorize.
+
+## Decision 2 — Surface parity model
+
+**Decision**: Model the new action on `ensure-game-running`, wiring it as **both** a sequence action
+type (`PrimitiveActionTypes.All` + `SequenceRunner.IsDispatchedPrimitiveAction` +
+`SequenceExecutionService.DispatchActionAsync`) and a command step type
+(`CommandStepType.GoToHomeScreen` + `CommandExecutor` + DTO mapping + web-ui selector/panel).
+
+**Rationale**: `ensure-game-running` is the only existing parameterless device action and is already
+wired through every surface an author touches. Cloning its wiring guarantees "available same as"
+parity with the least risk and the least novelty. `connect-to-game` additionally owns the
+`/api/sessions/start` endpoint only because it *creates a session from a payload*; a parameterless
+home-screen action has nothing to start, so that endpoint is out of scope (documented in the spec
+Assumptions).
+
+**Alternatives considered**:
+- *Sequence-action-only (no command step / no UI)*: rejected — would not appear in the web-ui
+  authoring surface where `ensure-game-running` lives, failing the parity requirement (FR-004).
+- *Add a `/api/sessions/home` or similar endpoint*: rejected — no session-lifecycle change is
+  involved; it would be an orphan surface with no analogue on the `ensure-game-running` side.
+
+## Decision 3 — Validation allow-lists
+
+**Decision**: Add the `go-to-home-screen` constant to `PrimitiveActionTypes.All`, and separately add
+`ActionTypes.GoToHomeScreen` to the hard-coded set in
+`FileSequenceRepository.ValidateActionPayloads`.
+
+**Rationale**: `SequenceStepValidationService`, `PrimitiveActionValidationService`, and
+`ActionPayloadValidationService` all derive their allow-list from `PrimitiveActionTypes.All`, so one
+edit covers them. `FileSequenceRepository` deliberately keeps its own literal set as a
+persistence-boundary guard; if it is not updated, saving a sequence that uses the action throws
+`InvalidOperationException` → HTTP 500. This is a known repository-vs-service allow-list split in
+this codebase and must be handled in both places.
+
+**Alternatives considered**:
+- *Point `FileSequenceRepository` at `PrimitiveActionTypes.All`*: attractive but out of scope for
+  this feature (would change unrelated behavior and risk widening what the repository accepts);
+  keep the change minimal and additive.
+
+## Decision 4 — Outcome semantics
+
+**Decision**: Dispatch returns `executed` on accepted input and `failed` (failing the step and the
+sequence) when no running session can be resolved or the device rejects the input — mirroring
+`DispatchPrimitiveInputAsync`. Success is idempotent (pressing HOME on the home screen still
+succeeds).
+
+**Rationale**: Consistent with the other device-driving primitives; a genuine "nothing reached the
+device" must not report a fake success (matches the existing runner contract for primitive
+actions). Idempotency is inherent to `KEYCODE_HOME`.
+
+## Open Questions
+
+None. Behavior (HOME-only, leave running) and workflow (full speckit feature) were clarified with
+the user before specification.

--- a/specs/069-go-home-screen/spec.md
+++ b/specs/069-go-home-screen/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `069-go-home-screen`  
 **Created**: 2026-07-17  
-**Status**: Draft  
+**Status**: Implemented  
 **Input**: User description: "the game should be switched off - android goes to main screen. this feature should be available same as connect to game." (Clarified: press the Android HOME button so the device returns to its main/home screen, leaving the game running in the background — the game is NOT force-stopped or closed.)
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/069-go-home-screen/spec.md
+++ b/specs/069-go-home-screen/spec.md
@@ -1,0 +1,82 @@
+# Feature Specification: Go To Home Screen Action
+
+**Feature Branch**: `069-go-home-screen`  
+**Created**: 2026-07-17  
+**Status**: Draft  
+**Input**: User description: "the game should be switched off - android goes to main screen. this feature should be available same as connect to game." (Clarified: press the Android HOME button so the device returns to its main/home screen, leaving the game running in the background — the game is NOT force-stopped or closed.)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Send the device to the home screen from a sequence (Priority: P1)
+
+An automation author building a sequence wants a step that leaves the game and returns the Android device to its home (main) screen, without closing the game, so a later step or a following run can resume the game exactly where it was. They add a "go to home screen" action to a sequence step, just as they would add a "connect to game" action, and when the sequence runs that step the device returns to the home screen.
+
+**Why this priority**: This is the core capability requested and the reason the feature exists. Without it there is nothing to deliver. It is the direct counterpart to the existing "connect to game" action and completes the pair (enter game / leave game).
+
+**Independent Test**: Author a one-step sequence containing only the "go to home screen" action, run it against a connected device on which the game is in the foreground, and confirm the device shows the home/main screen afterward while the game process is still alive (re-entering the game resumes it rather than restarting it).
+
+**Acceptance Scenarios**:
+
+1. **Given** a running session on a Windows host with a connected device and the game in the foreground, **When** a sequence step with the "go to home screen" action executes, **Then** the device leaves the game and displays the home/main screen, the game remains running in the background, and the step is recorded as succeeded.
+2. **Given** the device is already on the home screen, **When** the "go to home screen" action executes, **Then** the device remains on the home screen and the step is recorded as succeeded (the action is idempotent).
+3. **Given** a sequence containing a "go to home screen" step followed by other steps, **When** the sequence runs, **Then** the step completes and the sequence continues to the following steps.
+
+---
+
+### User Story 2 - Author the action through the same surfaces as connect-to-game (Priority: P2)
+
+An author using the web authoring UI and an operator using the automation tool interface (MCP) expect the new action to be selectable, configurable, and validated wherever the "connect to game" action already is, so there is nothing new to learn and no surface where the action is missing.
+
+**Why this priority**: The user explicitly required the feature to be available "same as connect to game." Parity across the authoring/validation/tooling surfaces is what makes the capability usable in practice, but it depends on the core execution behavior (US1) existing first.
+
+**Independent Test**: In each surface that offers the "connect to game" action (authoring UI action picker, action validation, the automation tool listing), confirm the "go to home screen" action is offered, accepted as a valid action, and round-trips through save/load without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the authoring UI action picker that lists selectable action types, **When** the author opens it, **Then** "go to home screen" appears alongside "connect to game" and can be added to a step.
+2. **Given** a sequence that contains a "go to home screen" step, **When** it is validated, **Then** validation passes (the action type is recognized and its payload is accepted).
+3. **Given** the automation tool surface used to drive sessions/actions, **When** the action set is enumerated, **Then** "go to home screen" is present and can be invoked the same way "connect to game" is.
+
+---
+
+### Edge Cases
+
+- **Non-Windows host / ADB unavailable**: When the host cannot drive the device (e.g., not on a Windows host, or device control is unavailable), the action degrades gracefully — it does not throw or crash the run — and reports a neutral "unsupported/not-applied" outcome, matching how the existing "ensure game running" action behaves in the same conditions.
+- **No connected device / device offline**: The action reports a non-succeeding outcome with a clear reason rather than crashing the sequence.
+- **Game not in the foreground (some other app or the launcher is showing)**: The action still returns the device to the home screen and reports success; it does not require the game to be in the foreground.
+- **Invalid or extra payload fields**: The action requires no target coordinates or image; unexpected payload fields do not cause validation to fail the whole action set in a way that differs from other parameterless actions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a new action type that, when executed, returns the Android device to its home/main screen by issuing the device HOME action.
+- **FR-002**: The action MUST leave the game application running in the background — it MUST NOT force-stop, close, or otherwise terminate the game.
+- **FR-003**: The action MUST require no target coordinates, reference image, or game/device identifiers in its own payload beyond the session context already available to the running sequence (i.e., it is a parameterless action from the author's perspective).
+- **FR-004**: The action MUST be selectable and configurable in every authoring/validation/tooling surface where the existing "connect to game" action is available, including the web authoring UI action picker, action validation, and the automation (MCP) tool surface.
+- **FR-005**: Action validation MUST recognize the new action type as valid and MUST NOT reject a sequence solely for containing it.
+- **FR-006**: When executed as a sequence step, the action MUST be dispatched through the same execution path used for the other device-driving primitive actions (tap / swipe / key / connect-to-game / ensure-game-running) and MUST record a step outcome (succeeded or failed with reason) in the execution log.
+- **FR-007**: On a host or environment that cannot drive the device (non-Windows host or device control unavailable), the action MUST degrade gracefully with a neutral, non-crashing outcome consistent with the existing "ensure game running" action's behavior in the same conditions.
+- **FR-008**: The action MUST be idempotent — executing it when the device is already on the home screen leaves the device on the home screen and reports success.
+- **FR-009**: A sequence step using this action MUST NOT abort the remaining steps when the action succeeds; a genuine failure to drive the device MUST fail the step consistently with the other device-driving primitive actions.
+
+### Key Entities
+
+- **Go-To-Home-Screen Action**: A named, parameterless action type representing "return the device to its home/main screen." It carries no author-supplied coordinates, image, or identifiers; its behavior is entirely defined by the action type. It is the leave-game counterpart to the enter-game "connect to game" action.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An author can add the "go to home screen" action to a sequence step using only the existing authoring surfaces, with no additional configuration fields required beyond selecting the action type.
+- **SC-002**: Running a sequence whose step is the "go to home screen" action returns the device to the home/main screen in 100% of runs on a connected, supported host, while the game process remains alive (re-entering resumes rather than restarts).
+- **SC-003**: The action is present and accepted wherever "connect to game" is offered — 100% parity across the authoring UI, validation, and automation tool surfaces.
+- **SC-004**: On an unsupported host or with device control unavailable, the action completes without crashing the sequence in 100% of runs and reports a clear, neutral outcome.
+- **SC-005**: Existing sequences and actions (including "connect to game" and "ensure game running") continue to behave exactly as before — zero regressions introduced by adding the new action.
+
+## Assumptions
+
+- "Switched off — Android goes to main screen" is interpreted (per user clarification) as pressing the device HOME button to reach the home/main screen, leaving the game running in the background. It does NOT mean force-stopping or closing the game.
+- "Available same as connect to game" means the action is exposed through the same set of surfaces the "connect to game" action already uses (authoring UI, validation, automation/MCP tool, sequence dispatch); it does not necessarily require a new dedicated session lifecycle endpoint beyond what those surfaces already provide.
+- The action operates within the device/session context that a running sequence already carries; the author does not supply device identifiers on the action itself.
+- Graceful-degradation expectations mirror the established behavior of the "ensure game running" action for the same unsupported conditions.

--- a/specs/069-go-home-screen/tasks.md
+++ b/specs/069-go-home-screen/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Go To Home Screen Action
+
+**Feature**: 069-go-home-screen | **Branch**: `069-go-home-screen`
+**Inputs**: [plan.md](plan.md), [spec.md](spec.md), [data-model.md](data-model.md), [research.md](research.md), [contracts/go-to-home-screen-action.md](contracts/go-to-home-screen-action.md)
+
+**Mechanism**: send Android `KEYCODE_HOME` (keycode 3) via the existing session input pipeline.
+**Parity model**: mirror `ensure-game-running` (parameterless; sequence action + command step + UI).
+
+## Phase 1: Setup
+
+No new dependencies, projects, or scaffolding. (Intentionally empty.)
+
+## Phase 2: Foundational (blocking prerequisites)
+
+These introduce the action-type identity every later phase depends on.
+
+- [ ] T001 Add `public const string GoToHomeScreen = "go-to-home-screen";` to `src/GameBot.Domain/Actions/ActionTypes.cs`
+- [ ] T002 Add `public const string GoToHomeScreen = "go-to-home-screen";` to `src/GameBot.Domain/Actions/PrimitiveActionTypes.cs` and include it in the `All` collection (this auto-covers `SequenceStepValidationService`, `PrimitiveActionValidationService`, and `ActionPayloadValidationService`)
+- [ ] T003 Add a parameterless `PrimitiveGoToHomeScreenAction : PrimitiveActionBase` (ctor passes `PrimitiveActionTypes.GoToHomeScreen`) to `src/GameBot.Domain/Actions/PrimitiveActionVariants.cs`
+
+**Checkpoint**: solution compiles; the new action type is a recognized primitive type in the three `PrimitiveActionTypes.All`-derived validators.
+
+## Phase 3: User Story 1 — Send the device to the home screen from a sequence (P1) 🎯 MVP
+
+**Goal**: A sequence step with the `go-to-home-screen` action returns the device to the home screen (game stays running) and records a succeeded step.
+
+**Independent test**: Author/run a one-step sequence containing only this action against a running (stub or ADB) session and confirm it succeeds and dispatches a HOME key event.
+
+- [ ] T004 [US1] Add `ActionTypes.GoToHomeScreen` to `IsDispatchedPrimitiveAction` in `src/GameBot.Domain/Services/SequenceRunner.cs` so the action is routed through `actionDispatcher` (not the command fallback)
+- [ ] T005 [US1] In `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`, route `ActionTypes.GoToHomeScreen` in `DispatchActionAsync` to a new `DispatchGoToHomeScreenAsync` that resolves the session (same single-running-session fallback as `DispatchPrimitiveInputAsync`), sends `new EmulatorInputAction("key", new Dictionary<string,object>{ ["keyCode"] = 3 })` via `_sessionManager.SendInputsAsync`, and returns `executed` on accept / `failed` otherwise (with an XML doc comment)
+- [ ] T006 [US1] Add `ActionTypes.GoToHomeScreen` to the hard-coded `supportedActionTypes` set in `ValidateActionPayloads` in `src/GameBot.Domain/Commands/FileSequenceRepository.cs` (required or persisting a sequence that uses the action returns HTTP 500)
+- [ ] T007 [P] [US1] Unit test: `IsDispatchedPrimitiveAction` returns true for a `go-to-home-screen` action — add to `tests/unit/Sequences/SequenceRunnerGameActionDispatchTests.cs` (or the primitive-dispatch test file)
+- [ ] T008 [P] [US1] Unit test: dispatching a `go-to-home-screen` sequence action sends a `key`/keyCode 3 input and yields an `executed` outcome; missing session yields `failed` — add a test class under `tests/unit/Sequences/` (mirror `SequenceRunnerActionDispatchTests` / an ensure-game-running dispatch test)
+- [ ] T009 [US1] Integration test: a sequence whose single step is `go-to-home-screen` runs to `Succeeded` on a stub session — add under `tests/integration/Sequences/`
+
+**Checkpoint**: US1 is independently shippable — the action works end-to-end inside sequences.
+
+## Phase 4: User Story 2 — Author the action through the same surfaces as connect-to-game (P2)
+
+**Goal**: The action is selectable, validated, and round-trips wherever `ensure-game-running` / `connect-to-game` are — command authoring UI, command API, validation, and MCP tooling.
+
+**Independent test**: In each surface (web-ui action picker, command create/update API, sequence validation, MCP tool description) confirm the action is offered/accepted and round-trips through save/load.
+
+- [ ] T010 [US2] Add `GoToHomeScreen` to the `CommandStepType` enum in `src/GameBot.Domain/Commands/CommandStep.cs`
+- [ ] T011 [US2] Add `GoToHomeScreen` to the `CommandStepTypeDto` enum in `src/GameBot.Service/Models/Commands.cs`
+- [ ] T012 [US2] In `src/GameBot.Service/Endpoints/CommandsEndpoints.cs`, map `GoToHomeScreen` both directions in `MapStepTypeFromDto`/`MapStepTypeToDto`, and return `null` (no error) for it in `ValidateStep` (parallels `EnsureGameRunning`)
+- [ ] T013 [US2] In `src/GameBot.Service/Services/CommandExecutor.cs` `ExecuteOneStepAsync`, add a `CommandStepType.GoToHomeScreen` branch that sends a `key`/keyCode 3 input via `_sessions.SendInputsAsync` and returns a `PrimitiveTapStepOutcome` with `StepType: "go-to-home-screen"` (mirror the `KeyInput` branch, fixed keycode)
+- [ ] T014 [P] [US2] Add `'GoToHomeScreen'` to the `PrimitiveActionType` union and a `<option value="GoToHomeScreen">Go to Home Screen</option>` in `src/web-ui/src/components/commands/ActionTypeSelector.tsx`
+- [ ] T015 [P] [US2] Create `src/web-ui/src/components/commands/GoToHomeScreenPanel.tsx` — a parameterless Add/Cancel panel mirroring `EnsureGameRunningPanel.tsx` (description: returns the device to the home screen, leaving the game running)
+- [ ] T016 [US2] Wire the new action type into `src/web-ui/src/components/commands/CommandForm.tsx` so selecting it adds a `GoToHomeScreen` step (mirror the `EnsureGameRunning` add-step path)
+- [ ] T017 [US2] Update the `create_command` (and, if it enumerates step types, `create_sequence`) tool description text in `src/mcp-server/src/tools/commands.ts` to list `GoToHomeScreen` among the primitive step types
+- [ ] T018 [P] [US2] Unit test: `PrimitiveActionValidationService.Validate` accepts a `go-to-home-screen` action with no errors — add to `tests/unit/Domain/PrimitiveActionValidationServiceTests.cs`
+- [ ] T019 [P] [US2] Unit test: `SequenceStepValidationService.Validate` accepts a step whose action type is `go-to-home-screen` — add to the sequence validation test suite under `tests/unit/Sequences/`
+- [ ] T020 [P] [US2] Unit test: `FileSequenceRepository` upsert accepts a sequence containing a `go-to-home-screen` step (no `unsupported action type` throw) — add under `tests/unit/`
+- [ ] T021 [P] [US2] Unit test: `CommandExecutor` executes a `GoToHomeScreen` command step by sending keyCode 3 — add under `tests/unit/Commands/` (mirror `CommandExecutorEnsureGameRunningTests`)
+- [ ] T022 [P] [US2] web-ui tests: `ActionTypeSelector` offers the option, `GoToHomeScreenPanel` renders + fires Add/Cancel, and `CommandForm` adds the step — add under `src/web-ui/src/components/commands/__tests__/`
+
+**Checkpoint**: US2 is complete — full authoring/validation/tooling parity.
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [ ] T023 Update `docs/architecture.md` (capability set + API surface) to document the `go-to-home-screen` action, and refresh its "Last reviewed" date (Constitution V)
+- [ ] T024 Ensure `specs/069-go-home-screen/spec.md` carries an accurate `**Status**:` line on completion and update `specs/STATUS.md` to include feature 069
+- [ ] T025 Run the green gate — backend `dotnet build` + `dotnet test`, and web-ui `npm run build` + `npm test -- --watchAll=false` (per [quickstart.md](quickstart.md)) — and fix any failures before marking the feature done
+
+## Dependencies & Execution Order
+
+- **Phase 2 (T001–T003)** blocks everything.
+- **US1 (Phase 3)** depends only on Phase 2 → this is the MVP; ship after T004–T009.
+- **US2 (Phase 4)** depends on Phase 2; independent of US1 (can proceed in parallel once foundations exist, though both touch the dispatch/executor areas).
+- **Polish (Phase 5)** runs last.
+
+### Parallel opportunities
+
+- Within US1: T007, T008 are `[P]` (distinct test files); T009 after T004–T006.
+- Within US2: T014, T015 (distinct new/edited UI files) and the test tasks T018–T022 are `[P]`; backend T010→T012 are sequential (same/adjacent files), T013 after T010/T011.
+
+## Implementation Strategy
+
+- **MVP = US1**: foundational constants + sequence dispatch + repository allow-list + tests. Delivers the core capability the request is about.
+- **Increment = US2**: command-step + web-ui + MCP + validation parity to satisfy "available same as connect-to-game."
+- **Finish**: living docs + STATUS + full green gate.

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -103,6 +103,8 @@ Status vocabulary:
 | 065 | Sequence Self-Rescheduling into the Originating Queue Run | Implemented |
 | 066 | Break Step Success/Failure Execution Statuses | Implemented |
 | 067 | If-Then-Else Conditions in Sequences | Implemented |
+| 068 | OCR-Parsed Dynamic Offset for Reschedule-Self | Implemented |
+| 069 | Go To Home Screen Action | Implemented |
 
 ## Numbering notes
 

--- a/src/GameBot.Domain/Actions/ActionTypes.cs
+++ b/src/GameBot.Domain/Actions/ActionTypes.cs
@@ -13,6 +13,13 @@ public static class ActionTypes {
   public const string EnsureGameRunning = "ensure-game-running";
 
   /// <summary>
+  /// Go-to-home-screen action (feature 069): presses the Android HOME button so the device returns
+  /// to its home/main screen, leaving the game running in the background. The leave-game counterpart
+  /// to <see cref="ConnectToGame"/>.
+  /// </summary>
+  public const string GoToHomeScreen = "go-to-home-screen";
+
+  /// <summary>
   /// Self-reschedule action (feature 065): schedules one additional firing of the current
   /// sequence into its originating queue run. No-op success when not started from a queue.
   /// </summary>

--- a/src/GameBot.Domain/Actions/PrimitiveActionBase.cs
+++ b/src/GameBot.Domain/Actions/PrimitiveActionBase.cs
@@ -11,6 +11,9 @@ public static class PrimitiveActionTypes {
   public const string WaitForImage = "WaitForImage";
   public const string EnsureGameRunning = "ensure-game-running";
 
+  /// <summary>Feature 069: presses the Android HOME button (leaves the game running).</summary>
+  public const string GoToHomeScreen = "go-to-home-screen";
+
   public static IReadOnlyCollection<string> All { get; } = new ReadOnlyCollection<string>(new[] {
     Tap,
     Swipe,
@@ -18,7 +21,8 @@ public static class PrimitiveActionTypes {
     Command,
     ConnectToGame,
     WaitForImage,
-    EnsureGameRunning
+    EnsureGameRunning,
+    GoToHomeScreen
   });
 }
 

--- a/src/GameBot.Domain/Actions/PrimitiveActionVariants.cs
+++ b/src/GameBot.Domain/Actions/PrimitiveActionVariants.cs
@@ -36,6 +36,14 @@ public sealed class PrimitiveEnsureGameRunningAction : PrimitiveActionBase {
   public PrimitiveEnsureGameRunningAction() : base(PrimitiveActionTypes.EnsureGameRunning) { }
 }
 
+/// <summary>
+/// Feature 069: parameterless action that presses the Android HOME button so the device returns to
+/// its home/main screen, leaving the game running in the background.
+/// </summary>
+public sealed class PrimitiveGoToHomeScreenAction : PrimitiveActionBase {
+  public PrimitiveGoToHomeScreenAction() : base(PrimitiveActionTypes.GoToHomeScreen) { }
+}
+
 public sealed class PrimitiveConnectToGameAction : PrimitiveActionBase {
   public string? GameId { get; set; }
   public string? AdbSerial { get; set; }

--- a/src/GameBot.Domain/Commands/CommandStep.cs
+++ b/src/GameBot.Domain/Commands/CommandStep.cs
@@ -6,7 +6,8 @@ public enum CommandStepType {
   WaitForImage,
   EnsureGameRunning,
   KeyInput,
-  Swipe
+  Swipe,
+  GoToHomeScreen
 }
 
 public sealed class PrimitiveTapConfig {

--- a/src/GameBot.Domain/Commands/FileSequenceRepository.cs
+++ b/src/GameBot.Domain/Commands/FileSequenceRepository.cs
@@ -108,6 +108,7 @@ namespace GameBot.Domain.Commands {
                 ActionTypes.Key,
                 ActionTypes.ConnectToGame,
                 ActionTypes.EnsureGameRunning,
+                ActionTypes.GoToHomeScreen,
                 ActionTypes.WaitForImage,
                 ActionTypes.RescheduleSelf
             };

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -672,7 +672,8 @@ namespace GameBot.Domain.Services {
           || string.Equals(action?.Type, ActionTypes.Swipe, StringComparison.OrdinalIgnoreCase)
           || string.Equals(action?.Type, ActionTypes.Key, StringComparison.OrdinalIgnoreCase)
           || string.Equals(action?.Type, ActionTypes.ConnectToGame, StringComparison.OrdinalIgnoreCase)
-          || string.Equals(action?.Type, ActionTypes.EnsureGameRunning, StringComparison.OrdinalIgnoreCase);
+          || string.Equals(action?.Type, ActionTypes.EnsureGameRunning, StringComparison.OrdinalIgnoreCase)
+          || string.Equals(action?.Type, ActionTypes.GoToHomeScreen, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsWaitForImageStep(SequenceStep step) {

--- a/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
@@ -26,6 +26,7 @@ internal static class CommandsEndpoints {
     CommandStepTypeDto.Command => CommandStepType.Command,
     CommandStepTypeDto.WaitForImage => CommandStepType.WaitForImage,
     CommandStepTypeDto.EnsureGameRunning => CommandStepType.EnsureGameRunning,
+    CommandStepTypeDto.GoToHomeScreen => CommandStepType.GoToHomeScreen,
     CommandStepTypeDto.KeyInput => CommandStepType.KeyInput,
     CommandStepTypeDto.Swipe => CommandStepType.Swipe,
     _ => CommandStepType.PrimitiveTap
@@ -35,6 +36,7 @@ internal static class CommandsEndpoints {
     CommandStepType.Command => CommandStepTypeDto.Command,
     CommandStepType.WaitForImage => CommandStepTypeDto.WaitForImage,
     CommandStepType.EnsureGameRunning => CommandStepTypeDto.EnsureGameRunning,
+    CommandStepType.GoToHomeScreen => CommandStepTypeDto.GoToHomeScreen,
     CommandStepType.KeyInput => CommandStepTypeDto.KeyInput,
     CommandStepType.Swipe => CommandStepTypeDto.Swipe,
     _ => CommandStepTypeDto.PrimitiveTap
@@ -119,6 +121,10 @@ internal static class CommandsEndpoints {
     }
 
     if (step.Type == CommandStepTypeDto.EnsureGameRunning) {
+      return null;
+    }
+
+    if (step.Type == CommandStepTypeDto.GoToHomeScreen) {
       return null;
     }
 

--- a/src/GameBot.Service/Models/Commands.cs
+++ b/src/GameBot.Service/Models/Commands.cs
@@ -43,7 +43,8 @@ internal enum CommandStepTypeDto {
   WaitForImage,
   EnsureGameRunning,
   KeyInput,
-  Swipe
+  Swipe,
+  GoToHomeScreen
 }
 
 internal sealed class KeyInputConfigDto {

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -220,6 +220,19 @@ internal sealed class CommandExecutor : ICommandExecutor {
         : (0, new PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running"));
     }
 
+    if (step.Type == CommandStepType.GoToHomeScreen) {
+      // Feature 069: press Android HOME (keycode 3) so the device returns to the home/main screen.
+      // The game is left running in the background (HOME does not force-stop it). Reuses the key
+      // input path, which stubs success on non-Windows/non-ADB sessions.
+      const int androidKeyCodeHome = 3;
+      var homeArgs = new Dictionary<string, object> { ["keyCode"] = androidKeyCodeHome };
+      var homeAction = new GameBot.Emulator.Session.InputAction("key", homeArgs, null, null);
+      var homeAccepted = await _sessions.SendInputsAsync(sessionId, new[] { homeAction }, ct).ConfigureAwait(false);
+      return homeAccepted > 0
+        ? (homeAccepted, new PrimitiveTapStepOutcome(step.Order, "executed", null, null, null, StepType: "go-to-home-screen"))
+        : (0, new PrimitiveTapStepOutcome(step.Order, "not_accepted", "go_to_home_screen_not_accepted", null, null, StepType: "go-to-home-screen"));
+    }
+
     if (step.Type == CommandStepType.KeyInput) {
       if (step.KeyInput is null) {
         return (0, new PrimitiveTapStepOutcome(step.Order, "skipped_invalid_config", "key_input_missing_config", null, null, StepType: "key"));

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -489,6 +489,10 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       return DispatchEnsureGameRunningAsync(sessionId, ct);
     }
 
+    if (string.Equals(action.Type, ActionTypes.GoToHomeScreen, StringComparison.OrdinalIgnoreCase)) {
+      return DispatchGoToHomeScreenAsync(sessionId, ct);
+    }
+
     return DispatchPrimitiveInputAsync(action, sessionId, ct);
   }
 
@@ -546,6 +550,41 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     return result.IsSuccess
       ? new ActionDispatchResult("executed", "game is running in the foreground (game_running)")
       : new ActionDispatchResult("failed", $"ensure-game-running failed: {result.ReasonCode}");
+  }
+
+  // Android KEYCODE_HOME. Pressing it returns the device to the home/main screen without stopping
+  // the foreground app, so the game keeps running in the background (feature 069).
+  private const int AndroidKeyCodeHome = 3;
+
+  /// <summary>
+  /// Handles a <c>go-to-home-screen</c> sequence step by sending the Android HOME key to the session
+  /// (feature 069). The game is left running in the background — HOME does not force-stop it. Reuses
+  /// the session input pipeline, which retries on Windows/ADB and returns a stub success on
+  /// non-Windows or non-ADB sessions (graceful degradation). Returns a <c>failed</c> outcome — which
+  /// fails the step and the sequence — when no running session can be resolved or the device rejects
+  /// the input.
+  /// </summary>
+  private async Task<ActionDispatchResult> DispatchGoToHomeScreenAsync(
+      string? sessionId,
+      CancellationToken ct) {
+    var resolvedSessionId = sessionId;
+    if (string.IsNullOrWhiteSpace(resolvedSessionId)) {
+      var runningSessions = _sessionManager.ListSessions()
+        .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
+        .ToList();
+      if (runningSessions.Count != 1) {
+        return new ActionDispatchResult(
+          "failed",
+          "no session available for 'go-to-home-screen' step; start a session or pass a sessionId");
+      }
+      resolvedSessionId = runningSessions[0].Id;
+    }
+
+    var input = new EmulatorInputAction("key", new Dictionary<string, object> { ["keyCode"] = AndroidKeyCodeHome });
+    var accepted = await _sessionManager.SendInputsAsync(resolvedSessionId!, new[] { input }, ct).ConfigureAwait(false);
+    return accepted > 0
+      ? new ActionDispatchResult("executed", "pressed HOME; device returned to the home screen (game left running)")
+      : new ActionDispatchResult("failed", $"'go-to-home-screen' input was not accepted by session '{resolvedSessionId}'");
   }
 
   /// <summary>

--- a/src/mcp-server/src/tools/commands.ts
+++ b/src/mcp-server/src/tools/commands.ts
@@ -7,7 +7,7 @@ import { jsonResult } from "../results.js";
 const commandBody = z
   .record(z.unknown())
   .describe(
-    "Full command JSON: ordered steps of primitive actions (PrimitiveTap, WaitForImage, KeyInput, Swipe, EnsureGameRunning, ...), optionally gated by triggers. In any polymorphic step object, put the \"type\" property FIRST - the service's JSON deserializer requires the discriminator before other fields. Fetch an existing command with get_command to copy the exact shape.",
+    "Full command JSON: ordered steps of primitive actions (PrimitiveTap, WaitForImage, KeyInput, Swipe, EnsureGameRunning, GoToHomeScreen, ...), optionally gated by triggers. GoToHomeScreen presses the Android HOME button so the device returns to the home screen, leaving the game running in the background. In any polymorphic step object, put the \"type\" property FIRST - the service's JSON deserializer requires the discriminator before other fields. Fetch an existing command with get_command to copy the exact shape.",
   );
 
 export function registerCommandTools(server: McpServer, client: GameBotClient): void {
@@ -87,7 +87,7 @@ export function registerCommandTools(server: McpServer, client: GameBotClient): 
   apiTool(
     server,
     "execute_step",
-    "Execute a single ad-hoc command step (PrimitiveTap, WaitForImage, KeyInput, Swipe, EnsureGameRunning) without saving it. 10 second execution timeout. Command-type steps are not allowed here.",
+    "Execute a single ad-hoc command step (PrimitiveTap, WaitForImage, KeyInput, Swipe, EnsureGameRunning, GoToHomeScreen) without saving it. 10 second execution timeout. Command-type steps are not allowed here.",
     {
       step: z
         .record(z.unknown())

--- a/src/web-ui/src/components/commands/ActionTypeSelector.tsx
+++ b/src/web-ui/src/components/commands/ActionTypeSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type PrimitiveActionType = 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
+export type PrimitiveActionType = 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe' | 'GoToHomeScreen';
 
 export type ActionTypeSelectorProps = {
   value: PrimitiveActionType | '';
@@ -22,6 +22,7 @@ export const ActionTypeSelector: React.FC<ActionTypeSelectorProps> = ({ value, o
         <option value="PrimitiveTap">Tap</option>
         <option value="WaitForImage">Wait for Image</option>
         <option value="EnsureGameRunning">Ensure Game Running</option>
+        <option value="GoToHomeScreen">Go to Home Screen</option>
         <option value="KeyInput">Key Input</option>
         <option value="Swipe">Swipe</option>
       </select>

--- a/src/web-ui/src/components/commands/CommandForm.tsx
+++ b/src/web-ui/src/components/commands/CommandForm.tsx
@@ -10,6 +10,7 @@ import { ActionTypeSelector, PrimitiveActionType } from './ActionTypeSelector';
 import { TapPanel } from './TapPanel';
 import { WaitForImagePanel } from './WaitForImagePanel';
 import { EnsureGameRunningPanel } from './EnsureGameRunningPanel';
+import { GoToHomeScreenPanel } from './GoToHomeScreenPanel';
 import { KeyInputPanel } from './KeyInputPanel';
 import { SwipePanel } from './SwipePanel';
 import { VisualStepPicker } from './VisualStepPicker/VisualStepPicker';
@@ -17,7 +18,7 @@ import './CommandForm.css';
 
 export type StepEntry = {
   id: string;
-  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'GoToHomeScreen' | 'KeyInput' | 'Swipe';
   targetId?: string;
   primitiveTap?: {
     detectionTarget: DetectionTargetForm;
@@ -89,6 +90,14 @@ const toStepItems = (steps: StepEntry[], commandOpts: SearchableOption[]): Reord
       };
     }
 
+    if (step.type === 'GoToHomeScreen') {
+      return {
+        id: step.id,
+        label: 'Go to home screen',
+        description: 'Presses HOME; leaves the game running in the background',
+      };
+    }
+
     if (step.type === 'KeyInput') {
       return {
         id: step.id,
@@ -115,7 +124,7 @@ const toStepItems = (steps: StepEntry[], commandOpts: SearchableOption[]): Reord
   });
 };
 
-const EDITABLE_TYPES = new Set<string>(['PrimitiveTap', 'WaitForImage', 'EnsureGameRunning', 'KeyInput', 'Swipe']);
+const EDITABLE_TYPES = new Set<string>(['PrimitiveTap', 'WaitForImage', 'EnsureGameRunning', 'GoToHomeScreen', 'KeyInput', 'Swipe']);
 
 export const CommandForm: React.FC<CommandFormProps> = ({
   value,
@@ -330,6 +339,14 @@ export const CommandForm: React.FC<CommandFormProps> = ({
         {pendingActionType === 'EnsureGameRunning' && (
           <EnsureGameRunningPanel
             onConfirm={() => handlePanelConfirm({ type: 'EnsureGameRunning' })}
+            onCancel={handlePanelCancel}
+            disabled={submitting}
+          />
+        )}
+
+        {pendingActionType === 'GoToHomeScreen' && (
+          <GoToHomeScreenPanel
+            onConfirm={() => handlePanelConfirm({ type: 'GoToHomeScreen' })}
             onCancel={handlePanelCancel}
             disabled={submitting}
           />

--- a/src/web-ui/src/components/commands/GoToHomeScreenPanel.tsx
+++ b/src/web-ui/src/components/commands/GoToHomeScreenPanel.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export type GoToHomeScreenPanelProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+  disabled?: boolean;
+};
+
+export const GoToHomeScreenPanel: React.FC<GoToHomeScreenPanelProps> = ({
+  onConfirm,
+  onCancel,
+  disabled,
+}) => {
+  return (
+    <div className="action-panel action-panel--go-to-home-screen">
+      <p className="action-panel__description">
+        Presses the Android HOME button to return to the home screen. The game is left running in the background.
+      </p>
+      <div className="action-panel__controls">
+        <button type="button" onClick={onConfirm} disabled={disabled}>
+          Add
+        </button>
+        <button type="button" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/web-ui/src/components/commands/__tests__/ActionTypeSelector.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/ActionTypeSelector.test.tsx
@@ -11,7 +11,7 @@ describe('ActionTypeSelector', () => {
     expect(options[0].value).toBe('');
   });
 
-  it('renders exactly Tap, Wait for Image, Ensure Game Running, Key Input, Swipe options', () => {
+  it('renders exactly Tap, Wait for Image, Ensure Game Running, Go to Home Screen, Key Input, Swipe options', () => {
     render(<ActionTypeSelector value="" onChange={() => {}} />);
     const select = screen.getByRole('combobox', { name: /action type/i });
     const options = Array.from((select as HTMLSelectElement).options).map((o) => ({
@@ -23,10 +23,11 @@ describe('ActionTypeSelector', () => {
       { value: 'PrimitiveTap', text: 'Tap' },
       { value: 'WaitForImage', text: 'Wait for Image' },
       { value: 'EnsureGameRunning', text: 'Ensure Game Running' },
+      { value: 'GoToHomeScreen', text: 'Go to Home Screen' },
       { value: 'KeyInput', text: 'Key Input' },
       { value: 'Swipe', text: 'Swipe' },
     ]);
-    expect(options).toHaveLength(6);
+    expect(options).toHaveLength(7);
   });
 
   it('onChange fires with PrimitiveTap when Tap is selected', () => {
@@ -54,6 +55,15 @@ describe('ActionTypeSelector', () => {
       target: { value: 'EnsureGameRunning' },
     });
     expect(onChange).toHaveBeenCalledWith('EnsureGameRunning');
+  });
+
+  it('onChange fires with GoToHomeScreen when Go to Home Screen is selected', () => {
+    const onChange = jest.fn();
+    render(<ActionTypeSelector value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /action type/i }), {
+      target: { value: 'GoToHomeScreen' },
+    });
+    expect(onChange).toHaveBeenCalledWith('GoToHomeScreen');
   });
 
   it('onChange fires with empty string when blank option is selected', () => {

--- a/src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/CommandForm.steps.test.tsx
@@ -340,6 +340,17 @@ describe('CommandForm — US4: Ensure Game Running panel add', () => {
     expect(getSelector()).toHaveValue('');
   });
 
+  it('adding GoToHomeScreen step calls onChange with correct type and resets selector', () => {
+    const onChange = jest.fn();
+    render(<CommandForm value={emptyForm} commandOptions={[]} onChange={onChange} />);
+    fireEvent.change(getSelector(), { target: { value: 'GoToHomeScreen' } });
+    expect(screen.getByText(/presses the android home button/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    const updated: CommandFormValue = onChange.mock.calls[0][0];
+    expect(updated.steps[0].type).toBe('GoToHomeScreen');
+    expect(getSelector()).toHaveValue('');
+  });
+
   it('clicking Edit on an EnsureGameRunning step opens the panel', () => {
     render(
       <CommandForm

--- a/src/web-ui/src/components/commands/__tests__/GoToHomeScreenPanel.test.tsx
+++ b/src/web-ui/src/components/commands/__tests__/GoToHomeScreenPanel.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GoToHomeScreenPanel } from '../GoToHomeScreenPanel';
+
+describe('GoToHomeScreenPanel', () => {
+  describe('field rendering', () => {
+    it('renders a description of the action', () => {
+      render(<GoToHomeScreenPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(
+        screen.getByText(/presses the android home button/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders Add and Cancel buttons', () => {
+      render(<GoToHomeScreenPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('does not render any input fields', () => {
+      render(<GoToHomeScreenPanel onConfirm={() => {}} onCancel={() => {}} />);
+      expect(screen.queryAllByRole('textbox')).toHaveLength(0);
+      expect(screen.queryAllByRole('spinbutton')).toHaveLength(0);
+      expect(screen.queryAllByRole('combobox')).toHaveLength(0);
+    });
+  });
+
+  describe('confirm', () => {
+    it('calls onConfirm when Add is clicked', () => {
+      const onConfirm = jest.fn();
+      render(<GoToHomeScreenPanel onConfirm={onConfirm} onCancel={() => {}} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cancel', () => {
+    it('calls onCancel and does not call onConfirm when Cancel is clicked', () => {
+      const onConfirm = jest.fn();
+      const onCancel = jest.fn();
+      render(<GoToHomeScreenPanel onConfirm={onConfirm} onCancel={onCancel} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables Add and Cancel buttons when disabled', () => {
+      render(<GoToHomeScreenPanel onConfirm={() => {}} onCancel={() => {}} disabled />);
+      expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+  });
+});

--- a/src/web-ui/src/pages/CommandsPage.tsx
+++ b/src/web-ui/src/pages/CommandsPage.tsx
@@ -114,6 +114,10 @@ const stepsToDto = (steps: StepEntry[]): CommandStepDto[] => steps.map((s, idx) 
     return { type: 'EnsureGameRunning', order: idx };
   }
 
+  if (s.type === 'GoToHomeScreen') {
+    return { type: 'GoToHomeScreen', order: idx };
+  }
+
   if (s.type === 'KeyInput') {
     return { type: 'KeyInput', order: idx, keyInput: { key: s.keyInput?.key ?? '' } };
   }

--- a/src/web-ui/src/services/commands.ts
+++ b/src/web-ui/src/services/commands.ts
@@ -18,7 +18,7 @@ export type CommandCreate = {
 export type CommandUpdate = CommandCreate;
 
 export type CommandStepDto = {
-  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'KeyInput' | 'Swipe';
+  type: 'Command' | 'PrimitiveTap' | 'WaitForImage' | 'EnsureGameRunning' | 'GoToHomeScreen' | 'KeyInput' | 'Swipe';
   targetId?: string;
   order: number;
   primitiveTap?: PrimitiveTapConfigDto;

--- a/tests/contract/Sequences/SequenceActionPayloadValidationContractTests.cs
+++ b/tests/contract/Sequences/SequenceActionPayloadValidationContractTests.cs
@@ -44,6 +44,33 @@ public sealed class SequenceActionPayloadValidationContractTests {
   }
 
   [Fact]
+  public async Task CreateSequenceAcceptsGoToHomeScreenActionType() {
+    using var app = CreateFactory();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var payload = new {
+      name = "go-to-home-screen-accepted",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "leave-game",
+          label = "Leave game",
+          primitiveAction = new {
+            type = "go-to-home-screen",
+            schemaVersion = "v1",
+            payload = new { }
+          }
+        }
+      }
+    };
+
+    var response = await client.PostAsJsonAsync("/api/sequences", payload).ConfigureAwait(false);
+    response.IsSuccessStatusCode.Should().BeTrue(
+      "go-to-home-screen is a supported primitive action type and must pass sequence validation and persistence");
+  }
+
+  [Fact]
   public async Task CreateSequenceRejectsMalformedActionPayloadReference() {
     using var app = CreateFactory();
     var client = app.CreateClient();

--- a/tests/unit/Commands/CommandExecutorGoToHomeScreenTests.cs
+++ b/tests/unit/Commands/CommandExecutorGoToHomeScreenTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using GameBot.Domain.Sessions;
+using GameBot.Domain.Triggers;
+using GameBot.Domain.Triggers.Evaluators;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+// Test-code analyzer relaxations permitted by the constitution:
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Commands;
+
+/// <summary>
+/// Feature 069: a GoToHomeScreen command step sends the Android HOME key (keycode 3) through the
+/// session input pipeline. The game is left running — the step never force-stops it.
+/// </summary>
+public sealed class CommandExecutorGoToHomeScreenTests {
+  private sealed class FakeCommandRepository : ICommandRepository {
+    private readonly Dictionary<string, Command> _cmds = new(StringComparer.Ordinal);
+    public void Seed(Command c) => _cmds[c.Id] = c;
+    public Task<Command> AddAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult(c); }
+    public Task<Command?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.TryGetValue(id, out var c) ? c : null);
+    public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Command>)_cmds.Values.ToList());
+    public Task<Command?> UpdateAsync(Command c, CancellationToken ct = default) { _cmds[c.Id] = c; return Task.FromResult<Command?>(c); }
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_cmds.Remove(id));
+  }
+
+  private sealed class RecordingSessionManager : ISessionManager {
+    private readonly EmulatorSession _session;
+    public RecordingSessionManager(EmulatorSession session) => _session = session;
+    public List<InputAction> Sent { get; } = new();
+    public int ActiveCount => 1;
+    public bool CanCreateSession => false;
+    public EmulatorSession? GetSession(string id) => id == _session.Id ? _session : null;
+    public EmulatorSession CreateSession(string g, string? s = null) => throw new NotSupportedException();
+    public IReadOnlyCollection<EmulatorSession> ListSessions() => new[] { _session };
+    public bool StopSession(string id) => false;
+    public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) {
+      var list = actions.ToList();
+      Sent.AddRange(list);
+      return Task.FromResult(list.Count);
+    }
+    public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+  }
+
+  private sealed class FakeTriggerRepository : ITriggerRepository {
+    public Task<Trigger?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<Trigger?>(null);
+    public Task<IReadOnlyList<Trigger>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Trigger>)Array.Empty<Trigger>());
+    public Task UpsertAsync(Trigger t, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+  }
+
+  private sealed class FakeSessionContextCache : ISessionContextCache {
+    public void SetSessionId(string g, string a, string s) { }
+    public string? GetSessionId(string g, string a) => null;
+    public void ClearSession(string g, string a) { }
+  }
+
+  private static EmulatorSession RunningSession(string id = "session1") =>
+    new() { Id = id, GameId = "game-1", Status = SessionStatus.Running, DeviceSerial = "emulator-5554" };
+
+  private static Command GoHomeCommand(string id = "cmd1") => new() {
+    Id = id,
+    Name = "GoHome",
+    TriggerId = null,
+    Steps = new Collection<CommandStep> {
+      new() { Type = CommandStepType.GoToHomeScreen, TargetId = string.Empty, Order = 1 }
+    }
+  };
+
+  private static CommandExecutor BuildExecutor(FakeCommandRepository cmds, ISessionManager sessions) =>
+    new(cmds, sessions, new FakeTriggerRepository(),
+        new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+        NullLogger<CommandExecutor>.Instance,
+        new FakeSessionContextCache());
+
+  [Fact]
+  public async Task GoToHomeScreenStepSendsHomeKeyAndReportsExecuted() {
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(GoHomeCommand());
+    var sessions = new RecordingSessionManager(RunningSession());
+    var executor = BuildExecutor(cmds, sessions);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(1);
+    var outcome = result.StepOutcomes.Should().ContainSingle().Which;
+    outcome.Status.Should().Be("executed");
+    outcome.StepType.Should().Be("go-to-home-screen");
+
+    var sent = sessions.Sent.Should().ContainSingle().Which;
+    sent.Type.Should().Be("key");
+    sent.Args.Should().ContainKey("keyCode");
+    Convert.ToInt32(sent.Args["keyCode"], CultureInfo.InvariantCulture).Should().Be(3);
+  }
+}

--- a/tests/unit/Domain/PrimitiveActionValidationServiceTests.cs
+++ b/tests/unit/Domain/PrimitiveActionValidationServiceTests.cs
@@ -30,6 +30,15 @@ public sealed class PrimitiveActionValidationServiceTests {
   }
 
   [Fact]
+  public void ValidateReturnsNoErrorsForGoToHomeScreenPrimitive() {
+    var primitiveAction = new PrimitiveGoToHomeScreenAction();
+
+    var errors = PrimitiveActionValidationService.Validate(primitiveAction);
+
+    errors.Should().BeEmpty();
+  }
+
+  [Fact]
   public void ValidateRejectsMissingRequiredFields() {
     var primitiveAction = new PrimitiveCommandAction();
 
@@ -47,7 +56,8 @@ public sealed class PrimitiveActionValidationServiceTests {
       PrimitiveActionTypes.Command,
       PrimitiveActionTypes.ConnectToGame,
       PrimitiveActionTypes.WaitForImage,
-      PrimitiveActionTypes.EnsureGameRunning
+      PrimitiveActionTypes.EnsureGameRunning,
+      PrimitiveActionTypes.GoToHomeScreen
     });
   }
 }

--- a/tests/unit/Sequences/SequenceRunnerGameActionDispatchTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerGameActionDispatchTests.cs
@@ -103,6 +103,51 @@ public sealed class SequenceRunnerGameActionDispatchTests {
   }
 
   [Fact]
+  public async Task GoToHomeScreenStepIsDispatchedAndRecordedWithDispatchOutcome() {
+    var executedCommands = new List<string>();
+    var dispatched = new List<SequenceActionPayload>();
+    var sequence = Sequence(
+      ActionStep(0, "home-step", ActionTypes.GoToHomeScreen),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "game-action-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (action, _) => {
+        dispatched.Add(action);
+        return Task.FromResult(new ActionDispatchResult("executed", "pressed HOME; device returned to the home screen (game left running)"));
+      },
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Succeeded");
+    dispatched.Should().ContainSingle();
+    dispatched[0].Type.Should().Be(ActionTypes.GoToHomeScreen);
+    result.Steps.Should().Contain(s => s.CommandId == "home-step" && s.ActionOutcome == "executed");
+    // The action step performed no command I/O; the following command step still ran.
+    executedCommands.Should().Equal("cmd-after");
+  }
+
+  [Fact]
+  public async Task FailedGoToHomeScreenDispatchFailsTheStepAndStopsTheSequence() {
+    var executedCommands = new List<string>();
+    var sequence = Sequence(
+      ActionStep(0, "home-step", ActionTypes.GoToHomeScreen),
+      new SequenceStep { Order = 1, StepId = "after", CommandId = "cmd-after", StepType = SequenceStepType.Command });
+    var runner = new SequenceRunner(new StubRepo(sequence));
+
+    var result = await runner.ExecuteAsync(
+      "game-action-seq",
+      commandId => { executedCommands.Add(commandId); return Task.CompletedTask; },
+      actionDispatcher: (_, _) => Task.FromResult(new ActionDispatchResult("failed", "no session available for 'go-to-home-screen' step; start a session or pass a sessionId")),
+      ct: CancellationToken.None);
+
+    result.Status.Should().Be("Failed");
+    result.Steps.Should().Contain(s => s.CommandId == "home-step" && s.Status == "Failed" && s.ActionOutcome == "failed");
+    executedCommands.Should().BeEmpty();
+  }
+
+  [Fact]
   public async Task FailedEnsureGameRunningDispatchFailsTheStepAndStopsTheSequence() {
     var executedCommands = new List<string>();
     var sequence = Sequence(


### PR DESCRIPTION
## Summary

Adds a new parameterless action, **`go-to-home-screen`**, that presses the Android HOME button (`KEYCODE_HOME` = 3) so the device returns to its home/main screen, **leaving the game running in the background** (it is not force-stopped). It is the leave-game counterpart to `connect-to-game`.

Behavior and workflow were clarified up front with the requester: **HOME-only** (game keeps running), built as a **full spec-kit feature**.

## Design

The action mirrors `ensure-game-running` — the closest existing parameterless device action — and is wired as **both a sequence action and a command step**. The device operation reuses the existing session input pipeline (`key` input with `keyCode` 3), which already retries on Windows/ADB and returns a stub success on non-Windows / non-ADB sessions, giving the required graceful degradation (FR-007) with no new ADB plumbing. `KeyNameMap["HOME"] = 3` already existed.

"Available same as connect-to-game" is honored as parity across the authoring / validation / dispatch / tooling surfaces (the `ensure-game-running` model), **not** a new `/api/sessions/start`-style endpoint — this action is parameterless and starts no session (see spec Assumptions).

## Changes

- **Domain**: `ActionTypes` / `PrimitiveActionTypes` (+ `All`); new `PrimitiveGoToHomeScreenAction`; `CommandStepType.GoToHomeScreen`; `SequenceRunner.IsDispatchedPrimitiveAction`; `FileSequenceRepository` payload allow-list (separate hard-coded set — omitting it would 500 on save)
- **Service**: `SequenceExecutionService.DispatchGoToHomeScreenAsync` → HOME key; `CommandExecutor` command-step branch; `CommandStepTypeDto` + `CommandsEndpoints` DTO⇄domain mapping + `ValidateStep`
- **web-ui**: `ActionTypeSelector`, new `GoToHomeScreenPanel`, `CommandForm`, `CommandsPage` step mapping + service DTO type
- **MCP**: `create_command` / `execute_step` tool descriptions
- **Docs**: `docs/architecture.md` (capability + refreshed review date), `specs/STATUS.md`, spec `Status: Implemented`

## Spec-kit artifacts

`specs/069-go-home-screen/`: spec, plan, research, data-model, contract, quickstart, tasks, requirements checklist.

## Testing

All green locally:

- Backend build: 0 warnings / 0 errors
- Backend tests: **92 contract + 612 unit + 287 integration**, all passing (incl. new runner-dispatch, command-executor HOME-key, validation, and a contract test asserting the API accepts a `go-to-home-screen` sequence)
- web-ui: **94 suites / 551 tests** passing (incl. selector, new panel, and CommandForm add-flow)
- MCP server: `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)