### PR TITLE
Add optional visual readiness gate to ensure-game-running

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,16 @@ not survive a service restart; queue *configuration* and templates are persisted
   session start, while success or a neutral unsupported outcome proceeds; with no instance identifier
   the connect behaves exactly as before. (The separate interactive `/api/sessions/start` endpoint is
   unchanged.)
+  The `ensure-game-running` **command step** has an OPTIONAL readiness gate: with no config it reports
+  success as soon as the game package is foreground (legacy behavior), but when its
+  `EnsureGameRunningConfig.ReadinessImage` is set the step, after best-effort launching the game, polls
+  the live screen for that image (via `IGameReadinessProbe` → `ImageDetectionHelper`, the same
+  template-match cycle as `waitForImage`) for up to `ReadinessTimeoutMs` (default 90s) before reporting
+  `game_ready`; on timeout it fails the step with `readiness_timeout`. This prevents a cold-launched
+  game that is still on its splash/loading screen from letting the queue's startup sweep run daily
+  sequences prematurely. If the game/session cannot be resolved the step short-circuits to the handler
+  failure without polling; the probe is Windows-only (the vision stack), so off Windows the step keeps
+  its foreground-only behavior.
 - **Sequence** — an ordered list of steps that run **commands**, with random inter-step delays,
   conditional steps, loop/flow blocks (`SequenceFlowGraph`, `Blocks/`), and **if blocks**
   (`SequenceStepType.If`, feature 067): a condition (same model as while-loop conditions —

--- a/src/GameBot.Domain/Commands/CommandStep.cs
+++ b/src/GameBot.Domain/Commands/CommandStep.cs
@@ -21,6 +21,19 @@ public sealed class EnsureEmulatorRunningConfig {
   public required string AdbSerial { get; init; }
 }
 
+/// <summary>
+/// Config for the ensure-game-running command step. When <see cref="ReadinessImage"/> is set, the
+/// step does not report success as soon as the game package is foreground; instead, after launching
+/// the game it polls the screen for the readiness image (e.g. the city-view sentinel) for up to
+/// <see cref="ReadinessTimeoutMs"/> milliseconds, so a cold-launched game that is still on its
+/// splash/loading screen does not let the queue proceed prematurely. When null the step keeps its
+/// legacy behavior (success iff the game is already foreground).
+/// </summary>
+public sealed class EnsureGameRunningConfig {
+  public DetectionTarget? ReadinessImage { get; init; }
+  public int ReadinessTimeoutMs { get; init; } = 90_000;
+}
+
 public sealed class PrimitiveTapConfig {
   public required DetectionTarget DetectionTarget { get; init; }
 }
@@ -45,5 +58,6 @@ public sealed class CommandStep {
   public KeyInputConfig? KeyInput { get; init; }
   public SwipeConfig? Swipe { get; init; }
   public EnsureEmulatorRunningConfig? EnsureEmulatorRunning { get; init; }
+  public EnsureGameRunningConfig? EnsureGameRunning { get; init; }
   public int Order { get; init; }
 }

--- a/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
@@ -123,6 +123,13 @@ internal static class CommandsEndpoints {
     }
 
     if (step.Type == CommandStepTypeDto.EnsureGameRunning) {
+      var cfg = step.EnsureGameRunning;
+      if (cfg?.ReadinessImage is not null && string.IsNullOrWhiteSpace(cfg.ReadinessImage.ReferenceImageId)) {
+        return "ensureGameRunning.readinessImage.referenceImageId must not be empty when readinessImage is provided";
+      }
+      if (cfg?.ReadinessTimeoutMs is < 0) {
+        return "ensureGameRunning.readinessTimeoutMs must be greater than or equal to zero";
+      }
       return null;
     }
 
@@ -174,6 +181,7 @@ internal static class CommandsEndpoints {
     KeyInput = s.Type == CommandStepTypeDto.KeyInput ? ToDomainKeyInput(s.KeyInput) : null,
     Swipe = s.Type == CommandStepTypeDto.Swipe ? ToDomainSwipe(s.Swipe) : null,
     EnsureEmulatorRunning = s.Type == CommandStepTypeDto.EnsureEmulatorRunning ? ToDomainEnsureEmulator(s.EnsureEmulatorRunning) : null,
+    EnsureGameRunning = s.Type == CommandStepTypeDto.EnsureGameRunning ? ToDomainEnsureGame(s.EnsureGameRunning) : null,
     Order = s.Order
   };
 
@@ -185,6 +193,7 @@ internal static class CommandsEndpoints {
     KeyInput = s.Type == CommandStepType.KeyInput ? ToResponseKeyInput(s.KeyInput) : null,
     Swipe = s.Type == CommandStepType.Swipe ? ToResponseSwipe(s.Swipe) : null,
     EnsureEmulatorRunning = s.Type == CommandStepType.EnsureEmulatorRunning ? ToResponseEnsureEmulator(s.EnsureEmulatorRunning) : null,
+    EnsureGameRunning = s.Type == CommandStepType.EnsureGameRunning ? ToResponseEnsureGame(s.EnsureGameRunning) : null,
     Order = s.Order
   };
 
@@ -200,6 +209,27 @@ internal static class CommandsEndpoints {
       InstanceName = config.InstanceName,
       InstanceIndex = config.InstanceIndex,
       AdbSerial = config.AdbSerial
+    };
+
+  private static EnsureGameRunningConfig? ToDomainEnsureGame(EnsureGameRunningConfigDto? dto) {
+    if (dto is null) return null;
+    var readiness = ToDomainDetection(dto.ReadinessImage);
+    // No readiness image configured → represent as legacy behavior (null config).
+    if (readiness is null) return null;
+    var timeoutMs = dto.ReadinessTimeoutMs ?? 90_000;
+    if (timeoutMs < 0) {
+      timeoutMs = 90_000;
+    }
+    return new EnsureGameRunningConfig {
+      ReadinessImage = readiness,
+      ReadinessTimeoutMs = timeoutMs
+    };
+  }
+
+  private static EnsureGameRunningConfigDto? ToResponseEnsureGame(EnsureGameRunningConfig? config) =>
+    config is null ? null : new EnsureGameRunningConfigDto {
+      ReadinessImage = ToResponseDetection(config.ReadinessImage),
+      ReadinessTimeoutMs = config.ReadinessTimeoutMs
     };
 
   private static StepExecutionOutcomeDto ToResponseOutcome(PrimitiveTapStepOutcome outcome) => new() {

--- a/src/GameBot.Service/GameBotServiceSetup.cs
+++ b/src/GameBot.Service/GameBotServiceSetup.cs
@@ -140,6 +140,16 @@ internal static class GameBotServiceSetup {
     });
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IAdbGameOperations, GameBot.Service.Services.EnsureGameRunning.AdbGameOperations>();
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IEnsureGameRunningActionHandler, GameBot.Service.Services.EnsureGameRunning.EnsureGameRunningActionHandler>();
+    // Readiness probe needs the vision stack (IScreenSource is Windows-only). Off Windows it stays
+    // unregistered and the ensure-game-running step falls back to its foreground-only behavior.
+    if (OperatingSystem.IsWindows()) {
+      builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IGameReadinessProbe>(sp =>
+        new GameBot.Service.Services.EnsureGameRunning.GameReadinessProbe(
+          sp.GetRequiredService<GameBot.Domain.Triggers.Evaluators.IScreenSource>(),
+          sp.GetRequiredService<GameBot.Domain.Triggers.Evaluators.IReferenceImageStore>(),
+          sp.GetRequiredService<GameBot.Domain.Vision.ITemplateMatcher>(),
+          sp.GetRequiredService<GameBot.Domain.Config.AppConfig>()));
+    }
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureEmulatorRunning.IEmulatorControl, GameBot.Service.Services.EnsureEmulatorRunning.LdConsoleEmulatorControl>();
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureEmulatorRunning.IEmulatorDeviceProbe, GameBot.Service.Services.EnsureEmulatorRunning.AdbEmulatorDeviceProbe>();
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureEmulatorRunning.IEnsureEmulatorRunningActionHandler, GameBot.Service.Services.EnsureEmulatorRunning.EnsureEmulatorRunningActionHandler>();

--- a/src/GameBot.Service/Models/Commands.cs
+++ b/src/GameBot.Service/Models/Commands.cs
@@ -75,6 +75,11 @@ internal sealed class WaitForImageConfigDto {
   public int? TimeoutMs { get; init; }
 }
 
+internal sealed class EnsureGameRunningConfigDto {
+  public DetectionTargetDto? ReadinessImage { get; init; }
+  public int? ReadinessTimeoutMs { get; init; }
+}
+
 internal sealed class CommandStepDto {
   public required CommandStepTypeDto Type { get; init; }
   public string? TargetId { get; init; }
@@ -83,6 +88,7 @@ internal sealed class CommandStepDto {
   public KeyInputConfigDto? KeyInput { get; init; }
   public SwipeConfigDto? Swipe { get; init; }
   public EnsureEmulatorRunningConfigDto? EnsureEmulatorRunning { get; init; }
+  public EnsureGameRunningConfigDto? EnsureGameRunning { get; init; }
   public int Order { get; init; }
 }
 

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -28,8 +28,9 @@ internal sealed class CommandExecutor : ICommandExecutor {
   private readonly AppConfig _appConfig;
   private readonly IEnsureGameRunningActionHandler? _ensureGameRunning;
   private readonly IEnsureEmulatorRunningActionHandler? _ensureEmulatorRunning;
+  private readonly IGameReadinessProbe? _gameReadiness;
 
-  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, AppConfig appConfig, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null, IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null) {
+  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, AppConfig appConfig, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null, IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null, IGameReadinessProbe? gameReadiness = null) {
     _commands = commands;
     _sessions = sessions;
     _triggers = triggers;
@@ -43,10 +44,11 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _executionLogService = executionLogService;
     _ensureGameRunning = ensureGameRunning;
     _ensureEmulatorRunning = ensureEmulatorRunning;
+    _gameReadiness = gameReadiness;
   }
 
   // Fallback constructor for environments without detection services registered (non-Windows or tests)
-  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, ISessionContextCache sessionCache, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null, IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null) {
+  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, ISessionContextCache sessionCache, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null, IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null, IGameReadinessProbe? gameReadiness = null) {
     _commands = commands;
     _sessions = sessions;
     _triggers = triggers;
@@ -60,6 +62,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _executionLogService = executionLogService;
     _ensureGameRunning = ensureGameRunning;
     _ensureEmulatorRunning = ensureEmulatorRunning;
+    _gameReadiness = gameReadiness;
   }
 
   public Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default)
@@ -220,9 +223,35 @@ internal sealed class CommandExecutor : ICommandExecutor {
         ? await _ensureGameRunning.ExecuteAsync(sessionId, ct).ConfigureAwait(false)
         : new EnsureGameRunningActionResult(EnsureGameRunningOutcome.PlatformUnsupported);
 
-      return result.IsSuccess
-        ? (1, new PrimitiveTapStepOutcome(step.Order, "executed", result.ReasonCode, null, null, StepType: "ensure-game-running"))
-        : (0, new PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running"));
+      var readiness = step.EnsureGameRunning?.ReadinessImage;
+      var hasReadinessGate = _gameReadiness is not null
+        && readiness is not null
+        && !string.IsNullOrWhiteSpace(readiness.ReferenceImageId);
+
+      // Without a readiness image (or a probe to run it), preserve the legacy behavior:
+      // success iff the game was already the foreground app.
+      if (!hasReadinessGate) {
+        return result.IsSuccess
+          ? (1, new PrimitiveTapStepOutcome(step.Order, "executed", result.ReasonCode, null, null, StepType: "ensure-game-running"))
+          : (0, new PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running"));
+      }
+
+      // The game/session could not be resolved (or the platform is unsupported) — there is nothing
+      // to wait for, so surface the handler failure directly instead of spinning on the screen.
+      if (result.Outcome is EnsureGameRunningOutcome.NoQueueContext
+          or EnsureGameRunningOutcome.NoLinkedGame
+          or EnsureGameRunningOutcome.NoPackageName
+          or EnsureGameRunningOutcome.PlatformUnsupported) {
+        return (0, new PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running"));
+      }
+
+      // Handler has (best-effort) launched the game if it was not foreground. Now wait for it to
+      // actually reach the ready screen before letting the queue proceed.
+      var readinessTimeoutMs = Math.Max(0, step.EnsureGameRunning!.ReadinessTimeoutMs);
+      var readinessResult = await _gameReadiness!.WaitUntilReadyAsync(readiness!, readinessTimeoutMs, ct).ConfigureAwait(false);
+      return readinessResult.Ready
+        ? (1, new PrimitiveTapStepOutcome(step.Order, "executed", "game_ready", null, null, StepType: "ensure-game-running", TimeoutMs: readinessTimeoutMs, EffectiveTimeoutMs: readinessTimeoutMs, ReferenceImageId: readiness!.ReferenceImageId, ImageLoadStatus: readinessResult.ImageLoadStatus))
+        : (0, new PrimitiveTapStepOutcome(step.Order, "readiness_timeout", "readiness_timeout", null, null, StepType: "ensure-game-running", TimeoutMs: readinessTimeoutMs, EffectiveTimeoutMs: readinessTimeoutMs, ReferenceImageId: readiness!.ReferenceImageId, ImageLoadStatus: readinessResult.ImageLoadStatus));
     }
 
     if (step.Type == CommandStepType.EnsureEmulatorRunning) {
@@ -515,58 +544,8 @@ internal sealed class CommandExecutor : ICommandExecutor {
     DetectionTarget detectionTarget,
     GameBot.Domain.Vision.ITemplateMatcher matcher,
     out PrimitiveTapResolvedPoint? resolvedPoint,
-    out double? detectionConfidence) {
-    resolvedPoint = null;
-    detectionConfidence = null;
-
-    var screenshotBmp = screenSrc.GetLatestScreenshot();
-    if (screenshotBmp is null) {
-      return false;
-    }
-
-    using var template = new System.Drawing.Bitmap(templateBmp);
-    using var screenMs = new System.IO.MemoryStream();
-    using var templateMs = new System.IO.MemoryStream();
-    screenshotBmp.Save(screenMs, System.Drawing.Imaging.ImageFormat.Png);
-    template.Save(templateMs, System.Drawing.Imaging.ImageFormat.Png);
-    using var screenMat = OpenCvSharp.Mat.FromImageData(screenMs.ToArray(), OpenCvSharp.ImreadModes.Color);
-    using var templateMat = OpenCvSharp.Mat.FromImageData(templateMs.ToArray(), OpenCvSharp.ImreadModes.Color);
-
-    var adapter = new GameBot.Domain.Services.ActionExecutionAdapter(matcher);
-    var primitiveAction = new GameBot.Domain.Actions.InputAction {
-      Type = "tap",
-      Args = new Dictionary<string, object> { ["x"] = 0, ["y"] = 0 }
-    };
-
-    var ok = adapter.TryApplyDetectionCoordinates(
-      primitiveAction,
-      detectionTarget,
-      screenMat,
-      templateMat,
-      detectionTarget.Confidence,
-      out var err,
-      DetectionSelectionStrategy.HighestConfidence);
-
-    if (!ok || err is not null) {
-      return false;
-    }
-
-    if (!primitiveAction.Args.TryGetValue("x", out var xVal) || !primitiveAction.Args.TryGetValue("y", out var yVal)) {
-      return false;
-    }
-
-    var x = Convert.ToInt32(xVal, CultureInfo.InvariantCulture);
-    var y = Convert.ToInt32(yVal, CultureInfo.InvariantCulture);
-    if (x < 0 || y < 0 || x >= screenshotBmp.Width || y >= screenshotBmp.Height) {
-      return false;
-    }
-
-    detectionConfidence = primitiveAction.Args.TryGetValue("confidence", out var confidenceVal)
-      ? Convert.ToDouble(confidenceVal, CultureInfo.InvariantCulture)
-      : (double?)null;
-    resolvedPoint = new PrimitiveTapResolvedPoint(x, y);
-    return true;
-  }
+    out double? detectionConfidence)
+    => ImageDetectionHelper.TryDetect(screenSrc, templateBmp, detectionTarget, matcher, out resolvedPoint, out detectionConfidence);
 
   /// <summary>
   /// Attempts a single screenshot-fetch → template-match → coordinate-resolve → tap cycle.

--- a/src/GameBot.Service/Services/EnsureGameRunning/GameReadinessProbe.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/GameReadinessProbe.cs
@@ -1,0 +1,52 @@
+using GameBot.Domain.Commands;
+using GameBot.Domain.Config;
+using GameBot.Domain.Triggers.Evaluators;
+using GameBot.Domain.Vision;
+
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+internal sealed class GameReadinessProbe : IGameReadinessProbe {
+  private readonly IScreenSource _screen;
+  private readonly IReferenceImageStore _images;
+  private readonly ITemplateMatcher _matcher;
+  private readonly AppConfig _appConfig;
+
+  public GameReadinessProbe(IScreenSource screen, IReferenceImageStore images, ITemplateMatcher matcher, AppConfig appConfig) {
+    _screen = screen;
+    _images = images;
+    _matcher = matcher;
+    _appConfig = appConfig;
+  }
+
+  public async Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, CancellationToken ct = default) {
+    if (!OperatingSystem.IsWindows()) {
+      return new GameReadinessResult(false, "unavailable");
+    }
+
+    if (!_images.TryGet(readinessImage.ReferenceImageId, out var templateBmp) || templateBmp is null) {
+      return new GameReadinessResult(false, "missing");
+    }
+
+    var deadline = DateTimeOffset.UtcNow.AddMilliseconds(Math.Max(0, timeoutMs));
+
+    if (ImageDetectionHelper.TryDetect(_screen, templateBmp, readinessImage, _matcher, out _, out _)) {
+      return new GameReadinessResult(true, "loaded");
+    }
+
+    while (DateTimeOffset.UtcNow < deadline) {
+      var remaining = deadline - DateTimeOffset.UtcNow;
+      if (remaining <= TimeSpan.Zero) {
+        break;
+      }
+
+      var pollMs = Math.Max(1, Math.Min(_appConfig.CaptureIntervalMs, (int)Math.Ceiling(remaining.TotalMilliseconds)));
+      await Task.Delay(pollMs, ct).ConfigureAwait(false);
+
+      if (ImageDetectionHelper.TryDetect(_screen, templateBmp, readinessImage, _matcher, out _, out _)) {
+        return new GameReadinessResult(true, "loaded");
+      }
+    }
+
+    return new GameReadinessResult(false, "loaded");
+  }
+}

--- a/src/GameBot.Service/Services/EnsureGameRunning/IGameReadinessProbe.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/IGameReadinessProbe.cs
@@ -1,0 +1,16 @@
+using GameBot.Domain.Commands;
+
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+/// <summary>Result of a game-readiness poll: whether the readiness image was detected, plus the
+/// reference-image load status for diagnostics (<c>loaded</c>, <c>missing</c>, <c>unavailable</c>).</summary>
+internal readonly record struct GameReadinessResult(bool Ready, string ImageLoadStatus);
+
+/// <summary>
+/// Polls the live emulator screen for a readiness image after a game launch, so the
+/// <c>ensure-game-running</c> step only reports success once the game has actually reached the
+/// configured ready screen (rather than as soon as its package is foreground).
+/// </summary>
+internal interface IGameReadinessProbe {
+  Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, CancellationToken ct = default);
+}

--- a/src/GameBot.Service/Services/ImageDetectionHelper.cs
+++ b/src/GameBot.Service/Services/ImageDetectionHelper.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Triggers;
+
+namespace GameBot.Service.Services;
+
+/// <summary>
+/// Shared single-shot template-detection cycle (screenshot → template-match → coordinate-resolve).
+/// Extracted so both the <c>waitForImage</c> step in <see cref="CommandExecutor"/> and the
+/// game-readiness probe run the identical detection logic.
+/// </summary>
+internal static class ImageDetectionHelper {
+  public static bool TryDetect(
+    GameBot.Domain.Triggers.Evaluators.IScreenSource screenSrc,
+    System.Drawing.Bitmap templateBmp,
+    DetectionTarget detectionTarget,
+    GameBot.Domain.Vision.ITemplateMatcher matcher,
+    out PrimitiveTapResolvedPoint? resolvedPoint,
+    out double? detectionConfidence) {
+    resolvedPoint = null;
+    detectionConfidence = null;
+
+    var screenshotBmp = screenSrc.GetLatestScreenshot();
+    if (screenshotBmp is null) {
+      return false;
+    }
+
+    using var template = new System.Drawing.Bitmap(templateBmp);
+    using var screenMs = new System.IO.MemoryStream();
+    using var templateMs = new System.IO.MemoryStream();
+    screenshotBmp.Save(screenMs, System.Drawing.Imaging.ImageFormat.Png);
+    template.Save(templateMs, System.Drawing.Imaging.ImageFormat.Png);
+    using var screenMat = OpenCvSharp.Mat.FromImageData(screenMs.ToArray(), OpenCvSharp.ImreadModes.Color);
+    using var templateMat = OpenCvSharp.Mat.FromImageData(templateMs.ToArray(), OpenCvSharp.ImreadModes.Color);
+
+    var adapter = new GameBot.Domain.Services.ActionExecutionAdapter(matcher);
+    var primitiveAction = new GameBot.Domain.Actions.InputAction {
+      Type = "tap",
+      Args = new Dictionary<string, object> { ["x"] = 0, ["y"] = 0 }
+    };
+
+    var ok = adapter.TryApplyDetectionCoordinates(
+      primitiveAction,
+      detectionTarget,
+      screenMat,
+      templateMat,
+      detectionTarget.Confidence,
+      out var err,
+      DetectionSelectionStrategy.HighestConfidence);
+
+    if (!ok || err is not null) {
+      return false;
+    }
+
+    if (!primitiveAction.Args.TryGetValue("x", out var xVal) || !primitiveAction.Args.TryGetValue("y", out var yVal)) {
+      return false;
+    }
+
+    var x = Convert.ToInt32(xVal, CultureInfo.InvariantCulture);
+    var y = Convert.ToInt32(yVal, CultureInfo.InvariantCulture);
+    if (x < 0 || y < 0 || x >= screenshotBmp.Width || y >= screenshotBmp.Height) {
+      return false;
+    }
+
+    detectionConfidence = primitiveAction.Args.TryGetValue("confidence", out var confidenceVal)
+      ? Convert.ToDouble(confidenceVal, CultureInfo.InvariantCulture)
+      : (double?)null;
+    resolvedPoint = new PrimitiveTapResolvedPoint(x, y);
+    return true;
+  }
+}

--- a/tests/unit/Commands/CommandExecutorEnsureGameRunningTests.cs
+++ b/tests/unit/Commands/CommandExecutorEnsureGameRunningTests.cs
@@ -64,6 +64,16 @@ public sealed class CommandExecutorEnsureGameRunningTests {
     public Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default) => Task.FromResult(_result);
   }
 
+  private sealed class StubReadinessProbe : IGameReadinessProbe {
+    private readonly GameReadinessResult _result;
+    public StubReadinessProbe(bool ready, string loadStatus = "loaded") => _result = new GameReadinessResult(ready, loadStatus);
+    public int CallCount { get; private set; }
+    public Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, CancellationToken ct = default) {
+      CallCount++;
+      return Task.FromResult(_result);
+    }
+  }
+
   // ── Helpers ───────────────────────────────────────────────────────────────
 
   private static EmulatorSession RunningSession(string id = "session1") =>
@@ -78,12 +88,30 @@ public sealed class CommandExecutorEnsureGameRunningTests {
     }
   };
 
-  private static CommandExecutor BuildExecutor(IEnsureGameRunningActionHandler? handler, FakeCommandRepository cmds, ISessionManager sessions) =>
+  private static Command EnsureRunningCommandWithReadiness(string imageId = "city-sentinel", int timeoutMs = 90_000, string id = "cmd1") => new() {
+    Id = id,
+    Name = "EnsureGameRunning",
+    TriggerId = null,
+    Steps = new Collection<CommandStep> {
+      new() {
+        Type = CommandStepType.EnsureGameRunning,
+        TargetId = string.Empty,
+        Order = 1,
+        EnsureGameRunning = new EnsureGameRunningConfig {
+          ReadinessImage = new DetectionTarget(imageId),
+          ReadinessTimeoutMs = timeoutMs
+        }
+      }
+    }
+  };
+
+  private static CommandExecutor BuildExecutor(IEnsureGameRunningActionHandler? handler, FakeCommandRepository cmds, ISessionManager sessions, IGameReadinessProbe? readiness = null) =>
     new(cmds, sessions, new FakeTriggerRepository(),
         new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
         NullLogger<CommandExecutor>.Instance,
         new FakeSessionContextCache(),
-        ensureGameRunning: handler);
+        ensureGameRunning: handler,
+        gameReadiness: readiness);
 
   // ── Tests ─────────────────────────────────────────────────────────────────
 
@@ -140,5 +168,77 @@ public sealed class CommandExecutorEnsureGameRunningTests {
     var act = async () => await executor.ForceExecuteDetailedAsync("session1", "cmd1");
 
     await act.Should().NotThrowAsync();
+  }
+
+  // ── Readiness gate ──────────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task ReadinessGateWaitsPastLaunchAndSucceedsWhenImageDetected() {
+    // Handler reports GameNotRunning (it just launched the game), but the readiness probe
+    // detects the ready screen — the step must succeed with "game_ready", not fail on the launch.
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommandWithReadiness());
+    var probe = new StubReadinessProbe(ready: true);
+    var executor = BuildExecutor(
+      new StubHandler(new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameNotRunning)),
+      cmds, new FakeSessionManager(RunningSession()), probe);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(1);
+    var outcome = result.StepOutcomes.Should().ContainSingle().Subject;
+    outcome.Status.Should().Be("executed");
+    outcome.Reason.Should().Be("game_ready");
+    probe.CallCount.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task ReadinessGateFailsWithReadinessTimeoutWhenImageNeverAppears() {
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommandWithReadiness());
+    var probe = new StubReadinessProbe(ready: false);
+    var executor = BuildExecutor(
+      new StubHandler(new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameNotRunning)),
+      cmds, new FakeSessionManager(RunningSession()), probe);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("readiness_timeout");
+    probe.CallCount.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task ReadinessGateShortCircuitsWithoutProbingWhenGameCannotBeResolved() {
+    // No linked game means there is nothing to wait for — surface the handler failure and never
+    // spin the readiness probe.
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommandWithReadiness());
+    var probe = new StubReadinessProbe(ready: true);
+    var executor = BuildExecutor(
+      new StubHandler(new EnsureGameRunningActionResult(EnsureGameRunningOutcome.NoLinkedGame)),
+      cmds, new FakeSessionManager(RunningSession()), probe);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(0);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("no_linked_game");
+    probe.CallCount.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task ReadinessImageConfiguredButNoProbeFallsBackToLegacyForegroundBehavior() {
+    // Without a probe registered (e.g. non-Windows), a configured readiness image cannot be
+    // verified, so the step keeps its legacy success-iff-foreground semantics.
+    var cmds = new FakeCommandRepository();
+    cmds.Seed(EnsureRunningCommandWithReadiness());
+    var executor = BuildExecutor(
+      new StubHandler(new EnsureGameRunningActionResult(EnsureGameRunningOutcome.GameRunning)),
+      cmds, new FakeSessionManager(RunningSession()), readiness: null);
+
+    var result = await executor.ForceExecuteDetailedAsync("session1", "cmd1");
+
+    result.Accepted.Should().Be(1);
+    result.StepOutcomes.Should().ContainSingle().Which.Status.Should().Be("executed");
   }
 }


### PR DESCRIPTION
## Why

Diagnosed from live execution logs: at queue startup the game was not running. The `ensure-game-running` step launches the app **best-effort but returns immediately** (`EnsureGameRunningActionHandler` fires the launch, reports `GameNotRunning`, and moves on). The queue then ran its entire startup sweep of daily sequences against a still-loading game, so every city-dependent sequence's `recover` loop timed out (BACK ×4 + `waitForImage`, city sentinel never appears) and the day's dailies were skipped. Once the game finished loading, all sequences succeeded again — confirming a pure cold-start race. (This is **not** related to the 075 self-reschedule dedup, which was verified working.)

## What

Add an **optional visual readiness gate** to the `ensure-game-running` command step:

- New `EnsureGameRunningConfig { ReadinessImage, ReadinessTimeoutMs = 90000 }` on `CommandStep`.
- When `ReadinessImage` is set, after the handler best-effort launches the game, `CommandExecutor` polls the live screen for that image via the new **`IGameReadinessProbe` / `GameReadinessProbe`**, reusing the exact template-match cycle as `waitForImage` (extracted into the shared **`ImageDetectionHelper`**). It reports `executed` / `game_ready` once detected, or fails with `readiness_timeout` on timeout.
- **Backward compatible**: with no `ReadinessImage`, the step keeps its legacy behavior (success as soon as the game package is foreground).
- If the game/session can't be resolved (`NoQueueContext`/`NoLinkedGame`/`NoPackageName`/`PlatformUnsupported`) the gate short-circuits to the handler failure without polling.
- The probe needs the vision stack, so DI registration is **Windows-guarded**; off Windows the step falls back to legacy behavior.

Wired through: domain `CommandStep`, `CommandExecutor` gate, DTO round-trip + validation (`CommandsEndpoints`, `Models/Commands`), DI (`GameBotServiceSetup`), unit tests, and `docs/architecture.md`.

## Tests

- `dotnet build` clean; full unit suite green (readiness-gate cases added to `CommandExecutorEnsureGameRunningTests`: detected→`game_ready` even when the handler reports `GameNotRunning`; not-detected→`readiness_timeout`; unresolved game short-circuits without probing; no-probe falls back to legacy).

## How to use (after deploy)

Set the readiness image on the queue's Connect command's `ensure-game-running` step to the city sentinel (`world-nav`, confidence 0.8), e.g. `PATCH /api/commands/{id}` with both steps, adding `ensureGameRunning: { readinessImage: { referenceImageId: "world-nav", confidence: 0.8 }, readinessTimeoutMs: 90000 }`.

## UI logic still needed (intentionally NOT in this PR)

The web-ui command editor has no field for the readiness image yet, so **editing the Connect command in the UI would resend steps without `ensureGameRunning` and wipe the config**. The UI change needed:

1. **Types** (`services/commands.ts`): add `EnsureGameRunningConfigDto { readinessImage?: DetectionTargetDto; readinessTimeoutMs?: number }` and `ensureGameRunning?` on `CommandStepDto`.
2. **Panel** (`EnsureGameRunningPanel.tsx`): add an optional readiness image selector (`ImageSelectorDropdown`) + confidence (0–1) + timeout(ms) inputs, disabled until an image is chosen; emit `{ readinessImageId?, confidence?, timeoutMs? }`; show "Save" vs "Add" based on `initialValue`.
3. **Form** (`CommandForm.tsx`): add `ensureGameRunning` to `StepEntry`; pass `initialValue={editingStep ? (editingStep.ensureGameRunning ?? {}) : undefined}`; build the config on confirm; update the step-summary line to show the readiness image when set.
4. **Page mapping** (`CommandsPage.tsx`): the critical round-trip — `stepsFromDto` maps `s.ensureGameRunning.readinessImage` → form strings; `stepsToDto` maps form → `{ ensureGameRunning: { readinessImage: { referenceImageId, confidence }, readinessTimeoutMs } }`, emitting `undefined` when no image so blank stays legacy.
5. **Validation**: readiness image optional; if provided, `referenceImageId` non-empty and `readinessTimeoutMs >= 0` (mirrors the backend validation already in `CommandsEndpoints.ValidateStep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)