### PR TITLE
Add live queue monitor view (072)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/071-connect-ensure-emulator"
+  "feature_directory": "specs/072-queue-monitor"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/071-connect-ensure-emulator/plan.md
+at specs/072-queue-monitor/plan.md
 <!-- SPECKIT END -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ For the *history* of how the system got here — one folder per feature, point-i
 history; this file is the current-state source of truth. When the two disagree, this file wins and
 the relevant spec should be marked superseded.
 
-_Last reviewed: 2026-07-17._
+_Last reviewed: 2026-07-23._
 
 ## What GameBot is
 
@@ -93,6 +93,15 @@ not survive a service restart; queue *configuration* and templates are persisted
   only, never persisted) and a **success no-op** when the sequence was not started from a queue. The
   run's active-run state lives in a singleton `IQueueRunRegistry`; an `ISelfRescheduleCoordinator`
   injects the ephemeral firing, which the queue run loop drains at the matching boundary.
+- **Queue monitor** — a read-only "live plan" view of a *running* queue. `GET /api/queues/{id}/monitor`
+  returns a pure projection (`IQueueMonitorService`) that folds the active `QueueRunHandle` (the
+  sequence-level "now" indicator plus pending live schedules and self-reschedule firings) and the
+  linked template with the current local clock into the sequence running **now** and the ordered
+  **up-next** list — each with a schedule reason and a best-effort expected time (exact for
+  live/self-reschedule/relative; next-eligible for time-of-day timers). Nothing is persisted; the
+  snapshot is computed per request. When the queue is not running the endpoint returns
+  `running:false` with the best-effort last outcome from the execution log. The web UI opens this
+  monitor (polling ~2.5s) in place of the entry editor while a queue is Running (feature 072).
 - **Trigger** — an evaluation construct (image-visible / text-match / time / delay / schedule),
   used internally to decide whether a step executes. Still present in the domain and on the API,
   but **no longer authored as a standalone object in the UI**.
@@ -110,8 +119,9 @@ not survive a service restart; queue *configuration* and templates are persisted
 - **Execution**: per-emulator queues with start/stop, cycle execution, scheduling areas
   (start / once-per-run / after-every-step / scheduled), live relative scheduling against a running
   queue, sequences that can **self-reschedule** into their originating queue run (ephemeral, any
-  schedule option, IF-gated), a background screen-capture service reporting FPS, and "ensure game
-  running" handling.
+  schedule option, IF-gated), a **live monitor** that shows a running queue's now/up-next plan
+  (read-only, auto-refreshing) in place of the editor, a background screen-capture service reporting
+  FPS, and "ensure game running" handling.
 - **Execution Logs** (separate tab): filterable/sortable grid, expandable hierarchy reflecting
   what actually executed, deep links into authoring, snapshots and step outcomes; non-technical
   presentation (no raw JSON).

--- a/specs/072-queue-monitor/checklists/requirements.md
+++ b/specs/072-queue-monitor/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Live Queue Monitor View
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- The "no controls (yet)" boundary and the running-vs-stopped view split are captured
+  explicitly (FR-001–FR-003, FR-012) and in Assumptions; both were direct requests.
+- Future-time precision for lazily-evaluated timers is intentionally scoped as best-effort
+  (Assumptions + FR-013) rather than a guaranteed timeline; flag for `/speckit-plan` if a
+  stricter guarantee is wanted.

--- a/specs/072-queue-monitor/contracts/queue-monitor.md
+++ b/specs/072-queue-monitor/contracts/queue-monitor.md
@@ -1,0 +1,110 @@
+# Contract: Queue Monitor Endpoint
+
+## `GET /api/queues/{id}/monitor`
+
+Returns a read-only snapshot of what a queue's current run is doing now and will do next. Safe to poll
+(the web-ui monitor calls it every ~2.5s while open). No side effects.
+
+### Path parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| `id` | string | Queue id. |
+
+### Responses
+
+- **200 OK** — `QueueMonitorResponse` (below), for both running and not-running queues.
+- **404 Not Found** — `{ "error": { "code": "not_found", "message": "Queue not found" } }` when the
+  queue id does not exist.
+
+The endpoint intentionally returns **200 with `running:false`** (not 404/409) when the queue exists but
+is not running, so the client can render the "not running / run ended" state and the last outcome.
+
+### `QueueMonitorResponse`
+
+```jsonc
+{
+  "queueId": "q-123",
+  "name": "PNS Daily 5558",
+  "running": true,
+  "cycleExecution": false,
+  "runStartedAt": "2026-07-23T09:15:02.51+02:00",   // null when not running
+  "current": {                                        // null when idle or not running
+    "sequenceId": "seq-help-all",
+    "sequenceName": "Alliance Help All",
+    "stale": false,
+    "scheduleKind": "OncePerRun",
+    "reason": "Once per run",
+    "expectedAt": null,
+    "relativeLabel": "now",
+    "repeats": false,
+    "order": 0
+  },
+  "upcoming": [
+    {
+      "sequenceId": "seq-gift",
+      "sequenceName": "Collect Gifts",
+      "stale": false,
+      "scheduleKind": "OncePerRun",
+      "reason": "Once per run",
+      "expectedAt": null,
+      "relativeLabel": "up next",
+      "repeats": false,
+      "order": 1
+    },
+    {
+      "sequenceId": "seq-chest",
+      "sequenceName": "Daily Chest",
+      "stale": false,
+      "scheduleKind": "TimerTimeOfDay",
+      "reason": "At 03:30",
+      "expectedAt": "2026-07-24T03:30:00+02:00",
+      "relativeLabel": null,
+      "repeats": false,
+      "order": 2
+    },
+    {
+      "sequenceId": "seq-adhoc",
+      "sequenceName": "One-off Scan",
+      "stale": false,
+      "scheduleKind": "LiveSchedule",
+      "reason": "Scheduled live",
+      "expectedAt": "2026-07-23T09:20:00+02:00",
+      "relativeLabel": null,
+      "repeats": false,
+      "order": 3
+    }
+  ],
+  "nothingScheduled": false,
+  "lastOutcome": null                                 // { "status": "...", "summary": "..." } when not running
+}
+```
+
+### Field semantics
+
+| Field | Meaning |
+|-------|---------|
+| `running` | Whether a run is currently registered for the queue. |
+| `cycleExecution` | Queue repeats its OncePerRun steps each cycle. |
+| `runStartedAt` | Local-clock instant the run loop started (anchor for relative timers). |
+| `current` | The sequence executing right now (sequence-level; per-step detail stays in Execution Logs). `relativeLabel:"now"`. |
+| `upcoming[]` | Ordered next items: OncePerRun spine (template order) → EveryStep (once, "After Every Step") → timed/live/self-reschedule firings sorted by `expectedAt`. Excludes `current`. |
+| `scheduleKind` | One of `AtQueueStart`, `OncePerRun`, `EveryStep`, `TimerTimeOfDay`, `TimerRelative`, `LiveSchedule`, `SelfReschedule` (string enum). |
+| `reason` | Human-readable schedule reason for display. |
+| `expectedAt` | Absolute expected time when known; `null` for spine steps with no wall-clock time. Best-effort for far-future timers (next-eligible). |
+| `relativeLabel` | Hint when there is no absolute time: `now` / `next` / `up next` / `waiting`. |
+| `repeats` | Item recurs every cycle (cycling queues). |
+| `nothingScheduled` | Running but nothing to execute (no template/entries, no pending firings). |
+| `lastOutcome` | Best-effort last finalized run (`status`, `summary`) when `running:false`; `null` otherwise. |
+
+### Time zone
+
+All instants are ISO-8601 **with offset**, using the service local clock (consistent with the queue
+engine's `GetLocalNow()`), so the client renders one unambiguous local time.
+
+### Notes
+
+- Read-only. No start/stop/schedule controls are exposed by this endpoint (those remain the existing
+  `POST {id}/start`, `POST {id}/stop`, `POST {id}/live-schedule`).
+- The projection reflects the same schedule semantics the run executes; ordering and reasons are exact,
+  far-future timer instants are approximate (next-eligible).

--- a/specs/072-queue-monitor/data-model.md
+++ b/specs/072-queue-monitor/data-model.md
@@ -1,0 +1,89 @@
+# Phase 1 Data Model: Live Queue Monitor View
+
+No persisted entities are added. This feature introduces **in-memory / wire-only** shapes: two fields on
+the existing run handle, and the projection/DTO types returned by the monitor endpoint. Times are
+local-clock `DateTimeOffset` (service-local offset) on the wire (ISO-8601 with offset).
+
+## 1. `QueueRunHandle` additions (in-memory, not persisted)
+
+| Member | Type | Purpose |
+|--------|------|---------|
+| `CurrentSequenceId` | `volatile string?` | Sequence id currently executing; `null` between firings. Set at the top of `RunOneSequenceAsync`, cleared in its `finally`. Drives the sequence-level "now" indicator. |
+| `CurrentSequenceStartedAt` | `DateTimeOffset?` (guarded) | When the current firing started (local clock); for "running for Ns". Set/cleared alongside `CurrentSequenceId`. |
+| `SnapshotPendingTimerFirings()` | `IReadOnlyList<SelfRescheduleEntry>` | Read accessor returning a copy (under the existing `_timerLock`) of pending self-reschedule Timer firings, each with `SequenceId` + `FireAt`. |
+
+Existing already-usable members: `QueueId`, `CycleExecution`, `RunStartedAt`, `RootExecutionId`,
+`PendingLiveSchedules` (`sequenceId → fireAt`), `EveryStepInjections`, `PendingOncePerRun`,
+`PendingNextCycleStart`.
+
+## 2. `QueueMonitorSnapshot` (internal projection result)
+
+Produced by `IQueueMonitorService.BuildAsync(queueId, ct)`. Pure function of
+(linked `QueueTemplate`, `QueueRunHandle` snapshot, `now = TimeProvider.GetLocalNow()`,
+best-effort last-outcome).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `QueueId` | `string` | |
+| `Name` | `string` | Queue name. |
+| `Running` | `bool` | From `IQueueRunRegistry.IsRunning`. When `false`, `Current`/`Upcoming` are empty. |
+| `CycleExecution` | `bool` | Drives the "repeats" marker on OncePerRun items. |
+| `RunStartedAt` | `DateTimeOffset?` | Handle anchor; `null` when not running. |
+| `Current` | `QueueMonitorItem?` | The now-executing sequence, or `null` when idle/not running. |
+| `Upcoming` | `IReadOnlyList<QueueMonitorItem>` | Ordered list (see ordering rules below). |
+| `NothingScheduled` | `bool` | `true` when running but no template/entries and no pending firings. |
+| `LastOutcome` | `RunOutcome?` | Best-effort last finalized run (`Status`, `Summary`); `null` if none/running. |
+
+### `QueueMonitorItem`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `SequenceId` | `string` | |
+| `SequenceName` | `string?` | Resolved from the sequence repository; `null`/`Stale` if unresolved. |
+| `ScheduleKind` | enum (`AtQueueStart`/`OncePerRun`/`EveryStep`/`TimerTimeOfDay`/`TimerRelative`/`LiveSchedule`/`SelfReschedule`) | Drives the human-readable reason label. |
+| `Reason` | `string` | Operator-facing label, e.g. "Once per run", "After Every Step", "At 08:30", "+00:10:00 after start", "Scheduled live", "Rescheduled by a sequence". |
+| `ExpectedAt` | `DateTimeOffset?` | Absolute expected time when known (live/self-reschedule exact; time-of-day next-eligible; relative = anchor+offset). `null` for spine steps with no wall-clock time. |
+| `RelativeLabel` | `string?` | Human hint when there is no absolute time, e.g. "next", "up next", "waiting". |
+| `Repeats` | `bool` | `true` for OncePerRun/EveryStep on a cycling queue. |
+| `Order` | `int` | Stable position within `Upcoming`. |
+
+### `RunOutcome`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Status` | `string` | e.g. "success" / "failure" (from the finalized log entry). |
+| `Summary` | `string` | The queue-run summary text already produced by `QueueExecutionService.BuildSummary`. |
+
+## 3. Ordering rules for `Upcoming`
+
+1. **OncePerRun spine** in template order (the "playlist" backbone). `ExpectedAt = null`,
+   `RelativeLabel = "next"` for the first, `"up next"` thereafter; `Repeats = CycleExecution`.
+2. **EveryStep** entries appended once each, labeled "After Every Step" (not interleaved per step);
+   `Repeats = CycleExecution`.
+3. **Timed firings** — the union of template time-of-day timers (next-eligible), pending relative
+   timers (`RunStartedAt + offset`, only if not yet elapsed or shown as "due"), live schedules
+   (exact `fireAt`), and self-reschedule Timer firings (exact `FireAt`) — sorted ascending by
+   `ExpectedAt`.
+4. **AtQueueStart** items are normally already past once a run is underway; they are omitted from
+   `Upcoming` after the start pre-pass (the projection does not resurrect them).
+
+`Current` is excluded from `Upcoming`.
+
+## 4. Wire DTOs (`Contracts/Queues`)
+
+- **`QueueMonitorResponse`** — camelCase serialization of `QueueMonitorSnapshot`:
+  `queueId, name, running, cycleExecution, runStartedAt, current, upcoming[], nothingScheduled,
+  lastOutcome`.
+- **`QueueMonitorItemResponse`** — camelCase of `QueueMonitorItem`:
+  `sequenceId, sequenceName, stale, scheduleKind, reason, expectedAt, relativeLabel, repeats, order`.
+- `scheduleKind` serializes as a string (JsonStringEnumConverter), consistent with `ScheduleType`.
+
+## 5. Validation / edge behavior
+
+- **Not running** → `running:false`, empty `current`/`upcoming`, `lastOutcome` best-effort. (Endpoint
+  returns 200, not 404, so the UI can render the "ended/not running" state.)
+- **Running, no template/entries, no pending firings** → `nothingScheduled:true`, empty lists.
+- **Stale sequence reference** (name unresolved) → item still listed with `sequenceName:null`,
+  `stale:true`, consistent with existing `ProjectEntry` behavior.
+- **Timer already fired today** → shown as next-eligible (tomorrow) rather than imminent, per best-effort
+  projection (satisfies the edge case without exposing run-loop fired-state).

--- a/specs/072-queue-monitor/plan.md
+++ b/specs/072-queue-monitor/plan.md
@@ -1,0 +1,190 @@
+# Implementation Plan: Live Queue Monitor View
+
+**Branch**: `072-queue-monitor` | **Date**: 2026-07-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/072-queue-monitor/spec.md`
+
+## Summary
+
+When a queue is **running**, opening it in the web UI shows a read-only **monitor** ("playlist")
+instead of the entry editor: the sequence running **now**, the ordered **up-next** list, and — for
+each item — why it is scheduled and when it is expected to run. The view auto-refreshes on a short
+fixed interval (~2–3s). When a queue is **stopped**, opening it shows the existing editor unchanged.
+
+The running queue already holds all the state needed (`QueueRunHandle`: partitioned entries via its
+linked template, `PendingLiveSchedules`, self-reschedule timer firings, cycle flag, run-start anchor)
+— but none of it is exposed. This feature adds (1) minimal **current-sequence tracking** to the run
+handle, (2) a pure **projection** that folds the run handle + linked template + current wall-clock
+into an ordered monitor snapshot (now + upcoming, with best-effort expected times and repeat markers),
+(3) a read-only endpoint `GET /api/queues/{id}/monitor`, and (4) a **QueueMonitor** web-UI panel that
+QueuesPage renders in place of the editor for running queues and polls every ~2.5s. Run controls
+(start/stop/schedule) stay where they are today (the queues overview) and are out of scope for the
+monitor panel.
+
+## Technical Context
+
+**Language/Version**: C# / .NET (net9.0) backend; TypeScript + React (web-ui)
+**Primary Dependencies**: ASP.NET Minimal APIs; System.Text.Json; React 18 + Vite; xUnit; Jest
+**Storage**: None new. The monitor reads the in-memory `QueueRunHandle` (via `IQueueRunRegistry`) plus
+the already-persisted linked `QueueTemplate` (file-based). Nothing about the run is persisted by this
+feature; the snapshot is computed on demand and discarded per request.
+**Testing**: xUnit (`tests/unit`, `tests/integration`); web-ui Jest (component + page). Real green gate
+is `vite build` + `jest` for web-ui (lint/tsc have pre-existing failures).
+**Target Platform**: Windows host running the GameBot service (port 8080) + the web-ui SPA
+**Project Type**: Web service (backend) + React SPA (web-ui) — both touched
+**Performance Goals**: One monitor poll every ~2.5s per open panel; each request builds an in-memory
+projection (no new I/O beyond the one linked-template read that `GET {id}` already performs). Snapshot
+build is O(entries + pending firings) with no per-request allocation on the run's hot path.
+**Constraints**: CamelCase method names; functions ≈<50 LOC; keep `Program.cs`/endpoint maps thin;
+≥80% line / ≥70% branch coverage on touched areas; `docs/architecture.md` + `specs/STATUS.md` updated.
+The run loop change is limited to setting/clearing two current-sequence fields — no change to scheduling
+behavior (zero regression to the queue engine).
+**Scale/Scope**: ~4–5 backend files (handle, projection service + interface, DTOs, endpoint, DI) + tests;
+~3 web-ui files (service types, QueueMonitor component + css, QueuesPage routing) + tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), progression is blocked
+until fixed or a documented waiver exists.
+
+- **I. Code Quality Discipline**: PASS — additive, read-only projection over existing state; new members
+  documented; functions kept small (partition → per-kind mappers → merge/sort); CamelCase throughout; no
+  dead code. The only mutation to existing code is two field writes in `RunOneSequenceAsync`.
+- **II. Testing Standards**: PASS — the projection is a **pure function** of (template, run-handle
+  snapshot, `now`) and is unit-tested deterministically with a fake `TimeProvider` and hand-built handle
+  across every schedule kind (AtQueueStart/OncePerRun/EveryStep/Timer-time-of-day/Timer-relative/live/
+  self-reschedule), cycling vs non-cycling, current-sequence highlight, nothing-scheduled, and
+  not-running→last-outcome. Endpoint tested for running (snapshot) vs stopped (running:false + outcome).
+  web-ui Jest covers monitor render, polling update (fake timers), running→stopped transition, and
+  QueuesPage monitor-vs-editor routing. Coverage ≥80/70 on touched areas.
+- **III. UX Consistency**: PASS — reuses existing table/panel styling and the app's request/refresh
+  idiom; schedule reasons use the operator-facing vocabulary already established ("After Every Step",
+  time-of-day, etc.); read-only, so no destructive controls; empty/idle/ended states are explicit and
+  actionable ("running & waiting until …", "run ended — see Execution Logs").
+- **IV. Performance**: PASS — declared goal above; the monitor is off the run's hot path. Polling is a
+  small periodic GET; the projection is in-memory. Perf note: no busy work added to the queue engine;
+  current-sequence tracking is two field assignments per firing.
+- **V. Living Documentation**: PASS (planned) — `docs/architecture.md` Queues section gains the monitor
+  endpoint + live-plan projection; `spec.md` carries a `Status` line; `specs/STATUS.md` gets a 072 row.
+  Complements 046/051 (queue runtime), 059 (live schedule), 065 (self-reschedule); supersedes nothing;
+  no new env vars, so `ENVIRONMENT.md` unchanged.
+
+No violations → Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/072-queue-monitor/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── queue-monitor.md # GET /api/queues/{id}/monitor contract
+├── checklists/
+│   └── requirements.md  # from /speckit-specify
+└── tasks.md             # /speckit-tasks (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/GameBot.Service/Services/QueueExecution/
+├── QueueRunHandle.cs                 # + CurrentSequenceId/CurrentSequenceStartedAt (volatile), set/clear
+│                                     #   in RunOneSequenceAsync; + SnapshotPendingTimerFirings() accessor
+├── QueueExecutionService.cs          # set/clear current-sequence fields around ExecuteAsync (only change)
+├── IQueueMonitorService.cs           # NEW: BuildAsync(queueId, ct) → QueueMonitorSnapshot
+└── QueueMonitorService.cs            # NEW: pure projection (registry + template repo + TimeProvider +
+                                      #   best-effort last-outcome via IExecutionLogService.QueryAsync)
+
+src/GameBot.Service/Contracts/Queues/
+├── QueueMonitorResponse.cs           # NEW: running, cycleExecution, runStartedAt, current, upcoming[],
+│                                     #   nothingScheduled, lastOutcome
+└── QueueMonitorItemResponse.cs       # NEW: sequenceId, sequenceName, reason, scheduleKind,
+                                      #   expectedAt?, relativeLabel, repeats, order
+
+src/GameBot.Service/Endpoints/
+└── QueuesEndpoints.cs                # + GET {id}/monitor → IQueueMonitorService
+
+src/GameBot.Service/GameBotServiceSetup.cs  # register IQueueMonitorService (singleton/scoped)
+
+src/web-ui/src/services/
+└── queues.ts                         # + QueueMonitorDto types + getQueueMonitor(id)
+
+src/web-ui/src/components/queues/
+├── QueueMonitor.tsx                  # NEW: read-only now/next playlist; polls ~2.5s while mounted
+└── QueueMonitor.css                  # NEW
+
+src/web-ui/src/pages/
+└── QueuesPage.tsx                    # open running queue → <QueueMonitor>; stopped → existing editor
+
+tests/unit/…                         # QueueMonitorService projection matrix
+tests/integration/…                  # GET {id}/monitor running vs stopped (optional but preferred)
+src/web-ui/src/components/queues/__tests__/QueueMonitor.test.tsx
+src/web-ui/src/pages/__tests__/QueuesPage.monitor.spec.tsx
+
+docs/architecture.md                 # Queues: monitor endpoint + live-plan projection
+specs/STATUS.md                      # new 072 row
+```
+
+**Structure Decision**: Web service + React SPA — both are in scope. The backend adds a read-only
+projection endpoint over already-in-memory run state; the web-ui adds a monitor panel and routes to it
+based on the queue's running status. No persistence, no schema, no new config/env.
+
+## Design Decisions
+
+1. **Current-sequence tracking is the only run-engine change.** `RunOneSequenceAsync` is the single
+   choke point through which every firing (at-start, once-per-run, every-step, timer, relative, live,
+   self-reschedule) flows. Set `handle.CurrentSequenceId` + `handle.CurrentSequenceStartedAt` at the top
+   and clear them in `finally`. Fields are `volatile`/interlocked-simple so a concurrent monitor read is
+   safe without locking. This yields the sequence-level "now" indicator (clarified granularity) with no
+   change to scheduling behavior — zero regression.
+
+2. **The monitor snapshot is a pure projection, not stored state.** A new `QueueMonitorService` reads the
+   `QueueRunHandle` (via `IQueueRunRegistry.TryGet`) and the linked `QueueTemplate`, and folds them with
+   `TimeProvider.GetLocalNow()` into an ordered snapshot. Keeping it pure (inputs → output) makes it
+   deterministically unit-testable and keeps all timing logic out of the endpoint. It mirrors — but does
+   not duplicate — the run loop's schedule semantics.
+
+3. **Expected times are best-effort by design (per clarification).** The run loop evaluates timers
+   lazily at iteration boundaries, so the monitor does not attempt a guaranteed timeline:
+   - **Live schedules** → exact `fireAt` from `PendingLiveSchedules`.
+   - **Self-reschedule Timer firings** → exact `FireAt` via a new `SnapshotPendingTimerFirings()`.
+   - **Timer (time-of-day)** → next eligible instant: today at `HH:mm` if `now < HH:mm`, else tomorrow.
+   - **Timer (relative)** → `RunStartedAt + offset`; if already elapsed, shown as "due/soon" (fires once
+     per run). No run-loop `relativeTimerFired`/`timerFiredDate` state is exposed — the wall-clock
+     approximation satisfies the "next eligible time" allowance and keeps the engine untouched.
+   Ordering and schedule **reasons** are exact; only far-future timer instants are approximate.
+
+4. **OncePerRun is the spine; EveryStep is an annotation, not N interleaved copies.** The upcoming list
+   shows OncePerRun entries in template order (the "playlist" spine). EveryStep sequences are surfaced
+   once, labeled "After Every Step" (existing operator vocabulary), rather than exploding the list with a
+   copy after every step — this keeps a long/cycling run readable (spec FR-008, edge cases). Timed/live/
+   self-reschedule firings are merged into the list ordered by expected time.
+
+5. **Cycling is a marker, not an unrolled timeline (per clarification).** For a cycling queue the
+   OncePerRun spine is shown **once** with a `repeats: true` marker; the endpoint never projects an
+   infinite future. Pending timed/live firings are shown alongside with their concrete times.
+
+6. **View routing keys off existing running/stopped status; no new "mode" concept.** QueuesPage opens the
+   monitor when `status === 'Running'` and the editor when `'Stopped'`, reusing the status the overview
+   already shows. The overview keeps Start/Stop/Schedule. The Edit button (already disabled while running)
+   is complemented by a name-click / "Monitor" affordance that opens the panel for a running queue. When a
+   poll returns `running: false`, the panel switches to an "ended" state showing `lastOutcome` and a path
+   back to the editor / Execution Logs (FR-010).
+
+7. **Last outcome is best-effort via the execution log.** When the queue is not running, the projection
+   queries `IExecutionLogService.QueryAsync` for the most recent finalized queue-run entry for that queue
+   and returns its status + summary as `lastOutcome`. Absent/none → `null` (UI shows a neutral "not
+   running"). This satisfies "surface the final outcome where available" without new persistence.
+
+8. **Times cross the wire as ISO-8601 with offset.** The service uses local-clock instants
+   (`GetLocalNow()`, service-local offset — consistent with the queue engine and the known +02:00 memory
+   note), so `DateTimeOffset` carries the offset and the UI renders one unambiguous local time (FR-014).
+
+## Complexity Tracking
+
+No constitution violations — no entries required.

--- a/specs/072-queue-monitor/quickstart.md
+++ b/specs/072-queue-monitor/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart: Live Queue Monitor View
+
+## What this delivers
+
+Open a **running** queue in the web UI and see a live "playlist": the sequence running **now**, the
+ordered **up-next** list, and each item's schedule reason + expected time. It auto-refreshes every
+~2.5s. Open a **stopped** queue and you get the existing editor unchanged.
+
+## Try it (manual)
+
+1. Build & run the service (port 8080) and the web-ui, or use the installed app.
+2. Create/pick a queue with a linked template that mixes schedule types — e.g. a couple of
+   **Once per run** sequences, one **After Every Step**, and one **Timer** (time-of-day or relative).
+   Optionally enable **Cycle**.
+3. From the Queues overview, **Start** the queue.
+4. Open the running queue (click its name / the Monitor affordance). Expect the **monitor** panel, not
+   the editor:
+   - A **Now** row showing the currently executing sequence.
+   - An **Up next** list: OncePerRun steps in order, "After Every Step" noted once, and any timed/live
+     firings with their expected times, ordered by time. A cycling queue marks its steps **repeats**.
+5. Use the overview's **Schedule** control to live-schedule a sequence a few seconds out; within ~1
+   refresh it appears in **Up next** at its expected time — no manual reload.
+6. **Stop** the queue (overview). The open monitor flips to an **ended / not running** state showing the
+   last run outcome, with a path back to the editor / Execution Logs.
+7. Open a **stopped** queue directly → the **editor** appears as before.
+
+## Verify (automated)
+
+Backend (from repo root):
+
+```bash
+dotnet test
+```
+
+- `QueueMonitorService` projection matrix: each schedule kind → correct `reason`/`ExpectedAt`;
+  cycling → `repeats`; current-sequence highlighted as `Current`; running-but-empty →
+  `nothingScheduled`; not-running → `running:false` + best-effort `lastOutcome`; timed/live/
+  self-reschedule ordered by time.
+- Endpoint: `GET /api/queues/{id}/monitor` returns 200 snapshot when running, 200 `running:false`
+  when stopped, 404 for unknown id.
+
+web-ui (from `src/web-ui`):
+
+```bash
+npm run build
+npm test
+```
+
+- `QueueMonitor.test.tsx`: renders Now/Up-next from a mocked `getQueueMonitor`; advancing fake timers
+  triggers a re-poll and updates the list; a `running:false` poll shows the ended state.
+- `QueuesPage.monitor.spec.tsx`: opening a Running queue renders the monitor; opening a Stopped queue
+  renders the editor.
+
+## Notes
+
+- Read-only: the monitor shows information only; start/stop/schedule stay in the overview.
+- Expected times are best-effort for far-future timers (shown as their next eligible time); ordering and
+  schedule reasons are exact.
+- No new config, env vars, or persisted data.

--- a/specs/072-queue-monitor/research.md
+++ b/specs/072-queue-monitor/research.md
@@ -1,0 +1,79 @@
+# Phase 0 Research: Live Queue Monitor View
+
+All Technical Context items are known from the existing codebase; there were no open
+`NEEDS CLARIFICATION` markers (the four spec clarifications were resolved in `/speckit-clarify`).
+This file records the decisions that shape the design.
+
+## R1 — Where does the running queue's live plan already live?
+
+- **Decision**: Read the existing in-memory `QueueRunHandle` (owned by `IQueueRunRegistry`) plus the
+  queue's linked `QueueTemplate`; do not add persistence.
+- **Findings**:
+  - `QueueRunHandle` (`Services/QueueExecution/QueueRunHandle.cs`) already carries: `CycleExecution`,
+    `RunStartedAt` (local-clock anchor), `RootExecutionId`, `SessionId`, `PendingLiveSchedules`
+    (`sequenceId → fireAt`), self-reschedule registers (`PendingOncePerRun`, `PendingNextCycleStart`,
+    `EveryStepInjections`), and private timer firings with `FireAt`.
+  - The **schedule types and order** live on `QueueTemplate.Entries` (`ScheduleType`,
+    `TimerTimeOfDay`, `TimerRelativeOffset`). The runtime store only holds sequence ids, so the
+    projection must load the template (same read `GET /api/queues/{id}` already performs).
+  - `IQueueRunRegistry.TryGet(queueId, out handle)` gives O(1) access to the active handle; all types
+    are `internal` to `GameBot.Service`, so a projection service in the same assembly can read them.
+- **Gap**: the handle does **not** track which sequence is executing right now, and the private timer
+  firings have no read accessor. Both are added (minimally) — see R2.
+- **Alternatives considered**: (a) Persist a plan snapshot each iteration — rejected: adds I/O to the
+  hot path and a storage surface for ephemeral data. (b) Derive everything from Execution Logs —
+  rejected: logs are historical/after-the-fact and cannot show *upcoming* work or future times.
+
+## R2 — How to expose the "now" sequence and pending timer firings with minimal engine change?
+
+- **Decision**: Add two `volatile` fields (`CurrentSequenceId`, `CurrentSequenceStartedAt`) set/cleared
+  in `RunOneSequenceAsync`, and a `SnapshotPendingTimerFirings()` read accessor on the handle.
+- **Rationale**: `RunOneSequenceAsync` is the single method every firing passes through, so two field
+  writes there capture the current sequence for **all** schedule kinds without touching scheduling
+  logic. `volatile` (reference/`DateTimeOffset?` via a small lock or `Interlocked` on a struct box) makes
+  a concurrent monitor read safe without introducing locks on the run path. The timer-firings list is
+  already lock-guarded internally; the accessor returns a copy under the same lock.
+- **Alternatives considered**: threading a callback/event out of the loop (heavier, more surface);
+  exposing `relativeTimerFired`/`timerFiredDate` (unnecessary given best-effort times — see R3).
+
+## R3 — How to present expected times without a guaranteed timeline?
+
+- **Decision**: Best-effort per the clarified assumption. Exact where the handle has an instant
+  (`PendingLiveSchedules` fireAt; self-reschedule `FireAt`); next-eligible wall-clock projection for
+  template timers (time-of-day → today/tomorrow at `HH:mm`; relative → `RunStartedAt + offset`).
+- **Rationale**: The engine evaluates timers lazily at iteration boundaries; there is no precomputed
+  schedule to read. The spec explicitly permits "next eligible time" for far-future timers. This keeps
+  the engine untouched and the projection a pure function of (template, handle snapshot, `now`).
+- **Ordering vs timing**: schedule **reason/kind** and **order** are exact; only far-future absolute
+  timer instants are approximate. The projection sorts timed/live/self-reschedule items by expected
+  time and keeps the OncePerRun spine in template order.
+
+## R4 — Live-update mechanism (clarified: ~2–3s auto-refresh)
+
+- **Decision**: Client-side polling of `GET /api/queues/{id}/monitor` on a fixed ~2.5s interval while
+  the monitor panel is mounted (`setInterval`, cleared on unmount / when the queue is no longer
+  running). No server push / SSE / WebSocket.
+- **Rationale**: Matches the clarification and the app's existing request/refresh idiom (QueuesPage,
+  Execution Logs); trivial load at this scale (single-operator tool); far simpler to build and test than
+  streaming. Jest fake timers make the polling deterministically testable.
+- **Alternatives considered**: SSE/WebSocket push (rejected: disproportionate complexity for one local
+  operator); manual refresh only (rejected: contradicts "dynamic").
+
+## R5 — View routing (monitor vs editor)
+
+- **Decision**: QueuesPage selects the panel from the queue's `status`: `Running` → `QueueMonitor`
+  (read-only); `Stopped` → existing editor. Run controls stay in the overview row.
+- **Rationale**: Reuses the status the overview already renders and the existing rule that editing is
+  disabled while running; no new "mode" concept. Satisfies FR-001..FR-003 and keeps controls out of the
+  monitor panel (FR-012).
+- **Transition**: a poll returning `running:false` flips the panel to an "ended" state (shows
+  `lastOutcome`, offers return to editor / Execution Logs), covering the stop-while-open edge case.
+
+## R6 — Last-run outcome when not running (FR-010)
+
+- **Decision**: Best-effort via `IExecutionLogService.QueryAsync` for the most recent finalized
+  queue-run entry for the queue; return its `status` + `summary` as `lastOutcome`, else `null`.
+- **Rationale**: Reuses the existing execution-log query surface (queue runs are already finalized with
+  a summary by `QueueExecutionService`), so no new persistence and the outcome text matches the logs.
+- **Alternatives considered**: caching the last `QueueRunResult` on a service field (rejected: extra
+  mutable state, lost across restarts, duplicates what the log already stores).

--- a/specs/072-queue-monitor/spec.md
+++ b/specs/072-queue-monitor/spec.md
@@ -1,0 +1,241 @@
+# Feature Specification: Live Queue Monitor View
+
+**Feature Branch**: `072-queue-monitor`
+**Created**: 2026-07-23
+**Status**: Implemented
+**Input**: User description: "I need to be able to monitor the Queue when it runs: what are the next steps, in which order will they be executed and for what time are the sequence scheduled. Think of it like a playlist in music player. I don't need controls (yet), but the list showing what the queue is doing and what are the next steps. This should be dynamic, as the queue is dynamic in run-time. I want to see it when I open the running queue in the UI. Maybe instead of editing the queue when it's running (which doesn't make sense anyway), display different pages for stopped queue - edit page, and for running queue - monitor page."
+
+## Clarifications
+
+### Session 2026-07-23
+
+- Q: How often should the monitor update while open (live-update cadence)? → A: Auto-refresh on a short fixed interval (~2–3 seconds) while the monitor is open.
+- Q: How far ahead should the up-next list extend for a cycling / long-running queue? → A: Show the upcoming cycle's steps once, marked as repeating, plus all currently-pending timed/live firings (no projected infinite timeline).
+- Q: Does the monitor show already-completed steps, or only the current + upcoming steps? → A: Now + upcoming only; completed steps drop off the list (full run history remains in the Execution Logs).
+- Q: At what granularity does the "now" indicator identify current work — sequence or step within it? → A: Sequence-level (highlight the currently-running sequence); per-step detail stays in the Execution Logs.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Watch a running queue like a playlist (Priority: P1)
+
+An operator opens a queue that is currently running. Instead of the entry-editing form,
+they see a live "now-and-next" view: what the queue is doing right now and the ordered
+list of sequences coming up, each annotated with when it is expected to run and why it is
+scheduled (e.g. runs once at start, runs every cycle, fires at a time of day, fires after
+an offset, or was scheduled live). The list updates on its own as the run progresses —
+finished steps drop off the top, and newly scheduled work appears — without the operator
+having to reload the page.
+
+**Why this priority**: This is the core of the request. A queue's run-time behavior is
+currently invisible: the operator can only infer what happened after the fact from the
+Execution Logs. Seeing the upcoming plan while it runs is the entire value of the feature,
+and it delivers a usable result on its own even without the page-switching of Story 2.
+
+**Independent Test**: Start a queue with a mix of at-start, once-per-run, every-step, and
+timed entries, open it, and confirm the monitor lists the upcoming sequences in the order
+they will execute with a schedule label and expected time for each, and that the list
+visibly changes as steps complete — all without manual refresh.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running queue with several scheduled sequences, **When** the operator opens
+   it, **Then** they see an ordered list of the upcoming sequences with, for each, the
+   sequence name, why it is scheduled (its schedule type), and the time it is expected to
+   run (or "next" / "now" for the imminent one).
+2. **Given** the monitor is open on a running queue, **When** a step finishes and the run
+   moves on, **Then** the view updates on its own so the completed step is no longer shown
+   as upcoming and the currently-executing step is reflected, without the operator
+   reloading the page.
+3. **Given** a running queue with a sequence scheduled for a specific time of day, **When**
+   the operator views the monitor, **Then** that sequence appears with its scheduled time
+   so the operator can see when it will fire.
+4. **Given** a sequence is scheduled live against the running queue (or a sequence
+   reschedules itself), **When** that firing is registered, **Then** it appears in the
+   upcoming list at its expected time without the operator reloading the page.
+
+---
+
+### User Story 2 - Separate monitor page for running, edit page for stopped (Priority: P1)
+
+Opening a queue shows a different page depending on its state. A stopped queue opens the
+existing editor (entries, schedule types, templates, game/emulator links). A running queue
+opens the read-only monitor from Story 1 instead of the editor, because editing a queue's
+entries while it is executing does not make sense and is already disallowed.
+
+**Why this priority**: The user explicitly asked for this split, and it removes a
+confusing state — today opening a running queue shows an editor whose controls are all
+disabled. Routing running queues to the monitor and stopped queues to the editor makes the
+distinction obvious and is a prerequisite for the monitor to be the thing an operator sees
+when they "open the running queue."
+
+**Independent Test**: Open a stopped queue and confirm the editor appears; start it (or
+open an already-running queue) and confirm the monitor appears instead of the editor;
+stop it and confirm opening it returns to the editor.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stopped queue, **When** the operator opens it, **Then** the entry/template
+   editor is shown as it is today.
+2. **Given** a running queue, **When** the operator opens it, **Then** the monitor view is
+   shown and the entry-editing controls are not presented.
+3. **Given** the operator has the monitor open, **When** the queue stops (manually,
+   completed, or failed), **Then** the view reflects that the queue is no longer running
+   and the operator can return to the editor.
+4. **Given** the operator has the editor open on a stopped queue, **When** the queue is
+   started, **Then** the operator can reach the monitor view for that queue.
+
+---
+
+### User Story 3 - Understand a queue that has nothing imminent (Priority: P2)
+
+Some running queues spend long stretches idle — e.g. a non-cycling queue that has finished
+its once-per-run work and is only waiting for a timed firing much later, or a cycling queue
+paused between cycles. The monitor makes this legible: it shows that the queue is alive but
+waiting, and what it is waiting for, rather than looking empty or broken.
+
+**Why this priority**: Without it, an idle-but-healthy queue is indistinguishable from a
+stuck or empty one, which erodes trust in the view. It builds on Story 1 but is not
+required for the first useful version.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running queue that is between scheduled firings, **When** the operator views
+   the monitor, **Then** it clearly indicates the queue is running and waiting, and shows
+   the next thing it will do and when.
+2. **Given** a running queue whose only remaining work is a timer far in the future, **When**
+   the operator views the monitor, **Then** that pending firing is shown with its expected
+   time so the operator understands why the queue is still running.
+
+---
+
+### Edge Cases
+
+- **Cycling queue (repeats indefinitely)**: The once-per-run steps repeat every cycle with
+  no natural end. The monitor presents the upcoming cycle's steps once, marked as repeating,
+  alongside any currently-pending timed/live firings — rather than implying a finite end or
+  attempting to list infinite future firings.
+- **Queue stops while the monitor is open**: The monitor stops showing upcoming work and
+  indicates the run has ended (with its outcome), then the operator can return to the
+  editor. It must not keep showing stale "upcoming" steps as if the queue were still live.
+- **Queue with no linked template / no entries**: The monitor shows that there is nothing
+  scheduled, rather than an error or a blank area.
+- **Time-of-day timer that already fired today**: A once-per-day timer that has already
+  fired should not be shown as imminent; it is either omitted or shown as scheduled for its
+  next eligible day, consistent with how the run actually treats it.
+- **A step is currently executing and taking a long time**: The monitor shows it as the
+  active/now-running step; it should not disappear or be shown as "next" while still running.
+- **Rapid changes**: Live schedules, self-reschedules, and completing steps can change the
+  plan quickly; the view must converge to the current truth without flicker that makes it
+  unreadable.
+- **Two people watching the same running queue**: Each sees a consistent live view; the
+  monitor is read-only so there is no conflicting edit.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When a queue is running, the system MUST present a monitor view for that
+  queue instead of the entry-editing form.
+- **FR-002**: When a queue is stopped, the system MUST present the existing entry/template
+  editor for that queue.
+- **FR-003**: The system MUST route to the correct view based on the queue's current
+  running state at the time it is opened, and MUST let the operator reach the monitor for a
+  queue that is running and the editor for a queue that is stopped.
+- **FR-004**: The monitor MUST display the ordered list of upcoming sequences the running
+  queue is expected to execute, in the order they will be executed. The list is
+  forward-looking: it shows the currently-executing step and upcoming steps only, and a
+  completed step drops off as the run advances. The full run history is not duplicated in
+  the monitor (it remains available in the Execution Logs).
+- **FR-005**: For each upcoming sequence, the monitor MUST show the sequence's name (or a
+  clear identifier), the reason it is scheduled (its schedule type — e.g. runs once at
+  start, once per cycle, after every step, at a time of day, after an offset, or scheduled
+  live), and the time it is expected to run where a time is known.
+- **FR-006**: The monitor MUST distinguish the sequence that is currently executing (the
+  "now" item) from the sequences that are still upcoming (the "next" items). The "now"
+  indicator is sequence-level (which sequence is running); it does not track which internal
+  step of that sequence is executing — per-step detail remains in the Execution Logs.
+- **FR-007**: The monitor MUST reflect changes to the running queue's plan over time —
+  steps completing, new live or self-rescheduled firings appearing, and timed firings
+  becoming imminent — without requiring the operator to manually reload the page. It MUST
+  do so by refreshing on its own on a short fixed interval of roughly 2–3 seconds while
+  open.
+- **FR-008**: The monitor MUST convey that a cycling queue repeats. For the repeating work
+  it MUST show the upcoming cycle's steps once, marked as repeating, rather than projecting
+  an unbounded timeline; alongside these it MUST show all currently-pending timed and live
+  firings. It MUST NOT imply a false finite end for a cycling queue.
+- **FR-009**: The monitor MUST clearly indicate when a running queue is alive but idle
+  (waiting for a future firing), including what it is waiting for and when, so an idle
+  healthy queue is distinguishable from a stuck or empty one.
+- **FR-010**: When the queue is not running (stopped, completed, or failed), the monitor
+  MUST indicate the run has ended rather than continuing to show upcoming steps, and MUST
+  surface the run's final outcome where available.
+- **FR-011**: The monitor MUST handle a running queue that currently has nothing scheduled
+  (no template/entries) by clearly showing that nothing is scheduled, without error.
+- **FR-012**: The monitor MUST be read-only — it presents information only and MUST NOT
+  offer entry editing or, for this feature, run controls (start/stop/schedule).
+- **FR-013**: The information the monitor shows MUST correspond to what the running queue
+  will actually do (the same schedule types, order, and timing the run uses), so the
+  operator can trust the view as an accurate preview of the run.
+- **FR-014**: Times shown to the operator MUST be presented consistently and
+  unambiguously (so, for example, a time-of-day firing is not misread against the wrong
+  clock/zone).
+
+### Key Entities *(include if data involved)*
+
+- **Running queue state**: The live status of a queue's current run — whether it is
+  running, which sequence it is currently running, and its start time. Basis for choosing
+  monitor vs. editor and for the sequence-level "now" indicator.
+- **Upcoming step (schedule item)**: A single planned firing of a sequence within the run —
+  the sequence being fired, its schedule reason/type, its expected run time (absolute time,
+  relative offset, "next", or "repeats each cycle"), and its position in the execution
+  order. The collection of these, ordered, is the "playlist."
+- **Schedule type**: The classification that explains why and when a sequence fires
+  (at-queue-start, once-per-run, every-step, timer by time-of-day, timer by relative
+  offset, live/ad-hoc schedule, self-reschedule). Drives the label and the expected time
+  shown for each upcoming step.
+- **Run outcome**: The terminal result of a run (completed / stopped / failed, with a
+  summary) shown when the monitored queue is no longer running.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator opening a running queue can, within a few seconds and without any
+  manual refresh, tell what the queue is doing now and see the ordered list of what it will
+  do next with times — without consulting the Execution Logs.
+- **SC-002**: 100% of the time, opening a running queue shows the monitor and opening a
+  stopped queue shows the editor; the two are never confused.
+- **SC-003**: As a run progresses, the monitor reflects a completed step and a newly
+  scheduled firing on its own within roughly one refresh interval (~2–3 seconds), so the
+  displayed plan matches the run's actual next actions.
+- **SC-004**: For every schedule type a queue can use, the monitor shows a correct,
+  human-readable reason and expected time (or an explicit "next"/"repeats"/"waiting"
+  indicator) — verified across at-start, once-per-run, every-step, time-of-day, relative,
+  and live/self-rescheduled entries.
+- **SC-005**: A running queue that is idle-but-waiting is never presented as empty, broken,
+  or finished; the operator can always tell it is alive and what it is waiting for.
+
+## Assumptions
+
+- **Read-only, no controls now**: Per the request, this feature adds monitoring only. Run
+  controls (start/stop/schedule) remain where they are today (the queues overview) and are
+  explicitly out of scope for the monitor page. This can be revisited later.
+- **View selection follows existing running/stopped status**: The system already tracks
+  whether a queue is Running vs. Stopped and already disables entry editing while running.
+  The monitor/editor split reuses that same status signal rather than introducing a new
+  concept of "monitor mode."
+- **The monitor reflects the actual run plan, best-effort for future times**: The running
+  queue evaluates timers at run-time boundaries rather than precomputing a fixed schedule.
+  The monitor is expected to present the best available view of upcoming work and expected
+  times (including "next", "repeats each cycle", and "waiting until <time>"), not a
+  guaranteed-to-the-second future timeline. Ordering and schedule reasons are exact; far-
+  future timer instants may be shown as their next eligible time.
+- **Live updating cadence**: "Dynamic / updates on its own" is satisfied by the view
+  refreshing on a short fixed interval of roughly 2–3 seconds (clarified) rather than an
+  instantaneous push; the exact request mechanism is an implementation choice for planning.
+- **Scope is the web UI**: The monitor is a web-UI concern surfaced when opening a running
+  queue. Backend support to expose the running queue's live plan (order, schedule reasons,
+  expected times, current step) is in scope as the data source for the view; automation
+  behavior of the run itself is unchanged.
+- **Time presentation**: Times are shown in a single, clearly indicated frame of reference
+  to avoid the known ambiguity between the service's local clock and other zones.

--- a/specs/072-queue-monitor/tasks.md
+++ b/specs/072-queue-monitor/tasks.md
@@ -1,0 +1,209 @@
+---
+
+description: "Task list for Live Queue Monitor View (072-queue-monitor)"
+---
+
+# Tasks: Live Queue Monitor View
+
+**Input**: Design documents from `specs/072-queue-monitor/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/queue-monitor.md](contracts/queue-monitor.md)
+
+**Tests**: INCLUDED — the project constitution (Testing Standards) requires unit + integration coverage
+for executable logic (≥80% line / ≥70% branch on touched areas). The projection is a pure function and
+is the primary unit-test target.
+
+**Organization**: Tasks are grouped by user story. Foundational phase builds the shared read-only data
+source (endpoint returning a running/not-running envelope). US1 fills the "playlist" content, US2 routes
+the UI, US3 adds the idle/empty/ended states.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 (setup, foundational, polish have no story label)
+
+## Path Conventions
+
+Web service backend under `src/GameBot.Service/`; React SPA under `src/web-ui/`; xUnit tests under
+`tests/unit/` and `tests/integration/`; Jest tests colocated under `src/web-ui/src/**/__tests__/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm a green baseline before adding the feature. No new dependencies, config, or env vars.
+
+- [X] T001 Confirm baseline builds/tests are green: `dotnet build` + `dotnet test` (backend) and, in `src/web-ui`, `npm run build` + `npm test` (the real web-ui gate per project notes). Record any pre-existing failures so new work is not blamed for them. Also confirm the actual xUnit test-project layout for `tests/unit`/`tests/integration` and adjust the test file paths in T011/T016/T020 if the repo uses different project directories.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared, read-only data source every story depends on — the run-handle "now" tracking,
+the projection types, the `IQueueMonitorService` skeleton (running/not-running envelope only), DI, the
+`GET {id}/monitor` endpoint, and the web-ui client call. After this phase the endpoint returns
+`running` + empty `current`/`upcoming` (no schedule content yet).
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 Add current-sequence tracking to the run handle in `src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs`: `volatile string? CurrentSequenceId`, a lock/`Interlocked`-guarded `DateTimeOffset? CurrentSequenceStartedAt`, and a `SnapshotPendingTimerFirings()` accessor that returns a copy of `_pendingTimerFirings` under the existing `_timerLock`. Document each member.
+- [X] T003 Set/clear the current-sequence fields around execution in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` `RunOneSequenceAsync`: set `CurrentSequenceId`/`CurrentSequenceStartedAt` before `ExecuteAsync`, clear them in `finally`. This is the ONLY queue-engine change — no scheduling behavior changes.
+- [X] T004 [P] Create internal projection types in `src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs`: `ScheduleKind` enum (`AtQueueStart`/`OncePerRun`/`EveryStep`/`TimerTimeOfDay`/`TimerRelative`/`LiveSchedule`/`SelfReschedule`), records `QueueMonitorSnapshot`, `QueueMonitorItem`, `RunOutcome` per [data-model.md](data-model.md) §2.
+- [X] T005 [P] Create wire DTOs `src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs` and `src/GameBot.Service/Contracts/Queues/QueueMonitorItemResponse.cs` (camelCase; `scheduleKind` as string enum) per [contracts/queue-monitor.md](contracts/queue-monitor.md).
+- [X] T006 Add `IQueueMonitorService` in `src/GameBot.Service/Services/QueueExecution/IQueueMonitorService.cs` with `Task<QueueMonitorSnapshot> BuildAsync(string queueId, CancellationToken ct = default)`.
+- [X] T007 Implement the envelope-only `QueueMonitorService` in `src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs`: inject `IQueueRunRegistry`, `IQueueRepository`, `IQueueTemplateRepository`, `ISequenceRepository`, `IExecutionLogService`, `TimeProvider`. For now return `Running` from the registry, queue `Name`, `CycleExecution`/`RunStartedAt` from the handle when running, and empty `Current`/`Upcoming`, `LastOutcome = null`. Define `NothingScheduled` correctly from the start — `true` only when the run has **no** schedulable work of **any** kind: no template entries (AtQueueStart/OncePerRun/EveryStep/Timer) AND no pending live schedules (`handle.PendingLiveSchedules`) AND no pending self-reschedule timer firings (`handle.SnapshotPendingTimerFirings()`). This keeps FR-011 correct even for an MVP that ships without US3 (e.g. a live-scheduled-only run must not read as "nothing scheduled"). (US1 fills `Current`/`Upcoming`; US3 adds `LastOutcome` and the idle "waiting" label.)
+- [X] T008 Register `IQueueMonitorService → QueueMonitorService` in `src/GameBot.Service/GameBotServiceSetup.cs` alongside the other QueueExecution services.
+- [X] T009 Add `GET {id}/monitor` in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: 404 when the queue is unknown; otherwise 200 with `BuildAsync(...)` projected to `QueueMonitorResponse` (including `running:false` when not running). Keep the endpoint map thin (delegate to the service + a small projector helper).
+- [X] T010 [P] Add web-ui client types + call in `src/web-ui/src/services/queues.ts`: `QueueMonitorItemDto`, `QueueMonitorDto` (matching the contract), and `getQueueMonitor(id) => getJson<QueueMonitorDto>(\`${base}/${id}/monitor\`)`.
+
+**Checkpoint**: `GET /api/queues/{id}/monitor` returns a valid running/not-running envelope; the web-ui can call it. User stories can now begin.
+
+---
+
+## Phase 3: User Story 1 - Watch a running queue like a playlist (Priority: P1) 🎯 MVP
+
+**Goal**: The monitor shows the sequence running **now** and the ordered **up-next** list, each with a
+schedule reason and expected time, updating itself every ~2.5s.
+
+**Independent Test**: Start a queue mixing at-start/once-per-run/every-step/timed entries, open it, and
+confirm the ordered upcoming list with reasons + times, a highlighted "now" item, and self-updating
+without manual refresh.
+
+### Tests for User Story 1 ⚠️ (write first, ensure they fail)
+
+- [X] T011 [P] [US1] Projection unit tests in `tests/unit/QueueMonitorServiceTests.cs`: with a fake `TimeProvider` and a hand-built `QueueRunHandle` + fake template repo, assert — OncePerRun spine in template order (`reason`, `relativeLabel` next/up-next); EveryStep surfaced once as "After Every Step"; TimerTimeOfDay → next-eligible `ExpectedAt` (today vs tomorrow); TimerRelative → `RunStartedAt + offset`; LiveSchedule → exact `fireAt`; SelfReschedule Timer → exact `FireAt`; timed items sorted ascending by `ExpectedAt`; `Current` reflects `CurrentSequenceId` and is excluded from `Upcoming`; and, for a **cycling** queue, OncePerRun/EveryStep items carry `Repeats:true` while a non-cycling queue leaves them `false` (FR-008).
+- [X] T012 [P] [US1] Component test `src/web-ui/src/components/queues/__tests__/QueueMonitor.test.tsx`: mock `getQueueMonitor`; assert the "Now" row and ordered "Up next" list render; advance Jest fake timers ~2.5s and assert a re-poll updates the list.
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Implement the projection body in `src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs`: load the linked `QueueTemplate`, partition by `ScheduleType`, resolve sequence names (stale when unresolved), build `Current` from the handle's `CurrentSequenceId`/`StartedAt`, and build `Upcoming` per [data-model.md](data-model.md) §3 (OncePerRun spine → EveryStep annotation → merged timed/live/self-reschedule sorted by `ExpectedAt`). Keep helpers small (per-kind mappers) under ~50 LOC each.
+- [X] T014 [US1] Compute best-effort `ExpectedAt`/`Reason` for template timers in a small pure helper (time-of-day next-eligible; relative = anchor + offset) in `QueueMonitorService.cs`; pull live schedules from `handle.PendingLiveSchedules` and self-reschedule firings from `handle.SnapshotPendingTimerFirings()`.
+- [X] T015 [P] [US1] Build the `QueueMonitor` component in `src/web-ui/src/components/queues/QueueMonitor.tsx` + `QueueMonitor.css`: read-only "Now" row + "Up next" list (name, reason, expected time / relative label, repeats badge); poll `getQueueMonitor` on a ~2.5s `setInterval` (within the spec's 2–3s target, FR-007) while mounted, clearing on unmount. No run controls. Render a neutral "Nothing scheduled" empty state when `nothingScheduled` is true (so the component is correct even if the release stops at US1; US3 enriches the idle/ended states).
+- [X] T016 [US1] Integration test `tests/integration/QueueMonitorEndpointTests.cs`: `GET {id}/monitor` returns a populated snapshot (current + ordered upcoming) for a running queue and 404 for an unknown id; assert `expectedAt` values serialize as ISO-8601 **with a numeric offset** (FR-014), not a bare/UTC-`Z` local time.
+
+**Checkpoint**: Opening a running queue via the component shows a live, correct playlist. MVP complete.
+
+---
+
+## Phase 4: User Story 2 - Monitor page for running, edit page for stopped (Priority: P1)
+
+**Goal**: Opening a queue shows the monitor when Running and the existing editor when Stopped; a
+running→stopped transition flips the open monitor to an ended state with a path back to the editor.
+
+**Independent Test**: Open a stopped queue → editor; open/started a running queue → monitor; stop it →
+monitor shows "ended" and the editor is reachable again.
+
+### Tests for User Story 2 ⚠️ (write first, ensure they fail)
+
+- [X] T017 [P] [US2] Page test `src/web-ui/src/pages/__tests__/QueuesPage.monitor.spec.tsx`: opening a `Running` queue renders `QueueMonitor` (not the editor form); opening a `Stopped` queue renders the editor; a monitor poll returning `running:false` surfaces the ended state and a way back to the editor. Mock/stub the `QueueMonitor` component so routing is asserted independently of US1's rendering (keeps US2 testable even if US1 is incomplete).
+
+### Implementation for User Story 2
+
+- [X] T018 [US2] Route views by status in `src/web-ui/src/pages/QueuesPage.tsx`: when the opened queue is `Running`, render `<QueueMonitor queueId=…>` instead of the `QueueForm` editor; keep the editor for `Stopped`. Add a name-click / "Monitor" affordance to open the panel for a running queue (Edit stays disabled while running). Leave Start/Stop/Schedule controls in the overview row unchanged (FR-012).
+- [X] T019 [US2] Handle the running→stopped transition in `QueuesPage.tsx`/`QueueMonitor.tsx`: when a poll returns `running:false`, stop polling and show the "run ended / not running" state with the option to return to the editor (and a link to Execution Logs).
+
+**Checkpoint**: View routing is correct in both directions and survives a mid-view stop.
+
+---
+
+## Phase 5: User Story 3 - Understand a queue with nothing imminent (Priority: P2)
+
+**Goal**: A running-but-idle queue reads as alive and waiting (what it waits for and when); a
+running queue with no schedule reads as "nothing scheduled"; a stopped queue surfaces its last outcome.
+
+**Independent Test**: A non-cycling queue whose only work is a far-future timer shows "waiting until
+<time>"; an empty running queue shows "nothing scheduled"; a stopped queue shows its last run outcome.
+
+### Tests for User Story 3 ⚠️ (write first, ensure they fail)
+
+- [X] T020 [P] [US3] Extend `tests/unit/QueueMonitorServiceTests.cs`: running with no work of any kind → `NothingScheduled:true` with empty lists; running with **only** a pending live schedule (no template entries) → `NothingScheduled:false` (regression guard for F1); a lone pending future timer → item present with its `ExpectedAt` and a "waiting" `RelativeLabel`; not-running with a prior finalized run → `LastOutcome` populated from `IExecutionLogService.QueryAsync`; not-running with no history → `LastOutcome:null`.
+- [X] T021 [P] [US3] Extend `src/web-ui/src/components/queues/__tests__/QueueMonitor.test.tsx`: renders the "running & waiting until …" state, the "nothing scheduled" empty state, and the "ended — <outcome>" state.
+
+### Implementation for User Story 3
+
+- [X] T022 [US3] Populate `LastOutcome` in `src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs` when not running: query `IExecutionLogService.QueryAsync` for the most recent finalized queue-run entry for the queue and map its status + summary to `RunOutcome` (null when none).
+- [X] T023 [US3] Add idle "waiting" semantics in `QueueMonitorService.cs`: when running with no imminent OncePerRun step but a pending future firing exists, set the earliest pending timed item's `RelativeLabel` to "waiting" so an idle-but-alive run is legible. (`NothingScheduled` is already computed correctly in T007 — do not redefine it here.)
+- [X] T024 [US3] Render the idle/empty/ended states in `src/web-ui/src/components/queues/QueueMonitor.tsx`: "Running — waiting until <time>", "Nothing scheduled", and the ended state showing `lastOutcome.status`/`summary`. Ensure an idle-but-alive queue never looks empty or broken (FR-009/SC-005).
+
+**Checkpoint**: Idle, empty, and ended queues are all legible and never confused with a stuck queue.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Living documentation and final verification (constitution Principle V + Definition of Done).
+
+- [X] T025 [P] Update `docs/architecture.md` Queues section: document `GET /api/queues/{id}/monitor`, the read-only live-plan projection, and the sequence-level "now" tracking; refresh the "Last reviewed" date.
+- [X] T026 [P] Add the `Status` line to `specs/072-queue-monitor/spec.md` and a 072 row to `specs/STATUS.md` consistent with the other entries.
+- [X] T027 Verify coverage ≥80% line / ≥70% branch on touched backend areas and run the full gates: `dotnet build` + `dotnet test`, and in `src/web-ui` `npm run build` + `npm test`. Fix any regressions (hard stop per constitution).
+- [ ] T028 Run the [quickstart.md](quickstart.md) manual walkthrough end-to-end against a live queue (mixed schedule types + cycling) to confirm the playlist, live-schedule appearance, and stop transition. _(Not run in the implementation environment — requires a live emulator/game. The equivalent scenarios are covered by automated tests: the projection matrix in [QueueMonitorServiceTests.cs](../../tests/unit/Queues/QueueMonitorServiceTests.cs), the endpoint integration in [QueueMonitorEndpointTests.cs](../../tests/integration/Queues/QueueMonitorEndpointTests.cs), and the component/routing specs QueueMonitor.test.tsx + QueuesPage.monitor.spec.tsx.)_
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately.
+- **Foundational (Phase 2)**: after Setup — **BLOCKS all user stories**. Within it: T002→T003 (same area); T004/T005/T010 are [P]; T006→T007→T008/T009 (service before DI/endpoint); T007 depends on T004.
+- **US1 (Phase 3)**: after Foundational. MVP.
+- **US2 (Phase 4)**: after Foundational; uses the `QueueMonitor` component from US1 (T015) — do US1 first, or stub the component to test routing independently.
+- **US3 (Phase 5)**: after Foundational; extends the projection (T013/T014) and component (T015), so best after US1.
+- **Polish (Phase 6)**: after all desired stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: independent given Foundational — the core deliverable.
+- **US2 (P1)**: depends on Foundational's `running` flag + endpoint; consumes US1's component.
+- **US3 (P2)**: depends on Foundational; builds on US1's projection/component.
+
+### Within Each User Story
+
+- Tests written first and failing before implementation.
+- Backend projection before endpoint/integration assertions; service before UI consumption.
+
+### Parallel Opportunities
+
+- Foundational: T004, T005, T010 in parallel; T002 (backend handle) and T010 (web-ui service) are independent.
+- US1: T011 (backend test) ‖ T012 (web-ui test); T013/T014 (backend) ‖ T015 (web-ui component).
+- US3: T020 (backend test) ‖ T021 (web-ui test).
+- Polish: T025 ‖ T026.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (parallel — different files):
+Task: "Projection unit tests in tests/unit/QueueMonitorServiceTests.cs"          # T011
+Task: "Component test in src/web-ui/src/components/queues/__tests__/QueueMonitor.test.tsx"  # T012
+
+# Then implementation (backend ‖ web-ui):
+Task: "Projection body in QueueMonitorService.cs"                                 # T013/T014
+Task: "QueueMonitor.tsx + QueueMonitor.css with ~2.5s polling"                    # T015
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (blocks everything) → 3. Phase 3 US1 →
+   **STOP & VALIDATE**: a running queue shows a correct, self-updating playlist.
+
+### Incremental Delivery
+
+1. Foundational → endpoint envelope + client call working.
+2. US1 → live playlist content (MVP, demoable).
+3. US2 → monitor-vs-editor routing + stop transition.
+4. US3 → idle/empty/ended legibility.
+5. Polish → docs + gates.
+
+---
+
+## Notes
+
+- [P] = different files, no dependencies. [Story] labels map tasks to US1/US2/US3 for traceability.
+- The only queue-engine change is T002/T003 (current-sequence tracking) — keep scheduling behavior identical.
+- Times cross the wire as ISO-8601 with offset (service local clock) for one unambiguous local time (FR-014).
+- Commit after each task or logical group; never mark a phase complete on a red build/test (constitution hard stop).

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -107,6 +107,7 @@ Status vocabulary:
 | 069 | Go To Home Screen Action | Implemented |
 | 070 | Ensure Emulator Running Action | Implemented |
 | 071 | Connect-to-Game Emulator Pre-heal | Implemented |
+| 072 | Live Queue Monitor View | Implemented |
 
 ## Numbering notes
 

--- a/src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs
+++ b/src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.ObjectModel;
+
+namespace GameBot.Service.Contracts.Queues {
+  /// <summary>
+  /// Read-only snapshot of a queue's live run plan for the monitor panel: the sequence running now,
+  /// the ordered up-next list, and (when not running) the best-effort last outcome. Serialized
+  /// camelCase; <c>scheduleKind</c> as a string enum. Returned by <c>GET {id}/monitor</c>.
+  /// </summary>
+  internal sealed class QueueMonitorResponse {
+    public string QueueId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Whether a run is currently registered for the queue.</summary>
+    public bool Running { get; set; }
+
+    /// <summary>Queue repeats its once-per-run steps each cycle (drives the "repeats" marker).</summary>
+    public bool CycleExecution { get; set; }
+
+    /// <summary>Local-clock instant the run loop started (anchor for relative timers); null when not running.</summary>
+    public DateTimeOffset? RunStartedAt { get; set; }
+
+    /// <summary>The sequence executing right now; null when idle or not running.</summary>
+    public QueueMonitorItemResponse? Current { get; set; }
+
+    /// <summary>Ordered next items (once-per-run spine → every-step → timed/live/self-reschedule).</summary>
+    public Collection<QueueMonitorItemResponse> Upcoming { get; } = new();
+
+    /// <summary>Running but nothing to execute (no template/entries and no pending firings).</summary>
+    public bool NothingScheduled { get; set; }
+
+    /// <summary>Best-effort last finalized run outcome when <see cref="Running"/> is false; null otherwise.</summary>
+    public RunOutcomeResponse? LastOutcome { get; set; }
+  }
+
+  /// <summary>A single now/up-next monitor item (camelCase wire shape).</summary>
+  internal sealed class QueueMonitorItemResponse {
+    public string SequenceId { get; set; } = string.Empty;
+
+    /// <summary>Resolved sequence display name; null when the reference is stale/unresolved.</summary>
+    public string? SequenceName { get; set; }
+
+    /// <summary>True when the referenced sequence can no longer be resolved.</summary>
+    public bool Stale { get; set; }
+
+    /// <summary>One of AtQueueStart/OncePerRun/EveryStep/TimerTimeOfDay/TimerRelative/LiveSchedule/SelfReschedule.</summary>
+    public string ScheduleKind { get; set; } = string.Empty;
+
+    /// <summary>Human-readable schedule reason for display.</summary>
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>Absolute expected time when known; null for spine steps with no wall-clock time.</summary>
+    public DateTimeOffset? ExpectedAt { get; set; }
+
+    /// <summary>Hint when there is no absolute time: now / next / up next / waiting.</summary>
+    public string? RelativeLabel { get; set; }
+
+    /// <summary>Item recurs every cycle (cycling queues).</summary>
+    public bool Repeats { get; set; }
+
+    /// <summary>Stable position within the list.</summary>
+    public int Order { get; set; }
+  }
+
+  /// <summary>Best-effort last finalized run outcome for a stopped queue.</summary>
+  internal sealed class RunOutcomeResponse {
+    public string Status { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+  }
+}

--- a/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
@@ -44,6 +44,16 @@ internal static class QueuesEndpoints {
       return Results.Ok(await BuildDetailAsync(queue, runtime, sequences, templates, games).ConfigureAwait(false));
     }).WithName("GetQueue");
 
+    // Live monitor (feature 072): read-only snapshot of what a running queue is doing now and next.
+    // Returns 200 with running:false (not 404/409) when the queue exists but is not running, so the
+    // client can render the "not running / run ended" state and the last outcome. Safe to poll.
+    group.MapGet("{id}/monitor", async (string id, IQueueRepository repo, IQueueMonitorService monitor) => {
+      var queue = await repo.GetAsync(id).ConfigureAwait(false);
+      if (queue is null) return NotFound();
+      var snapshot = await monitor.BuildAsync(id).ConfigureAwait(false);
+      return Results.Ok(ProjectMonitor(snapshot));
+    }).WithName("GetQueueMonitor");
+
     group.MapPut("{id}", async (string id, UpdateQueueRequest? req, IQueueRepository repo, IQueueRuntimeStore runtime) => {
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
       if (queue is null) return NotFound();
@@ -230,6 +240,35 @@ internal static class QueuesEndpoints {
     var game = await games.GetAsync(gameId).ConfigureAwait(false);
     return game?.Name;
   }
+
+  private static QueueMonitorResponse ProjectMonitor(QueueMonitorSnapshot snapshot) {
+    var resp = new QueueMonitorResponse {
+      QueueId = snapshot.QueueId,
+      Name = snapshot.Name,
+      Running = snapshot.Running,
+      CycleExecution = snapshot.CycleExecution,
+      RunStartedAt = snapshot.RunStartedAt,
+      Current = snapshot.Current is null ? null : ProjectMonitorItem(snapshot.Current),
+      NothingScheduled = snapshot.NothingScheduled,
+      LastOutcome = snapshot.LastOutcome is null
+        ? null
+        : new RunOutcomeResponse { Status = snapshot.LastOutcome.Status, Summary = snapshot.LastOutcome.Summary }
+    };
+    foreach (var item in snapshot.Upcoming) resp.Upcoming.Add(ProjectMonitorItem(item));
+    return resp;
+  }
+
+  private static QueueMonitorItemResponse ProjectMonitorItem(QueueMonitorItem item) => new() {
+    SequenceId = item.SequenceId,
+    SequenceName = item.SequenceName,
+    Stale = item.Stale,
+    ScheduleKind = item.ScheduleKind.ToString(),
+    Reason = item.Reason,
+    ExpectedAt = item.ExpectedAt,
+    RelativeLabel = item.RelativeLabel,
+    Repeats = item.Repeats,
+    Order = item.Order
+  };
 
   private static QueueEntryResponse ProjectEntry(QueueEntry entry, string? sequenceName) => new() {
     EntryId = entry.EntryId,

--- a/src/GameBot.Service/GameBotServiceSetup.cs
+++ b/src/GameBot.Service/GameBotServiceSetup.cs
@@ -170,6 +170,8 @@ internal static class GameBotServiceSetup {
     builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IQueueRunRegistry, GameBot.Service.Services.QueueExecution.QueueRunRegistry>();
     builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.ISelfRescheduleCoordinator, GameBot.Service.Services.QueueExecution.SelfRescheduleCoordinator>();
     builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IQueueExecutionService, GameBot.Service.Services.QueueExecution.QueueExecutionService>();
+    // Read-only live monitor projection (feature 072): pure fold of run handle + linked template + now.
+    builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IQueueMonitorService, GameBot.Service.Services.QueueExecution.QueueMonitorService>();
     builder.Services.AddSingleton<SemanticVersionComparer>();
     builder.Services.AddSingleton<VersionSourceLoader>();
     builder.Services.AddSingleton<VersionResolutionService>();

--- a/src/GameBot.Service/Services/QueueExecution/IQueueMonitorService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/IQueueMonitorService.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// Builds the read-only <see cref="QueueMonitorSnapshot"/> for a queue: a pure projection over the
+/// active <see cref="QueueRunHandle"/>, the linked template, and the current wall-clock. Has no side
+/// effects and never mutates the run — safe to call on the monitor's poll interval.
+/// </summary>
+internal interface IQueueMonitorService {
+  /// <summary>
+  /// Projects the current live plan for <paramref name="queueId"/>. Returns a running snapshot when a
+  /// run is registered, otherwise a not-running envelope with a best-effort last outcome. The caller
+  /// is responsible for translating a missing queue into a 404 (this returns a not-running snapshot).
+  /// </summary>
+  Task<QueueMonitorSnapshot> BuildAsync(string queueId, CancellationToken ct = default);
+}

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -431,6 +431,12 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     // freeze the whole queue. Linked to ct so a real stop request still cancels immediately.
     using var watchdog = CancellationTokenSource.CreateLinkedTokenSource(ct);
     watchdog.CancelAfter(SequenceWatchdogTimeout);
+    // Sequence-level "now" tracking for the live monitor (feature 072): every firing — at-start,
+    // once-per-run, every-step, timer, relative, live, self-reschedule — flows through here, so
+    // set the current sequence at the top and clear it in the finally. This is purely observational
+    // and does not change scheduling behavior.
+    var trackedHandle = _registry.TryGet(queueId, out var handle) ? handle : null;
+    trackedHandle?.SetCurrentSequence(sequenceId, _timeProvider.GetLocalNow());
     try {
       var parentContext = new ExecutionLogContext {
         ParentExecutionId = rootId,
@@ -458,6 +464,9 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
       // Unexpected per-sequence error (e.g. a stale/unresolved reference): non-fatal (FR-008/008b).
       QueueExecutionLog.SequenceFaulted(_logger, sequenceId, ex);
       return false;
+    }
+    finally {
+      trackedHandle?.ClearCurrentSequence();
     }
   }
 

--- a/src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Logging;
+using GameBot.Domain.Queues;
+using GameBot.Domain.QueueTemplates;
+using GameBot.Service.Services.ExecutionLog;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// Pure projection of a queue's live run plan for the monitor panel. Reads the active
+/// <see cref="QueueRunHandle"/> (via <see cref="IQueueRunRegistry"/>) and the linked
+/// <see cref="QueueTemplate"/>, folds them with the current local wall-clock into an ordered
+/// now/up-next snapshot, and — when the queue is not running — surfaces the best-effort last
+/// finalized run outcome from the execution log. No side effects; mirrors, but never duplicates,
+/// the run loop's schedule semantics (feature 072).
+/// </summary>
+internal sealed class QueueMonitorService : IQueueMonitorService {
+  private readonly IQueueRunRegistry _registry;
+  private readonly IQueueRepository _queues;
+  private readonly IQueueTemplateRepository _templates;
+  private readonly ISequenceRepository _sequences;
+  private readonly IExecutionLogService _log;
+  private readonly TimeProvider _timeProvider;
+
+  public QueueMonitorService(
+    IQueueRunRegistry registry,
+    IQueueRepository queues,
+    IQueueTemplateRepository templates,
+    ISequenceRepository sequences,
+    IExecutionLogService log,
+    TimeProvider? timeProvider = null) {
+    _registry = registry;
+    _queues = queues;
+    _templates = templates;
+    _sequences = sequences;
+    _log = log;
+    _timeProvider = timeProvider ?? TimeProvider.System;
+  }
+
+  public async Task<QueueMonitorSnapshot> BuildAsync(string queueId, CancellationToken ct = default) {
+    var queue = await _queues.GetAsync(queueId).ConfigureAwait(false);
+    var name = queue?.Name ?? string.Empty;
+
+    // Not running → 200 envelope with best-effort last outcome (the endpoint maps a missing queue to 404).
+    if (!_registry.TryGet(queueId, out var handle)) {
+      var lastOutcome = await BuildLastOutcomeAsync(queueId, ct).ConfigureAwait(false);
+      return new QueueMonitorSnapshot(
+        queueId, name, Running: false, CycleExecution: queue?.CycleExecution ?? false,
+        RunStartedAt: null, Current: null, Upcoming: Array.Empty<QueueMonitorItem>(),
+        NothingScheduled: false, LastOutcome: lastOutcome);
+    }
+
+    var template = string.IsNullOrEmpty(queue?.LinkedTemplateId)
+      ? null
+      : await _templates.GetAsync(queue!.LinkedTemplateId).ConfigureAwait(false);
+    var names = await ResolveSequenceNamesAsync().ConfigureAwait(false);
+    var now = _timeProvider.GetLocalNow();
+    var cycling = handle.CycleExecution;
+
+    // NothingScheduled (FR-011): running with no schedulable work of ANY kind — no template entries,
+    // no pending live schedules, and no pending self-reschedule timer firings. Computed up front so it
+    // stays correct even for a live-scheduled-only run (which must NOT read as "nothing scheduled").
+    var liveSchedules = handle.PendingLiveSchedules.ToArray();
+    var selfTimerFirings = handle.SnapshotPendingTimerFirings();
+    var hasTemplateWork = template is not null && template.Entries.Count > 0;
+    var nothingScheduled = !hasTemplateWork && liveSchedules.Length == 0 && selfTimerFirings.Count == 0;
+
+    var current = BuildCurrent(handle, template, names, cycling);
+    var upcoming = BuildUpcoming(handle, template, names, now, cycling, current, liveSchedules, selfTimerFirings);
+
+    return new QueueMonitorSnapshot(
+      queueId, name, Running: true, CycleExecution: cycling, RunStartedAt: handle.RunStartedAt,
+      Current: current, Upcoming: upcoming, NothingScheduled: nothingScheduled, LastOutcome: null);
+  }
+
+  // ── Current ("now") ────────────────────────────────────────────────────────────────────────
+
+  private static QueueMonitorItem? BuildCurrent(
+    QueueRunHandle handle, QueueTemplate? template, IReadOnlyDictionary<string, string> names, bool cycling) {
+    var sequenceId = handle.CurrentSequenceId;
+    if (string.IsNullOrEmpty(sequenceId)) return null;
+
+    // Best-effort schedule kind: the first template entry referencing this sequence, else OncePerRun.
+    var entry = template?.Entries.FirstOrDefault(e => string.Equals(e.SequenceId, sequenceId, StringComparison.Ordinal));
+    var kind = entry is null ? ScheduleKind.OncePerRun : KindFor(entry);
+    return NewItem(sequenceId, names, kind, ReasonFor(kind, entry), expectedAt: null,
+      relativeLabel: "now", repeats: Repeats(kind, cycling), order: 0);
+  }
+
+  // ── Upcoming ("up next") ──────────────────────────────────────────────────────────────────
+
+  private static List<QueueMonitorItem> BuildUpcoming(
+    QueueRunHandle handle, QueueTemplate? template, IReadOnlyDictionary<string, string> names,
+    DateTimeOffset now, bool cycling, QueueMonitorItem? current,
+    KeyValuePair<string, DateTimeOffset>[] liveSchedules, IReadOnlyList<SelfRescheduleEntry> selfTimerFirings) {
+    var entries = template?.Entries ?? new System.Collections.ObjectModel.Collection<QueueTemplateEntry>();
+
+    // (1) OncePerRun spine in template order — the "playlist" backbone. AtQueueStart is omitted
+    // (already ran); the currently-executing once-per-run step is excluded (Current holds it).
+    var spine = entries.Where(e => e.ScheduleType == ScheduleType.OncePerRun).ToList();
+    if (current is not null) {
+      var idx = spine.FindIndex(e => string.Equals(e.SequenceId, current.SequenceId, StringComparison.Ordinal));
+      if (idx >= 0) spine.RemoveAt(idx);
+    }
+    var spineItems = spine.Select((e, i) => NewItem(
+      e.SequenceId, names, ScheduleKind.OncePerRun, ReasonFor(ScheduleKind.OncePerRun, e),
+      expectedAt: null, relativeLabel: i == 0 ? "next" : "up next",
+      repeats: Repeats(ScheduleKind.OncePerRun, cycling), order: 0)).ToList();
+
+    // (2) EveryStep entries, surfaced once each as "After Every Step" (not interleaved per step).
+    var everyStepItems = entries.Where(e => e.ScheduleType == ScheduleType.EveryStep)
+      .Select(e => NewItem(e.SequenceId, names, ScheduleKind.EveryStep, ReasonFor(ScheduleKind.EveryStep, e),
+        expectedAt: null, relativeLabel: null, repeats: Repeats(ScheduleKind.EveryStep, cycling), order: 0))
+      .ToList();
+
+    // (3) Timed firings — template timers (time-of-day next-eligible; relative anchor+offset), live
+    // schedules (exact), and self-reschedule Timer firings (exact) — merged, sorted by ExpectedAt.
+    var timed = new List<QueueMonitorItem>();
+    foreach (var e in entries.Where(e => e.ScheduleType == ScheduleType.Timer)) {
+      if (e.TimerTimeOfDay is { } tod) {
+        timed.Add(NewItem(e.SequenceId, names, ScheduleKind.TimerTimeOfDay, $"At {tod:HH:mm}",
+          NextEligible(now, tod), relativeLabel: null, repeats: false, order: 0));
+      }
+      else if (e.TimerRelativeOffset is { } offset) {
+        var expectedAt = handle.RunStartedAt + offset;
+        var elapsed = expectedAt <= now;
+        timed.Add(NewItem(e.SequenceId, names, ScheduleKind.TimerRelative, $"+{offset} after start",
+          expectedAt, relativeLabel: elapsed ? "due" : null, repeats: false, order: 0));
+      }
+    }
+    foreach (var kv in liveSchedules) {
+      timed.Add(NewItem(kv.Key, names, ScheduleKind.LiveSchedule, "Scheduled live",
+        kv.Value, relativeLabel: null, repeats: false, order: 0));
+    }
+    foreach (var firing in selfTimerFirings.Where(f => f.FireAt is not null)) {
+      timed.Add(NewItem(firing.SequenceId, names, ScheduleKind.SelfReschedule, "Rescheduled by a sequence",
+        firing.FireAt, relativeLabel: null, repeats: false, order: 0));
+    }
+    timed = timed.OrderBy(i => i.ExpectedAt).ToList();
+
+    // Idle-but-alive (FR-009): with no imminent once-per-run step but a pending future firing, label
+    // the earliest timed item "waiting" so the run reads as alive rather than empty/stuck.
+    if (spineItems.Count == 0 && timed.Count > 0 && timed[0].RelativeLabel is null) {
+      timed[0] = timed[0] with { RelativeLabel = "waiting" };
+    }
+
+    // Assign stable order across the whole list: spine → every-step → sorted timed.
+    return spineItems.Concat(everyStepItems).Concat(timed)
+      .Select((item, i) => item with { Order = i }).ToList();
+  }
+
+  // ── Last outcome (not running) ──────────────────────────────────────────────────────────────
+
+  private async Task<RunOutcome?> BuildLastOutcomeAsync(string queueId, CancellationToken ct) {
+    var page = await _log.QueryAsync(
+      new ExecutionLogQuery { ObjectType = "queue", ObjectId = queueId, RootsOnly = true, PageSize = 20 }, ct)
+      .ConfigureAwait(false);
+    // Default sort is timestamp descending → the first finalized queue-run entry is the latest one.
+    var latest = page.Items.FirstOrDefault(e =>
+      string.Equals(e.ObjectRef.ObjectType, "queue", StringComparison.OrdinalIgnoreCase)
+      && string.Equals(e.ObjectRef.ObjectId, queueId, StringComparison.Ordinal)
+      && !string.Equals(e.FinalStatus, "running", StringComparison.OrdinalIgnoreCase));
+    return latest is null ? null : new RunOutcome(latest.FinalStatus, latest.Summary);
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────────────────────
+
+  private async Task<IReadOnlyDictionary<string, string>> ResolveSequenceNamesAsync() {
+    var all = await _sequences.ListAsync().ConfigureAwait(false);
+    return all.ToDictionary(s => s.Id, s => s.Name, StringComparer.Ordinal);
+  }
+
+  private static QueueMonitorItem NewItem(
+    string sequenceId, IReadOnlyDictionary<string, string> names, ScheduleKind kind, string reason,
+    DateTimeOffset? expectedAt, string? relativeLabel, bool repeats, int order) {
+    var resolved = names.TryGetValue(sequenceId, out var n) ? n : null;
+    return new QueueMonitorItem(sequenceId, resolved, Stale: resolved is null, kind, reason,
+      expectedAt, relativeLabel, repeats, order);
+  }
+
+  private static ScheduleKind KindFor(QueueTemplateEntry entry) => entry.ScheduleType switch {
+    ScheduleType.AtQueueStart => ScheduleKind.AtQueueStart,
+    ScheduleType.EveryStep => ScheduleKind.EveryStep,
+    ScheduleType.Timer => entry.TimerTimeOfDay is not null ? ScheduleKind.TimerTimeOfDay : ScheduleKind.TimerRelative,
+    _ => ScheduleKind.OncePerRun
+  };
+
+  private static string ReasonFor(ScheduleKind kind, QueueTemplateEntry? entry) => kind switch {
+    ScheduleKind.AtQueueStart => "At queue start",
+    ScheduleKind.EveryStep => "After Every Step",
+    ScheduleKind.TimerTimeOfDay => entry?.TimerTimeOfDay is { } tod ? $"At {tod:HH:mm}" : "Timed",
+    ScheduleKind.TimerRelative => entry?.TimerRelativeOffset is { } off ? $"+{off} after start" : "Timed",
+    ScheduleKind.LiveSchedule => "Scheduled live",
+    ScheduleKind.SelfReschedule => "Rescheduled by a sequence",
+    _ => "Once per run"
+  };
+
+  // OncePerRun/EveryStep recur every cycle on a cycling queue; timed/live/self-reschedule fire once.
+  private static bool Repeats(ScheduleKind kind, bool cycling) =>
+    cycling && kind is ScheduleKind.OncePerRun or ScheduleKind.EveryStep;
+
+  // Next-eligible wall-clock for a time-of-day timer: today at HH:mm if still ahead, else tomorrow.
+  private static DateTimeOffset NextEligible(DateTimeOffset now, TimeOnly tod) {
+    var todayAt = new DateTimeOffset(now.Year, now.Month, now.Day, tod.Hour, tod.Minute, tod.Second, now.Offset);
+    return now.TimeOfDay < tod.ToTimeSpan() ? todayAt : todayAt.AddDays(1);
+  }
+}

--- a/src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// Why a monitor item is scheduled to run. Mirrors the schedule semantics the run loop executes,
+/// mapping template <c>ScheduleType</c> (plus the timer time-of-day/relative split and the two
+/// ephemeral run-scoped kinds) to a single operator-facing vocabulary for the live monitor.
+/// </summary>
+internal enum ScheduleKind {
+  /// <summary>Ran once at run start, before timers and the first once-per-run step.</summary>
+  AtQueueStart,
+
+  /// <summary>The regular "step" — executed in template order; defines run completion.</summary>
+  OncePerRun,
+
+  /// <summary>Executed after each once-per-run step; surfaced once as "After Every Step".</summary>
+  EveryStep,
+
+  /// <summary>Template Timer in time-of-day mode — fires at a wall-clock <c>HH:mm</c>.</summary>
+  TimerTimeOfDay,
+
+  /// <summary>Template Timer in relative mode — fires at <c>RunStartedAt + offset</c>.</summary>
+  TimerRelative,
+
+  /// <summary>Ephemeral live schedule (feature 059) — fires at an exact instant.</summary>
+  LiveSchedule,
+
+  /// <summary>Ephemeral self-reschedule Timer firing (feature 065) — fires at an exact instant.</summary>
+  SelfReschedule
+}
+
+/// <summary>
+/// Read-only projection of what a queue's current run is doing now and will do next. A pure function
+/// of (linked template, run-handle snapshot, <c>now</c>, best-effort last outcome); never persisted.
+/// </summary>
+internal sealed record QueueMonitorSnapshot(
+  string QueueId,
+  string Name,
+  bool Running,
+  bool CycleExecution,
+  DateTimeOffset? RunStartedAt,
+  QueueMonitorItem? Current,
+  IReadOnlyList<QueueMonitorItem> Upcoming,
+  bool NothingScheduled,
+  RunOutcome? LastOutcome);
+
+/// <summary>One item in the monitor's now/up-next plan.</summary>
+internal sealed record QueueMonitorItem(
+  string SequenceId,
+  string? SequenceName,
+  bool Stale,
+  ScheduleKind ScheduleKind,
+  string Reason,
+  DateTimeOffset? ExpectedAt,
+  string? RelativeLabel,
+  bool Repeats,
+  int Order);
+
+/// <summary>Best-effort last finalized run outcome (shown when the queue is not running).</summary>
+internal sealed record RunOutcome(string Status, string Summary);

--- a/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
@@ -61,8 +61,47 @@ internal sealed class QueueRunHandle {
   public ConcurrentDictionary<string, SelfRescheduleEntry> EveryStepInjections { get; } =
     new(StringComparer.Ordinal);
 
+  // ── Current-sequence tracking (feature 072) ──────────────────────────────────────────────────
+  // The sequence-level "now" indicator for the live monitor. Set at the top of every firing in
+  // RunOneSequenceAsync and cleared in its finally, so the monitor can read which sequence is
+  // executing right now (across ALL schedule kinds) without touching scheduling behavior. A
+  // concurrent monitor read is lock-free for the id (volatile) and lock-guarded for the instant.
+
+  private volatile string? _currentSequenceId;
+  private DateTimeOffset? _currentSequenceStartedAt;
+  private readonly object _currentLock = new();
+
+  /// <summary>Sequence id currently executing; <c>null</c> between firings. Safe to read concurrently.</summary>
+  public string? CurrentSequenceId => _currentSequenceId;
+
+  /// <summary>When the current firing started (local clock); <c>null</c> between firings.</summary>
+  public DateTimeOffset? CurrentSequenceStartedAt {
+    get { lock (_currentLock) { return _currentSequenceStartedAt; } }
+  }
+
+  /// <summary>Marks <paramref name="sequenceId"/> as the sequence executing now (set at firing start).</summary>
+  public void SetCurrentSequence(string sequenceId, DateTimeOffset startedAt) {
+    lock (_currentLock) { _currentSequenceStartedAt = startedAt; }
+    _currentSequenceId = sequenceId;
+  }
+
+  /// <summary>Clears the current-sequence indicator (in the firing's finally).</summary>
+  public void ClearCurrentSequence() {
+    _currentSequenceId = null;
+    lock (_currentLock) { _currentSequenceStartedAt = null; }
+  }
+
   private readonly List<SelfRescheduleEntry> _pendingTimerFirings = new();
   private readonly object _timerLock = new();
+
+  /// <summary>
+  /// Returns a copy of the pending self-reschedule Timer firings (each with <c>SequenceId</c> +
+  /// <c>FireAt</c>) under the same lock that guards the list. Used by the monitor projection to show
+  /// upcoming self-reschedule firings without mutating the queue (unlike <see cref="DrainDueTimerFirings"/>).
+  /// </summary>
+  public IReadOnlyList<SelfRescheduleEntry> SnapshotPendingTimerFirings() {
+    lock (_timerLock) { return _pendingTimerFirings.ToArray(); }
+  }
 
   /// <summary>Adds a resolved Timer firing (fires once at/after its <see cref="SelfRescheduleEntry.FireAt"/>).</summary>
   public void AddTimerFiring(SelfRescheduleEntry entry) {

--- a/src/web-ui/src/components/queues/QueueMonitor.css
+++ b/src/web-ui/src/components/queues/QueueMonitor.css
@@ -1,0 +1,123 @@
+.queue-monitor {
+  border: 1px solid var(--border-color, #d0d0d0);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-top: 8px;
+  background: var(--panel-bg, #fafafa);
+}
+
+.queue-monitor-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.queue-monitor-header h4 {
+  margin: 0;
+}
+
+.queue-monitor-now {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-color, #e0e0e0);
+}
+
+.monitor-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-color, #777);
+  min-width: 4.5em;
+}
+
+.monitor-current strong {
+  margin-right: 8px;
+}
+
+.monitor-idle {
+  font-style: italic;
+  color: var(--muted-color, #777);
+}
+
+.queue-monitor-upcoming {
+  display: flex;
+  gap: 10px;
+  padding-top: 8px;
+}
+
+.queue-monitor-upcoming ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+}
+
+.queue-monitor-upcoming li {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 4px 0;
+}
+
+.monitor-seq {
+  font-weight: 600;
+  min-width: 12em;
+}
+
+.monitor-reason {
+  color: var(--muted-color, #777);
+  font-size: 0.85rem;
+}
+
+.monitor-when {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-color, #555);
+}
+
+.monitor-badge {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: var(--badge-bg, #e6e6e6);
+  color: var(--badge-color, #444);
+}
+
+.monitor-stale .monitor-seq {
+  color: var(--danger-color, #b00);
+}
+
+.queue-monitor-empty {
+  color: var(--muted-color, #777);
+  font-style: italic;
+  padding: 6px 0;
+}
+
+.queue-monitor-ended h4 {
+  margin: 0 0 6px;
+}
+
+.queue-monitor-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.monitor-outcome {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.monitor-outcome-success {
+  color: var(--success-color, #2a7);
+}
+
+.monitor-outcome-failure {
+  color: var(--danger-color, #b00);
+}

--- a/src/web-ui/src/components/queues/QueueMonitor.tsx
+++ b/src/web-ui/src/components/queues/QueueMonitor.tsx
@@ -1,0 +1,146 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { getQueueMonitor, QueueMonitorDto, QueueMonitorItemDto } from '../../services/queues';
+import './QueueMonitor.css';
+
+// Poll interval for the live monitor. Kept within the spec's 2–3s auto-refresh target (FR-007).
+const POLL_INTERVAL_MS = 2500;
+
+export type QueueMonitorProps = {
+  queueId: string;
+  /** Invoked when the operator returns to the editor from the ended state. */
+  onReturnToEditor?: () => void;
+};
+
+const formatTime = (iso: string | null): string => {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+};
+
+const itemName = (item: QueueMonitorItemDto): string =>
+  item.sequenceName ?? `Unknown sequence${item.stale ? ' (stale)' : ''}`;
+
+const itemTiming = (item: QueueMonitorItemDto): string => {
+  if (item.expectedAt) return formatTime(item.expectedAt);
+  if (item.relativeLabel) return item.relativeLabel;
+  return '';
+};
+
+/**
+ * Read-only live "playlist" for a running queue (feature 072): the sequence running now and the
+ * ordered up-next list, each with its schedule reason and expected time. Polls
+ * <c>GET /api/queues/{id}/monitor</c> every ~2.5s while mounted; a poll returning <c>running:false</c>
+ * switches to an "ended" state and stops polling. No run controls — start/stop/schedule stay in the
+ * queues overview.
+ */
+export const QueueMonitor: React.FC<QueueMonitorProps> = ({ queueId, onReturnToEditor }) => {
+  const [snapshot, setSnapshot] = useState<QueueMonitorDto | undefined>(undefined);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const stoppedRef = useRef(false);
+
+  const poll = useCallback(async () => {
+    try {
+      const data = await getQueueMonitor(queueId);
+      setSnapshot(data);
+      setError(undefined);
+      if (!data.running) stoppedRef.current = true;
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load monitor');
+    }
+  }, [queueId]);
+
+  useEffect(() => {
+    stoppedRef.current = false;
+    void poll();
+    const timer = setInterval(() => {
+      if (stoppedRef.current) return; // run ended → stop refreshing (interval cleared on unmount)
+      void poll();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [poll]);
+
+  if (error && !snapshot) {
+    return <div className="queue-monitor" data-testid="queue-monitor"><div className="form-error" role="alert">{error}</div></div>;
+  }
+  if (!snapshot) {
+    return <div className="queue-monitor" data-testid="queue-monitor">Loading…</div>;
+  }
+
+  // Ended / not-running state (FR-010): show the last outcome and a path back to the editor + logs.
+  if (!snapshot.running) {
+    return (
+      <div className="queue-monitor" data-testid="queue-monitor">
+        <div className="queue-monitor-ended" data-testid="monitor-ended" role="status">
+          <h4>Run ended</h4>
+          {snapshot.lastOutcome ? (
+            <p>
+              <span className={`monitor-outcome monitor-outcome-${snapshot.lastOutcome.status}`}>{snapshot.lastOutcome.status}</span>
+              {' — '}
+              {snapshot.lastOutcome.summary}
+            </p>
+          ) : (
+            <p>The queue is not running.</p>
+          )}
+          <div className="queue-monitor-actions">
+            {onReturnToEditor && (
+              <button type="button" onClick={onReturnToEditor}>Back to editor</button>
+            )}
+            <a href="#/execution">See Execution Logs</a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const waiting = !snapshot.current && snapshot.upcoming.find((i) => i.relativeLabel === 'waiting' && i.expectedAt);
+
+  return (
+    <div className="queue-monitor" data-testid="queue-monitor">
+      <div className="queue-monitor-header">
+        <h4>{snapshot.name} — live monitor</h4>
+        {snapshot.cycleExecution && <span className="monitor-badge">cycling</span>}
+      </div>
+
+      {/* "Now" row */}
+      <div className="queue-monitor-now" data-testid="monitor-now">
+        <span className="monitor-label">Now</span>
+        {snapshot.current ? (
+          <span className="monitor-current">
+            <strong>{itemName(snapshot.current)}</strong>
+            <span className="monitor-reason">{snapshot.current.reason}</span>
+          </span>
+        ) : waiting ? (
+          <span className="monitor-current monitor-idle">Running — waiting until {formatTime(waiting.expectedAt)}</span>
+        ) : snapshot.nothingScheduled ? (
+          <span className="monitor-current monitor-idle">Running — nothing scheduled</span>
+        ) : (
+          <span className="monitor-current monitor-idle">Running</span>
+        )}
+      </div>
+
+      {/* "Up next" list */}
+      {snapshot.nothingScheduled ? (
+        <div className="queue-monitor-empty" data-testid="monitor-nothing">Nothing scheduled.</div>
+      ) : (
+        <div className="queue-monitor-upcoming">
+          <span className="monitor-label">Up next</span>
+          {snapshot.upcoming.length === 0 ? (
+            <div className="queue-monitor-empty">Nothing up next.</div>
+          ) : (
+            <ul>
+              {snapshot.upcoming.map((item) => (
+                <li key={`${item.order}-${item.sequenceId}`} data-testid="monitor-upcoming-item" className={item.stale ? 'monitor-stale' : undefined}>
+                  <span className="monitor-seq">{itemName(item)}</span>
+                  <span className="monitor-reason">{item.reason}</span>
+                  <span className="monitor-when">{itemTiming(item)}</span>
+                  {item.repeats && <span className="monitor-badge" title="Repeats each cycle">repeats</span>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/web-ui/src/components/queues/__tests__/QueueMonitor.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueMonitor.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { QueueMonitor } from '../QueueMonitor';
+import { getQueueMonitor, QueueMonitorDto } from '../../../services/queues';
+
+jest.mock('../../../services/queues');
+
+const getQueueMonitorMock = getQueueMonitor as jest.MockedFunction<typeof getQueueMonitor>;
+
+const item = (over: Partial<QueueMonitorDto['upcoming'][number]> = {}): QueueMonitorDto['upcoming'][number] => ({
+  sequenceId: 's', sequenceName: 'Seq', stale: false, scheduleKind: 'OncePerRun',
+  reason: 'Once per run', expectedAt: null, relativeLabel: null, repeats: false, order: 0, ...over,
+});
+
+const snapshot = (over: Partial<QueueMonitorDto> = {}): QueueMonitorDto => ({
+  queueId: 'q1', name: 'Daily', running: true, cycleExecution: false, runStartedAt: '2026-01-01T12:00:00+00:00',
+  current: null, upcoming: [], nothingScheduled: false, lastOutcome: null, ...over,
+});
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('QueueMonitor', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetAllMocks();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders the Now row and the ordered Up next list', async () => {
+    getQueueMonitorMock.mockResolvedValue(snapshot({
+      current: item({ sequenceId: 'A', sequenceName: 'Alpha', relativeLabel: 'now' }),
+      upcoming: [
+        item({ sequenceId: 'B', sequenceName: 'Bravo', relativeLabel: 'next', order: 0 }),
+        item({ sequenceId: 'C', sequenceName: 'Charlie', relativeLabel: 'up next', order: 1 }),
+      ],
+    }));
+
+    render(<QueueMonitor queueId="q1" />);
+    await flush();
+
+    expect(screen.getByTestId('monitor-now')).toHaveTextContent('Alpha');
+    const rows = screen.getAllByTestId('monitor-upcoming-item');
+    expect(rows.map((r) => r.textContent)).toEqual([
+      expect.stringContaining('Bravo'),
+      expect.stringContaining('Charlie'),
+    ]);
+  });
+
+  it('re-polls on the ~2.5s interval and updates the list', async () => {
+    getQueueMonitorMock.mockResolvedValueOnce(snapshot({ upcoming: [item({ sequenceId: 'B', sequenceName: 'Bravo' })] }));
+    getQueueMonitorMock.mockResolvedValueOnce(snapshot({ upcoming: [item({ sequenceId: 'C', sequenceName: 'Charlie' })] }));
+
+    render(<QueueMonitor queueId="q1" />);
+    await flush();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+    expect(getQueueMonitorMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => { jest.advanceTimersByTime(2500); });
+    await flush();
+
+    expect(getQueueMonitorMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  // ── US3: idle / empty / ended states ─────────────────────────────────────
+
+  it('renders the running & waiting-until state for an idle-but-alive queue', async () => {
+    getQueueMonitorMock.mockResolvedValue(snapshot({
+      current: null,
+      upcoming: [item({ sequenceId: 'T', sequenceName: 'Timer', scheduleKind: 'TimerTimeOfDay', reason: 'At 15:00', expectedAt: '2026-01-01T15:00:00+00:00', relativeLabel: 'waiting' })],
+    }));
+
+    render(<QueueMonitor queueId="q1" />);
+    await flush();
+
+    expect(screen.getByTestId('monitor-now')).toHaveTextContent(/waiting until/i);
+  });
+
+  it('renders the nothing-scheduled empty state', async () => {
+    getQueueMonitorMock.mockResolvedValue(snapshot({ nothingScheduled: true, upcoming: [] }));
+
+    render(<QueueMonitor queueId="q1" />);
+    await flush();
+
+    expect(screen.getByTestId('monitor-nothing')).toBeInTheDocument();
+  });
+
+  it('renders the ended state with the last outcome and stops polling', async () => {
+    getQueueMonitorMock.mockResolvedValue(snapshot({
+      running: false, current: null,
+      lastOutcome: { status: 'success', summary: 'Queue completed full run: 3 sequence(s) executed.' },
+    }));
+
+    render(<QueueMonitor queueId="q1" />);
+    await flush();
+
+    const ended = screen.getByTestId('monitor-ended');
+    expect(ended).toHaveTextContent(/Run ended/i);
+    expect(ended).toHaveTextContent(/completed full run/i);
+
+    // Polling stops once the run has ended: further ticks do not re-fetch.
+    const callsAfterEnd = getQueueMonitorMock.mock.calls.length;
+    await act(async () => { jest.advanceTimersByTime(7500); });
+    await flush();
+    expect(getQueueMonitorMock).toHaveBeenCalledTimes(callsAfterEnd);
+  });
+});

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../services/queues';
 import { listSequences, SequenceDto } from '../services/sequences';
 import { QueueForm, QueueFormValue } from '../components/queues/QueueForm';
+import { QueueMonitor } from '../components/queues/QueueMonitor';
 import { EntrySchedule } from '../components/queues/QueueEntryList';
 import { QueueSchedulingAreas } from '../components/queues/QueueSchedulingAreas';
 import { SchedulingAreasState } from '../components/queues/schedulingAreas';
@@ -462,7 +463,22 @@ export const QueuesPage: React.FC = () => {
         </section>
       )}
 
-      {detail && !creating && (
+      {detail && !creating && detail.status === 'Running' && (
+        <section>
+          <h3>Monitor: {detail.name}</h3>
+          <QueueMonitor
+            queueId={detail.id}
+            onReturnToEditor={async () => {
+              // The run has ended (or the operator chose to leave the monitor): reload the queue so
+              // the panel flips back to the editor and the overview row reflects the stopped status.
+              await refresh();
+              await openEdit(detail.id);
+            }}
+          />
+        </section>
+      )}
+
+      {detail && !creating && detail.status !== 'Running' && (
         <section>
           <h3>Edit Queue</h3>
           <QueueForm

--- a/src/web-ui/src/pages/__tests__/QueuesPage.monitor.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.monitor.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueuesPage } from '../QueuesPage';
+import { listQueues, getQueue } from '../../services/queues';
+import { listSequences } from '../../services/sequences';
+
+jest.mock('../../services/queues');
+jest.mock('../../services/sequences');
+jest.mock('../../services/useAdbDevices', () => ({
+  useAdbDevices: () => ({ devices: [{ serial: 'emu-1' }], loading: false, error: undefined, refresh: () => {} }),
+}));
+
+// Stub the monitor so US2 routing is asserted independently of US1's rendering. The stub exposes the
+// running→stopped transition via a button that invokes onReturnToEditor.
+jest.mock('../../components/queues/QueueMonitor', () => ({
+  QueueMonitor: ({ queueId, onReturnToEditor }: { queueId: string; onReturnToEditor?: () => void }) => (
+    <div data-testid="queue-monitor-stub">
+      monitor:{queueId}
+      <button type="button" onClick={() => onReturnToEditor?.()}>Back to editor</button>
+    </div>
+  ),
+}));
+
+const listQueuesMock = listQueues as jest.MockedFunction<typeof listQueues>;
+const getQueueMock = getQueue as jest.MockedFunction<typeof getQueue>;
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+
+const row = (over: Partial<any> = {}) => ({
+  id: 'q1', name: 'Daily', emulatorSerial: 'emu-1', cycleExecution: false, status: 'Stopped', entryCount: 0, ...over,
+});
+const detail = (over: Partial<any> = {}) => ({
+  ...row(over), entries: [], linkedTemplateId: null, linkedTemplateName: null, linkedGameId: null, linkedGameName: null, ...over,
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  listSequencesMock.mockResolvedValue([] as any);
+});
+
+describe('QueuesPage monitor-vs-editor routing', () => {
+  it('renders the monitor (not the editor) when the opened queue is Running', async () => {
+    listQueuesMock.mockResolvedValue([row({ status: 'Running' })] as any);
+    getQueueMock.mockResolvedValue(detail({ status: 'Running' }) as any);
+
+    render(<QueuesPage />);
+    await screen.findByText('Daily');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+
+    await screen.findByTestId('queue-monitor-stub');
+    expect(screen.queryByText('Edit Queue')).not.toBeInTheDocument();
+  });
+
+  it('renders the editor when the opened queue is Stopped', async () => {
+    listQueuesMock.mockResolvedValue([row({ status: 'Stopped' })] as any);
+    getQueueMock.mockResolvedValue(detail({ status: 'Stopped' }) as any);
+
+    render(<QueuesPage />);
+    await screen.findByText('Daily');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+
+    await screen.findByText('Edit Queue');
+    expect(screen.queryByTestId('queue-monitor-stub')).not.toBeInTheDocument();
+  });
+
+  it('returns to the editor when the run ends (running → stopped transition)', async () => {
+    listQueuesMock.mockResolvedValue([row({ status: 'Running' })] as any);
+    getQueueMock
+      .mockResolvedValueOnce(detail({ status: 'Running' }) as any)
+      .mockResolvedValueOnce(detail({ status: 'Stopped' }) as any);
+
+    render(<QueuesPage />);
+    await screen.findByText('Daily');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+    await screen.findByTestId('queue-monitor-stub');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to editor' }));
+
+    await screen.findByText('Edit Queue');
+    await waitFor(() => expect(screen.queryByTestId('queue-monitor-stub')).not.toBeInTheDocument());
+  });
+});

--- a/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.templates.spec.tsx
@@ -277,15 +277,16 @@ describe('QueuesPage template load wiring', () => {
     expect(within(area).getByLabelText('Template name')).toHaveValue('Daily Farm');
   });
 
-  it('disables the Load action while the queue is running', async () => {
+  it('shows the read-only monitor (not the editable template controls) while the queue is running', async () => {
+    // Feature 072: opening a Running queue routes to the live monitor instead of the editor, so the
+    // template Load control is not reachable at all (a stronger guarantee than the old disabled-Load state).
     getQueueMock.mockResolvedValue({ ...detailWithEntries(), status: 'Running' } as any);
     render(<QueuesPage />);
     await screen.findByText('Daily');
     fireEvent.click(screen.getByText('Daily'));
-    await screen.findByText('Edit Queue');
-    fireEvent.click(screen.getByText('(no template)'));
-    const picker = await screen.findByRole('region', { name: 'Load template' });
-    expect(within(picker).getByText('Load')).toBeDisabled();
+    await screen.findByTestId('queue-monitor');
+    expect(screen.queryByText('Edit Queue')).not.toBeInTheDocument();
+    expect(screen.queryByText('(no template)')).not.toBeInTheDocument();
   });
 
   it('loads the same template independently into two different queues (FR-016)', async () => {

--- a/src/web-ui/src/services/queues.ts
+++ b/src/web-ui/src/services/queues.ts
@@ -75,3 +75,52 @@ export type LiveScheduleResult = {
  */
 export const liveScheduleSequence = (queueId: string, sequenceId: string, offset: string) =>
   postJson<LiveScheduleResult>(`${base}/${queueId}/live-schedule`, { sequenceId, offset });
+
+// ── Live monitor (feature 072) ────────────────────────────────────────────────────────────────
+
+/** Why a monitor item is scheduled, mirroring the run loop's schedule semantics. */
+export type ScheduleKind =
+  | 'AtQueueStart'
+  | 'OncePerRun'
+  | 'EveryStep'
+  | 'TimerTimeOfDay'
+  | 'TimerRelative'
+  | 'LiveSchedule'
+  | 'SelfReschedule';
+
+/** One now/up-next item in the live monitor plan. */
+export type QueueMonitorItemDto = {
+  sequenceId: string;
+  sequenceName: string | null;
+  stale: boolean;
+  scheduleKind: ScheduleKind;
+  reason: string;
+  /** Absolute expected time (ISO-8601 with offset) when known; null for spine steps. */
+  expectedAt: string | null;
+  /** Hint when there is no absolute time: now / next / up next / waiting / due. */
+  relativeLabel: string | null;
+  repeats: boolean;
+  order: number;
+};
+
+/** Best-effort last finalized run outcome (shown when the queue is not running). */
+export type RunOutcomeDto = {
+  status: string;
+  summary: string;
+};
+
+/** Read-only snapshot of a queue's live run plan. */
+export type QueueMonitorDto = {
+  queueId: string;
+  name: string;
+  running: boolean;
+  cycleExecution: boolean;
+  runStartedAt: string | null;
+  current: QueueMonitorItemDto | null;
+  upcoming: QueueMonitorItemDto[];
+  nothingScheduled: boolean;
+  lastOutcome: RunOutcomeDto | null;
+};
+
+/** Fetch the live monitor snapshot for a queue. Safe to poll; no side effects. */
+export const getQueueMonitor = (id: string) => getJson<QueueMonitorDto>(`${base}/${id}/monitor`);

--- a/tests/integration/Queues/QueueMonitorEndpointTests.cs
+++ b/tests/integration/Queues/QueueMonitorEndpointTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.RegularExpressions;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Queues;
+
+/// <summary>
+/// Exercises GET /api/queues/{id}/monitor through the real HTTP stack. ADB runs in stub mode, so a
+/// cycling queue holds a deterministic "Running" window while the snapshot is read (feature 072).
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class QueueMonitorEndpointTests {
+  public QueueMonitorEndpointTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static async Task<string> CreateQueueAsync(HttpClient client, bool cycle) {
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative),
+      new { name = "Mon", emulatorSerial = "emu-offline", cycleExecution = cycle }).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  // Template with a OncePerRun spine step and a time-of-day Timer entry (so the snapshot carries an
+  // expectedAt that must serialize with a numeric offset, FR-014).
+  private static async Task<string> CreateTemplateAsync(HttpClient client) {
+    var entries = new object[] {
+      new { sequenceId = "seq-loop", scheduleType = "OncePerRun", timerTimeOfDay = (string?)null },
+      new { sequenceId = "seq-timer", scheduleType = "Timer", timerTimeOfDay = "23:59" }
+    };
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Tpl-" + Guid.NewGuid().ToString("N"), entries, overwrite = false }).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static async Task<string> StatusAsync(HttpClient client, string id) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}", UriKind.Relative)).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("status").GetString()!;
+  }
+
+  private static async Task WaitForStatusAsync(HttpClient client, string id, string expected, int timeoutMs = 5000) {
+    var sw = Stopwatch.StartNew();
+    while (sw.ElapsedMilliseconds < timeoutMs) {
+      if (await StatusAsync(client, id).ConfigureAwait(true) == expected) return;
+      await Task.Delay(25).ConfigureAwait(true);
+    }
+  }
+
+  [Fact]
+  public async Task MonitorForUnknownQueueReturns404() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var resp = await client.GetAsync(new Uri("/api/queues/missing/monitor", UriKind.Relative)).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+  }
+
+  [Fact]
+  public async Task MonitorForStoppedQueueReturns200NotRunning() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client, cycle: false).ConfigureAwait(true);
+
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}/monitor", UriKind.Relative)).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var root = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    root.GetProperty("running").GetBoolean().Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task MonitorForRunningQueueReturnsPopulatedSnapshotWithOffsetTimes() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateQueueAsync(client, cycle: true).ConfigureAwait(true);
+    var tpl = await CreateTemplateAsync(client).ConfigureAwait(true);
+    await client.PutAsJsonAsync(new Uri($"/api/queues/{id}/template", UriKind.Relative), new { templateId = tpl }).ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true);
+    await WaitForStatusAsync(client, id, "Running").ConfigureAwait(true);
+
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}/monitor", UriKind.Relative)).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var root = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+
+    root.GetProperty("running").GetBoolean().Should().BeTrue();
+
+    // The timer entry must appear in upcoming with an expectedAt serialized as ISO-8601 WITH a numeric
+    // offset (…+hh:mm / …-hh:mm), never a bare/UTC-Z instant (FR-014).
+    var upcoming = root.GetProperty("upcoming");
+    upcoming.GetArrayLength().Should().BeGreaterThan(0);
+    string? expectedAt = null;
+    foreach (var item in upcoming.EnumerateArray()) {
+      if (item.GetProperty("scheduleKind").GetString() == "TimerTimeOfDay") {
+        expectedAt = item.GetProperty("expectedAt").GetString();
+      }
+    }
+    expectedAt.Should().NotBeNull();
+    expectedAt.Should().NotEndWith("Z");
+    Regex.IsMatch(expectedAt!, @"[+-]\d{2}:\d{2}$").Should().BeTrue($"expectedAt '{expectedAt}' should carry a numeric offset");
+
+    await client.PostAsync(new Uri($"/api/queues/{id}/stop", UriKind.Relative), null).ConfigureAwait(true);
+  }
+}

--- a/tests/unit/Queues/QueueMonitorServiceTests.cs
+++ b/tests/unit/Queues/QueueMonitorServiceTests.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Commands.SelfReschedule;
+using GameBot.Domain.Logging;
+using GameBot.Domain.Queues;
+using GameBot.Domain.QueueTemplates;
+using GameBot.Service.Services;
+using GameBot.Service.Services.ExecutionLog;
+using GameBot.Service.Services.QueueExecution;
+using Xunit;
+
+// Test-code analyzer relaxations (permitted by the constitution for test code).
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Queues;
+
+/// <summary>
+/// Deterministic projection tests for <see cref="QueueMonitorService"/> (feature 072). The projection
+/// is a pure function of (linked template, hand-built run handle, fixed clock), so every schedule kind,
+/// ordering rule, current-highlight, cycling marker, nothing-scheduled and last-outcome case is asserted
+/// without spinning the queue engine.
+/// </summary>
+public sealed class QueueMonitorServiceTests {
+  private static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+  // ── Fakes ─────────────────────────────────────────────────────────────
+
+  private sealed class FakeQueueRepository : IQueueRepository {
+    private readonly Dictionary<string, ExecutionQueue> _items = new(StringComparer.Ordinal);
+    public void Add(ExecutionQueue q) => _items[q.Id] = q;
+    public Task<ExecutionQueue?> GetAsync(string id) => Task.FromResult(_items.TryGetValue(id, out var q) ? q : null);
+    public Task<IReadOnlyList<ExecutionQueue>> ListAsync() => Task.FromResult((IReadOnlyList<ExecutionQueue>)_items.Values.ToList());
+    public Task<ExecutionQueue> CreateAsync(ExecutionQueue queue) { _items[queue.Id] = queue; return Task.FromResult(queue); }
+    public Task<ExecutionQueue> UpdateAsync(ExecutionQueue queue) { _items[queue.Id] = queue; return Task.FromResult(queue); }
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(_items.Remove(id));
+  }
+
+  private sealed class FakeTemplateRepository : IQueueTemplateRepository {
+    private readonly Dictionary<string, QueueTemplate> _items = new(StringComparer.Ordinal);
+    public void Add(QueueTemplate t) => _items[t.Id] = t;
+    public Task<QueueTemplate?> GetAsync(string id) => Task.FromResult(_items.TryGetValue(id, out var t) ? t : null);
+    public Task<IReadOnlyList<QueueTemplate>> ListAsync() => Task.FromResult((IReadOnlyList<QueueTemplate>)_items.Values.ToList());
+    public Task<QueueTemplate?> FindByNameAsync(string name) => Task.FromResult<QueueTemplate?>(null);
+    public Task<QueueTemplate> CreateAsync(QueueTemplate item) { _items[item.Id] = item; return Task.FromResult(item); }
+    public Task<QueueTemplate> UpdateAsync(QueueTemplate item) { _items[item.Id] = item; return Task.FromResult(item); }
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(_items.Remove(id));
+  }
+
+  private sealed class FakeSequenceRepository : ISequenceRepository {
+    private readonly Dictionary<string, CommandSequence> _items = new(StringComparer.Ordinal);
+    public void Add(string id, string name) => _items[id] = new CommandSequence { Id = id, Name = name };
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult(_items.TryGetValue(id, out var s) ? s : null);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() => Task.FromResult((IReadOnlyList<CommandSequence>)_items.Values.ToList());
+    public Task<CommandSequence> CreateAsync(CommandSequence sequence) { _items[sequence.Id] = sequence; return Task.FromResult(sequence); }
+    public Task<CommandSequence> UpdateAsync(CommandSequence sequence) { _items[sequence.Id] = sequence; return Task.FromResult(sequence); }
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(_items.Remove(id));
+  }
+
+  private sealed class FakeExecutionLog : IExecutionLogService {
+    public List<ExecutionLogEntry> Entries { get; } = new();
+    public Task<ExecutionLogPage> QueryAsync(ExecutionLogQuery query, CancellationToken ct = default)
+      => Task.FromResult(new ExecutionLogPage(Entries, null));
+
+    // Unused by the monitor projection.
+    public Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, string? parentExecutionId, int depth, CancellationToken ct = default) => Task.CompletedTask;
+    public Task LogCommandExecutionAsync(string commandId, string commandName, string finalStatus, IReadOnlyList<PrimitiveTapStepOutcome> primitiveOutcomes, ExecutionLogContext context, CancellationToken ct = default) => Task.CompletedTask;
+    public Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, string? parentExecutionId, int depth, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default) => Task.CompletedTask;
+    public Task LogSequenceExecutionAsync(string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<string> LogSequenceStartAsync(string sequenceId, string sequenceName, CancellationToken ct = default) => Task.FromResult(Guid.NewGuid().ToString("N"));
+    public Task<string> LogSequenceStartAsync(string sequenceId, string sequenceName, ExecutionLogContext parentContext, CancellationToken ct = default) => Task.FromResult(Guid.NewGuid().ToString("N"));
+    public Task LogSequenceFinalizeAsync(string executionId, string sequenceId, string sequenceName, string finalStatus, string summary, ExecutionLogContext context, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<string> LogQueueStartAsync(string queueId, string queueName, CancellationToken ct = default) => Task.FromResult(Guid.NewGuid().ToString("N"));
+    public Task LogQueueFinalizeAsync(string executionId, string queueId, string queueName, string finalStatus, string summary, IReadOnlyList<ExecutionDetailItem>? details = null, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<ExecutionSubtreeProjection?> GetSubtreeAsync(string executionId, CancellationToken ct = default) => Task.FromResult<ExecutionSubtreeProjection?>(null);
+    public Task<ExecutionLogEntry?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<ExecutionLogEntry?>(null);
+    public Task<ExecutionLogRetentionPolicy> GetRetentionAsync(CancellationToken ct = default) => Task.FromResult(new ExecutionLogRetentionPolicy());
+    public Task<ExecutionLogRetentionPolicy> UpdateRetentionAsync(bool enabled, int? retentionDays, int? cleanupIntervalMinutes, CancellationToken ct = default) => Task.FromResult(new ExecutionLogRetentionPolicy());
+    public Task<int> CleanupExpiredAsync(CancellationToken ct = default) => Task.FromResult(0);
+  }
+
+  // ── Harness ───────────────────────────────────────────────────────────
+
+  private sealed class Harness {
+    public FakeQueueRepository Queues { get; } = new();
+    public FakeTemplateRepository Templates { get; } = new();
+    public FakeSequenceRepository Sequences { get; } = new();
+    public FakeExecutionLog Log { get; } = new();
+    public QueueRunRegistry Registry { get; } = new();
+    public FakeTimeProvider Clock { get; } = new(Now);
+    public QueueMonitorService Service { get; }
+
+    public Harness() {
+      Service = new QueueMonitorService(Registry, Queues, Templates, Sequences, Log, Clock);
+    }
+
+    public QueueTemplate Template { get; } = new() { Id = "tpl", Name = "T" };
+
+    public void AddQueue(bool cycle = false, bool linkTemplate = true) {
+      Templates.Add(Template);
+      Queues.Add(new ExecutionQueue {
+        Id = "q1", Name = "Q1", EmulatorSerial = "emu", CycleExecution = cycle,
+        LinkedTemplateId = linkTemplate ? "tpl" : null
+      });
+    }
+
+    public QueueRunHandle StartHandle(bool cycle = false, DateTimeOffset? runStartedAt = null) {
+      var handle = new QueueRunHandle { QueueId = "q1", Cts = new CancellationTokenSource() };
+      handle.CycleExecution = cycle;
+      handle.RunStartedAt = runStartedAt ?? Now;
+      Registry.TryAdd("q1", handle);
+      return handle;
+    }
+
+    public void Entry(string sequenceId, string name, ScheduleType type = ScheduleType.OncePerRun, TimeOnly? tod = null, TimeSpan? rel = null) {
+      Sequences.Add(sequenceId, name);
+      Template.Entries.Add(new QueueTemplateEntry { SequenceId = sequenceId, ScheduleType = type, TimerTimeOfDay = tod, TimerRelativeOffset = rel });
+    }
+  }
+
+  // ── T011: OncePerRun spine ─────────────────────────────────────────────
+
+  [Fact]
+  public async Task OncePerRunSpineIsTemplateOrderWithNextAndUpNextLabels() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Entry("B", "Bravo");
+    h.Entry("C", "Charlie");
+    h.StartHandle();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Running.Should().BeTrue();
+    snap.Upcoming.Select(i => i.SequenceId).Should().Equal("A", "B", "C");
+    snap.Upcoming.Select(i => i.Reason).Should().AllBe("Once per run");
+    snap.Upcoming[0].RelativeLabel.Should().Be("next");
+    snap.Upcoming[1].RelativeLabel.Should().Be("up next");
+    snap.Upcoming[2].RelativeLabel.Should().Be("up next");
+    snap.Upcoming.Select(i => i.Order).Should().Equal(0, 1, 2);
+  }
+
+  [Fact]
+  public async Task EveryStepIsSurfacedOnceAsAfterEveryStep() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Entry("C", "Chore", ScheduleType.EveryStep);
+    h.StartHandle();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    var everyStep = snap.Upcoming.Where(i => i.ScheduleKind == ScheduleKind.EveryStep).ToList();
+    everyStep.Should().ContainSingle();
+    everyStep[0].Reason.Should().Be("After Every Step");
+  }
+
+  [Fact]
+  public async Task TimerTimeOfDayResolvesNextEligibleTodayOrTomorrow() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("Ahead", "Later today", ScheduleType.Timer, tod: new TimeOnly(15, 0));   // now 12:00 → today 15:00
+    h.Entry("Passed", "Tomorrow", ScheduleType.Timer, tod: new TimeOnly(9, 0));      // now 12:00 → tomorrow 09:00
+    h.StartHandle();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    var ahead = snap.Upcoming.Single(i => i.SequenceId == "Ahead");
+    ahead.ExpectedAt.Should().Be(new DateTimeOffset(2026, 1, 1, 15, 0, 0, TimeSpan.Zero));
+    ahead.Reason.Should().Be("At 15:00");
+    var passed = snap.Upcoming.Single(i => i.SequenceId == "Passed");
+    passed.ExpectedAt.Should().Be(new DateTimeOffset(2026, 1, 2, 9, 0, 0, TimeSpan.Zero));
+  }
+
+  [Fact]
+  public async Task TimerRelativeResolvesRunStartPlusOffset() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("R", "Relative", ScheduleType.Timer, rel: TimeSpan.FromMinutes(30));
+    h.StartHandle(runStartedAt: Now);
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    var r = snap.Upcoming.Single(i => i.SequenceId == "R");
+    r.ScheduleKind.Should().Be(ScheduleKind.TimerRelative);
+    r.ExpectedAt.Should().Be(Now + TimeSpan.FromMinutes(30));
+  }
+
+  [Fact]
+  public async Task LiveScheduleUsesExactFireAt() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Sequences.Add("L", "Live one");
+    var handle = h.StartHandle();
+    var fireAt = Now + TimeSpan.FromMinutes(5);
+    handle.PendingLiveSchedules["L"] = fireAt;
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    var live = snap.Upcoming.Single(i => i.SequenceId == "L");
+    live.ScheduleKind.Should().Be(ScheduleKind.LiveSchedule);
+    live.Reason.Should().Be("Scheduled live");
+    live.ExpectedAt.Should().Be(fireAt);
+  }
+
+  [Fact]
+  public async Task SelfRescheduleTimerFiringUsesExactFireAt() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Sequences.Add("R", "Rescheduled");
+    var handle = h.StartHandle();
+    var fireAt = Now + TimeSpan.FromMinutes(7);
+    handle.AddTimerFiring(new SelfRescheduleEntry("f1", "R", SelfRescheduleOption.Timer, fireAt));
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    var item = snap.Upcoming.Single(i => i.SequenceId == "R");
+    item.ScheduleKind.Should().Be(ScheduleKind.SelfReschedule);
+    item.ExpectedAt.Should().Be(fireAt);
+  }
+
+  [Fact]
+  public async Task TimedItemsAreSortedAscendingByExpectedAt() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha"); // OncePerRun spine keeps the idle "waiting" override from firing
+    h.Sequences.Add("L", "Live");
+    h.Sequences.Add("R", "Resched");
+    h.Entry("T", "Timer", ScheduleType.Timer, tod: new TimeOnly(13, 0)); // today 13:00
+    var handle = h.StartHandle();
+    handle.PendingLiveSchedules["L"] = Now + TimeSpan.FromMinutes(90); // 13:30
+    handle.AddTimerFiring(new SelfRescheduleEntry("f1", "R", SelfRescheduleOption.Timer, Now + TimeSpan.FromMinutes(10))); // 12:10
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    // Only the timed items, in ascending ExpectedAt order: R (12:10) < T (13:00) < L (13:30).
+    snap.Upcoming.Where(i => i.ExpectedAt is not null).Select(i => i.SequenceId).Should().Equal("R", "T", "L");
+  }
+
+  [Fact]
+  public async Task CurrentReflectsCurrentSequenceIdAndIsExcludedFromUpcoming() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Entry("B", "Bravo");
+    var handle = h.StartHandle();
+    handle.SetCurrentSequence("A", Now);
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Current.Should().NotBeNull();
+    snap.Current!.SequenceId.Should().Be("A");
+    snap.Current.RelativeLabel.Should().Be("now");
+    snap.Upcoming.Select(i => i.SequenceId).Should().Equal("B"); // A excluded
+    snap.Upcoming[0].RelativeLabel.Should().Be("next");
+  }
+
+  [Fact]
+  public async Task CyclingMarksOncePerRunAndEveryStepAsRepeating() {
+    var h = new Harness();
+    h.AddQueue(cycle: true);
+    h.Entry("A", "Alpha");
+    h.Entry("C", "Chore", ScheduleType.EveryStep);
+    h.StartHandle(cycle: true);
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Should().OnlyContain(i => i.Repeats);
+  }
+
+  [Fact]
+  public async Task NonCyclingLeavesRepeatsFalse() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Entry("C", "Chore", ScheduleType.EveryStep);
+    h.StartHandle();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Should().OnlyContain(i => !i.Repeats);
+  }
+
+  [Fact]
+  public async Task StaleSequenceReferenceIsListedWithNullNameAndStaleTrue() {
+    var h = new Harness();
+    h.AddQueue();
+    // Template references "A" but no sequence with that id exists in the library.
+    h.Template.Entries.Add(new QueueTemplateEntry { SequenceId = "A", ScheduleType = ScheduleType.OncePerRun });
+    h.StartHandle();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Should().ContainSingle();
+    snap.Upcoming[0].SequenceName.Should().BeNull();
+    snap.Upcoming[0].Stale.Should().BeTrue();
+  }
+
+  // ── T020: US3 idle / empty / not-running ───────────────────────────────
+
+  [Fact]
+  public async Task RunningWithNoWorkOfAnyKindIsNothingScheduled() {
+    var h = new Harness();
+    h.AddQueue(); // linked template with zero entries
+    h.StartHandle();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.NothingScheduled.Should().BeTrue();
+    snap.Upcoming.Should().BeEmpty();
+    snap.Current.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task RunningWithOnlyPendingLiveScheduleIsNotNothingScheduled() {
+    var h = new Harness();
+    h.AddQueue(); // empty template
+    h.Sequences.Add("L", "Live");
+    var handle = h.StartHandle();
+    handle.PendingLiveSchedules["L"] = Now + TimeSpan.FromMinutes(5);
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.NothingScheduled.Should().BeFalse(); // regression guard: live-only run is not "nothing scheduled"
+    snap.Upcoming.Should().ContainSingle(i => i.SequenceId == "L");
+  }
+
+  [Fact]
+  public async Task LonePendingFutureTimerIsLabelledWaiting() {
+    var h = new Harness();
+    h.AddQueue(); // no OncePerRun spine
+    h.Entry("T", "Timer", ScheduleType.Timer, tod: new TimeOnly(15, 0)); // future today
+    h.StartHandle();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    var timer = snap.Upcoming.Single(i => i.SequenceId == "T");
+    timer.ExpectedAt.Should().Be(new DateTimeOffset(2026, 1, 1, 15, 0, 0, TimeSpan.Zero));
+    timer.RelativeLabel.Should().Be("waiting");
+  }
+
+  [Fact]
+  public async Task NotRunningWithPriorFinalizedRunPopulatesLastOutcome() {
+    var h = new Harness();
+    h.AddQueue();
+    // No handle registered → not running.
+    h.Log.Entries.Add(new ExecutionLogEntry {
+      ExecutionType = "queue",
+      FinalStatus = "success",
+      Summary = "Queue 'Q1' completed full run: 3 sequence(s) executed.",
+      ObjectRef = new ExecutionObjectReference("queue", "q1", "Q1"),
+      Navigation = new ExecutionNavigationContext("/x", null),
+      Hierarchy = new ExecutionHierarchyContext("root", null, 0, null)
+    });
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Running.Should().BeFalse();
+    snap.LastOutcome.Should().NotBeNull();
+    snap.LastOutcome!.Status.Should().Be("success");
+    snap.LastOutcome.Summary.Should().Contain("completed full run");
+  }
+
+  [Fact]
+  public async Task NotRunningWithNoHistoryHasNullLastOutcome() {
+    var h = new Harness();
+    h.AddQueue();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Running.Should().BeFalse();
+    snap.LastOutcome.Should().BeNull();
+  }
+}


### PR DESCRIPTION
## Summary

Adds a read-only **live monitor** for running queues (feature 072). Opening a **running** queue in the web UI now shows a "playlist" view — the sequence running **now**, the ordered **up-next** list, and, per item, *why* it is scheduled and *when* it is expected to run — instead of the entry editor. The panel auto-refreshes every ~2.5s. A **stopped** queue still opens the editor unchanged.

## What changed

**Backend (`GameBot.Service`)**
- `QueueRunHandle`: minimal sequence-level "now" tracking (`CurrentSequenceId`/`CurrentSequenceStartedAt`) + `SnapshotPendingTimerFirings()`. The only queue-engine change is setting/clearing those fields around each firing in `QueueExecutionService.RunOneSequenceAsync` — **no scheduling behavior changes**.
- New pure projection `QueueMonitorService` (run handle + linked template + wall-clock → ordered now/up-next snapshot) behind `GET /api/queues/{id}/monitor`.
  - Exact expected times for live / self-reschedule / relative firings; next-eligible for time-of-day timers.
  - `nothingScheduled`, idle "waiting", cycling `repeats` markers, stale-reference handling.
  - Not running → `200 running:false` with best-effort last outcome from the execution log; unknown queue → `404`.
- Wire DTOs, DI registration, and a thin endpoint projector.

**Web UI**
- `QueueMonitor` component (polling, idle/empty/ended states) + CSS.
- `QueuesPage` routes running → monitor, stopped → editor, with a run-ended transition back to the editor.

## Testing

All gates green:
- Backend: `dotnet build` clean; **unit 687/687**, **integration** incl. new monitor endpoint tests (running snapshot with ISO-8601 offset times, `404`, not-running).
- Web-ui: `vite build` green; **jest 566/566 (97 suites)**.
- New tests: projection matrix (unit), endpoint (integration), `QueueMonitor` component + `QueuesPage` routing (jest).
- Updated one superseded template-spec test: a running queue now shows the monitor rather than the editor's disabled Load control.

## Notes

- Docs updated: `docs/architecture.md` (Queues section + last-reviewed date), `specs/STATUS.md` (072 row), spec `Status: Implemented`.
- **T028** (manual quickstart walkthrough against a live emulator) was **not run** — it requires physical hardware unavailable in the implementation environment; its scenarios are covered by the automated unit/integration/component tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
