### PR TITLE
[074] Cold-start the emulator at queue startup before binding the session

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/073-queue-idle-pause"
+  "feature_directory": "specs/074-sessionless-emulator-start"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/073-queue-idle-pause/plan.md
+at specs/074-sessionless-emulator-start/plan.md
 <!-- SPECKIT END -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ For the *history* of how the system got here — one folder per feature, point-i
 history; this file is the current-state source of truth. When the two disagree, this file wins and
 the relevant spec should be marked superseded.
 
-_Last reviewed: 2026-07-23._
+_Last reviewed: 2026-07-24._
 
 ## What GameBot is
 
@@ -114,6 +114,17 @@ not survive a service restart; queue *configuration* and templates are persisted
   the `QueueRunHandle` carries an idle-pause register that the monitor projects as a synthetic current
   item (`ScheduleKind.IdlePause`, `SequenceName` "Idle Pause", with the resume time), so an idle queue
   never reads as hung. Disabled queues are byte-for-byte unchanged.
+- **Pre-session emulator cold-start** (feature 074) — an opt-in per-queue behavior
+  (`ExecutionQueue.EmulatorInstanceName` / `EmulatorInstanceIndex`, both optional/null by default;
+  exposed via the REST API and web-ui). When set, the queue run brings the target **LDPlayer**
+  instance up **before** it binds its device session — reusing the feature-070
+  `ensure-emulator-running` capability (`IEnsureEmulatorRunningActionHandler`) with the queue's
+  `EmulatorSerial` as the responsiveness probe — so a queue can self-start from a backend-only cold
+  state (a closed emulator would otherwise fail `CreateSession`). An already-healthy / started /
+  restarted or neutral unsupported outcome proceeds to create the session as before; a genuine failure
+  (recovery timeout / instance-not-found) fails the run with an actionable reason and creates **no**
+  session. No new emulator-tuning configuration is introduced (feature-070 timeouts apply). Queues
+  with the fields unset perform no emulator management (byte-for-byte unchanged).
 - **Trigger** — an evaluation construct (image-visible / text-match / time / delay / schedule),
   used internally to decide whether a step executes. Still present in the domain and on the API,
   but **no longer authored as a standalone object in the UI**.

--- a/specs/074-sessionless-emulator-start/checklists/requirements.md
+++ b/specs/074-sessionless-emulator-start/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Start the Emulator From a Backend-Only, Session-Less State
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Instance-identification inputs (name/index + device serial) intentionally reference the shape of the
+  existing emulator-aware actions (features 070/071) at the domain level, not implementation detail —
+  they describe author-facing capability parity, not code.

--- a/specs/074-sessionless-emulator-start/contracts/queue-emulator-instance-config.md
+++ b/specs/074-sessionless-emulator-start/contracts/queue-emulator-instance-config.md
@@ -1,0 +1,76 @@
+# Contract: Queue Emulator-Instance Cold-Start Configuration
+
+Extends the existing queue REST contract (`/api/queues`) with two optional emulator-instance fields and
+defines the pre-session cold-start behavior at queue start. No new endpoints.
+
+## Request/response fields (additive)
+
+Applies to `POST /api/queues` (create), `PUT /api/queues/{id}` (update), and the queue response body
+(list/get). Field names are camelCase over the wire.
+
+| Field | JSON type | Required | Default | Rules |
+|-------|-----------|----------|---------|-------|
+| `emulatorInstanceName` | string \| null | no | null | LDPlayer instance name. Blank treated as null. |
+| `emulatorInstanceIndex` | integer \| null | no | null | LDPlayer instance index; when present MUST be ≥ 0. |
+
+### Validation
+
+- Both optional; omitting both preserves today's behavior (no emulator management).
+- `emulatorInstanceIndex` < 0 ⇒ **400 Bad Request** (mirrors the connect-to-game / ensure-emulator
+  negative-index rejection).
+- When both are present, `emulatorInstanceName` wins at runtime (documented precedence).
+- Absent fields on an older stored queue deserialize to null (back-compat; no migration).
+
+### Examples
+
+Create a queue that cold-starts LDPlayer instance "PNS" bound to `emulator-5558`:
+
+```json
+POST /api/queues
+{
+  "name": "PNS Daily 5558",
+  "emulatorSerial": "emulator-5558",
+  "cycleExecution": false,
+  "emulatorInstanceName": "PNS"
+}
+```
+
+Response (get/list) echoes the fields:
+
+```json
+{
+  "id": "…",
+  "name": "PNS Daily 5558",
+  "emulatorSerial": "emulator-5558",
+  "cycleExecution": false,
+  "pauseWhenIdle": false,
+  "idleThresholdSeconds": 30,
+  "emulatorInstanceName": "PNS",
+  "emulatorInstanceIndex": null,
+  "status": "Stopped",
+  "entryCount": 0
+}
+```
+
+## Runtime behavior contract (queue start)
+
+Given a queue whose `emulatorInstanceName`/`emulatorInstanceIndex` is set, when the queue starts, the
+run performs a feature-070 emulator ensure **before** creating its device session:
+
+| Precondition | Ensure outcome | Session created? | Run result |
+|--------------|----------------|:----------------:|-----------|
+| instance fields unset | (not invoked) | yes | unchanged from today |
+| emulator already up | already_healthy | yes | runs; no restart |
+| emulator closed | started | yes | runs |
+| emulator hung | restarted | yes | runs |
+| non-Windows / tooling missing | platform_unsupported / control_unavailable | yes | runs (neutral not-applied) |
+| never boots in time | recovery_timed_out | **no** | **Failure**, actionable reason |
+| identifier matches nothing | instance_not_found | **no** | **Failure**, actionable reason |
+
+Guarantees:
+- The ensure is invoked at most once per run, before `CreateSession`.
+- A genuine failure (recovery_timed_out / instance_not_found) never creates a session and never runs a
+  sequence; the run ends as Failure with a reason naming the instance and the outcome.
+- A stop request during the ensure aborts promptly (handler honors the cancellation token).
+- No new emulator-tuning configuration; feature-070 timeouts/knobs apply unchanged.
+- The cold-start outcome is recorded (queue logs / stop reason) so it is observable after the fact.

--- a/specs/074-sessionless-emulator-start/data-model.md
+++ b/specs/074-sessionless-emulator-start/data-model.md
@@ -1,0 +1,70 @@
+# Phase 1 Data Model: Queue Emulator-Instance Cold-Start
+
+## Entity: ExecutionQueue (extended)
+
+Persisted queue configuration (`src/GameBot.Domain/Queues/ExecutionQueue.cs`). Two new optional fields.
+
+| Field | Type | Default | Persisted | Notes |
+|-------|------|---------|-----------|-------|
+| `EmulatorInstanceName` | `string?` | `null` | yes | LDPlayer instance name to cold-start at queue run start. Null/blank ⇒ not used. |
+| `EmulatorInstanceIndex` | `int?` | `null` | yes | LDPlayer instance index. Null ⇒ not used. Must be ≥ 0 when set. |
+
+Existing fields used by this feature: `EmulatorSerial` (the device serial reused for the feature-070
+responsiveness probe).
+
+**Validation rules** (enforced at the API boundary, reusing feature-070 semantics via
+`EnsureEmulatorRunningArgs.TryCreate` at runtime):
+- Both fields optional. When **neither** is set, the queue performs no emulator management (total no-op).
+- When set: `EmulatorInstanceIndex`, if supplied, MUST be ≥ 0 (negative rejected at create/update).
+- When both name and index are supplied, **name takes precedence** (consistent with feature 070/071).
+- No new constraint couples the instance fields to `EmulatorSerial` beyond what exists today; the serial
+  is already required to create a queue.
+
+**Persistence / back-compat**: `FileQueueRepository` serializes the whole `ExecutionQueue` via
+System.Text.Json. Nullable properties absent from an older queue's JSON deserialize to `null`, so
+pre-existing queues load as "unset" with no migration (FR-014).
+
+**Mutability**: Settable on both create and update (mirrors the mutable idle-pause fields), so an
+operator can enable cold-start on an existing queue without recreating it. (`EmulatorSerial` itself
+remains immutable-after-create; these instance fields are additive config.)
+
+## Runtime concept: Pre-Session Emulator Cold-Start
+
+Not persisted. Computed once per queue run in `QueueExecutionService.RunAsync`, before `CreateSession`.
+
+**Input**: the queue's `EmulatorInstanceName`/`EmulatorInstanceIndex` + `EmulatorSerial`.
+
+**Precondition to run**: at least one instance identifier is set AND the injected
+`IEnsureEmulatorRunningActionHandler` is non-null. Otherwise skipped (no-op; behave as today).
+
+**Outcome mapping** (from feature-070 `EnsureEmulatorRunningActionResult`):
+
+| Feature-070 outcome | `IsSuccess` | `IsUnsupported` | Run behavior |
+|---------------------|:-----------:|:---------------:|--------------|
+| `already_healthy` | ✅ | | Create session, run normally (no restart). |
+| `started` | ✅ | | Create session, run normally. |
+| `restarted` | ✅ | | Create session, run normally. |
+| `platform_unsupported` | | ✅ | **Proceed**: create session as today (neutral not-applied). |
+| `control_unavailable` | | ✅ | **Proceed**: create session as today (neutral not-applied). |
+| `recovery_timed_out` | | | **Fail run**: reason set, **no session created**. |
+| `instance_not_found` | | | **Fail run**: reason set, **no session created**. |
+
+**Failure reason (actionable)**: e.g. `emulator instance ('<name-or-#index>') could not be started: <reasonCode>`.
+
+**Ordering guarantee**: the ensure completes before any call to `_sessions.CreateSession`; on a genuine
+failure `sessionId` stays null so the existing `if (sessionId is not null)` guard skips the entire
+sequence-running phase and the run ends as `Failure` (FR-002/FR-007/FR-013).
+
+## State / flow
+
+```text
+queue run start
+  ├─ template resolved (existing)
+  ├─ [NEW] instance identifier set?
+  │     ├─ no  → skip (no emulator work)                         ── warm/legacy path, unchanged
+  │     └─ yes → ensure-emulator-running(instance, serial)
+  │             ├─ success / unsupported → continue
+  │             └─ recovery_timeout / not_found → Failure, STOP (no session)
+  ├─ CreateSession(EmulatorSerial)   (existing; now reached even from a cold emulator)
+  └─ run sequences (existing)
+```

--- a/specs/074-sessionless-emulator-start/plan.md
+++ b/specs/074-sessionless-emulator-start/plan.md
@@ -1,0 +1,143 @@
+# Implementation Plan: Start the Emulator From a Backend-Only, Session-Less State
+
+**Branch**: `074-sessionless-emulator-start` | **Date**: 2026-07-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/074-sessionless-emulator-start/spec.md`
+
+## Summary
+
+An execution queue creates its ADB-bound device session **up front**, before it runs any sequence
+(`QueueExecutionService.RunAsync` step 2: `_sessions.CreateSession(queue.EmulatorSerial)`). When the
+emulator is closed, `CreateSession` → `ResolveOrValidateDeviceSerial` throws `no_adb_devices`, the run
+is marked `Failure` ("emulator could not be reached"), and the queue never reaches the sequences that
+would start the emulator. That is the concrete bootstrap gap: from a backend-only, session-less cold
+state, a scheduled queue cannot self-start.
+
+This feature adds a **pre-session emulator cold-start** to the queue run: when a queue is configured
+with an optional emulator-instance identifier (name or index), `RunAsync` invokes the existing
+feature-070 `IEnsureEmulatorRunningActionHandler` **before** `CreateSession`, using the queue's
+existing `EmulatorSerial` for the responsiveness probe. A healthy/started/restarted or neutral
+unsupported outcome proceeds to create the session and run exactly as today; a genuine emulator failure
+(recovery timeout / instance-not-found) fails the run with a clear reason **without** creating a
+session. Queues with the fields unset behave byte-for-byte as today.
+
+Technical approach: reuse feature 070 wholesale (handler, `EnsureEmulatorRunningArgs`, outcome
+semantics, timeouts) — no new emulator machinery. Add two optional persisted fields to `ExecutionQueue`
+(`EmulatorInstanceName`, `EmulatorInstanceIndex`) and thread them through the queue-config path
+(domain → repository JSON → API contracts → endpoints → web-ui), mirroring exactly how feature 073
+added `PauseWhenIdle`/`IdleThresholdSeconds`. Inject the handler into `QueueExecutionService` as an
+optional nullable constructor parameter (like the existing `IEnsureGameRunningActionHandler`), so DI
+wires the real handler and existing test constructions keep compiling.
+
+## Technical Context
+
+**Language/Version**: C# / .NET (GameBot.Service, GameBot.Domain); TypeScript (web-ui React)
+**Primary Dependencies**: ASP.NET minimal APIs, System.Text.Json; React + Jest/RTL; feature-070
+emulator control (`LdConsoleEmulatorControl`, `AdbEmulatorDeviceProbe`) reused unchanged
+**Storage**: JSON file persistence for queue config (`FileQueueRepository` serializes the whole
+`ExecutionQueue`); runtime run state is in-memory (`QueueRunHandle`), never persisted
+**Testing**: xUnit (`tests/unit`, `tests/integration`, `tests/contract`); Jest + React Testing Library
+(web-ui); `dotnet test`; web-ui green gate = `vite build` + `jest`
+**Target Platform**: Windows host driving an Android/LDPlayer emulator via ADB
+**Project Type**: Web application — .NET backend service + React web-ui
+**Performance Goals**: The pre-session ensure runs once per queue start, before any session; it adds the
+feature-070 probe cost (≤10 s probe, ≤120 s boot wait) only on a cold/hung emulator and an
+already-healthy instance returns after a single fast probe. No hot-path/steady-state change; the run
+loop cadence is untouched.
+**Constraints**: The ensure MUST run before `CreateSession`; a genuine failure MUST NOT create a
+session (FR-002/FR-007/FR-013); a stop request during the ensure must abort promptly (the handler is
+`ct`-aware); unset fields MUST be a total no-op (FR-014). Reuse feature-070 config — no new tuning
+settings (FR-011/SC-008). CamelCase method names only.
+**Scale/Scope**: One production machine, one emulator per queue; ~a dozen live daily queues that would
+opt in. Touches one domain entity, three queue contracts, one endpoint mapper, one runtime method, and
+the web-ui queue config form.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation
+progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+- **I. Code Quality Discipline**: PASS (planned). Change is cohesive and localized: two domain fields,
+  standard contract/endpoint plumbing (copy of the 073 pattern), and one new private helper +
+  call-site in `RunAsync`. The helper stays under ~50 LOC. No dead code; no new dependencies. Public
+  members get XML docs. **CamelCase method names only — no underscores.**
+- **II. Testing Standards**: PASS (planned). Bug-repro-first: a unit test proving a cold queue with an
+  instance identifier now starts the emulator before `CreateSession` (and that a genuine failure skips
+  session creation) is written before the runtime change. Full behavior matrix (unset / already-healthy
+  / started / restarted / recovery-timeout / instance-not-found / unsupported) with a fake handler;
+  contract tests for the new fields' round-trip + negative-index rejection + back-compat default;
+  repository back-compat test; web-ui tests for the config control + types. Targets the ≥80% line /
+  ≥70% branch baseline on touched code.
+- **III. UX Consistency**: PASS (planned). New fields surfaced consistently across the API
+  (create/update/response) and web-ui, mirroring `cycleExecution`/`pauseWhenIdle`. The cold-start
+  outcome is recorded in the queue execution log so operators can see what happened (FR-010). Failure
+  message is actionable ("emulator instance '<x>' could not be started: <reason>").
+- **IV. Performance**: PASS. One extra probe at queue start, only when opted in; already-healthy is a
+  single fast probe; no steady-state or hot-path change. Perf note captured above.
+- **V. Living Documentation**: PASS (planned). `docs/architecture.md` updated (queue config gains the
+  emulator-instance fields; queue-start pre-session emulator ensure behavior; "Last reviewed"
+  refreshed). `spec.md` Status set to Implemented on completion; `specs/STATUS.md` updated. Features
+  070/071/073 referenced, not superseded (this complements them; no earlier spec misrepresents current
+  behavior, so no Status edits needed elsewhere).
+
+**Initial gate**: PASS. No violations; Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/074-sessionless-emulator-start/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (design decisions)
+├── data-model.md        # Phase 1 output (queue fields + outcome mapping)
+├── quickstart.md        # Phase 1 output (enable + verify cold-start)
+├── contracts/
+│   └── queue-emulator-instance-config.md   # Phase 1 output (API contract for new fields + run behavior)
+├── checklists/
+│   └── requirements.md  # from /speckit-specify (+ clarify re-validation)
+└── tasks.md             # /speckit-tasks output
+```
+
+### Source Code (repository root)
+
+```text
+src/GameBot.Domain/
+└── Queues/
+    └── ExecutionQueue.cs            # + EmulatorInstanceName (string?), EmulatorInstanceIndex (int?)
+                                     #   (optional, null default → JSON back-compat via FileQueueRepository whole-object serialization)
+
+src/GameBot.Service/
+├── Services/QueueExecution/
+│   └── QueueExecutionService.cs     # inject IEnsureEmulatorRunningActionHandler? (optional ctor param);
+│                                    #   pre-session EnsureEmulatorBeforeSessionAsync helper called in RunAsync before CreateSession;
+│                                    #   genuine failure → Failure reason, no session; log outcome
+├── Contracts/Queues/
+│   ├── CreateQueueRequest.cs        # + EmulatorInstanceName, EmulatorInstanceIndex
+│   ├── UpdateQueueRequest.cs        # + EmulatorInstanceName, EmulatorInstanceIndex
+│   └── QueueResponse.cs             # + EmulatorInstanceName, EmulatorInstanceIndex
+└── Endpoints/QueuesEndpoints.cs     # map new fields on create/update/response; reject negative index
+
+src/web-ui/src/
+├── services/queues.ts               # types for new fields (Queue, Create/Update payloads)
+└── pages/QueuesPage.tsx             # emulator-instance inputs in the queue config form
+
+tests/
+├── unit/Queues/QueueExecutionServiceTests.cs   # pre-session cold-start behavior matrix (fake handler)
+├── contract/ (queues)                           # new fields round-trip + negative-index reject + back-compat default
+├── unit/Queues/FileQueueRepositoryTests.cs      # back-compat: JSON without fields → null
+└── (web-ui) QueuesPage.*                         # config control renders + posts new fields
+
+docs/architecture.md                 # living-docs update: queue config fields + pre-session emulator ensure behavior
+specs/STATUS.md                       # add 074
+```
+
+**Structure Decision**: Existing web-application layout (backend service + web-ui). The feature threads
+two optional config fields through the established queue-config path (identical to `PauseWhenIdle`) and
+adds a single pre-session ensure call in the run loop. No new projects, services, or persistence
+stores. The emulator control itself is reused from feature 070 with zero changes.
+
+## Complexity Tracking
+
+Not required — Constitution Check passed with no violations.

--- a/specs/074-sessionless-emulator-start/quickstart.md
+++ b/specs/074-sessionless-emulator-start/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: Cold-Start the Emulator From a Backend-Only State
+
+This feature lets a scheduled queue start its LDPlayer emulator instance itself when the machine has
+**only the backend service running** (no session, emulator closed) — so unattended automation
+self-recovers instead of failing at session creation.
+
+## Enable it on a queue
+
+Set the queue's optional emulator-instance identifier (name or index). The queue reuses its existing
+emulator serial for the responsiveness probe.
+
+Via REST (create or update):
+
+```bash
+curl -X PUT http://localhost:8080/api/queues/<queueId> \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "PNS Daily 5558", "cycleExecution": false, "emulatorInstanceName": "PNS" }'
+```
+
+Or in the web-ui: open the queue's configuration and fill in **Emulator instance name** (or **index**).
+
+Leave both blank to keep today's behavior (no emulator management).
+
+## Verify the cold-start (the whole point)
+
+1. Close the emulator entirely. Ensure no session exists — only the backend service is running.
+2. Start the queue (schedule fires, or start it manually).
+3. Expected: the queue starts the emulator instance, waits for it to become responsive, then creates
+   its session and runs its sequences — **no manual emulator launch or session start needed**.
+
+## Behavior summary
+
+- **Emulator already up** → no restart; queue runs exactly as today.
+- **Emulator closed / hung** → started / restarted, then the queue proceeds.
+- **Instance can't be brought up** (never boots, or the name/index matches nothing) → the queue run
+  fails with a clear reason and does **not** create a session.
+- **Non-Windows host / emulator tooling missing** → neutral "not-applied"; the queue proceeds to create
+  its session exactly as before (no new failure).
+- **Fields unset** → the queue does no emulator work at all (100% backward compatible).
+
+## Notes
+
+- No new emulator-tuning settings: the responsiveness-probe timeout (10 s), boot wait (120 s), and poll
+  interval (3 s) are inherited from feature 070 and overridable via the existing configuration.
+- When both name and index are set, the **name** takes precedence.
+- The cold-start runs once at queue start, before the session; the outcome is recorded in the queue's
+  logs / stop reason.

--- a/specs/074-sessionless-emulator-start/research.md
+++ b/specs/074-sessionless-emulator-start/research.md
@@ -1,0 +1,101 @@
+# Phase 0 Research: Session-Less (Cold) Emulator Start at Queue Startup
+
+## Decision 1 — Integration point: queue startup, before session creation
+
+**Decision**: Perform the emulator cold-start inside `QueueExecutionService.RunAsync`, immediately
+before the existing step 2 (`_sessions.CreateSession(queue.EmulatorSerial)`).
+
+**Rationale**: Tracing the cold path shows the queue is where it breaks. `RunAsync` creates the
+device-bound session up front; `SessionManager.CreateSession` (with ADB enabled) calls
+`ResolveOrValidateDeviceSerial`, which throws `no_adb_devices` when no device is present — i.e. when
+the emulator is closed. The run is then marked `Failure` ("emulator could not be reached") and never
+runs the sequences that ensure the game is running. The queue is exactly "the thing that makes sure the
+game is running" at runtime, so healing the emulator at queue startup — before the session — is the
+correct and minimal integration point.
+
+**Alternatives considered**:
+- *Lazy/per-step session resolution in `CommandExecutor`* (the initial clarify hypothesis): addresses
+  the standalone command/sequence dispatch path (`ForceExecuteDetailedAsync` resolves a session up
+  front and throws `missing_session_context`). Rejected as the primary fix because it does **not**
+  unblock the scheduled-queue automation the user actually runs — the queue fails earlier, at
+  `CreateSession`, before any command/sequence dispatch. Left as possible future work (spec Assumptions,
+  out of scope).
+- *A new dedicated "cold start" endpoint/tool*: rejected — the user explicitly wants this "integrated
+  into the current commands/sequences that make sure the game is running," and a parallel path would
+  not self-heal scheduled runs.
+- *Auto-starting the emulator implicitly for every queue*: rejected — must be opt-in and backward
+  compatible; a queue with no instance identifier does no emulator work.
+
+## Decision 2 — Reuse feature-070 `ensure-emulator-running` wholesale
+
+**Decision**: Call the existing internal `IEnsureEmulatorRunningActionHandler.ExecuteAsync(
+EnsureEmulatorRunningArgs, ct)` with args built from the queue's instance identifier + `EmulatorSerial`.
+
+**Rationale**: Feature 070 already implements health-probe, start, restart-on-hang, bounded boot wait,
+graceful degradation, and the outcome taxonomy (already_healthy / started / restarted /
+recovery_timed_out / instance_not_found / platform_unsupported / control_unavailable). Reusing it
+guarantees identical semantics and requires no new emulator machinery or configuration (FR-011,
+SC-008). The handler and its result type are `internal` to `GameBot.Service`, same assembly as
+`QueueExecutionService`, so it can be injected and consumed directly.
+
+**Outcome → run behavior mapping**:
+- `IsSuccess` (already_healthy / started / restarted) → proceed to `CreateSession`.
+- `IsUnsupported` (platform_unsupported / control_unavailable) → **proceed** to `CreateSession` (neutral
+  not-applied; preserves today's behavior on non-Windows / missing tooling — FR-008).
+- Otherwise (recovery_timed_out / instance_not_found) → **fail the run** with a clear reason and do
+  **not** create a session (FR-002/FR-007/FR-013).
+
+**Alternatives considered**: reimplementing a lighter probe inline — rejected (duplication, drift from
+070 semantics).
+
+## Decision 3 — Opt-in via optional queue-config fields (name or index)
+
+**Decision**: Add `EmulatorInstanceName` (string?) and `EmulatorInstanceIndex` (int?) to
+`ExecutionQueue`, both optional/nullable, reusing the queue's existing `EmulatorSerial` for the probe.
+The pre-session ensure runs only when at least one identifier is set.
+
+**Rationale**: The queue currently carries only `EmulatorSerial`, not an LDPlayer instance identity.
+Feature 070/071 identify an instance by name or index; mirroring that on the queue keeps parity and
+lets `EnsureEmulatorRunningArgs.TryFrom`/validation reuse the same rules (name-or-index required,
+index ≥ 0, name precedence). Optional + null default means existing queues are a total no-op (FR-014),
+and `FileQueueRepository` serializes the whole `ExecutionQueue`, so nullable properties round-trip with
+back-compat for free.
+
+**Alternatives considered**:
+- *Derive the instance from the serial*: rejected — no reliable serial→instance mapping; feature 070
+  explicitly does not auto-discover.
+- *Reuse a single string field for both name and index*: rejected — 070's args model distinguishes
+  name vs index; keeping two fields matches and validates cleanly.
+
+## Decision 4 — Inject the handler as an optional nullable ctor parameter
+
+**Decision**: Add `IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null` as the last
+`QueueExecutionService` constructor parameter; when null (tests that omit it), skip the pre-session
+ensure (degrade to today's behavior).
+
+**Rationale**: Mirrors the existing optional `IEnsureGameRunningActionHandler?` parameter. DI already
+registers the handler as a singleton, so production wiring is automatic; existing test constructions
+that don't pass it keep compiling. New tests inject a fake to drive the behavior matrix.
+
+**Alternatives considered**: a required parameter — rejected (breaks every existing
+`QueueExecutionService` test construction unnecessarily).
+
+## Decision 5 — Observability
+
+**Decision**: Log the cold-start outcome via the existing queue execution logger (a new
+`LoggerMessage`), and set an actionable `failureReason` on genuine failure so the queue's recorded stop
+reason explains it. No new execution-log entry type.
+
+**Rationale**: FR-010 requires the outcome be observable after the fact; the queue already records a
+stop reason and structured logs. Keeping to the existing channels avoids new log schema.
+
+## Reused / referenced components (no change)
+
+- `GameBot.Service.Services.EnsureEmulatorRunning.*` (handler, control, probe, result) — feature 070.
+- `GameBot.Domain.Actions.EnsureEmulatorRunningArgs` — args + `TryCreate` validation (name-or-index,
+  index ≥ 0).
+- Queue config plumbing pattern — feature 073 (`PauseWhenIdle`/`IdleThresholdSeconds`).
+
+## Open questions
+
+None. All NEEDS CLARIFICATION resolved in the spec's Clarifications (Session 2026-07-24).

--- a/specs/074-sessionless-emulator-start/spec.md
+++ b/specs/074-sessionless-emulator-start/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Start the Emulator From a Backend-Only, Session-Less State
+
+**Feature Branch**: `074-sessionless-emulator-start`
+**Created**: 2026-07-24
+**Status**: Draft
+**Input**: User description: "I need a way to start the emulator when NO session is started. Make sure an emulator can be started where there's nothing but the backend service running. This behaviour has to be integrated into the current commands/sequences that make sure the game is running"
+
+## Overview
+
+Today the automation can heal or start the emulator, but only from **inside** a run that already has (or can resolve) a live session — and a session can only attach to a device that a **running** emulator exposes. That creates a bootstrap gap: from a truly cold state where **only the backend service is running** (no session, no attached device, emulator possibly closed), there is no reliable, supported path for the automation to bring the emulator up. The actions that would start it (`ensure-emulator-running`, `connect-to-game`, `ensure-game-running`) are reached through a command/sequence dispatch path that expects a session to already exist, so an operator returning to a machine where everything but the backend is down cannot get automation moving again without manual intervention.
+
+This feature closes that gap: it makes starting the emulator possible from a backend-only state with no session, and wires that capability into the existing "make sure the game is running" flow so the same commands/sequences that operators already author and schedule can bootstrap the environment from cold.
+
+## Clarifications
+
+### Session 2026-07-24
+
+- Q: Where exactly does the automation break today when only the backend is running, and where must the cold-start be integrated? → A: An execution **queue** binds its device session up front — it creates the ADB-bound session for its emulator serial **before** running any sequence — and that session creation fails when the emulator is closed, so the queue never reaches the sequences that ensure the game is running. The cold-start must therefore run **inside the queue's own startup, before it binds the session**: the queue ensures its emulator instance is up (reusing the feature-070 `ensure-emulator-running` capability) and only then creates the session and runs its sequences. Rationale: this is the actual upstream blocker for the automation operators run (scheduled queues); fixing it at queue startup is what makes "only the backend running → automation self-starts" true, and it is the queue that "makes sure the game is running," so this is the correct integration point.
+- Q: How does the queue know which emulator instance to start (it only carries a device serial today)? → A: Add **optional** emulator-instance fields to the queue configuration (an instance name or index), persisted and surfaced through the REST API and web-ui exactly like the existing queue config fields. When set, the queue runs the pre-session emulator ensure using those fields plus its existing emulator serial; when unset, the queue behaves exactly as today (no emulator management). Rationale: mirrors how `connect-to-game` gained optional instance fields in feature 071 and how queue config was extended in features 052/073; no new machinery or global settings.
+- Q: How is the warm path kept unchanged and the cold-start kept idempotent (how is "cold" distinguished from "warm")? → A: Reuse the feature-070 emulator health probe unchanged — the emulator is (re)started only when the target instance is not running/responsive; an already-healthy instance is a no-op, so a queue whose emulator is already up creates its session and runs exactly as today. A genuine emulator failure (recovery timeout or instance-not-found) fails the queue with a clear reason before session creation; a neutral unsupported-host outcome lets the queue proceed to create the session exactly as it does today. Rationale: reusing the established health-and-recover semantics avoids new "is it cold?" logic and guarantees backward compatibility.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Bring the emulator up from a cold, session-less machine (Priority: P1)
+
+An operator (or an unattended schedule) finds the machine in a cold state: the backend service is running, but there is no active session, no device attached, and the emulator is closed. They run the automation that "makes sure the game is running" and it starts the emulator from that cold state — without requiring them to first manually open the emulator, attach a device, or start a session by hand.
+
+**Why this priority**: This is the exact capability requested and the reason the feature exists. Without it, unattended recovery is impossible whenever the emulator is down and no session survives — the automation silently cannot start, because the only actions that could start the emulator are unreachable from a session-less state. This is the whole value of the feature.
+
+**Independent Test**: With only the backend service running (no session started, emulator closed), invoke the "ensure the game is running" automation and confirm that afterward the emulator is running and responsive, with no manual pre-steps (no manual emulator launch, no manual session start).
+
+**Acceptance Scenarios**:
+
+1. **Given** only the backend service is running — no session, emulator closed — **When** the ensure-game-running automation is run, **Then** the emulator is started, becomes responsive, and the run reports that it brought the emulator up (rather than failing for lack of a session).
+2. **Given** only the backend service is running and the emulator is closed, **When** the queue runs, **Then** it does not fail at session creation ("emulator could not be reached") before it has had the chance to start the emulator — the emulator is brought up first.
+3. **Given** the emulator is started successfully from cold, **When** the run continues, **Then** it proceeds through the remaining "ensure the game is running" steps (attach a session, foreground/launch the game) exactly as it would have if the emulator had been up to begin with.
+
+---
+
+### User Story 2 - Integrated into the existing ensure-game-running commands/sequences (Priority: P1)
+
+An automation author does not want a separate, bespoke bootstrap tool. They want the emulator cold-start folded into the commands/sequences they already use to guarantee the game is running, so that the same authored artifact works whether the machine is warm (session alive) or stone cold (backend only). They author it once and it is robust to either starting state.
+
+**Why this priority**: The user explicitly requires the behavior be "integrated into the current commands/sequences that make sure the game is running." A cold-start capability that lived only in a separate, manually-triggered tool would not satisfy the request and would leave the scheduled automation still unable to self-recover. It is co-P1 with US1 because "reachable from the existing flow" is what makes the cold-start actually useful.
+
+**Independent Test**: Take the command/sequence that operators currently use to ensure the game is running, run it from a cold session-less state, and confirm it performs the emulator cold-start as part of its normal execution — no new separate artifact required.
+
+**Acceptance Scenarios**:
+
+1. **Given** the existing command/sequence that ensures the game is running, **When** it runs from a cold session-less state, **Then** the emulator cold-start happens as an integrated part of that run.
+2. **Given** the same command/sequence, **When** it runs from a warm state (a healthy session/emulator already present), **Then** it behaves exactly as it does today — no redundant emulator restart, no regression to the warm path.
+3. **Given** an author configuring the ensure-game-running flow, **When** they supply the information needed to identify the emulator instance to start, **Then** the cold-start uses it and no additional, unfamiliar authoring surface is required beyond what the existing emulator-aware actions already expose.
+
+---
+
+### Edge Cases
+
+- **Warm start (session already alive)**: When a healthy session/emulator already exists, the flow must not force an unnecessary emulator restart or tear down a working session — the cold-start path is only taken when the environment is actually cold.
+- **Host cannot drive the emulator** (non-Windows host, emulator management tool unavailable): the cold-start degrades to a neutral "not-applied" outcome consistent with the existing emulator-aware actions, and does not turn a previously-working flow into a hard failure.
+- **Emulator starts but never becomes responsive within the allotted wait**: the run reports a clear, non-hanging failure at the configured maximum wait rather than blocking indefinitely, and does not proceed to attach a session against a dead device.
+- **Instance identifier missing or does not match any real instance**: a genuine misconfiguration fails the run with a clear reason (distinct from the neutral unsupported-host outcome); a missing identifier is reported clearly rather than silently doing nothing.
+- **Stale/leftover session record but no live device**: the flow treats the environment as cold enough to require the emulator to be brought to a healthy, responsive state before proceeding, rather than trusting a session record that no live device backs.
+- **Concurrent runs**: two runs that both try to cold-start the same instance do not corrupt each other's state or leave the emulator half-started; the second observes the first's result rather than launching a duplicate.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a supported path to start the target emulator instance from a state where only the backend service is running — no active session, no attached device — without requiring any manual pre-step (no manual emulator launch and no manual session start).
+- **FR-002**: The emulator cold-start MUST run before the queue binds its device session — it MUST NOT require an already-running session or an attached device to execute, so a queue configured for cold-start no longer fails session creation merely because the emulator was closed.
+- **FR-003**: The cold-start capability MUST be integrated into the existing queue run that ensures the game is running (the queue is what operators schedule to keep the game running), so enabling it requires no separate, dedicated bootstrap artifact — a queue configured with its emulator instance performs the cold-start automatically at run start.
+- **FR-004**: When the environment is already warm (a healthy, responsive emulator and/or a live session already exists), the flow MUST NOT perform an unnecessary emulator restart and MUST NOT disrupt the working session — the cold-start is taken only when needed (idempotent with respect to a healthy environment).
+- **FR-005**: After the emulator is started from cold and becomes responsive, the flow MUST continue with the remaining "ensure the game is running" behavior (attaching a session and bringing the game to the foreground) exactly as it does when the emulator was already up.
+- **FR-006**: The operator MUST be able to identify which emulator instance the queue starts via OPTIONAL emulator-instance fields (an instance name or index) on the queue configuration, reusing the queue's existing emulator serial; these fields MUST be persisted and surfaced through the REST API and web-ui consistently with the queue's existing configuration fields. When the fields are unset, the queue performs no emulator management.
+- **FR-007**: If the emulator cannot be brought to a running, responsive state within a bounded maximum wait, the run MUST report a clear, human-readable failure and MUST NOT block indefinitely, and MUST NOT attempt to attach a session against a device that is not present.
+- **FR-008**: On a host or environment that cannot drive the emulator (non-Windows host, or the emulator management tool cannot be located), the cold-start MUST degrade gracefully to a neutral, non-crashing "not-applied" outcome, consistent with the established behavior of the existing emulator-aware actions, and MUST NOT convert a previously-working flow into a failure.
+- **FR-009**: When the supplied instance identifier does not correspond to any real emulator instance at runtime, the run MUST fail with a clear reason distinguishable from the neutral unsupported-host outcome (a genuine misconfiguration, not graceful degradation).
+- **FR-010**: The run's recorded result MUST make it possible for an operator to see what happened to the emulator (already healthy, started from cold, restarted, failed to recover, or not-applied), so a cold-start recovery is observable after the fact.
+- **FR-011**: The feature MUST reuse the existing emulator health-and-recover capability and its existing configuration (responsiveness-probe timeout, maximum boot wait, poll interval) and MUST NOT introduce new emulator-tuning configuration beyond the instance-identification inputs already carried by the emulator-aware actions.
+- **FR-012**: Existing warm-path behavior of the ensure-game-running commands/sequences and of the `connect-to-game`, `ensure-game-running`, and `ensure-emulator-running` actions MUST be preserved with zero regressions; runs that already had a live session continue to behave exactly as before.
+- **FR-013**: When a queue configured with emulator-instance fields starts, it MUST perform the emulator ensure BEFORE creating its device session; a genuine emulator failure (recovery timeout or instance-not-found) MUST fail the queue run with a clear reason and MUST NOT attempt to create the session, while a neutral unsupported-host outcome MUST let the queue proceed to create the session exactly as it does today.
+- **FR-014**: The new emulator-instance queue fields MUST be OPTIONAL for validation and MUST default to "unset" for queues stored before this feature (backward-compatible persistence); a queue with the fields unset MUST behave byte-for-byte as it does today, performing no emulator health-check, start, or restart.
+
+### Key Entities
+
+- **Cold (backend-only) state**: The starting condition this feature targets — the backend service is up, but there is no active session, no attached device, and the emulator may be closed. The environment cannot currently bootstrap itself out of this state.
+- **Execution Queue (extended)**: The scheduled queue operators use to keep the game running, bound to an emulator serial and a template of sequences. Extended with OPTIONAL emulator-instance fields (name or index) that, when set, drive a pre-session emulator cold-start at run start. Today the queue creates its device session before running any sequence — the step that fails cold.
+- **Emulator Cold-Start Outcome**: The result of the pre-session emulator ensure — already-healthy / started-from-cold / restarted / failed-to-recover / instance-not-found / not-applied — surfaced in the queue run's recorded result/log so recovery is observable.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: From a cold state (backend only, emulator closed, no session), running the ensure-game-running automation results in a running, responsive emulator in 100% of runs on a supported host, with no manual pre-steps performed by the operator.
+- **SC-002**: From the same cold state, the queue never fails at session creation before it has attempted to start the emulator — 0% of cold runs abort with an "emulator could not be reached" session-creation failure caused solely by the emulator being down.
+- **SC-003**: After a successful cold-start, the run proceeds to a live session with the game in the foreground in 100% of runs on a supported host, matching the end state of a warm run.
+- **SC-004**: Running the same queue from a warm state (emulator already up) performs zero unnecessary emulator restarts and disrupts no working session — 100% backward compatible with today's warm-path behavior; a queue with the emulator-instance fields unset performs no emulator operations at all.
+- **SC-005**: When the emulator cannot be recovered, the run reports a clear failure within the configured maximum wait in 100% of such runs and never blocks indefinitely, and never attaches a session to an absent device.
+- **SC-006**: On a host that cannot drive the emulator, the flow completes without crashing and reports a clear, neutral "not-applied" outcome in 100% of runs — the missing emulator tooling never turns a previously-working flow into a failure.
+- **SC-007**: An operator can enable the cold-start by setting the queue's optional emulator-instance field (name or index) through the existing queue configuration surfaces (REST API and web-ui) — no new emulator-tuning settings.
+- **SC-008**: No new emulator-tuning configuration is introduced; the feature reuses the existing emulator health/timeout configuration (feature 070 defaults and knobs).
+
+## Assumptions
+
+- The emulator health-and-recover capability delivered in feature 070 (`ensure-emulator-running`) is the mechanism this feature builds on; the new work is invoking it at **queue startup, before the queue binds its device session**, so the queue no longer fails session creation when the emulator is closed.
+- "The commands/sequences that make sure the game is running" is realized at runtime by the execution **queue** that schedules those sequences; the queue creating its session up front is exactly what fails today when the emulator is down, so the queue's own startup is the correct integration point — not a new dedicated endpoint or tool.
+- "Genuine failure" versus "neutral/unsupported" mirrors the established emulator-action semantics: recovery-timeout and instance-not-found are failures (they fail the queue run before session creation); non-Windows host and unavailable emulator/management tooling are neutral "not-applied" outcomes that let the queue proceed to create the session as today.
+- The operator supplies the emulator instance identifier (name or index) on the queue configuration; the queue reuses its existing emulator serial for the device probe. The feature does not auto-discover which instance corresponds to a device serial.
+- Default emulator tuning values are inherited unchanged from feature 070 (responsiveness-probe timeout 10 s, maximum boot wait 120 s, poll interval 3 s) and remain overridable via the existing configuration.
+- The feature's responsibility ends at bringing the emulator up from cold and handing off to the existing session-create and sequence behavior; it does not redefine what "game running" means.
+- The interactive/manual session-start endpoint remains a separate, lighter path; this feature targets the scheduled-queue automation operators rely on for unattended recovery. Extending the standalone command/sequence dispatch path to run session-lessly is possible future work but is out of scope here.

--- a/specs/074-sessionless-emulator-start/spec.md
+++ b/specs/074-sessionless-emulator-start/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `074-sessionless-emulator-start`
 **Created**: 2026-07-24
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "I need a way to start the emulator when NO session is started. Make sure an emulator can be started where there's nothing but the backend service running. This behaviour has to be integrated into the current commands/sequences that make sure the game is running"
 
 ## Overview

--- a/specs/074-sessionless-emulator-start/tasks.md
+++ b/specs/074-sessionless-emulator-start/tasks.md
@@ -11,14 +11,14 @@ Reuses feature-070 `IEnsureEmulatorRunningActionHandler` + `EnsureEmulatorRunnin
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm baseline green gate before changes: run `dotnet build GameBot.sln` and, in `src/web-ui`, `npm run build` — record they pass so later regressions are attributable (no file changes).
+- [x] T001 Confirm baseline green gate before changes: run `dotnet build GameBot.sln` and, in `src/web-ui`, `npm run build` — record they pass so later regressions are attributable (no file changes).
 
 ## Phase 2: Foundational (blocking prerequisites — shared config plumbing)
 
-- [ ] T002 Add optional persisted fields `EmulatorInstanceName` (`string?`, null default) and `EmulatorInstanceIndex` (`int?`, null default) with XML docs to `src/GameBot.Domain/Queues/ExecutionQueue.cs` (mirror the `PauseWhenIdle` field style; null default gives JSON back-compat via whole-object serialization).
-- [ ] T003 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/CreateQueueRequest.cs`.
-- [ ] T004 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/UpdateQueueRequest.cs`.
-- [ ] T005 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/QueueResponse.cs`.
+- [x] T002 Add optional persisted fields `EmulatorInstanceName` (`string?`, null default) and `EmulatorInstanceIndex` (`int?`, null default) with XML docs to `src/GameBot.Domain/Queues/ExecutionQueue.cs` (mirror the `PauseWhenIdle` field style; null default gives JSON back-compat via whole-object serialization).
+- [x] T003 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/CreateQueueRequest.cs`.
+- [x] T004 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/UpdateQueueRequest.cs`.
+- [x] T005 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/QueueResponse.cs`.
 
 **Checkpoint**: domain + contract fields exist; solution still builds.
 
@@ -33,15 +33,15 @@ proven by the unit behavior matrix (T007) using a fake handler.
 
 ### Tests (write first — bug-repro-first)
 
-- [ ] T006 [US1] Add failing unit test to `tests/unit/Queues/QueueExecutionServiceTests.cs` reproducing the cold path: with an instance identifier set and a fake `IEnsureEmulatorRunningActionHandler` returning `already_healthy`/`started`, assert the handler is invoked **before** `CreateSession` (ordering) and the session is created. Use the existing test construction pattern + a spy session manager.
-- [ ] T007 [US1] Extend `tests/unit/Queues/QueueExecutionServiceTests.cs` with the full outcome matrix: `already_healthy`/`started`/`restarted` → session created + run proceeds; `platform_unsupported`/`control_unavailable` → session created (neutral); `recovery_timed_out`/`instance_not_found` → run ends `Failure` with an actionable reason and **no** `CreateSession` call; fields unset → handler never invoked (no-op).
+- [x] T006 [US1] Add failing unit test to `tests/unit/Queues/QueueExecutionServiceTests.cs` reproducing the cold path: with an instance identifier set and a fake `IEnsureEmulatorRunningActionHandler` returning `already_healthy`/`started`, assert the handler is invoked **before** `CreateSession` (ordering) and the session is created. Use the existing test construction pattern + a spy session manager.
+- [x] T007 [US1] Extend `tests/unit/Queues/QueueExecutionServiceTests.cs` with the full outcome matrix: `already_healthy`/`started`/`restarted` → session created + run proceeds; `platform_unsupported`/`control_unavailable` → session created (neutral); `recovery_timed_out`/`instance_not_found` → run ends `Failure` with an actionable reason and **no** `CreateSession` call; fields unset → handler never invoked (no-op).
 
 ### Implementation
 
-- [ ] T008 [US1] Inject `IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null` as the last constructor parameter of `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (mirror the existing optional `IEnsureGameRunningActionHandler?`), store in a readonly field with an XML-doc comment.
-- [ ] T009 [US1] Add a private `async Task<string?> EnsureEmulatorBeforeSessionAsync(ExecutionQueue queue, CancellationToken ct)` helper to `QueueExecutionService.cs`: returns null when no instance identifier is set or the handler is null (no-op); otherwise builds `EnsureEmulatorRunningArgs` from `EmulatorInstanceName`/`EmulatorInstanceIndex` + `queue.EmulatorSerial`, calls the handler, returns null on `IsSuccess`/`IsUnsupported`, and an actionable failure reason string (naming the instance + reason code) on `recovery_timed_out`/`instance_not_found`. CamelCase name, ≤50 LOC.
-- [ ] T010 [US1] Wire the helper into `RunAsync` in `QueueExecutionService.cs` immediately before step 2 (`_sessions.CreateSession`): if the helper returns a failure reason, set `reason = QueueStopReason.Failure` and `failureReason` and skip session creation (leave `sessionId` null so the existing `if (sessionId is not null)` guard skips the run); otherwise proceed to `CreateSession` unchanged.
-- [ ] T011 [US1] Add a `LoggerMessage` for the cold-start outcome (started/restarted/already-healthy/failed/not-applied) and log it from the helper so the outcome is observable (FR-010); keep it to the existing queue logger.
+- [x] T008 [US1] Inject `IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null` as the last constructor parameter of `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (mirror the existing optional `IEnsureGameRunningActionHandler?`), store in a readonly field with an XML-doc comment.
+- [x] T009 [US1] Add a private `async Task<string?> EnsureEmulatorBeforeSessionAsync(ExecutionQueue queue, CancellationToken ct)` helper to `QueueExecutionService.cs`: returns null when no instance identifier is set or the handler is null (no-op); otherwise builds `EnsureEmulatorRunningArgs` from `EmulatorInstanceName`/`EmulatorInstanceIndex` + `queue.EmulatorSerial`, calls the handler, returns null on `IsSuccess`/`IsUnsupported`, and an actionable failure reason string (naming the instance + reason code) on `recovery_timed_out`/`instance_not_found`. CamelCase name, ≤50 LOC.
+- [x] T010 [US1] Wire the helper into `RunAsync` in `QueueExecutionService.cs` immediately before step 2 (`_sessions.CreateSession`): if the helper returns a failure reason, set `reason = QueueStopReason.Failure` and `failureReason` and skip session creation (leave `sessionId` null so the existing `if (sessionId is not null)` guard skips the run); otherwise proceed to `CreateSession` unchanged.
+- [x] T011 [US1] Add a `LoggerMessage` for the cold-start outcome (started/restarted/already-healthy/failed/not-applied) and log it from the helper so the outcome is observable (FR-010); keep it to the existing queue logger.
 
 **Checkpoint**: US1 unit tests pass; cold queue starts the emulator before the session; genuine failure creates no session.
 
@@ -55,23 +55,23 @@ confirm it round-trips; a queue with the fields unset performs no emulator work.
 
 ### Tests
 
-- [ ] T012 [P] [US2] Add/extend queue contract tests under `tests/contract` (queues): create + update + response round-trip the new `emulatorInstanceName`/`emulatorInstanceIndex`; a negative `emulatorInstanceIndex` is rejected (400); omitting the fields yields null (back-compat).
-- [ ] T013 [P] [US2] Add a back-compat test to `tests/unit/Queues/FileQueueRepositoryTests.cs`: a queue JSON without the new fields deserializes with both properties null and re-serializes without data loss.
-- [ ] T014 [P] [US2] Add/extend web-ui tests (e.g. `src/web-ui/src/pages/__tests__/QueuesPage.*`) asserting the emulator-instance inputs render and their values are included in the create/update payload.
+- [x] T012 [P] [US2] Add/extend queue contract tests under `tests/contract` (queues): create + update + response round-trip the new `emulatorInstanceName`/`emulatorInstanceIndex`; a negative `emulatorInstanceIndex` is rejected (400); omitting the fields yields null (back-compat).
+- [x] T013 [P] [US2] Add a back-compat test to `tests/unit/Queues/FileQueueRepositoryTests.cs`: a queue JSON without the new fields deserializes with both properties null and re-serializes without data loss.
+- [x] T014 [P] [US2] Add/extend web-ui tests (e.g. `src/web-ui/src/pages/__tests__/QueuesPage.*`) asserting the emulator-instance inputs render and their values are included in the create/update payload.
 
 ### Implementation
 
-- [ ] T015 [US2] Map the new fields in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: set them from `CreateQueueRequest`/`UpdateQueueRequest` onto the queue, echo them in the response builder(s) (mirror the `PauseWhenIdle` lines at create/update/response), and reject a negative `EmulatorInstanceIndex` with a 400 (validation helper alongside the existing `CoerceThreshold`).
-- [ ] T016 [P] [US2] Add `emulatorInstanceName?: string | null` and `emulatorInstanceIndex?: number | null` to the queue types and create/update payloads in `src/web-ui/src/services/queues.ts` (mirror `pauseWhenIdle`).
-- [ ] T017 [US2] Add **Emulator instance name** and **Emulator instance index** inputs to the queue configuration form in `src/web-ui/src/pages/QueuesPage.tsx`, wired to the create/update payload (mirror the idle-pause control placement); optional/blank = unset.
+- [x] T015 [US2] Map the new fields in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: set them from `CreateQueueRequest`/`UpdateQueueRequest` onto the queue, echo them in the response builder(s) (mirror the `PauseWhenIdle` lines at create/update/response), and reject a negative `EmulatorInstanceIndex` with a 400 (validation helper alongside the existing `CoerceThreshold`).
+- [x] T016 [P] [US2] Add `emulatorInstanceName?: string | null` and `emulatorInstanceIndex?: number | null` to the queue types and create/update payloads in `src/web-ui/src/services/queues.ts` (mirror `pauseWhenIdle`).
+- [x] T017 [US2] Add **Emulator instance name** and **Emulator instance index** inputs to the queue configuration form in `src/web-ui/src/pages/QueuesPage.tsx`, wired to the create/update payload (mirror the idle-pause control placement); optional/blank = unset.
 
 **Checkpoint**: fields round-trip through REST + web-ui + persistence; unset queues unchanged.
 
 ## Phase 5: Polish & Cross-Cutting
 
-- [ ] T018 [P] Update `docs/architecture.md`: queue config gains `EmulatorInstanceName`/`EmulatorInstanceIndex`; describe the queue-start pre-session emulator ensure (reuses feature 070); refresh the "Last reviewed" date.
-- [ ] T019 [P] Add `074-sessionless-emulator-start` to `specs/STATUS.md` and set `spec.md` **Status** to Implemented once green.
-- [ ] T020 Run the full green gate: `dotnet test GameBot.sln`, then in `src/web-ui` `npm run build` and `npm test` — all green (fix any regressions before marking complete).
+- [x] T018 [P] Update `docs/architecture.md`: queue config gains `EmulatorInstanceName`/`EmulatorInstanceIndex`; describe the queue-start pre-session emulator ensure (reuses feature 070); refresh the "Last reviewed" date.
+- [x] T019 [P] Add `074-sessionless-emulator-start` to `specs/STATUS.md` and set `spec.md` **Status** to Implemented once green.
+- [x] T020 Run the full green gate: `dotnet test GameBot.sln`, then in `src/web-ui` `npm run build` and `npm test` — all green (fix any regressions before marking complete).
 - [ ] T021 [P] Manual quickstart smoke per [quickstart.md](quickstart.md): close the emulator, start a queue with `emulatorInstanceName` set, confirm it cold-starts the emulator then creates the session (or note if hardware unavailable in this environment).
 
 ## Dependencies & Execution Order

--- a/specs/074-sessionless-emulator-start/tasks.md
+++ b/specs/074-sessionless-emulator-start/tasks.md
@@ -1,0 +1,95 @@
+# Tasks: Start the Emulator From a Backend-Only, Session-Less State
+
+**Feature**: 074-sessionless-emulator-start
+**Plan**: [plan.md](plan.md) | **Spec**: [spec.md](spec.md) | **Data model**: [data-model.md](data-model.md) | **Contract**: [contracts/queue-emulator-instance-config.md](contracts/queue-emulator-instance-config.md)
+
+Tests are included: the constitution mandates bug-repro-first and coverage on touched code, and the
+plan commits to them.
+
+**Tech**: C# / .NET (GameBot.Domain, GameBot.Service), xUnit; TypeScript React web-ui, Jest/RTL.
+Reuses feature-070 `IEnsureEmulatorRunningActionHandler` + `EnsureEmulatorRunningArgs` unchanged.
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm baseline green gate before changes: run `dotnet build GameBot.sln` and, in `src/web-ui`, `npm run build` — record they pass so later regressions are attributable (no file changes).
+
+## Phase 2: Foundational (blocking prerequisites — shared config plumbing)
+
+- [ ] T002 Add optional persisted fields `EmulatorInstanceName` (`string?`, null default) and `EmulatorInstanceIndex` (`int?`, null default) with XML docs to `src/GameBot.Domain/Queues/ExecutionQueue.cs` (mirror the `PauseWhenIdle` field style; null default gives JSON back-compat via whole-object serialization).
+- [ ] T003 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/CreateQueueRequest.cs`.
+- [ ] T004 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/UpdateQueueRequest.cs`.
+- [ ] T005 [P] Add `EmulatorInstanceName` (`string?`) and `EmulatorInstanceIndex` (`int?`) to `src/GameBot.Service/Contracts/Queues/QueueResponse.cs`.
+
+**Checkpoint**: domain + contract fields exist; solution still builds.
+
+## Phase 3: User Story 1 — Bring the emulator up from a cold, session-less machine (P1)
+
+**Goal**: A queue configured with an emulator instance starts that emulator before creating its device
+session, so a backend-only cold state self-recovers.
+
+**Independent test**: With only the backend running (emulator closed, no session), start a queue that
+has `emulatorInstanceName` set and confirm the emulator comes up and the session is then created —
+proven by the unit behavior matrix (T007) using a fake handler.
+
+### Tests (write first — bug-repro-first)
+
+- [ ] T006 [US1] Add failing unit test to `tests/unit/Queues/QueueExecutionServiceTests.cs` reproducing the cold path: with an instance identifier set and a fake `IEnsureEmulatorRunningActionHandler` returning `already_healthy`/`started`, assert the handler is invoked **before** `CreateSession` (ordering) and the session is created. Use the existing test construction pattern + a spy session manager.
+- [ ] T007 [US1] Extend `tests/unit/Queues/QueueExecutionServiceTests.cs` with the full outcome matrix: `already_healthy`/`started`/`restarted` → session created + run proceeds; `platform_unsupported`/`control_unavailable` → session created (neutral); `recovery_timed_out`/`instance_not_found` → run ends `Failure` with an actionable reason and **no** `CreateSession` call; fields unset → handler never invoked (no-op).
+
+### Implementation
+
+- [ ] T008 [US1] Inject `IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null` as the last constructor parameter of `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` (mirror the existing optional `IEnsureGameRunningActionHandler?`), store in a readonly field with an XML-doc comment.
+- [ ] T009 [US1] Add a private `async Task<string?> EnsureEmulatorBeforeSessionAsync(ExecutionQueue queue, CancellationToken ct)` helper to `QueueExecutionService.cs`: returns null when no instance identifier is set or the handler is null (no-op); otherwise builds `EnsureEmulatorRunningArgs` from `EmulatorInstanceName`/`EmulatorInstanceIndex` + `queue.EmulatorSerial`, calls the handler, returns null on `IsSuccess`/`IsUnsupported`, and an actionable failure reason string (naming the instance + reason code) on `recovery_timed_out`/`instance_not_found`. CamelCase name, ≤50 LOC.
+- [ ] T010 [US1] Wire the helper into `RunAsync` in `QueueExecutionService.cs` immediately before step 2 (`_sessions.CreateSession`): if the helper returns a failure reason, set `reason = QueueStopReason.Failure` and `failureReason` and skip session creation (leave `sessionId` null so the existing `if (sessionId is not null)` guard skips the run); otherwise proceed to `CreateSession` unchanged.
+- [ ] T011 [US1] Add a `LoggerMessage` for the cold-start outcome (started/restarted/already-healthy/failed/not-applied) and log it from the helper so the outcome is observable (FR-010); keep it to the existing queue logger.
+
+**Checkpoint**: US1 unit tests pass; cold queue starts the emulator before the session; genuine failure creates no session.
+
+## Phase 4: User Story 2 — Integrated into the existing queue with no separate artifact (P1)
+
+**Goal**: Operators enable the cold-start purely through the queue's existing config surfaces (REST +
+web-ui); unset queues are byte-for-byte unchanged.
+
+**Independent test**: Create/update a queue via REST and the web-ui with `emulatorInstanceName` and
+confirm it round-trips; a queue with the fields unset performs no emulator work.
+
+### Tests
+
+- [ ] T012 [P] [US2] Add/extend queue contract tests under `tests/contract` (queues): create + update + response round-trip the new `emulatorInstanceName`/`emulatorInstanceIndex`; a negative `emulatorInstanceIndex` is rejected (400); omitting the fields yields null (back-compat).
+- [ ] T013 [P] [US2] Add a back-compat test to `tests/unit/Queues/FileQueueRepositoryTests.cs`: a queue JSON without the new fields deserializes with both properties null and re-serializes without data loss.
+- [ ] T014 [P] [US2] Add/extend web-ui tests (e.g. `src/web-ui/src/pages/__tests__/QueuesPage.*`) asserting the emulator-instance inputs render and their values are included in the create/update payload.
+
+### Implementation
+
+- [ ] T015 [US2] Map the new fields in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`: set them from `CreateQueueRequest`/`UpdateQueueRequest` onto the queue, echo them in the response builder(s) (mirror the `PauseWhenIdle` lines at create/update/response), and reject a negative `EmulatorInstanceIndex` with a 400 (validation helper alongside the existing `CoerceThreshold`).
+- [ ] T016 [P] [US2] Add `emulatorInstanceName?: string | null` and `emulatorInstanceIndex?: number | null` to the queue types and create/update payloads in `src/web-ui/src/services/queues.ts` (mirror `pauseWhenIdle`).
+- [ ] T017 [US2] Add **Emulator instance name** and **Emulator instance index** inputs to the queue configuration form in `src/web-ui/src/pages/QueuesPage.tsx`, wired to the create/update payload (mirror the idle-pause control placement); optional/blank = unset.
+
+**Checkpoint**: fields round-trip through REST + web-ui + persistence; unset queues unchanged.
+
+## Phase 5: Polish & Cross-Cutting
+
+- [ ] T018 [P] Update `docs/architecture.md`: queue config gains `EmulatorInstanceName`/`EmulatorInstanceIndex`; describe the queue-start pre-session emulator ensure (reuses feature 070); refresh the "Last reviewed" date.
+- [ ] T019 [P] Add `074-sessionless-emulator-start` to `specs/STATUS.md` and set `spec.md` **Status** to Implemented once green.
+- [ ] T020 Run the full green gate: `dotnet test GameBot.sln`, then in `src/web-ui` `npm run build` and `npm test` — all green (fix any regressions before marking complete).
+- [ ] T021 [P] Manual quickstart smoke per [quickstart.md](quickstart.md): close the emulator, start a queue with `emulatorInstanceName` set, confirm it cold-starts the emulator then creates the session (or note if hardware unavailable in this environment).
+
+## Dependencies & Execution Order
+
+- **Phase 1** (T001) → **Phase 2** (T002–T005) → **Phase 3** (US1) → **Phase 4** (US2) → **Phase 5**.
+- US1 depends on Foundational (needs the domain field T002). US2 depends on Foundational (contracts) and
+  is cleanest after US1's runtime exists, but its plumbing (T015–T017) is independent of US1 internals.
+- T002 blocks T009/T010 (uses the new domain fields) and T013.
+- T003/T004/T005 block T015 and T012.
+
+## Parallel Opportunities
+
+- T003, T004, T005 (three separate contract files) can run in parallel after T002.
+- T012, T013, T014 (contract / repo / web-ui tests) are independent files — parallel.
+- T016 (web-ui types) and T018/T019 (docs) are independent — parallel.
+
+## Implementation Strategy
+
+MVP = Phase 2 + Phase 3 (US1): the runtime cold-start with the domain field is the whole value — a
+queue can be configured via REST (Phase 4 REST mapping T015) and self-start the emulator. US2's web-ui
+form (T017) and the remaining tests/docs complete the increment. Ship US1 first, then US2.

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -109,6 +109,7 @@ Status vocabulary:
 | 071 | Connect-to-Game Emulator Pre-heal | Implemented |
 | 072 | Live Queue Monitor View | Implemented |
 | 073 | Idle-Pause the Game During Queue Gaps; Retire the MCP Server | Implemented |
+| 074 | Start the Emulator From a Backend-Only, Session-Less State | Implemented |
 
 ## Numbering notes
 

--- a/src/GameBot.Domain/Queues/ExecutionQueue.cs
+++ b/src/GameBot.Domain/Queues/ExecutionQueue.cs
@@ -43,6 +43,22 @@ namespace GameBot.Domain.Queues {
     public int IdleThresholdSeconds { get; set; } = 30;
 
     /// <summary>
+    /// Optional LDPlayer instance name to cold-start at queue run start (feature 074). When set (or
+    /// <see cref="EmulatorInstanceIndex"/> is set), the queue verifies/starts this emulator instance —
+    /// reusing the feature-070 ensure-emulator-running capability with <see cref="EmulatorSerial"/> as
+    /// the responsiveness probe — BEFORE it binds its device session, so a queue can self-start from a
+    /// backend-only cold state. Null/blank ⇒ no emulator management (behaves exactly as before).
+    /// When both name and index are supplied, the name takes precedence.
+    /// </summary>
+    public string? EmulatorInstanceName { get; set; }
+
+    /// <summary>
+    /// Optional LDPlayer instance index for the feature-074 pre-session cold-start (see
+    /// <see cref="EmulatorInstanceName"/>). Null ⇒ not used; when supplied it MUST be ≥ 0.
+    /// </summary>
+    public int? EmulatorInstanceIndex { get; set; }
+
+    /// <summary>
     /// Optional link to a single queue template by its stable template ID
     /// (0..1). Persisted. References by ID, so renaming the template keeps the link intact;
     /// only deleting the template makes it unresolvable. Null when the queue is unlinked.

--- a/src/GameBot.Service/Contracts/Queues/CreateQueueRequest.cs
+++ b/src/GameBot.Service/Contracts/Queues/CreateQueueRequest.cs
@@ -10,5 +10,11 @@ namespace GameBot.Service.Contracts.Queues {
 
     /// <summary>Idle-detection threshold in seconds. Absent or &lt; 1 → coerced to the default 30.</summary>
     public int IdleThresholdSeconds { get; set; }
+
+    /// <summary>Optional LDPlayer instance name to cold-start before session creation (feature 074). Absent → no emulator management.</summary>
+    public string? EmulatorInstanceName { get; set; }
+
+    /// <summary>Optional LDPlayer instance index for the pre-session cold-start (feature 074). When supplied MUST be ≥ 0.</summary>
+    public int? EmulatorInstanceIndex { get; set; }
   }
 }

--- a/src/GameBot.Service/Contracts/Queues/QueueResponse.cs
+++ b/src/GameBot.Service/Contracts/Queues/QueueResponse.cs
@@ -14,6 +14,12 @@ namespace GameBot.Service.Contracts.Queues {
     /// <summary>Idle-detection threshold in seconds (default 30).</summary>
     public int IdleThresholdSeconds { get; set; } = 30;
 
+    /// <summary>Optional LDPlayer instance name cold-started before session creation (feature 074); null when unset.</summary>
+    public string? EmulatorInstanceName { get; set; }
+
+    /// <summary>Optional LDPlayer instance index for the pre-session cold-start (feature 074); null when unset.</summary>
+    public int? EmulatorInstanceIndex { get; set; }
+
     public QueueExecutionStatus Status { get; set; } = QueueExecutionStatus.Stopped;
     public int EntryCount { get; set; }
 

--- a/src/GameBot.Service/Contracts/Queues/UpdateQueueRequest.cs
+++ b/src/GameBot.Service/Contracts/Queues/UpdateQueueRequest.cs
@@ -12,5 +12,11 @@ namespace GameBot.Service.Contracts.Queues {
 
     /// <summary>Idle-detection threshold in seconds. Absent or &lt; 1 → coerced to the default 30.</summary>
     public int IdleThresholdSeconds { get; set; }
+
+    /// <summary>Optional LDPlayer instance name to cold-start before session creation (feature 074). Absent → no emulator management.</summary>
+    public string? EmulatorInstanceName { get; set; }
+
+    /// <summary>Optional LDPlayer instance index for the pre-session cold-start (feature 074). When supplied MUST be ≥ 0.</summary>
+    public int? EmulatorInstanceIndex { get; set; }
   }
 }

--- a/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
@@ -22,13 +22,16 @@ internal static class QueuesEndpoints {
       if (string.IsNullOrWhiteSpace(name)) return Error(400, "invalid_request", "name is required");
       var serial = req?.EmulatorSerial?.Trim();
       if (string.IsNullOrWhiteSpace(serial)) return Error(400, "invalid_request", "emulatorSerial is required");
+      if (req!.EmulatorInstanceIndex is < 0) return Error(400, "invalid_request", "emulatorInstanceIndex must be >= 0");
 
       var created = await repo.CreateAsync(new ExecutionQueue {
         Name = name,
         EmulatorSerial = serial,
-        CycleExecution = req!.CycleExecution,
+        CycleExecution = req.CycleExecution,
         PauseWhenIdle = req.PauseWhenIdle,
-        IdleThresholdSeconds = CoerceThreshold(req.IdleThresholdSeconds)
+        IdleThresholdSeconds = CoerceThreshold(req.IdleThresholdSeconds),
+        EmulatorInstanceName = NormalizeInstanceName(req.EmulatorInstanceName),
+        EmulatorInstanceIndex = req.EmulatorInstanceIndex
       }).ConfigureAwait(false);
       return Results.Created($"{ApiRoutes.Queues}/{created.Id}", BuildResponse(created, runtime));
     }).WithName("CreateQueue");
@@ -63,10 +66,13 @@ internal static class QueuesEndpoints {
         return Error(409, "queue_running", "Stop the queue before editing.");
       var name = req?.Name?.Trim();
       if (string.IsNullOrWhiteSpace(name)) return Error(400, "invalid_request", "name is required");
+      if (req!.EmulatorInstanceIndex is < 0) return Error(400, "invalid_request", "emulatorInstanceIndex must be >= 0");
       queue.Name = name;
-      queue.CycleExecution = req!.CycleExecution;
+      queue.CycleExecution = req.CycleExecution;
       queue.PauseWhenIdle = req.PauseWhenIdle;
       queue.IdleThresholdSeconds = CoerceThreshold(req.IdleThresholdSeconds);
+      queue.EmulatorInstanceName = NormalizeInstanceName(req.EmulatorInstanceName);
+      queue.EmulatorInstanceIndex = req.EmulatorInstanceIndex;
       var saved = await repo.UpdateAsync(queue).ConfigureAwait(false);
       return Results.Ok(BuildResponse(saved, runtime));
     }).WithName("UpdateQueue");
@@ -206,6 +212,8 @@ internal static class QueuesEndpoints {
     CycleExecution = queue.CycleExecution,
     PauseWhenIdle = queue.PauseWhenIdle,
     IdleThresholdSeconds = queue.IdleThresholdSeconds,
+    EmulatorInstanceName = queue.EmulatorInstanceName,
+    EmulatorInstanceIndex = queue.EmulatorInstanceIndex,
     Status = runtime.GetStatus(queue.Id),
     EntryCount = runtime.GetEntries(queue.Id).Count,
     LinkedTemplateId = queue.LinkedTemplateId,
@@ -223,6 +231,8 @@ internal static class QueuesEndpoints {
       CycleExecution = queue.CycleExecution,
       PauseWhenIdle = queue.PauseWhenIdle,
       IdleThresholdSeconds = queue.IdleThresholdSeconds,
+      EmulatorInstanceName = queue.EmulatorInstanceName,
+      EmulatorInstanceIndex = queue.EmulatorInstanceIndex,
       Status = runtime.GetStatus(queue.Id),
       EntryCount = entries.Count,
       LinkedTemplateId = queue.LinkedTemplateId,
@@ -288,6 +298,11 @@ internal static class QueuesEndpoints {
   // Idle-detection threshold must be at least 1 second; absent (0) or non-positive coerces to the
   // default 30 (feature 073, FR-010).
   private static int CoerceThreshold(int seconds) => seconds < 1 ? 30 : seconds;
+
+  // Trim the optional emulator instance name to null when blank so an empty string in the request
+  // means "unset" (feature 074), matching how the runtime treats a missing identifier.
+  private static string? NormalizeInstanceName(string? name) =>
+    string.IsNullOrWhiteSpace(name) ? null : name.Trim();
 
   private static IResult NotFound() => Error(404, "not_found", "Queue not found");
 

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using GameBot.Domain.Queues;
 using GameBot.Domain.QueueTemplates;
 using GameBot.Emulator.Session;
+using GameBot.Service.Services.EnsureEmulatorRunning;
 using GameBot.Service.Services.EnsureGameRunning;
 using GameBot.Service.Services.ExecutionLog;
 using GameBot.Service.Services.SequenceExecution;
@@ -48,6 +49,10 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   // ensure-game-running sequence step uses; reused directly here so the scheduler can bring the game
   // back without routing through a watchdog-subject sequence. Null only in tests that omit it.
   private readonly IEnsureGameRunningActionHandler? _ensureGameRunning;
+  // Cold-start the queue's LDPlayer instance before binding the device session (feature 074). Reuses
+  // the feature-070 ensure-emulator-running handler. Null only in tests that omit it (and when null the
+  // pre-session cold-start is skipped, degrading to the pre-074 behavior).
+  private readonly IEnsureEmulatorRunningActionHandler? _ensureEmulatorRunning;
 
   // How often a non-cyclic run re-checks pending relative/live timers while waiting for one to become
   // due. Small enough that a firing lands within roughly an iteration interval of the offset, large
@@ -79,7 +84,8 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     IHostApplicationLifetime? lifetime = null,
     BackgroundScreenCaptureService? captureService = null,
     TimeProvider? timeProvider = null,
-    IEnsureGameRunningActionHandler? ensureGameRunning = null) {
+    IEnsureGameRunningActionHandler? ensureGameRunning = null,
+    IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null) {
     _queues = queues;
     _runtime = runtime;
     _templates = templates;
@@ -92,6 +98,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     _timeProvider = timeProvider ?? TimeProvider.System;
     _appStopping = lifetime?.ApplicationStopping ?? CancellationToken.None;
     _ensureGameRunning = ensureGameRunning;
+    _ensureEmulatorRunning = ensureEmulatorRunning;
   }
 
   public bool IsRunning(string queueId) => _registry.IsRunning(queueId);
@@ -179,18 +186,30 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
         var everyStepEntries = allEntries.Where(e => e.ScheduleType == ScheduleType.EveryStep).ToList();
         var timerEntries = indexed.Where(x => x.Entry.ScheduleType == ScheduleType.Timer).ToList();
 
-        // 2. Connect to the bound emulator (FR-003/FR-004).
-        try {
-          var session = _sessions.CreateSession($"queue:{queue.Id}", queue.EmulatorSerial);
-          sessionId = session.Id;
-          handle.SessionId = sessionId;
-          if (_captureService is not null && !string.IsNullOrWhiteSpace(session.DeviceSerial)) {
-            _captureService.StartCapture(session.Id, session.DeviceSerial);
-          }
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or KeyNotFoundException) {
+        // 1.5 Feature 074: when the queue is configured with an emulator instance identifier, bring that
+        // instance up BEFORE binding the device session, so a queue can self-start from a backend-only
+        // cold state (the emulator being closed would otherwise fail CreateSession below). A genuine
+        // failure (recovery timeout / instance not found) fails the run here and skips session creation;
+        // success or a neutral unsupported outcome proceeds exactly as today.
+        var emulatorFailure = await EnsureEmulatorBeforeSessionAsync(queue, ct).ConfigureAwait(false);
+        if (emulatorFailure is not null) {
           reason = QueueStopReason.Failure;
-          failureReason = $"emulator could not be reached ('{queue.EmulatorSerial}'): {ex.Message}";
+          failureReason = emulatorFailure;
+        }
+        else {
+          // 2. Connect to the bound emulator (FR-003/FR-004).
+          try {
+            var session = _sessions.CreateSession($"queue:{queue.Id}", queue.EmulatorSerial);
+            sessionId = session.Id;
+            handle.SessionId = sessionId;
+            if (_captureService is not null && !string.IsNullOrWhiteSpace(session.DeviceSerial)) {
+              _captureService.StartCapture(session.Id, session.DeviceSerial);
+            }
+          }
+          catch (Exception ex) when (ex is InvalidOperationException or KeyNotFoundException) {
+            reason = QueueStopReason.Failure;
+            failureReason = $"emulator could not be reached ('{queue.EmulatorSerial}'): {ex.Message}";
+          }
         }
 
         // 3. Run sequences in order, respecting schedule types, optionally cycling.
@@ -451,6 +470,34 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   /// Runs one sequence as a child of the queue run. Per-sequence failures are non-fatal (FR-008):
   /// returns false on a failed/unresolved sequence so the run can continue.
   /// </summary>
+  /// <summary>
+  /// Feature 074: pre-session emulator cold-start. Returns <c>null</c> when no emulator work is needed
+  /// (no instance identifier configured, or no handler injected) or when the instance ends up healthy
+  /// (already-healthy / started / restarted) or the host cannot drive the emulator (neutral
+  /// unsupported). Returns an actionable failure reason string ONLY when the instance genuinely could
+  /// not be brought up (recovery timeout / instance not found) — in which case the caller must not
+  /// create the session and fails the run. Runs before <see cref="ISessionManager.CreateSession"/> so a
+  /// closed emulator no longer fails session creation.
+  /// </summary>
+  private async Task<string?> EnsureEmulatorBeforeSessionAsync(ExecutionQueue queue, CancellationToken ct) {
+    if (_ensureEmulatorRunning is null) return null;
+    if (string.IsNullOrWhiteSpace(queue.EmulatorInstanceName) && queue.EmulatorInstanceIndex is null) return null;
+
+    var args = new GameBot.Domain.Actions.EnsureEmulatorRunningArgs {
+      InstanceName = string.IsNullOrWhiteSpace(queue.EmulatorInstanceName) ? null : queue.EmulatorInstanceName,
+      InstanceIndex = queue.EmulatorInstanceIndex,
+      AdbSerial = queue.EmulatorSerial
+    };
+    var target = queue.EmulatorInstanceName ?? $"#{queue.EmulatorInstanceIndex}";
+    var result = await _ensureEmulatorRunning.ExecuteAsync(args, ct).ConfigureAwait(false);
+    if (result.IsSuccess || result.IsUnsupported) {
+      QueueExecutionLog.PreSessionEmulatorEnsured(_logger, queue.Id, target, result.ReasonCode);
+      return null;
+    }
+    QueueExecutionLog.PreSessionEmulatorFailed(_logger, queue.Id, target, result.ReasonCode);
+    return $"emulator instance ('{target}') could not be started: {result.ReasonCode}";
+  }
+
   private async Task<bool> RunOneSequenceAsync(string sequenceId, string rootId, int index, string sessionId, string queueId, CancellationToken ct, string? selfRescheduleOriginActionId = null) {
     // Watchdog: cancel a firing that overruns SequenceWatchdogTimeout so one stuck sequence cannot
     // freeze the whole queue. Linked to ct so a real stop request still cancels immediately.
@@ -590,4 +637,10 @@ internal static partial class QueueExecutionLog {
 
   [LoggerMessage(EventId = 1116, Level = LogLevel.Warning, Message = "Queue {QueueId} idle-pause could not foreground the game on resume; the due sequence will still run")]
   public static partial void IdlePauseForegroundFailed(ILogger logger, string QueueId, Exception ex);
+
+  [LoggerMessage(EventId = 1117, Level = LogLevel.Information, Message = "Queue {QueueId} pre-session emulator ensure for instance {Instance}: {ReasonCode}")]
+  public static partial void PreSessionEmulatorEnsured(ILogger logger, string QueueId, string Instance, string ReasonCode);
+
+  [LoggerMessage(EventId = 1118, Level = LogLevel.Warning, Message = "Queue {QueueId} pre-session emulator ensure for instance {Instance} failed ({ReasonCode}); the run will not create a session")]
+  public static partial void PreSessionEmulatorFailed(ILogger logger, string QueueId, string Instance, string ReasonCode);
 }

--- a/src/web-ui/src/components/queues/QueueForm.tsx
+++ b/src/web-ui/src/components/queues/QueueForm.tsx
@@ -10,6 +10,10 @@ export type QueueFormValue = {
   pauseWhenIdle: boolean;
   /** Idle-detection threshold in seconds (default 30). */
   idleThresholdSeconds: number;
+  /** Optional LDPlayer instance name to cold-start before the session (feature 074); '' means unset. */
+  emulatorInstanceName: string;
+  /** Optional LDPlayer instance index for the pre-session cold-start (feature 074); null means unset. */
+  emulatorInstanceIndex: number | null;
 };
 
 type QueueFormProps = {
@@ -142,6 +146,37 @@ export const QueueForm: React.FC<QueueFormProps> = ({
           />
         </div>
       )}
+
+      {/* Row 2c: Emulator cold-start (feature 074). Optional instance identifier; when set, the queue
+          starts this LDPlayer instance before binding its session, so it can self-start from cold. */}
+      <div className="field-row">
+        <div className="field">
+          <label htmlFor="queue-emulator-instance-name">Emulator instance name</label>
+          <input
+            id="queue-emulator-instance-name"
+            value={value.emulatorInstanceName}
+            onChange={(e) => onChange({ ...value, emulatorInstanceName: e.target.value })}
+            placeholder="e.g. PNS (optional — cold-start this instance)"
+            disabled={submitting}
+            aria-label="Emulator instance name"
+          />
+        </div>
+        <div className="field">
+          <label htmlFor="queue-emulator-instance-index">Emulator instance index</label>
+          <input
+            id="queue-emulator-instance-index"
+            type="number"
+            min={0}
+            value={value.emulatorInstanceIndex ?? ''}
+            onChange={(e) =>
+              onChange({ ...value, emulatorInstanceIndex: e.target.value === '' ? null : Number(e.target.value) })
+            }
+            placeholder="optional"
+            disabled={submitting}
+            aria-label="Emulator instance index"
+          />
+        </div>
+      </div>
 
       {/* Row 3: Game controls (edit only) */}
       {isEdit && gameControls}

--- a/src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueForm.test.tsx
@@ -6,7 +6,7 @@ jest.mock('../../../services/useAdbDevices', () => ({
   useAdbDevices: () => ({ devices: [{ serial: 'emu-1' }, { serial: 'emu-2' }], loading: false, error: undefined, refresh: () => {} }),
 }));
 
-const baseValue: QueueFormValue = { name: '', emulatorSerial: '', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30 };
+const baseValue: QueueFormValue = { name: '', emulatorSerial: '', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30, emulatorInstanceName: '', emulatorInstanceIndex: null };
 
 const renderForm = (overrides: Partial<React.ComponentProps<typeof QueueForm>> = {}) => {
   const onChange = jest.fn();
@@ -37,7 +37,7 @@ describe('QueueForm', () => {
   });
 
   it('shows the emulator read-only in edit mode without the "cannot be changed" hint', () => {
-    renderForm({ mode: 'edit', value: { name: 'Farm', emulatorSerial: 'emu-9', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30 } });
+    renderForm({ mode: 'edit', value: { ...baseValue, name: 'Farm', emulatorSerial: 'emu-9' } });
     const emulator = screen.getByLabelText('Emulator *') as HTMLInputElement;
     expect(emulator.tagName).toBe('INPUT');
     expect(emulator).toHaveValue('emu-9');
@@ -48,7 +48,7 @@ describe('QueueForm', () => {
   it('renders slots in the new order: emulator → cycle → game → Save → separator → template section', () => {
     renderForm({
       mode: 'edit',
-      value: { name: 'Farm', emulatorSerial: 'emu-9', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30 },
+      value: { ...baseValue, name: 'Farm', emulatorSerial: 'emu-9' },
       gameControls: <div data-testid="slot-game" />,
       templateControls: <div data-testid="slot-templates" />,
     });
@@ -83,7 +83,7 @@ describe('QueueForm', () => {
   });
 
   it('calls onSubmit when the form is submitted', () => {
-    const { onSubmit } = renderForm({ value: { name: 'Farm', emulatorSerial: 'emu-1', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30 } });
+    const { onSubmit } = renderForm({ value: { ...baseValue, name: 'Farm', emulatorSerial: 'emu-1' } });
     fireEvent.click(screen.getByText('Save'));
     expect(onSubmit).toHaveBeenCalled();
   });
@@ -113,5 +113,29 @@ describe('QueueForm', () => {
     expect(threshold).toHaveValue(30);
     fireEvent.change(threshold, { target: { value: '45' } });
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ idleThresholdSeconds: 45 }));
+  });
+
+  // ── Feature 074: emulator-instance cold-start config controls ───────────────
+
+  it('renders the emulator instance name and index inputs', () => {
+    renderForm();
+    expect(screen.getByLabelText('Emulator instance name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Emulator instance index')).toBeInTheDocument();
+  });
+
+  it('emits emulator instance name changes', () => {
+    const { onChange } = renderForm();
+    fireEvent.change(screen.getByLabelText('Emulator instance name'), { target: { value: 'PNS' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ emulatorInstanceName: 'PNS' }));
+  });
+
+  it('emits emulator instance index as a number, and null when cleared', () => {
+    const { onChange } = renderForm({ value: { ...baseValue, emulatorInstanceIndex: 2 } });
+    const index = screen.getByLabelText('Emulator instance index') as HTMLInputElement;
+    expect(index).toHaveValue(2);
+    fireEvent.change(index, { target: { value: '5' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ emulatorInstanceIndex: 5 }));
+    fireEvent.change(index, { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ emulatorInstanceIndex: null }));
   });
 });

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -35,7 +35,7 @@ type QueuesPageProps = {
   navResetSignal?: number;
 };
 
-const emptyForm: QueueFormValue = { name: '', emulatorSerial: '', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30 };
+const emptyForm: QueueFormValue = { name: '', emulatorSerial: '', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30, emulatorInstanceName: '', emulatorInstanceIndex: null };
 
 export const QueuesPage: React.FC<QueuesPageProps> = ({ navResetSignal }) => {
   const [queues, setQueues] = useState<QueueDto[]>([]);
@@ -113,7 +113,7 @@ export const QueuesPage: React.FC<QueuesPageProps> = ({ navResetSignal }) => {
     const q = await getQueue(id);
     setDetail(q);
     setAssociatedTemplateName(q.linkedTemplateName ?? undefined);
-    setForm({ name: q.name, emulatorSerial: q.emulatorSerial, cycleExecution: q.cycleExecution, pauseWhenIdle: q.pauseWhenIdle, idleThresholdSeconds: q.idleThresholdSeconds });
+    setForm({ name: q.name, emulatorSerial: q.emulatorSerial, cycleExecution: q.cycleExecution, pauseWhenIdle: q.pauseWhenIdle, idleThresholdSeconds: q.idleThresholdSeconds, emulatorInstanceName: q.emulatorInstanceName ?? '', emulatorInstanceIndex: q.emulatorInstanceIndex ?? null });
 
     // Restore per-entry schedule state from the linked template so that the editor
     // reflects previously saved schedule types and saving doesn't overwrite them with OncePerRun.
@@ -172,10 +172,10 @@ export const QueuesPage: React.FC<QueuesPageProps> = ({ navResetSignal }) => {
     setQueueSaveResult(undefined);
     try {
       if (creating) {
-        await createQueue({ name: form.name.trim(), emulatorSerial: form.emulatorSerial.trim(), cycleExecution: form.cycleExecution, pauseWhenIdle: form.pauseWhenIdle, idleThresholdSeconds: form.idleThresholdSeconds });
+        await createQueue({ name: form.name.trim(), emulatorSerial: form.emulatorSerial.trim(), cycleExecution: form.cycleExecution, pauseWhenIdle: form.pauseWhenIdle, idleThresholdSeconds: form.idleThresholdSeconds, emulatorInstanceName: form.emulatorInstanceName.trim() || null, emulatorInstanceIndex: form.emulatorInstanceIndex });
         setQueueSaveResult({ kind: 'success', message: 'Queue created successfully.' });
       } else if (detail) {
-        await updateQueue(detail.id, { name: form.name.trim(), cycleExecution: form.cycleExecution, pauseWhenIdle: form.pauseWhenIdle, idleThresholdSeconds: form.idleThresholdSeconds });
+        await updateQueue(detail.id, { name: form.name.trim(), cycleExecution: form.cycleExecution, pauseWhenIdle: form.pauseWhenIdle, idleThresholdSeconds: form.idleThresholdSeconds, emulatorInstanceName: form.emulatorInstanceName.trim() || null, emulatorInstanceIndex: form.emulatorInstanceIndex });
         setQueueSaveResult({ kind: 'success', message: 'Queue updated successfully.' });
       }
       // Keep the form open so the confirmation is visible at the Save action (FR-006); just

--- a/src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.layout.spec.tsx
@@ -71,7 +71,7 @@ describe('QueuesPage edit layout', () => {
     fireEvent.click(screen.getByLabelText('Cycle execution'));
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() =>
-      expect(updateQueueMock).toHaveBeenCalledWith('q1', { name: 'Daily Renamed', cycleExecution: true })
+      expect(updateQueueMock).toHaveBeenCalledWith('q1', { name: 'Daily Renamed', cycleExecution: true, emulatorInstanceName: null, emulatorInstanceIndex: null })
     );
   });
 

--- a/src/web-ui/src/pages/__tests__/QueuesPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.spec.tsx
@@ -53,7 +53,7 @@ describe('QueuesPage CRUD', () => {
     createQueueMock.mockResolvedValue({} as any);
 
     fireEvent.click(screen.getByText('Save'));
-    await waitFor(() => expect(createQueueMock).toHaveBeenCalledWith({ name: 'Daily', emulatorSerial: 'emu-1', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30 }));
+    await waitFor(() => expect(createQueueMock).toHaveBeenCalledWith({ name: 'Daily', emulatorSerial: 'emu-1', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30, emulatorInstanceName: null, emulatorInstanceIndex: null }));
   });
 
   it('opens edit and updates a queue', async () => {
@@ -69,7 +69,7 @@ describe('QueuesPage CRUD', () => {
     fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Daily 2' } });
     fireEvent.click(screen.getByText('Save'));
 
-    await waitFor(() => expect(updateQueueMock).toHaveBeenCalledWith('q1', { name: 'Daily 2', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30 }));
+    await waitFor(() => expect(updateQueueMock).toHaveBeenCalledWith('q1', { name: 'Daily 2', cycleExecution: false, pauseWhenIdle: false, idleThresholdSeconds: 30, emulatorInstanceName: null, emulatorInstanceIndex: null }));
   });
 
   it('deletes a queue after confirmation', async () => {

--- a/src/web-ui/src/services/queues.ts
+++ b/src/web-ui/src/services/queues.ts
@@ -11,6 +11,10 @@ export type QueueDto = {
   pauseWhenIdle: boolean;
   /** Idle-detection threshold in seconds (default 30). */
   idleThresholdSeconds: number;
+  /** Optional LDPlayer instance name cold-started before session creation (feature 074); null when unset. */
+  emulatorInstanceName?: string | null;
+  /** Optional LDPlayer instance index for the pre-session cold-start (feature 074); null when unset. */
+  emulatorInstanceIndex?: number | null;
   status: QueueStatus;
   entryCount: number;
   linkedTemplateId: string | null;
@@ -37,6 +41,8 @@ export type QueueCreate = {
   cycleExecution: boolean;
   pauseWhenIdle?: boolean;
   idleThresholdSeconds?: number;
+  emulatorInstanceName?: string | null;
+  emulatorInstanceIndex?: number | null;
 };
 
 export type QueueUpdate = {
@@ -44,6 +50,8 @@ export type QueueUpdate = {
   cycleExecution: boolean;
   pauseWhenIdle?: boolean;
   idleThresholdSeconds?: number;
+  emulatorInstanceName?: string | null;
+  emulatorInstanceIndex?: number | null;
 };
 
 const base = '/api/queues';

--- a/tests/contract/Queues/QueuesApiContractTests.cs
+++ b/tests/contract/Queues/QueuesApiContractTests.cs
@@ -118,4 +118,48 @@ public sealed class QueuesApiContractTests : IDisposable {
 
     (await client.DeleteAsync(new Uri($"/api/queues/{id}", UriKind.Relative)).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.NoContent);
   }
+
+  [Fact] // T012 — feature 074: emulator-instance fields round-trip; negative index rejected; default null
+  public async Task EmulatorInstanceConfigRoundTripsAndValidatesIndex() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    // Create WITHOUT the emulator-instance fields → exposed and null (back-compat default).
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative),
+      new { name = "ColdA", emulatorSerial = "emu-1" }).ConfigureAwait(true);
+    createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = JsonDocument.Parse(await createResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    foreach (var field in new[] { "emulatorInstanceName", "emulatorInstanceIndex" }) {
+      created.TryGetProperty(field, out _).Should().BeTrue($"QueueResponse must expose '{field}'");
+    }
+    created.GetProperty("emulatorInstanceName").ValueKind.Should().Be(JsonValueKind.Null);
+    created.GetProperty("emulatorInstanceIndex").ValueKind.Should().Be(JsonValueKind.Null);
+    var id = created.GetProperty("id").GetString();
+
+    // Update setting an instance name → response echoes it.
+    var updateResp = await client.PutAsJsonAsync(new Uri($"/api/queues/{id}", UriKind.Relative),
+      new { name = "ColdA", cycleExecution = false, emulatorInstanceName = "PNS", emulatorInstanceIndex = 2 }).ConfigureAwait(true);
+    updateResp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var updated = JsonDocument.Parse(await updateResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    updated.GetProperty("emulatorInstanceName").GetString().Should().Be("PNS");
+    updated.GetProperty("emulatorInstanceIndex").GetInt32().Should().Be(2);
+
+    // Re-read (detail) persists both.
+    var detail = JsonDocument.Parse(await (await client.GetAsync(new Uri($"/api/queues/{id}", UriKind.Relative)).ConfigureAwait(true)).Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    detail.GetProperty("emulatorInstanceName").GetString().Should().Be("PNS");
+    detail.GetProperty("emulatorInstanceIndex").GetInt32().Should().Be(2);
+
+    // Negative index → 400 Bad Request.
+    var badResp = await client.PutAsJsonAsync(new Uri($"/api/queues/{id}", UriKind.Relative),
+      new { name = "ColdA", cycleExecution = false, emulatorInstanceIndex = -1 }).ConfigureAwait(true);
+    badResp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+    // Negative index on create → 400 Bad Request.
+    var badCreate = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative),
+      new { name = "ColdB", emulatorSerial = "emu-1", emulatorInstanceIndex = -5 }).ConfigureAwait(true);
+    badCreate.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+    (await client.DeleteAsync(new Uri($"/api/queues/{id}", UriKind.Relative)).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+  }
 }

--- a/tests/unit/Queues/FileQueueRepositoryTests.cs
+++ b/tests/unit/Queues/FileQueueRepositoryTests.cs
@@ -139,6 +139,36 @@ public sealed class FileQueueRepositoryTests : IDisposable {
     loaded.IdleThresholdSeconds.Should().Be(30);      // initializer default preserved (back-compat)
   }
 
+  [Fact] // T013 — feature 074: emulator-instance config round-trips through persistence
+  public async Task UpdatePersistsEmulatorInstanceConfig() {
+    var repo = NewRepo();
+    var created = await repo.CreateAsync(new ExecutionQueue { Name = "A", EmulatorSerial = "emu-1" }).ConfigureAwait(true);
+
+    created.EmulatorInstanceName = "PNS";
+    created.EmulatorInstanceIndex = 3;
+    await repo.UpdateAsync(created).ConfigureAwait(true);
+
+    var loaded = await repo.GetAsync(created.Id).ConfigureAwait(true);
+    loaded!.EmulatorInstanceName.Should().Be("PNS");
+    loaded.EmulatorInstanceIndex.Should().Be(3);
+  }
+
+  [Fact] // T013 — a queue JSON written before feature 074 reads with both instance fields null
+  public async Task LegacyQueueJsonWithoutEmulatorInstanceFieldsLoadsAsNull() {
+    var repo = NewRepo();
+    var dir = Path.Combine(_root, "queues");
+    Directory.CreateDirectory(dir);
+    // A queue document written before feature 074: no EmulatorInstanceName/EmulatorInstanceIndex.
+    await File.WriteAllTextAsync(Path.Combine(dir, "legacy3.json"),
+      "{\"Id\":\"legacy3\",\"Name\":\"Old\",\"EmulatorSerial\":\"emu-1\",\"CycleExecution\":false}").ConfigureAwait(true);
+
+    var loaded = await repo.GetAsync("legacy3").ConfigureAwait(true);
+
+    loaded.Should().NotBeNull();
+    loaded!.EmulatorInstanceName.Should().BeNull();
+    loaded.EmulatorInstanceIndex.Should().BeNull();
+  }
+
   [Fact]
   public async Task GetWithUnsafeIdReturnsNull() {
     var repo = NewRepo();

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -13,6 +13,7 @@ using GameBot.Domain.Services;
 using GameBot.Domain.Sessions;
 using GameBot.Emulator.Session;
 using GameBot.Service.Services;
+using GameBot.Service.Services.EnsureEmulatorRunning;
 using GameBot.Service.Services.EnsureGameRunning;
 using GameBot.Service.Services.ExecutionLog;
 using GameBot.Service.Services.QueueExecution;
@@ -126,6 +127,24 @@ public sealed class QueueExecutionServiceTests {
     }
   }
 
+  // Feature 074: fake pre-session emulator cold-start handler. Records the call count, the args it was
+  // given, and how many sessions existed at the moment it ran (to prove the ensure precedes
+  // CreateSession). The returned outcome is configurable to drive the behavior matrix.
+  private sealed class FakeEnsureEmulatorRunning : IEnsureEmulatorRunningActionHandler {
+    public int Calls { get; private set; }
+    public GameBot.Domain.Actions.EnsureEmulatorRunningArgs? LastArgs { get; private set; }
+    public EnsureEmulatorRunningOutcome Outcome { get; set; } = EnsureEmulatorRunningOutcome.AlreadyHealthy;
+    public Func<int>? SessionCountProvider { get; set; }
+    public int SessionCountAtCall { get; private set; } = -1;
+
+    public Task<EnsureEmulatorRunningActionResult> ExecuteAsync(GameBot.Domain.Actions.EnsureEmulatorRunningArgs args, CancellationToken ct = default) {
+      if (SessionCountAtCall < 0 && SessionCountProvider is not null) SessionCountAtCall = SessionCountProvider();
+      Calls++;
+      LastArgs = args;
+      return Task.FromResult(new EnsureEmulatorRunningActionResult(Outcome));
+    }
+  }
+
   private sealed class RecordingExecutionLog : IExecutionLogService {
     public int QueueStarts { get; private set; }
     public string? FinalStatus { get; private set; }
@@ -173,13 +192,15 @@ public sealed class QueueExecutionServiceTests {
     public FakeTimeProvider? Clock { get; }
     public QueueRunRegistry Registry { get; } = new();
     public FakeEnsureGameRunning EnsureGame { get; } = new();
+    public FakeEnsureEmulatorRunning EnsureEmulator { get; } = new();
     public SelfRescheduleCoordinator Coordinator { get; }
     public QueueExecutionService Service { get; }
 
     public Harness(FakeTimeProvider? clock = null) {
       Clock = clock;
       Coordinator = new SelfRescheduleCoordinator(Registry, clock);
-      Service = new QueueExecutionService(Queues, Runtime, Templates, Sequences, Sessions, Log, NullLogger<QueueExecutionService>.Instance, Registry, timeProvider: clock, ensureGameRunning: EnsureGame);
+      EnsureEmulator.SessionCountProvider = () => Sessions.ActiveCount;
+      Service = new QueueExecutionService(Queues, Runtime, Templates, Sequences, Sessions, Log, NullLogger<QueueExecutionService>.Instance, Registry, timeProvider: clock, ensureGameRunning: EnsureGame, ensureEmulatorRunning: EnsureEmulator);
     }
 
     public ExecutionQueue AddQueue(string id, IReadOnlyList<string> sequenceIds, bool cycle = false, bool linkTemplate = true) {
@@ -351,6 +372,110 @@ public sealed class QueueExecutionServiceTests {
   public async Task StartUnknownQueueReturnsNotFound() {
     var h = new Harness();
     (await h.Service.StartAsync("nope")).Should().Be(QueueStartOutcome.NotFound);
+  }
+
+  // ── Feature 074: pre-session emulator cold-start ────────────────────────
+
+  [Fact] // T006 — cold path: the emulator ensure runs BEFORE the session is created
+  public async Task ConfiguredInstanceEnsuresEmulatorBeforeCreatingSession() {
+    var h = new Harness();
+    var queue = h.AddQueue("q1", new[] { "A" });
+    queue.EmulatorInstanceName = "PNS";
+    h.EnsureEmulator.Outcome = EnsureEmulatorRunningOutcome.Started;
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.EnsureEmulator.Calls.Should().Be(1);
+    h.EnsureEmulator.SessionCountAtCall.Should().Be(0); // no session existed when the ensure ran
+    h.EnsureEmulator.LastArgs!.InstanceName.Should().Be("PNS");
+    h.EnsureEmulator.LastArgs!.AdbSerial.Should().Be("emu-1");
+    h.Sessions.Stopped.Should().HaveCount(1); // a session was created (then torn down in teardown)             // session created after the ensure
+    h.Sequences.Executed.Should().Equal("A");           // run proceeded normally
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  [Fact] // T007 — unset fields: no emulator work at all (backward compatible)
+  public async Task UnsetInstanceFieldsSkipEmulatorEnsureEntirely() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }); // no instance identifier
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.EnsureEmulator.Calls.Should().Be(0);
+    h.Sessions.Stopped.Should().HaveCount(1); // a session was created (then torn down in teardown)
+    h.Sequences.Executed.Should().Equal("A");
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  // T007 — healthy/started/restarted all proceed to a session and run. (Separate Facts rather than a
+  // Theory because the outcome enum is internal and cannot be a public test-method parameter.)
+  [Fact]
+  public Task AlreadyHealthyEnsureProceedsToSessionAndRun() => AssertSuccessfulEnsureProceeds(EnsureEmulatorRunningOutcome.AlreadyHealthy);
+  [Fact]
+  public Task StartedEnsureProceedsToSessionAndRun() => AssertSuccessfulEnsureProceeds(EnsureEmulatorRunningOutcome.Started);
+  [Fact]
+  public Task RestartedEnsureProceedsToSessionAndRun() => AssertSuccessfulEnsureProceeds(EnsureEmulatorRunningOutcome.Restarted);
+
+  private static async Task AssertSuccessfulEnsureProceeds(EnsureEmulatorRunningOutcome outcome) {
+    var h = new Harness();
+    var queue = h.AddQueue("q1", new[] { "A" });
+    queue.EmulatorInstanceIndex = 0;
+    h.EnsureEmulator.Outcome = outcome;
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.EnsureEmulator.Calls.Should().Be(1);
+    h.EnsureEmulator.LastArgs!.InstanceIndex.Should().Be(0);
+    h.Sessions.Stopped.Should().HaveCount(1); // a session was created (then torn down in teardown)
+    h.Sequences.Executed.Should().Equal("A");
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  // T007 — unsupported host is neutral: proceed to the session exactly as today.
+  [Fact]
+  public Task PlatformUnsupportedEnsureProceedsToSession() => AssertUnsupportedEnsureProceeds(EnsureEmulatorRunningOutcome.PlatformUnsupported);
+  [Fact]
+  public Task ControlUnavailableEnsureProceedsToSession() => AssertUnsupportedEnsureProceeds(EnsureEmulatorRunningOutcome.ControlUnavailable);
+
+  private static async Task AssertUnsupportedEnsureProceeds(EnsureEmulatorRunningOutcome outcome) {
+    var h = new Harness();
+    var queue = h.AddQueue("q1", new[] { "A" });
+    queue.EmulatorInstanceName = "PNS";
+    h.EnsureEmulator.Outcome = outcome;
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.EnsureEmulator.Calls.Should().Be(1);
+    h.Sessions.Stopped.Should().HaveCount(1); // a session was created (then torn down in teardown)
+    h.Sequences.Executed.Should().Equal("A");
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  // T007 — genuine failure fails the run and creates NO session.
+  [Fact]
+  public Task RecoveryTimedOutEnsureFailsRunWithoutCreatingSession() => AssertGenuineEnsureFailure(EnsureEmulatorRunningOutcome.RecoveryTimedOut);
+  [Fact]
+  public Task InstanceNotFoundEnsureFailsRunWithoutCreatingSession() => AssertGenuineEnsureFailure(EnsureEmulatorRunningOutcome.InstanceNotFound);
+
+  private static async Task AssertGenuineEnsureFailure(EnsureEmulatorRunningOutcome outcome) {
+    var h = new Harness();
+    var queue = h.AddQueue("q1", new[] { "A" });
+    queue.EmulatorInstanceName = "PNS";
+    h.EnsureEmulator.Outcome = outcome;
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.EnsureEmulator.Calls.Should().Be(1);
+    h.Sessions.Connected.Should().BeFalse();   // never created a session
+    h.Sessions.Stopped.Should().BeEmpty();     // and never tore one down
+    h.Sequences.Executed.Should().BeEmpty();   // no sequence ran
+    h.Log.FinalStatus.Should().Be("failure");
+    h.Log.Summary.Should().Contain("could not be started");
   }
 
   // ── US3: cycle ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Lets a scheduled execution **queue** start its LDPlayer emulator instance from a backend-only, session-less cold state — closing a real bootstrap gap.

Today a queue creates its ADB-bound device session up front (`QueueExecutionService.RunAsync` → `CreateSession`) **before** running any sequence. When the emulator is closed, `CreateSession` throws `no_adb_devices` ("emulator could not be reached") and the queue fails before it can reach the sequences that would start the emulator. So from a state where only the backend service is running, scheduled automation could not self-recover.

This feature adds a **pre-session emulator cold-start**: when a queue is configured with an optional emulator-instance identifier, the run brings that instance up (reusing the feature-070 `ensure-emulator-running` handler, with the queue's existing `EmulatorSerial` as the probe) **before** binding the session.

## Behavior

- **Emulator already up** → no restart; queue runs exactly as today.
- **Emulator closed / hung** → started / restarted, then the queue proceeds.
- **Can't be brought up** (recovery timeout / instance-not-found) → run fails with an actionable reason and creates **no** session.
- **Non-Windows / tooling missing** → neutral "not-applied"; queue proceeds to create its session as before.
- **Fields unset** → no emulator work at all (byte-for-byte backward compatible).

No new emulator-tuning configuration — feature-070 timeouts apply unchanged.

## Changes

- **Domain**: `ExecutionQueue.EmulatorInstanceName` / `EmulatorInstanceIndex` (optional, null default → JSON back-compat).
- **Service**: inject `IEnsureEmulatorRunningActionHandler`; `EnsureEmulatorBeforeSessionAsync` runs before `CreateSession` in `RunAsync`; outcome logged.
- **API**: new fields on create/update/response; negative index rejected (400).
- **web-ui**: emulator-instance inputs on the queue config form + service types.
- **Tests**: queue cold-start behavior matrix, contract round-trip + negative-index rejection, repository back-compat, web-ui form.
- **Docs**: `docs/architecture.md` (+ "Last reviewed"), `specs/STATUS.md`.

## Verification

Local gate all green: unit **718**, contract **94**, integration **291**, web-ui `vite build` + **573** jest. CI green (.NET CI + Automatic Dependency Submission).

## Spec

`specs/074-sessionless-emulator-start/` (spec, plan, research, data-model, contract, quickstart, tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
