### PR TITLE
Project the queue monitor from the run's real schedule state

### DIFF
--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "1",
-  "minor": "0",
+  "minor": "1",
   "patch": "0",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-07-10T00:00:00Z"
+  "updatedAtUtc": "2026-07-23T00:00:00Z"
 }

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -169,11 +169,15 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
       }
       else {
         // Pre-partition entries by schedule type (FR-001). Snapshots taken once at run start.
+        // Once-per-run and timer partitions carry each entry's index in `allEntries`: that index is the
+        // stable key the run's QueueRunSchedule records consumed work under, so the monitor can project
+        // exactly what is left instead of re-deriving an idealized plan from the template.
         var allEntries = template.Entries.ToList();
+        var indexed = allEntries.Select((Entry, Index) => (Entry, Index)).ToList();
         var atQueueStartEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.AtQueueStart).ToList();
-        var oncePerRunEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.OncePerRun).ToList();
+        var oncePerRunEntries = indexed.Where(x => x.Entry.ScheduleType == ScheduleType.OncePerRun).ToList();
         var everyStepEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.EveryStep).ToList();
-        var timerEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.Timer).ToList();
+        var timerEntries = indexed.Where(x => x.Entry.ScheduleType == ScheduleType.Timer).ToList();
 
         // 2. Connect to the bound emulator (FR-003/FR-004).
         try {
@@ -207,74 +211,26 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
               if (!startOk) failed++;
             }
 
-            // Per-run timer state: maps timer-entry index → last-fired calendar date (FR-003/FR-012).
-            // Declared OUTSIDE the do-while loop so it persists across all cycles of this run.
-            var timerFiredDate = new Dictionary<int, DateOnly>();
-
-            // Relative-offset timer state (feature 059): the run-start anchor and the set of
-            // relative-timer indices already fired this run (fire-once-per-run, FR-005). Both live
-            // outside the loop so they survive cycles. Recomputed fresh on every run.
+            // Per-run scheduling state (FR-003/FR-012, feature 059 FR-005): the relative-offset anchor
+            // plus every "already consumed" register — time-of-day timers fired today, relative timers
+            // fired this run, once-per-run steps completed this cycle, and whether the once-per-run
+            // pass has run at all (a non-cyclic run does it once; later loop iterations exist only to
+            // wait for pending relative/live timers and must not re-run those steps). Lives outside the
+            // do-while so it survives cycles, and is published on the handle so the monitor projects the
+            // run's real remaining plan rather than an idealized one (feature 072/073 fix).
             var runStartedAt = _timeProvider.GetLocalNow();
             handle.RunStartedAt = runStartedAt;
-            var relativeTimerFired = new HashSet<int>();
-            // Tracks whether the once-per-run/every-step pass has executed. For a non-cyclic run the
-            // pass runs once; later loop iterations exist only to wait for pending relative/live
-            // timers and must not re-run those steps (feature 059).
-            var oncePerRunDone = false;
+            var schedule = new QueueRunSchedule(allEntries, runStartedAt, queue.CycleExecution);
+            handle.Schedule = schedule;
 
             // True while a relative-offset timer (template) or a live schedule is still pending and
             // could yet fire — keeps a non-cyclic run alive until its scheduled firings land.
             bool HasPendingRelativeOrLive() {
-              for (var pi = 0; pi < timerEntries.Count; pi++) {
-                if (timerEntries[pi].TimerRelativeOffset is not null && !relativeTimerFired.Contains(pi))
-                  return true;
-              }
+              if (schedule.HasUnfiredRelativeTimers) return true;
               if (!handle.PendingLiveSchedules.IsEmpty) return true;
               // feature 065: a self-reschedule Timer firing not yet due keeps a non-cyclic run alive
               // until it lands (or the run is stopped), exactly like a relative/live schedule.
               return handle.HasPendingTimerFirings;
-            }
-
-            // Earliest upcoming firing across every pending schedule source, used by idle-pause
-            // (feature 073) to decide whether the gap is worth pausing for and when to resume. Pure
-            // read of the same state the loop fires from; never mutates. Returns null when nothing is
-            // pending. Recomputed each poll tick so an earlier-arriving firing shortens the pause.
-            DateTimeOffset? ComputeNextDue(DateTimeOffset now) {
-              DateTimeOffset? earliest = null;
-              void Consider(DateTimeOffset candidate) {
-                if (earliest is null || candidate < earliest) earliest = candidate;
-              }
-
-              var today = DateOnly.FromDateTime(now.DateTime);
-              var nowTime = TimeOnly.FromDateTime(now.DateTime);
-              for (var ti = 0; ti < timerEntries.Count; ti++) {
-                var te = timerEntries[ti];
-                if (te.TimerTimeOfDay is { } tod) {
-                  var firedToday = timerFiredDate.TryGetValue(ti, out var last) && last == today;
-                  if (!firedToday) {
-                    // Due today at tod; if that instant is already past (overdue, not yet fired) it is
-                    // effectively due now.
-                    var todayAt = new DateTimeOffset(today.ToDateTime(tod), now.Offset);
-                    Consider(nowTime <= tod ? todayAt : now);
-                  }
-                  else {
-                    // Already fired today → next eligibility is tomorrow at the same wall-clock time.
-                    Consider(new DateTimeOffset(today.AddDays(1).ToDateTime(tod), now.Offset));
-                  }
-                }
-                if (te.TimerRelativeOffset is { } off && !relativeTimerFired.Contains(ti)) {
-                  Consider(runStartedAt + off);
-                }
-              }
-
-              foreach (var firing in handle.SnapshotPendingTimerFirings()) {
-                if (firing.FireAt is { } fireAt) Consider(fireAt);
-              }
-              foreach (var liveAt in handle.PendingLiveSchedules.Values) Consider(liveAt);
-              // Any queued self-reschedule work that would drain this cycle is effectively due now.
-              if (!handle.PendingOncePerRun.IsEmpty || !handle.PendingNextCycleStart.IsEmpty) Consider(now);
-
-              return earliest;
             }
 
             if (oncePerRunEntries.Count > 0 || everyStepEntries.Count > 0 || timerEntries.Count > 0) {
@@ -293,21 +249,19 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                 }
 
                 // (a) Evaluate timer entries at iteration boundary (FR-011/FR-012/FR-016).
-                for (var ti = 0; ti < timerEntries.Count; ti++) {
-                  var timerEntry = timerEntries[ti];
+                foreach (var (timerEntry, timerIndex) in timerEntries) {
                   if (timerEntry.TimerTimeOfDay is null) continue;
 
                   var localNow = _timeProvider.GetLocalNow();
                   var today = DateOnly.FromDateTime(localNow.DateTime);
                   var now = TimeOnly.FromDateTime(localNow.DateTime);
-                  if (now >= timerEntry.TimerTimeOfDay.Value
-                      && (!timerFiredDate.TryGetValue(ti, out var lastFired) || lastFired != today)) {
+                  if (now >= timerEntry.TimerTimeOfDay.Value && !schedule.TimeOfDayFiredOn(timerIndex, today)) {
                     ct.ThrowIfCancellationRequested();
                     if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
                     var timerOk = await RunOneSequenceAsync(timerEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                     if (!timerOk) failed++;
                     // Timer executions do not count toward `executed` (SC-002 analogue for timers)
-                    timerFiredDate[ti] = today;
+                    schedule.MarkTimeOfDayFired(timerIndex, today);
                   }
                 }
 
@@ -316,10 +270,9 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                 // COUNT toward `executed` (FR-016a), unlike time-of-day timers. A failed firing is
                 // non-fatal: recorded in `failed`, run continues (FR-016).
                 var elapsedSinceStart = _timeProvider.GetLocalNow() - runStartedAt;
-                for (var ri = 0; ri < timerEntries.Count; ri++) {
-                  var relEntry = timerEntries[ri];
+                foreach (var (relEntry, relIndex) in timerEntries) {
                   if (relEntry.TimerRelativeOffset is not { } relOffset) continue;
-                  if (relativeTimerFired.Contains(ri)) continue;
+                  if (schedule.RelativeFired(relIndex)) continue;
                   if (elapsedSinceStart < relOffset) continue;
 
                   ct.ThrowIfCancellationRequested();
@@ -327,7 +280,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                   var relOk = await RunOneSequenceAsync(relEntry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                   executed++;
                   if (!relOk) failed++;
-                  relativeTimerFired.Add(ri);
+                  schedule.MarkRelativeFired(relIndex);
                 }
 
                 // (a3) Evaluate live relative schedules at the iteration boundary (feature 059).
@@ -362,14 +315,16 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                 // (b) OncePerRun steps, each followed by all EveryStep sequences (FR-006/FR-007/FR-016).
                 // A cycling run executes these every cycle; a non-cyclic run executes them once, so the
                 // relative/live timer-wait passes below never re-run the once-per-run steps.
-                if (queue.CycleExecution || !oncePerRunDone) {
+                if (queue.CycleExecution || !schedule.OncePerRunPassDone) {
+                  schedule.BeginCycle();
                   if (oncePerRunEntries.Count > 0) {
-                    foreach (var entry in oncePerRunEntries) {
+                    foreach (var (entry, entryIndex) in oncePerRunEntries) {
                       ct.ThrowIfCancellationRequested();
                       if (_sessions.GetSession(sessionId) is null) throw new QueueConnectionLostException();
                       var ok = await RunOneSequenceAsync(entry.SequenceId, rootId, ++index, sessionId, queue.Id, ct).ConfigureAwait(false);
                       executed++;
                       if (!ok) failed++;
+                      schedule.MarkOncePerRunCompleted(entryIndex);
 
                       // Run every-step sequences after each OncePerRun step (FR-006).
                       foreach (var esEntry in everyStepEntries) {
@@ -416,7 +371,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                     if (!oprOk) failed++;
                   }
 
-                  oncePerRunDone = true;
+                  schedule.MarkOncePerRunPassDone();
                   cycles++;
                 }
 
@@ -434,12 +389,12 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
                 // poll delay. Watchdog-exempt and log-silent because it runs inline here, never via
                 // RunOneSequenceAsync. Otherwise fall back to the existing one-tick poll delay.
                 var pollNow = _timeProvider.GetLocalNow();
-                var nextDue = ComputeNextDue(pollNow);
+                var nextDue = schedule.ComputeNextDue(handle, pollNow);
                 var thresholdSeconds = Math.Max(1, queue.IdleThresholdSeconds);
                 if (queue.PauseWhenIdle
                     && nextDue is { } dueAt
                     && dueAt - pollNow > TimeSpan.FromSeconds(thresholdSeconds)) {
-                  await IdlePauseHoldAsync(dueAt, sessionId!, handle, ComputeNextDue, ct).ConfigureAwait(false);
+                  await IdlePauseHoldAsync(dueAt, sessionId!, handle, now => schedule.ComputeNextDue(handle, now), ct).ConfigureAwait(false);
                 }
                 else {
                   await Task.Delay(RelativeTimerPollInterval, ct).ConfigureAwait(false);

--- a/src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs
@@ -13,11 +13,15 @@ namespace GameBot.Service.Services.QueueExecution;
 
 /// <summary>
 /// Pure projection of a queue's live run plan for the monitor panel. Reads the active
-/// <see cref="QueueRunHandle"/> (via <see cref="IQueueRunRegistry"/>) and the linked
-/// <see cref="QueueTemplate"/>, folds them with the current local wall-clock into an ordered
-/// now/up-next snapshot, and — when the queue is not running — surfaces the best-effort last
-/// finalized run outcome from the execution log. No side effects; mirrors, but never duplicates,
-/// the run loop's schedule semantics (feature 072).
+/// <see cref="QueueRunHandle"/> (via <see cref="IQueueRunRegistry"/>) and — for a running queue — the
+/// <see cref="QueueRunSchedule"/> that run publishes, folding them with the current local wall-clock
+/// into an ordered now/up-next snapshot. When the queue is not running it instead surfaces the
+/// best-effort last finalized run outcome from the execution log. No side effects.
+///
+/// Projecting from the run's own schedule state (rather than re-deriving a plan from the linked
+/// <see cref="QueueTemplate"/>) is deliberate: work the run has already consumed — finished
+/// once-per-run steps, spent one-shot relative timers, time-of-day timers that fired today — must not
+/// be listed as upcoming, and the projection must agree with the resume time an idle pause reports.
 /// </summary>
 internal sealed class QueueMonitorService : IQueueMonitorService {
   private readonly IQueueRunRegistry _registry;
@@ -62,16 +66,23 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
     var now = _timeProvider.GetLocalNow();
     var cycling = handle.CycleExecution;
 
-    // NothingScheduled (FR-011): running with no schedulable work of ANY kind — no template entries,
-    // no pending live schedules, and no pending self-reschedule timer firings. Computed up front so it
-    // stays correct even for a live-scheduled-only run (which must NOT read as "nothing scheduled").
+    // The run publishes its own schedule state (entry snapshot + already-consumed work) on the handle;
+    // projecting from that — rather than re-deriving an idealized plan from the template — is what
+    // keeps "up next" honest about steps this run has already finished. The template fallback covers
+    // only the brief window before the run loop assigns it (nothing consumed yet).
+    var schedule = handle.Schedule
+      ?? new QueueRunSchedule(template?.Entries.ToArray() ?? Array.Empty<QueueTemplateEntry>(), handle.RunStartedAt, cycling);
+
     var liveSchedules = handle.PendingLiveSchedules.ToArray();
     var selfTimerFirings = handle.SnapshotPendingTimerFirings();
-    var hasTemplateWork = template is not null && template.Entries.Count > 0;
-    var nothingScheduled = !hasTemplateWork && liveSchedules.Length == 0 && selfTimerFirings.Count == 0;
 
-    var current = BuildCurrent(handle, template, names, cycling);
-    var upcoming = BuildUpcoming(handle, template, names, now, cycling, current, liveSchedules, selfTimerFirings);
+    var current = BuildCurrent(handle, schedule, names, cycling);
+    var upcoming = BuildUpcoming(schedule, names, now, cycling, current, liveSchedules, selfTimerFirings);
+
+    // NothingScheduled (FR-011): running with nothing left to do of ANY kind. Derived from the
+    // projection itself so the banner can never contradict the list next to it — a live-scheduled-only
+    // run still has an upcoming item and so must NOT read as "nothing scheduled".
+    var nothingScheduled = current is null && upcoming.Count == 0;
 
     return new QueueMonitorSnapshot(
       queueId, name, Running: true, CycleExecution: cycling, RunStartedAt: handle.RunStartedAt,
@@ -81,7 +92,7 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
   // ── Current ("now") ────────────────────────────────────────────────────────────────────────
 
   private static QueueMonitorItem? BuildCurrent(
-    QueueRunHandle handle, QueueTemplate? template, IReadOnlyDictionary<string, string> names, bool cycling) {
+    QueueRunHandle handle, QueueRunSchedule schedule, IReadOnlyDictionary<string, string> names, bool cycling) {
     var sequenceId = handle.CurrentSequenceId;
     if (string.IsNullOrEmpty(sequenceId)) {
       // Idle-pause (feature 073): no sequence is executing, but the run is intentionally backed out
@@ -104,7 +115,7 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
     }
 
     // Best-effort schedule kind: the first template entry referencing this sequence, else OncePerRun.
-    var entry = template?.Entries.FirstOrDefault(e => string.Equals(e.SequenceId, sequenceId, StringComparison.Ordinal));
+    var entry = schedule.Entries.FirstOrDefault(e => string.Equals(e.SequenceId, sequenceId, StringComparison.Ordinal));
     var kind = entry is null ? ScheduleKind.OncePerRun : KindFor(entry);
     return NewItem(sequenceId, names, kind, ReasonFor(kind, entry), expectedAt: null,
       relativeLabel: "now", repeats: Repeats(kind, cycling), order: 0);
@@ -113,14 +124,17 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
   // ── Upcoming ("up next") ──────────────────────────────────────────────────────────────────
 
   private static List<QueueMonitorItem> BuildUpcoming(
-    QueueRunHandle handle, QueueTemplate? template, IReadOnlyDictionary<string, string> names,
+    QueueRunSchedule schedule, IReadOnlyDictionary<string, string> names,
     DateTimeOffset now, bool cycling, QueueMonitorItem? current,
     KeyValuePair<string, DateTimeOffset>[] liveSchedules, IReadOnlyList<SelfRescheduleEntry> selfTimerFirings) {
-    var entries = template?.Entries ?? new System.Collections.ObjectModel.Collection<QueueTemplateEntry>();
+    var entries = schedule.Entries;
 
-    // (1) OncePerRun spine in template order — the "playlist" backbone. AtQueueStart is omitted
-    // (already ran); the currently-executing once-per-run step is excluded (Current holds it).
-    var spine = entries.Where(e => e.ScheduleType == ScheduleType.OncePerRun).ToList();
+    // (1) OncePerRun spine in template order — the "playlist" backbone, limited to the steps this run
+    // has NOT already consumed. A non-cycling run whose once-per-run pass is done never runs them
+    // again (it stays alive only to service timers), so its spine is empty; listing them there was
+    // what made a purely timer-driven wait look like it was about to run a step. AtQueueStart is
+    // omitted (already ran); the currently-executing step is excluded (Current holds it).
+    var spine = schedule.RemainingOncePerRun().ToList();
     if (current is not null) {
       var idx = spine.FindIndex(e => string.Equals(e.SequenceId, current.SequenceId, StringComparison.Ordinal));
       if (idx >= 0) spine.RemoveAt(idx);
@@ -130,22 +144,33 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
       expectedAt: null, relativeLabel: i == 0 ? "next" : "up next",
       repeats: Repeats(ScheduleKind.OncePerRun, cycling), order: 0)).ToList();
 
-    // (2) EveryStep entries, surfaced once each as "After Every Step" (not interleaved per step).
-    var everyStepItems = entries.Where(e => e.ScheduleType == ScheduleType.EveryStep)
-      .Select(e => NewItem(e.SequenceId, names, ScheduleKind.EveryStep, ReasonFor(ScheduleKind.EveryStep, e),
-        expectedAt: null, relativeLabel: null, repeats: Repeats(ScheduleKind.EveryStep, cycling), order: 0))
-      .ToList();
+    // (2) EveryStep entries, surfaced once each as "After Every Step" (not interleaved per step), and
+    // only while the once-per-run pass they hang off can still run — otherwise no every-step firing
+    // can follow and listing one is as misleading as listing the spine.
+    var everyStepItems = schedule.EveryStepCanStillRun
+      ? entries.Where(e => e.ScheduleType == ScheduleType.EveryStep)
+        .Select(e => NewItem(e.SequenceId, names, ScheduleKind.EveryStep, ReasonFor(ScheduleKind.EveryStep, e),
+          expectedAt: null, relativeLabel: null, repeats: Repeats(ScheduleKind.EveryStep, cycling), order: 0))
+        .ToList()
+      : new List<QueueMonitorItem>();
 
     // (3) Timed firings — template timers (time-of-day next-eligible; relative anchor+offset), live
     // schedules (exact), and self-reschedule Timer firings (exact) — merged, sorted by ExpectedAt.
+    // Times come from the run's own schedule state, so a timer that already fired today resolves to
+    // tomorrow, one that is overdue reads as due now, and a spent one-shot relative timer is dropped.
     var timed = new List<QueueMonitorItem>();
-    foreach (var e in entries.Where(e => e.ScheduleType == ScheduleType.Timer)) {
+    for (var i = 0; i < entries.Count; i++) {
+      var e = entries[i];
+      if (e.ScheduleType != ScheduleType.Timer) continue;
       if (e.TimerTimeOfDay is { } tod) {
+        var dueAt = schedule.NextTimeOfDayDue(i, tod, now);
         timed.Add(NewItem(e.SequenceId, names, ScheduleKind.TimerTimeOfDay, $"At {tod:HH:mm}",
-          NextEligible(now, tod), relativeLabel: null, repeats: false, order: 0));
+          dueAt, relativeLabel: dueAt <= now ? "due" : null, repeats: false, order: 0));
       }
       else if (e.TimerRelativeOffset is { } offset) {
-        var expectedAt = handle.RunStartedAt + offset;
+        // Fires at most once per run — once fired it is gone, not "due" forever.
+        if (schedule.RelativeFired(i)) continue;
+        var expectedAt = schedule.RunStartedAt + offset;
         var elapsed = expectedAt <= now;
         timed.Add(NewItem(e.SequenceId, names, ScheduleKind.TimerRelative, $"+{offset} after start",
           expectedAt, relativeLabel: elapsed ? "due" : null, repeats: false, order: 0));
@@ -221,10 +246,4 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
   // OncePerRun/EveryStep recur every cycle on a cycling queue; timed/live/self-reschedule fire once.
   private static bool Repeats(ScheduleKind kind, bool cycling) =>
     cycling && kind is ScheduleKind.OncePerRun or ScheduleKind.EveryStep;
-
-  // Next-eligible wall-clock for a time-of-day timer: today at HH:mm if still ahead, else tomorrow.
-  private static DateTimeOffset NextEligible(DateTimeOffset now, TimeOnly tod) {
-    var todayAt = new DateTimeOffset(now.Year, now.Month, now.Day, tod.Hour, tod.Minute, tod.Second, now.Offset);
-    return now.TimeOfDay < tod.ToTimeSpan() ? todayAt : todayAt.AddDays(1);
-  }
 }

--- a/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
@@ -35,6 +35,14 @@ internal sealed class QueueRunHandle {
   public DateTimeOffset RunStartedAt { get; set; }
 
   /// <summary>
+  /// This run's live scheduling state — the entry snapshot it executes plus the work it has already
+  /// consumed. Assigned by the run loop once the entries are resolved; null only in the brief window
+  /// before that (and in tests that hand-build a handle), where the monitor falls back to projecting
+  /// a fresh, nothing-consumed schedule from the linked template.
+  /// </summary>
+  public QueueRunSchedule? Schedule { get; set; }
+
+  /// <summary>
   /// Live, ephemeral relative schedules requested against this run via the live-schedule endpoint.
   /// Key = sequence id; value = expected fire instant (call time + offset, local clock). Upserts are
   /// most-recent-wins per sequence (FR-011); an entry is removed once fired (fires once, FR-009).

--- a/src/GameBot.Service/Services/QueueExecution/QueueRunSchedule.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueRunSchedule.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GameBot.Domain.QueueTemplates;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// The scheduling state of one queue run: the entry snapshot the run executes, its relative-timer
+/// anchor, and — crucially — which work has already been consumed (time-of-day timers fired today,
+/// relative timers fired once this run, once-per-run steps completed this cycle, and whether the
+/// once-per-run pass is done at all).
+///
+/// The run loop owns and mutates it as it fires; the monitor projection only reads it. Before this
+/// existed the two derived their plans independently — the loop from its own locals, the monitor from
+/// the raw template — so the monitor happily listed steps the run had already finished and would never
+/// repeat. Both now answer "what runs next" from the same state, and <see cref="ComputeNextDue"/> is
+/// the single shared implementation of "when does this run wake up next" (used by the idle-pause
+/// decision and by the monitor), so the two can no longer drift.
+///
+/// Written by the run-loop thread and read by monitor polls on another thread, so every member is
+/// lock-guarded. Entries are keyed by their index in <see cref="Entries"/>.
+/// </summary>
+internal sealed class QueueRunSchedule {
+  private readonly object _gate = new();
+  private readonly Dictionary<int, DateOnly> _timeOfDayFiredOn = new();
+  private readonly HashSet<int> _relativeFired = new();
+  private readonly HashSet<int> _oncePerRunDoneThisCycle = new();
+  private bool _oncePerRunPassDone;
+
+  public QueueRunSchedule(IReadOnlyList<QueueTemplateEntry> entries, DateTimeOffset runStartedAt, bool cycling) {
+    Entries = entries;
+    RunStartedAt = runStartedAt;
+    Cycling = cycling;
+  }
+
+  /// <summary>
+  /// The entries this run actually executes, snapshotted at run start. The monitor reads these rather
+  /// than re-fetching the template so a mid-run template edit cannot desynchronize the two (and so the
+  /// consumed-work indices below always line up with what is displayed).
+  /// </summary>
+  public IReadOnlyList<QueueTemplateEntry> Entries { get; }
+
+  /// <summary>The local-clock anchor relative-offset timers are measured from.</summary>
+  public DateTimeOffset RunStartedAt { get; }
+
+  /// <summary>Whether the run cycles (its once-per-run pass repeats indefinitely).</summary>
+  public bool Cycling { get; }
+
+  // ── Time-of-day timers (fire at most once per calendar day) ──────────────────────────────────
+
+  /// <summary>Records that the time-of-day timer at <paramref name="index"/> fired on <paramref name="day"/>.</summary>
+  public void MarkTimeOfDayFired(int index, DateOnly day) {
+    lock (_gate) { _timeOfDayFiredOn[index] = day; }
+  }
+
+  /// <summary>True when that time-of-day timer has already fired on <paramref name="day"/>.</summary>
+  public bool TimeOfDayFiredOn(int index, DateOnly day) {
+    lock (_gate) { return _timeOfDayFiredOn.TryGetValue(index, out var last) && last == day; }
+  }
+
+  /// <summary>
+  /// When the time-of-day timer at <paramref name="index"/> is next eligible to fire. Mirrors the run
+  /// loop's own condition (<c>now &gt;= tod &amp;&amp; not fired today</c>): already fired today → tomorrow at
+  /// the same wall-clock time; still ahead today → today at that time; past today but not yet fired →
+  /// <paramref name="now"/>, because the loop fires it on its very next iteration (catch-up).
+  /// </summary>
+  public DateTimeOffset NextTimeOfDayDue(int index, TimeOnly tod, DateTimeOffset now) {
+    var today = DateOnly.FromDateTime(now.DateTime);
+    if (TimeOfDayFiredOn(index, today)) {
+      return new DateTimeOffset(today.AddDays(1).ToDateTime(tod), now.Offset);
+    }
+    var todayAt = new DateTimeOffset(today.ToDateTime(tod), now.Offset);
+    return now.TimeOfDay <= tod.ToTimeSpan() ? todayAt : now;
+  }
+
+  // ── Relative-offset timers (fire at most once per run) ───────────────────────────────────────
+
+  /// <summary>Records that the relative-offset timer at <paramref name="index"/> has fired this run.</summary>
+  public void MarkRelativeFired(int index) {
+    lock (_gate) { _relativeFired.Add(index); }
+  }
+
+  /// <summary>True once that relative-offset timer has fired (it never fires again this run).</summary>
+  public bool RelativeFired(int index) {
+    lock (_gate) { return _relativeFired.Contains(index); }
+  }
+
+  /// <summary>True while any relative-offset timer of this run has yet to fire.</summary>
+  public bool HasUnfiredRelativeTimers {
+    get {
+      lock (_gate) {
+        for (var i = 0; i < Entries.Count; i++) {
+          if (IsTimer(Entries[i]) && Entries[i].TimerRelativeOffset is not null && !_relativeFired.Contains(i)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+  }
+
+  // ── Once-per-run pass ────────────────────────────────────────────────────────────────────────
+
+  /// <summary>Clears the per-cycle completion set at the top of a once-per-run pass.</summary>
+  public void BeginCycle() {
+    lock (_gate) { _oncePerRunDoneThisCycle.Clear(); }
+  }
+
+  /// <summary>Records that the once-per-run entry at <paramref name="index"/> ran in this cycle.</summary>
+  public void MarkOncePerRunCompleted(int index) {
+    lock (_gate) { _oncePerRunDoneThisCycle.Add(index); }
+  }
+
+  /// <summary>Records that the once-per-run/every-step pass has run (it repeats only when cycling).</summary>
+  public void MarkOncePerRunPassDone() {
+    lock (_gate) { _oncePerRunPassDone = true; }
+  }
+
+  /// <summary>Whether the once-per-run/every-step pass has run at least once.</summary>
+  public bool OncePerRunPassDone {
+    get { lock (_gate) { return _oncePerRunPassDone; } }
+  }
+
+  /// <summary>
+  /// Whether an every-step firing can still happen. Every-step sequences piggyback on the once-per-run
+  /// pass (and, with no once-per-run entries, run exactly once with it), so once a non-cycling run's
+  /// pass is done none can follow — the run stays alive purely to service timers.
+  /// </summary>
+  public bool EveryStepCanStillRun => Cycling || !OncePerRunPassDone;
+
+  /// <summary>
+  /// The once-per-run entries this run has still to execute, in template order. Empty for a
+  /// non-cycling run whose pass is done; a cycling run whose current cycle is exhausted reports the
+  /// next cycle's full spine.
+  /// </summary>
+  public IReadOnlyList<QueueTemplateEntry> RemainingOncePerRun() {
+    lock (_gate) {
+      if (_oncePerRunPassDone && !Cycling) return Array.Empty<QueueTemplateEntry>();
+
+      var remaining = new List<QueueTemplateEntry>();
+      for (var i = 0; i < Entries.Count; i++) {
+        if (Entries[i].ScheduleType != ScheduleType.OncePerRun) continue;
+        if (_oncePerRunDoneThisCycle.Contains(i)) continue;
+        remaining.Add(Entries[i]);
+      }
+      if (remaining.Count == 0 && Cycling) {
+        remaining.AddRange(Entries.Where(e => e.ScheduleType == ScheduleType.OncePerRun));
+      }
+      return remaining;
+    }
+  }
+
+  // ── Next-due projection (shared by the run loop's idle-pause and the monitor) ─────────────────
+
+  /// <summary>
+  /// Earliest upcoming firing across every pending schedule source of this run: template timers
+  /// (time-of-day next-eligible, relative anchor+offset, both skipping already-consumed ones), live
+  /// schedules, self-reschedule Timer firings, and any queued self-reschedule work (effectively due
+  /// now). Pure read; never mutates. Null when nothing is pending.
+  /// </summary>
+  public DateTimeOffset? ComputeNextDue(QueueRunHandle handle, DateTimeOffset now) {
+    DateTimeOffset? earliest = null;
+    void Consider(DateTimeOffset candidate) {
+      if (earliest is null || candidate < earliest) earliest = candidate;
+    }
+
+    for (var i = 0; i < Entries.Count; i++) {
+      var entry = Entries[i];
+      if (!IsTimer(entry)) continue;
+      if (entry.TimerTimeOfDay is { } tod) Consider(NextTimeOfDayDue(i, tod, now));
+      if (entry.TimerRelativeOffset is { } offset && !RelativeFired(i)) Consider(RunStartedAt + offset);
+    }
+
+    foreach (var firing in handle.SnapshotPendingTimerFirings()) {
+      if (firing.FireAt is { } fireAt) Consider(fireAt);
+    }
+    foreach (var liveAt in handle.PendingLiveSchedules.Values) Consider(liveAt);
+    // Any queued self-reschedule work that would drain this cycle is effectively due now.
+    if (!handle.PendingOncePerRun.IsEmpty || !handle.PendingNextCycleStart.IsEmpty) Consider(now);
+
+    return earliest;
+  }
+
+  private static bool IsTimer(QueueTemplateEntry entry) => entry.ScheduleType == ScheduleType.Timer;
+}

--- a/tests/unit/Queues/QueueMonitorServiceTests.cs
+++ b/tests/unit/Queues/QueueMonitorServiceTests.cs
@@ -120,6 +120,17 @@ public sealed class QueueMonitorServiceTests {
       Sequences.Add(sequenceId, name);
       Template.Entries.Add(new QueueTemplateEntry { SequenceId = sequenceId, ScheduleType = type, TimerTimeOfDay = tod, TimerRelativeOffset = rel });
     }
+
+    /// <summary>
+    /// Publishes the schedule state a real run loop would, so a test can mark work as consumed
+    /// (fired timers, completed once-per-run pass) and assert the projection reflects it. Call after
+    /// every <see cref="Entry"/> — the schedule snapshots the entry list, exactly as the run does.
+    /// </summary>
+    public QueueRunSchedule PublishSchedule(QueueRunHandle handle) {
+      var schedule = new QueueRunSchedule(Template.Entries.ToArray(), handle.RunStartedAt, handle.CycleExecution);
+      handle.Schedule = schedule;
+      return schedule;
+    }
   }
 
   // ── T011: OncePerRun spine ─────────────────────────────────────────────
@@ -160,11 +171,11 @@ public sealed class QueueMonitorServiceTests {
   }
 
   [Fact]
-  public async Task TimerTimeOfDayResolvesNextEligibleTodayOrTomorrow() {
+  public async Task TimerTimeOfDayResolvesTodayWhenAheadAndDueNowWhenOverdue() {
     var h = new Harness();
     h.AddQueue();
     h.Entry("Ahead", "Later today", ScheduleType.Timer, tod: new TimeOnly(15, 0));   // now 12:00 → today 15:00
-    h.Entry("Passed", "Tomorrow", ScheduleType.Timer, tod: new TimeOnly(9, 0));      // now 12:00 → tomorrow 09:00
+    h.Entry("Passed", "Overdue", ScheduleType.Timer, tod: new TimeOnly(9, 0));       // now 12:00, never fired → due now
     h.StartHandle();
 
     var snap = await h.Service.BuildAsync("q1");
@@ -172,8 +183,26 @@ public sealed class QueueMonitorServiceTests {
     var ahead = snap.Upcoming.Single(i => i.SequenceId == "Ahead");
     ahead.ExpectedAt.Should().Be(new DateTimeOffset(2026, 1, 1, 15, 0, 0, TimeSpan.Zero));
     ahead.Reason.Should().Be("At 15:00");
+    // A time-of-day timer that has not fired today fires on the run loop's very next iteration
+    // (catch-up), so the monitor must read "due now" — not "tomorrow", which would hide imminent work.
     var passed = snap.Upcoming.Single(i => i.SequenceId == "Passed");
-    passed.ExpectedAt.Should().Be(new DateTimeOffset(2026, 1, 2, 9, 0, 0, TimeSpan.Zero));
+    passed.ExpectedAt.Should().Be(Now);
+    passed.RelativeLabel.Should().Be("due");
+  }
+
+  [Fact]
+  public async Task TimerTimeOfDayAlreadyFiredTodayResolvesToTomorrow() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("T", "Daily", ScheduleType.Timer, tod: new TimeOnly(9, 0));
+    var handle = h.StartHandle();
+    var schedule = h.PublishSchedule(handle);
+    schedule.MarkTimeOfDayFired(0, new DateOnly(2026, 1, 1));
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Single(i => i.SequenceId == "T").ExpectedAt
+      .Should().Be(new DateTimeOffset(2026, 1, 2, 9, 0, 0, TimeSpan.Zero));
   }
 
   [Fact]
@@ -422,5 +451,126 @@ public sealed class QueueMonitorServiceTests {
   [Fact] // T014 — the idle-pause schedule kind serializes to the exact wire string "IdlePause"
   public void IdlePauseScheduleKindWireStringIsExact() {
     ScheduleKind.IdlePause.ToString().Should().Be("IdlePause");
+  }
+
+  // ── Consumed work must not be listed as upcoming ──────────────────────────
+  // Regression guards for the misleading "Up next" list: a non-cycling run that has finished its
+  // once-per-run pass and is only waiting on timers was still showing the finished steps first, its
+  // spent one-shot relative timer in the middle, and the one thing that would actually run last.
+
+  [Fact]
+  public async Task CompletedOncePerRunStepsAreNotListedAgainOnANonCyclingRun() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Entry("B", "Bravo");
+    var handle = h.StartHandle();
+    var schedule = h.PublishSchedule(handle);
+    schedule.BeginCycle();
+    schedule.MarkOncePerRunCompleted(0);
+    schedule.MarkOncePerRunCompleted(1);
+    schedule.MarkOncePerRunPassDone();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Should().BeEmpty();
+    snap.NothingScheduled.Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task PartiallyCompletedOncePerRunPassListsOnlyTheRemainingSteps() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Entry("B", "Bravo");
+    h.Entry("C", "Charlie");
+    var handle = h.StartHandle();
+    var schedule = h.PublishSchedule(handle);
+    schedule.BeginCycle();
+    schedule.MarkOncePerRunCompleted(0);
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Select(i => i.SequenceId).Should().Equal("B", "C");
+    snap.Upcoming[0].RelativeLabel.Should().Be("next");
+  }
+
+  [Fact]
+  public async Task CyclingRunWithAFinishedCycleListsTheNextCyclesSpine() {
+    var h = new Harness();
+    h.AddQueue(cycle: true);
+    h.Entry("A", "Alpha");
+    h.Entry("B", "Bravo");
+    var handle = h.StartHandle(cycle: true);
+    var schedule = h.PublishSchedule(handle);
+    schedule.BeginCycle();
+    schedule.MarkOncePerRunCompleted(0);
+    schedule.MarkOncePerRunCompleted(1);
+    schedule.MarkOncePerRunPassDone();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Select(i => i.SequenceId).Should().Equal("A", "B"); // the cycle comes round again
+  }
+
+  [Fact]
+  public async Task AlreadyFiredRelativeTimerIsDropped() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("R", "Relative", ScheduleType.Timer, rel: TimeSpan.FromSeconds(30));
+    h.Entry("T", "Daily", ScheduleType.Timer, tod: new TimeOnly(22, 30));
+    var handle = h.StartHandle();
+    var schedule = h.PublishSchedule(handle);
+    schedule.MarkRelativeFired(0);
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Should().NotContain(i => i.SequenceId == "R"); // fires once per run; already spent
+    snap.Upcoming.Should().ContainSingle(i => i.SequenceId == "T");
+  }
+
+  [Fact]
+  public async Task EveryStepIsDroppedOnceItsOncePerRunPassCanNoLongerRun() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("A", "Alpha");
+    h.Entry("G", "Guard", ScheduleType.EveryStep);
+    h.Entry("T", "Daily", ScheduleType.Timer, tod: new TimeOnly(22, 30));
+    var handle = h.StartHandle();
+    var schedule = h.PublishSchedule(handle);
+    schedule.BeginCycle();
+    schedule.MarkOncePerRunCompleted(0);
+    schedule.MarkOncePerRunPassDone();
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    // Every-step firings only follow a once-per-run step; with the pass done, none can happen again.
+    snap.Upcoming.Select(i => i.SequenceId).Should().Equal("T");
+  }
+
+  [Fact] // The reported case, end to end: only the 22:30 timer is really left, so it must lead the list.
+  public async Task IdlePausedRunListsTheResumingTimerFirstAndNothingElse() {
+    var h = new Harness();
+    h.AddQueue();
+    h.Entry("Help", "PNS Alliance Help All");
+    h.Entry("Guard", "PNS Update Popup Guard", ScheduleType.EveryStep);
+    h.Entry("Tavern", "PNS Tavern Free Recruits", ScheduleType.Timer, rel: TimeSpan.FromSeconds(30));
+    h.Entry("Chests", "PNS Daily Quest Chests", ScheduleType.Timer, tod: new TimeOnly(22, 30));
+    var handle = h.StartHandle();
+    var schedule = h.PublishSchedule(handle);
+    schedule.BeginCycle();
+    schedule.MarkOncePerRunCompleted(0);   // Help All ran
+    schedule.MarkOncePerRunPassDone();
+    schedule.MarkRelativeFired(2);         // Tavern's +30s one-shot already fired
+    var resumeAt = new DateTimeOffset(2026, 1, 1, 22, 30, 0, TimeSpan.Zero);
+    handle.EnterIdlePause(resumeAt);
+
+    var snap = await h.Service.BuildAsync("q1");
+
+    snap.Upcoming.Select(i => i.SequenceId).Should().Equal("Chests");
+    snap.Upcoming[0].ExpectedAt.Should().Be(resumeAt);
+    // The pause's resume time and the first up-next item now agree — they are the same firing.
+    snap.Current!.ScheduleKind.Should().Be(ScheduleKind.IdlePause);
+    snap.Current.ExpectedAt.Should().Be(resumeAt);
   }
 }


### PR DESCRIPTION
## Problem

On a running queue that was idle-paused until 22:30, the monitor's **Up next** list read:

| # | Item | Reason |
|---|---|---|
| 1 | PNS Alliance Help All | Once per run / next |
| 2 | PNS Update Popup Guard | After Every Step |
| 3 | PNS Tavern Free Recruits | +00:00:30 after start (22:12) |
| 4 | PNS Daily Quest Chests | At 22:30 |

Only #4 could actually run. The pause itself correctly reported "nothing due before 22:30", so the panel contradicted itself.

## Root cause

`QueueMonitorService` derived its plan from the **linked template**, while `QueueExecutionService` tracked what the run had actually consumed in locals private to `RunAsync` (`timerFiredDate`, `relativeTimerFired`, `oncePerRunDone`). The monitor could not see any of it, so it re-derived an idealized plan:

- **#1** — the once-per-run pass was already done. On a non-cycling run it never repeats; the run stays alive only to service timers. The monitor listed the whole spine unconditionally.
- **#3** — a relative timer fires **once per run**. It had already fired at 22:12; `relativeTimerFired` knew, the monitor did not.
- **#4** — sorted last only because the three phantom rows sat above it.

## Fix

New `QueueRunSchedule` holds the run-scoped entry snapshot plus every already-consumed register (time-of-day timers fired today, relative timers fired this run, once-per-run steps completed this cycle, whether the pass is done). The run loop owns and mutates it in place of its old locals and publishes it on `QueueRunHandle`; the monitor projects from it.

`ComputeNextDue` moves onto it as well, so the idle-pause resume time and the monitor's first up-next row are now computed by the same code and cannot drift apart again.

Resulting projection changes:

- Completed once-per-run steps drop off. A cycling run still shows the next cycle's spine.
- Spent one-shot relative timers drop off.
- Every-step entries are listed only while a once-per-run pass can still run — a firing can only follow such a step. (Not part of the original report, but the same defect.)
- A time-of-day timer that is **overdue but unfired** now reads `due` instead of `tomorrow`. The run loop fires those on its next iteration (catch-up), so `tomorrow` was hiding imminent work. This changes one existing test's expectation.
- `nothingScheduled` is derived from the projection rather than computed separately, so the banner can no longer contradict the list beside it.

Reading the run's own entry snapshot instead of re-fetching the template also means a mid-run template edit can no longer desynchronize the monitor from the run.

No front-end changes — `QueueMonitor.tsx` renders whatever order the API returns.

## Testing

- 151 queue unit tests and 78 queue integration tests pass. The integration suite exercises the refactored run loop (timers, self-reschedule, cycling).
- Six new regression tests, including `IdlePausedRunListsTheResumingTimerFirstAndNothingElse`, which pins the exact reported scenario: Chests is the only row and its time equals the pause's resume time.
- The full unit run showed one unrelated failure, `TemplateMatcherBench.BenchmarkVariousSizes` — a perf benchmark that passes in isolation and only fails under parallel load.

## Notes

- Also bumps the installer minor version to **1.1.0** (`installer/versioning/version.override.json`), per the `VERSIONING.md` "Example A: Minor version bump" procedure.
- The fix populates schedule state at run start, so a currently-running queue needs a service restart plus a queue restart to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
