### PR TITLE
chore(deps): raise js-yaml override floor to ^4.3.1

### DIFF
--- a/src/web-ui/package-lock.json
+++ b/src/web-ui/package-lock.json
@@ -6926,9 +6926,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.3.1"
   },
   "overrides": {
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "brace-expansion@1": "^1.1.16",
     "brace-expansion@2": "^2.1.2"
   },


### PR DESCRIPTION
Fixes the failing [Dependabot Updates run](https://github.com/bbqf/GameBotAI/actions/runs/32709325378) for `js-yaml` in `src/web-ui`.

## Cause

Not a build failure — Dependabot itself bailed out with `security_update_not_possible`:

```
"dependency-name": "js-yaml",
"latest-resolvable-version": "4.3.0",
"lowest-non-vulnerable-version": "4.3.1"
```

`js-yaml` is transitive only (`jest` → `@istanbuljs/load-nyc-config` → `js-yaml@^3.13.1`) and is already forced to a single hoisted copy by an npm `overrides` entry. Dependabot resolves against that override rather than raising it, so the stale `^4.3.0` floor capped it at 4.3.0. The only other path it could see was `js-yaml@5.x`, which would have downgraded jest from 29.7.0 to 25.0.0 — so it errored out instead of opening a PR.

Same stuck-override pattern as the earlier `brace-expansion` failures; the floor had simply gone stale.

## Change

Raise the override floor by one patch. `^4.3.1` stays inside the v4 line (npm's `v4-legacy` dist-tag is exactly 4.3.1), so jest keeps 29.7.0.

```diff
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
```

The lockfile was regenerated with node 24.12.0 / npm 11.16.0 to match CI's `node-version: '24.x'`, so the diff is limited to the single `node_modules/js-yaml` node moving 4.3.0 → 4.3.1. Four lines total across the two files.

## Verification

- `npm ci` — 663 packages, clean
- `npm run build` — vite build ✓
- `npm test` — 97 suites, 577 tests, all passing

`gh api .../dependabot/alerts` confirms js-yaml was the only open alert; this raises it above the patched version.

## Note

`npm audit` still reports 2 high findings (`brace-expansion` GHSA-rgw5-rvv9-x895, `nanoid` GHSA-2v37-7h3g-55p8). Both are **auto-dismissed** by GitHub as dev-only, so they are not open alerts and will not fail a Dependabot run — left alone deliberately to keep this PR scoped. Worth knowing the existing `brace-expansion@1`/`@2` floors (`^1.1.16`/`^2.1.2`) sit below that newer advisory's patched versions (1.1.18/2.1.4), so the identical failure would recur there if the auto-dismissal rule ever changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
