### PR TITLE
[078] Complete deferred parameter tasks: sequence editor, ad-hoc run form, contract tests

### DIFF
--- a/specs/078-sequence-parameters/quickstart.md
+++ b/specs/078-sequence-parameters/quickstart.md
@@ -67,10 +67,10 @@ automatically, so the queue's serial reaches the command with no configuration o
 all. That is the whole point of the inheritance rule — a sequence never has to re-declare a value
 merely to pass it through.
 
-> Explicitly overriding a parameter *at a particular sequence step* (rather than per queue or per
-> template entry) is not yet editable in the sequence editor. It is rarely what you want — a value
-> that differs per instance belongs on the queue or the template entry, which is what the rest of
-> this guide uses.
+If the command you pointed at declares parameters, the step shows a **Parameters** panel listing
+them, every row on **Inherit**. Leave them alone: inherit is what lets the queue's value flow down.
+Only clear **Inherit** when the value is a property of *that step* rather than of the instance — a
+value that differs per instance belongs on the queue or the template entry instead.
 
 ### Step 5 — Point one template at the shared sequence, and test it
 
@@ -144,8 +144,12 @@ Then put the reference into the field and save.
 
 ### 3b. Supply the value where it differs
 
-Queue templates → open the template → click **Parameters** on the entry → clear **Inherit** on the
-row and type the value. Use this whenever the value is a property of *that instance*.
+Two places, depending on what the value belongs to:
+
+- **Per instance** — Queue templates → open the template → click **Parameters** on the entry → clear
+  **Inherit** on the row and type the value. This is the usual case.
+- **Per step** — Sequences → open the sequence → expand the command step → clear **Inherit** in its
+  **Parameters** panel. Use this only when the value is a property of that step, not of the instance.
 
 The row shows the effective value and where it came from — `set on this entry`, `from the queue`, or
 `declared default` — so you can confirm the result without running anything. An entry that supplies

--- a/specs/078-sequence-parameters/tasks.md
+++ b/specs/078-sequence-parameters/tasks.md
@@ -157,8 +157,8 @@ that exist solely to feed the US3 authoring UI.
 - [X] T054 [P] [US3] Add `GET /api/sequences/{id}/parameter-scope` to `src/GameBot.Service/Endpoints/SequencesEndpoints.cs`, returning scope entries plus a `stepCallees` array of each `Command` step's referenced command declarations so the binding form needs no N+1 fetches (depends on T052)
 - [X] T055 [US3] Accept an optional `parameters` body on `POST /api/sequences/{id}/execute` in `src/GameBot.Service/Endpoints/SequencesEndpoints.cs` and return `409 missing_required_parameters` when a required parameter has neither a supplied value nor a default (FR-031) (depends on T052)
 - [X] T056 [US2] Project entry warnings (`unused_parameter_value`, `stale_parameter_binding`, `unsatisfied_required_parameter`) and `effectiveParameters` in `src/GameBot.Service/Endpoints/QueueTemplatesEndpoints.cs`; only `invalid_parameter_value_name` blocks with 400 (depends on T043, T050)
-- [ ] T057 [P] [US2] Write `tests/contract/Sequences/ParameterContractTests.cs` and `tests/contract/QueueTemplates/ParameterEntryContractTests.cs` covering the new members and every error code in contracts/api.md
-- [ ] T058 [US2] Regenerate the affected snapshots in `tests/contract/ApiContractSnapshots/` for the additive members and review the diff for unintended changes (depends on T048–T056)
+- [X] T057 [P] [US2] Write `tests/contract/Sequences/ParameterContractTests.cs` and `tests/contract/QueueTemplates/ParameterEntryContractTests.cs` covering the new members and every error code in contracts/api.md
+- [X] T058 [US2] Regenerate the affected snapshots in `tests/contract/ApiContractSnapshots/` for the additive members and review the diff for unintended changes (depends on T048–T056)
 
 ---
 
@@ -176,7 +176,7 @@ and template entry.
 - [X] T059 [P] [US3] Write `src/web-ui/src/components/parameters/__tests__/ParameterizableField.test.tsx`: the picker lists in-scope names with descriptions and inserts a valid reference on selection, in at most three interactions from the field (SC-004)
 - [X] T060 [P] [US3] Write `src/web-ui/src/components/parameters/__tests__/ParameterBindingForm.test.tsx`: every row defaults to "inherit"; an explicit value overrides; the effective value and its origin layer are shown
 - [X] T061 [P] [US3] Write `src/web-ui/src/components/parameters/__tests__/ParameterDeclarationList.test.tsx`: add, edit, reorder and remove declarations; invalid and reserved names are rejected inline
-- [ ] T061a [P] [US3] Write `src/web-ui/src/components/parameters/__tests__/inlineParameterValidation.test.tsx`: a server-reported `unresolvable_parameter_reference` renders as an error anchored at the offending field rather than only as a form-level message, and a `static_check_skipped` warning renders as a non-blocking notice at its field (FR-029)
+- [X] T061a [P] [US3] Write `src/web-ui/src/components/parameters/__tests__/inlineParameterValidation.test.tsx`: a server-reported `unresolvable_parameter_reference` renders as an error anchored at the offending field rather than only as a form-level message, and a `static_check_skipped` warning renders as a non-blocking notice at its field (FR-029)
 
 ### Implementation for User Story 3
 
@@ -186,11 +186,11 @@ and template entry.
 - [X] T065 [US3] Create `src/web-ui/src/components/parameters/ParameterBindingForm.tsx` — renders a callee's declarations as rows pre-set to "inherit", with effective value and origin preview, and an "Add value" affordance for ad-hoc names used only in the template-entry context (FR-027, FR-028) (depends on T062)
 - [X] T066 [P] [US3] Update `src/web-ui/src/services/commands.ts`, `sequences.ts` and `queueTemplates.ts` with the new types, the `/parameter-scope` calls, and the execute-with-parameters body
 - [X] T067 [US3] Add the Parameters section to `src/web-ui/src/components/commands/CommandForm.tsx` and wrap the parametrizable fields in `src/web-ui/src/components/commands/EnsureEmulatorRunningPanel.tsx`, `EnsureGameRunningPanel.tsx`, `KeyInputPanel.tsx`, `SwipePanel.tsx`, `TapPanel.tsx` and `WaitForImagePanel.tsx` in `ParameterizableField`, writing numeric placeholders to `fieldTemplates` and string placeholders inline (depends on T063, T064, T066)
-- [ ] T068 [US3] Add the Parameters section to the sequence editor and a per-step `ParameterBindingForm` in `src/web-ui/src/components/SortableSequenceStepList.tsx` (depends on T065, T066)
+- [X] T068 [US3] Add the Parameters section to the sequence editor and a per-step `ParameterBindingForm` in `src/web-ui/src/components/SortableSequenceStepList.tsx` (depends on T065, T066)
 - [X] T069 [US3] Add the entry parameter form with effective-value preview to `src/web-ui/src/components/queues/SchedulingSequenceCard.tsx` (depends on T065, T066)
 - [X] T070 [P] [US3] Add the parameter-override badge to `src/web-ui/src/components/queues/QueueEntryList.tsx` so overridden entries are identifiable without opening them (FR-030) (depends on T066)
-- [ ] T071 [US3] Surface parameter validation errors and warnings inline at the offending field in `src/web-ui/src/lib/validation.ts` and its consumers (FR-029) (depends on T066)
-- [ ] T072 [US3] Add the ad-hoc run parameter form to the sequence run action in `src/web-ui/src/pages/SequencesPage.tsx`, pre-filled with declared defaults and refusing to start while a required parameter is empty, sending the values as the `parameters` body added in T055 (FR-031) (depends on T055, T065, T066)
+- [X] T071 [US3] Surface parameter validation errors and warnings inline at the offending field in `src/web-ui/src/lib/validation.ts` and its consumers (FR-029) (depends on T066)
+- [X] T072 [US3] Add the ad-hoc run parameter form to the sequence run action in `src/web-ui/src/pages/SequencesPage.tsx`, pre-filled with declared defaults and refusing to start while a required parameter is empty, sending the values as the `parameters` body added in T055 (FR-031) (depends on T055, T065, T066)
 
 **Checkpoint**: All three behavioural stories are independently functional.
 
@@ -204,8 +204,8 @@ migration path, since no migration code is written.
 **Independent Test**: A reader who has never used the feature follows the guide end to end on the
 ensure-game-running / ADB-serial case and reaches a working single-command, single-sequence setup.
 
-- [ ] T073 [US4] Review [quickstart.md](./quickstart.md) against the shipped UI and correct every control name, field label and menu path so the steps match what an operator actually sees (the guide was written from the design, not the built UI) (depends on Phase 6)
-- [ ] T074 [US4] Verify the guide's Step 7 verification instructions against a real execution-log payload — confirm the "Resolved parameters" display name and content match what T037 actually emits (depends on T037, T073)
+- [X] T073 [US4] Review [quickstart.md](./quickstart.md) against the shipped UI and correct every control name, field label and menu path so the steps match what an operator actually sees (the guide was written from the design, not the built UI) (depends on Phase 6)
+- [X] T074 [US4] Verify the guide's Step 7 verification instructions against a real execution-log payload — confirm the "Resolved parameters" display name and content match what T037 actually emits (depends on T037, T073)
 - [ ] T075 [US4] Walk the full guide once end to end against the live service and record the elapsed time, confirming the SC-008 target of under 20 minutes for a three-instance conversion; adjust the guide wherever a step proved ambiguous (depends on T073, T074)
 
 ---
@@ -296,19 +296,19 @@ Each increment leaves every previously stored command, sequence and template run
 
 ---
 
-## Deferred (not implemented in this change)
+## Deferred
 
-The feature is complete and usable end to end without these; each is an additive convenience or an
-extra layer of test coverage on top of behaviour that is already covered elsewhere.
+Everything originally deferred was completed in the follow-up pass, except the one item that needs
+hardware this environment does not have.
 
-| Task | Why deferred | Impact today |
+| Task | Status | Note |
 |---|---|---|
-| T057, T058 | Contract tests + snapshot regeneration for the additive DTO members | The members are covered by the 9 end-to-end tests in `tests/integration/Queues/ParameterPropagationIntegrationTests.cs`, which exercise the real endpoints. The existing 94 contract tests still pass, confirming nothing pre-existing changed shape. |
-| T061a | A UI test for field-anchored validation rendering | `ParameterizableField` already renders and tests an inline `error`; what is untested is the page-level plumbing from a save response into that prop (T071). |
-| T068 | Parameters section + per-step binding form in the sequence editor (`SequencesPage.tsx`, 2000 lines) | **No workflow is blocked**: unbound parameters inherit automatically, which is the intended path for a value that varies per instance. Only an explicit per-step override is unavailable, and such a value belongs on the queue or template entry anyway. Sequence-level declarations remain settable through the API. |
-| T071 | Surfacing save-time parameter errors inline on the page | The backend returns them with `fieldPath`/`parameterName`, and they surface through the editor's existing error display; they are simply not yet anchored to the individual field. |
-| T072 | Ad-hoc run parameter form on the Sequences page | The API supports it (`POST /api/sequences/{id}/execute` with `parameters`, and the 409 refusal), so the behaviour exists; only the form is missing. |
-| T075 | Timed end-to-end walkthrough of the guide against a live emulator | Requires a real LDPlayer instance and a running service, which this environment does not have. T073/T074 corrected the guide against the shipped UI and the real log format instead. |
+| T057, T058 | **Done** (follow-up) | 21 contract tests across `tests/contract/Sequences/ParameterContractTests.cs` and `tests/contract/QueueTemplates/ParameterEntryContractTests.cs`. Writing them found a real contract bug: responses emitted `"parameters": null` instead of omitting the member. The route snapshot gained the two `parameter-scope` endpoints. |
+| T061a | **Done** (follow-up) | `inlineParameterValidation.test.tsx`, plus `lib/__tests__/parameterValidation.spec.ts` for the parser that feeds it. |
+| T068 | **Done** (follow-up) | Parameters section on both sequence forms, and a per-step binding form on command steps. Needed the commands **list** endpoint to return `parameters` too, otherwise the editor would refetch every command one by one. |
+| T071 | **Done** (follow-up) | `parseParameterErrors` / `parameterErrorFor` / `parameterErrorSummary` in `lib/validation.ts`, wired into both editors' save paths. |
+| T072 | **Done** (follow-up) | Ad-hoc run form on the Execution page — which is where the run action actually lives; this task's text said `SequencesPage.tsx`, which was wrong. |
+| T075 | **Blocked** | A timed walkthrough against a live emulator. Needs a running LDPlayer instance and service; T073/T074 verified the guide against the shipped UI and the real log format instead. |
 
 The picker (`ParameterizableField`) is wired into the ensure-emulator-running **ADB serial** field —
 the exact field the motivating scenario varies. Other fields accept a typed reference and are

--- a/src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
+++ b/src/GameBot.Service/Contracts/QueueTemplates/QueueTemplateDetailResponse.cs
@@ -40,7 +40,9 @@ namespace GameBot.Service.Contracts.QueueTemplates {
     /// </summary>
     public string? TimerRelativeOffset { get; set; }
 
-    /// <summary>Values this entry supplies (feature 078); null when it supplies none.</summary>
+    /// <summary>Values this entry supplies (feature 078); omitted when it supplies none.</summary>
+    [System.Text.Json.Serialization.JsonIgnore(
+        Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     public Collection<GameBot.Service.Models.ParameterBindingDto>? ParameterValues { get; set; }
 
     /// <summary>
@@ -52,8 +54,10 @@ namespace GameBot.Service.Contracts.QueueTemplates {
     /// <summary>
     /// Per-parameter effective value and originating scope for this entry (feature 078, FR-028),
     /// computed against the queue currently linked to this template when exactly one is linked.
-    /// Null when the referenced sequence declares nothing and the entry supplies nothing.
+    /// Omitted when the referenced sequence declares nothing and the entry supplies nothing.
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(
+        Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     public Collection<GameBot.Service.Models.ParameterScopeEntryDto>? EffectiveParameters { get; set; }
   }
 }

--- a/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/CommandsEndpoints.cs
@@ -388,7 +388,10 @@ internal static class CommandsEndpoints {
         Name = c.Name,
         TriggerId = c.TriggerId,
         Steps = new Collection<CommandStepDto>(c.Steps.Select(ToResponseStep).ToList()),
-        Detection = ToResponseDetection(c.Detection)
+        Detection = ToResponseDetection(c.Detection),
+        // Feature 078: the sequence editor renders a binding form per command step, so it needs each
+        // command's declarations up front — without this it would refetch every command one by one.
+        Parameters = ParameterDtoMapper.ToResponseDeclarations(c.Parameters)
       });
       return Results.Ok(resp);
     })

--- a/src/GameBot.Service/Models/Commands.cs
+++ b/src/GameBot.Service/Models/Commands.cs
@@ -85,10 +85,15 @@ internal sealed class CommandResponse {
   public Collection<CommandStepDto> Steps { get; init; } = new();
   public DetectionTargetDto? Detection { get; init; }
 
-  /// <summary>Parameters this command declares (feature 078); null when unparametrized.</summary>
+  /// <summary>
+  /// Parameters this command declares (feature 078). Omitted from the response entirely when the
+  /// command is unparametrized, so a pre-feature client sees exactly the payload it always saw.
+  /// </summary>
+  [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
   public Collection<ParameterDeclarationDto>? Parameters { get; init; }
 
-  /// <summary>Non-blocking parameter advisories; null when there are none.</summary>
+  /// <summary>Non-blocking parameter advisories; omitted when there are none.</summary>
+  [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
   public Collection<ParameterWarningDto>? Warnings { get; init; }
 }
 
@@ -150,9 +155,11 @@ internal sealed class CommandStepDto {
   /// Placeholders for this step's numeric fields, keyed by dotted path (feature 078). String fields
   /// carry their placeholder inline instead and never appear here.
   /// </summary>
+  [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
   public Dictionary<string, string>? FieldTemplates { get; init; }
 
   /// <summary>Values bound for the invoked command's parameters; only meaningful for Command steps.</summary>
+  [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
   public Collection<ParameterBindingDto>? ParameterBindings { get; init; }
 }
 

--- a/src/web-ui/src/lib/__tests__/parameterValidation.spec.ts
+++ b/src/web-ui/src/lib/__tests__/parameterValidation.spec.ts
@@ -1,0 +1,104 @@
+import { ApiError } from '../api';
+import { parseParameterErrors, parameterErrorFor, parameterErrorSummary } from '../validation';
+
+/**
+ * Feature 078 (FR-029): the backend anchors each parameter problem to a field path and parameter
+ * name. These cover the parsing that lets an editor render the message at the field it concerns
+ * instead of as one form-level banner.
+ */
+const parameterError = (details: unknown[], code = 'unresolvable_parameter_reference') =>
+  new ApiError(400, 'bad request', undefined, { error: code, message: 'nope', details });
+
+describe('parseParameterErrors', () => {
+  it('keys issues by the field path the backend reported', () => {
+    const parsed = parseParameterErrors(
+      parameterError([
+        {
+          code: 'unresolvable_parameter_reference',
+          message: "Step '0': 'typo' is not declared here and is not a queue built-in.",
+          fieldPath: 'ensureEmulatorRunning.adbSerial',
+          parameterName: 'typo',
+        },
+      ]),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.code).toBe('unresolvable_parameter_reference');
+    expect(parsed!.byFieldPath['ensureEmulatorRunning.adbSerial']).toHaveLength(1);
+    expect(parsed!.byFieldPath['ensureEmulatorRunning.adbSerial'][0].parameterName).toBe('typo');
+  });
+
+  it('collects issues that name no field as general', () => {
+    const parsed = parseParameterErrors(
+      parameterError(
+        [{ code: 'invalid_parameter_declaration', message: "parameter name 'iteration' is reserved" }],
+        'invalid_parameter_declaration',
+      ),
+    );
+
+    expect(parsed!.general).toHaveLength(1);
+    expect(parsed!.byFieldPath).toEqual({});
+  });
+
+  it('groups multiple issues on the same field', () => {
+    const parsed = parseParameterErrors(
+      parameterError([
+        { code: 'a', message: 'first', fieldPath: 'swipe.startX' },
+        { code: 'b', message: 'second', fieldPath: 'swipe.startX' },
+      ]),
+    );
+
+    expect(parsed!.byFieldPath['swipe.startX'].map((i) => i.message)).toEqual(['first', 'second']);
+  });
+
+  it('returns null for a non-parameter API error so existing handling is untouched', () => {
+    expect(parseParameterErrors(new ApiError(400, 'plain failure'))).toBeNull();
+    expect(parseParameterErrors(new ApiError(409, 'conflict', undefined, { error: 'already_running' }))).toBeNull();
+  });
+
+  it('returns null for a rejection that is not an ApiError at all', () => {
+    expect(parseParameterErrors(new Error('network down'))).toBeNull();
+    expect(parseParameterErrors(undefined)).toBeNull();
+  });
+
+  it('ignores malformed detail entries rather than throwing', () => {
+    const parsed = parseParameterErrors(
+      parameterError([null, 'nonsense', { code: 'x' }, { code: 'y', message: 'kept', fieldPath: 'keyInput.key' }]),
+    );
+
+    expect(parsed!.byFieldPath['keyInput.key']).toHaveLength(1);
+    expect(parsed!.general).toHaveLength(0);
+  });
+});
+
+describe('parameterErrorFor', () => {
+  it('returns the message for the requested field and nothing for a clean one', () => {
+    const parsed = parseParameterErrors(
+      parameterError([{ code: 'x', message: 'bad serial', fieldPath: 'ensureEmulatorRunning.adbSerial' }]),
+    );
+
+    expect(parameterErrorFor(parsed, 'ensureEmulatorRunning.adbSerial')).toBe('bad serial');
+    expect(parameterErrorFor(parsed, 'keyInput.key')).toBeUndefined();
+    expect(parameterErrorFor(null, 'anything')).toBeUndefined();
+  });
+});
+
+describe('parameterErrorSummary', () => {
+  it('joins general and field issues into one form-level message', () => {
+    const parsed = parseParameterErrors(
+      parameterError([
+        { code: 'x', message: 'general problem' },
+        { code: 'y', message: 'field problem', fieldPath: 'swipe.startX' },
+      ]),
+    );
+
+    const summary = parameterErrorSummary(parsed);
+
+    expect(summary).toContain('general problem');
+    expect(summary).toContain('field problem');
+  });
+
+  it('returns undefined when there is nothing to show', () => {
+    expect(parameterErrorSummary(null)).toBeUndefined();
+  });
+});

--- a/src/web-ui/src/lib/validation.ts
+++ b/src/web-ui/src/lib/validation.ts
@@ -55,6 +55,93 @@ export const parseFromError = (err: unknown): ParsedValidation | null => {
   return parseValidationErrors(errs);
 };
 
+/** One parameter problem the backend reported, already anchored to a field (feature 078). */
+export type ParameterFieldIssue = {
+  code: string;
+  message: string;
+  fieldPath?: string;
+  parameterName?: string;
+};
+
+/** Parameter problems from a save, keyed by the dotted field path they belong to. */
+export type ParsedParameterErrors = {
+  /** Keyed by `fieldPath`; a field with no path lands in {@link general} instead. */
+  byFieldPath: Record<string, ParameterFieldIssue[]>;
+  /** Problems that name no field, e.g. a malformed declaration. */
+  general: ParameterFieldIssue[];
+  /** The top-level error code, e.g. `unresolvable_parameter_reference`. */
+  code?: string;
+};
+
+/**
+ * Extracts the parameter validation `details` a 400 carries (feature 078, FR-029), so an editor can
+ * render each message at the field it concerns rather than as one form-level banner.
+ *
+ * Returns `null` for anything that is not a parameter error, so callers can fall through to their
+ * existing error handling untouched.
+ *
+ * @param err The rejection from a save call.
+ */
+export const parseParameterErrors = (err: unknown): ParsedParameterErrors | null => {
+  if (!(err instanceof ApiError)) return null;
+  const payload = err.payload;
+  if (!payload || typeof payload !== 'object') return null;
+
+  const details = (payload as { details?: unknown }).details;
+  if (!Array.isArray(details) || details.length === 0) return null;
+
+  const result: ParsedParameterErrors = {
+    byFieldPath: {},
+    general: [],
+    code: typeof (payload as { error?: unknown }).error === 'string'
+      ? (payload as { error: string }).error
+      : undefined,
+  };
+
+  for (const raw of details) {
+    if (!raw || typeof raw !== 'object') continue;
+    const detail = raw as Record<string, unknown>;
+    const message = typeof detail.message === 'string' ? detail.message : undefined;
+    if (!message) continue;
+
+    const issue: ParameterFieldIssue = {
+      code: typeof detail.code === 'string' ? detail.code : (result.code ?? 'parameter_error'),
+      message,
+      fieldPath: typeof detail.fieldPath === 'string' ? detail.fieldPath : undefined,
+      parameterName: typeof detail.parameterName === 'string' ? detail.parameterName : undefined,
+    };
+
+    if (issue.fieldPath) {
+      (result.byFieldPath[issue.fieldPath] ??= []).push(issue);
+    } else {
+      result.general.push(issue);
+    }
+  }
+
+  // Only a payload that actually carried a parameter issue counts as a parameter error.
+  return Object.keys(result.byFieldPath).length > 0 || result.general.length > 0 ? result : null;
+};
+
+/**
+ * The message to show at one field, or undefined when that field is clean.
+ *
+ * @param parsed Result of {@link parseParameterErrors}; `null` yields undefined.
+ * @param fieldPath Dotted path of the field being rendered, e.g. `ensureEmulatorRunning.adbSerial`.
+ */
+export const parameterErrorFor = (
+  parsed: ParsedParameterErrors | null,
+  fieldPath: string,
+): string | undefined => parsed?.byFieldPath[fieldPath]?.[0]?.message;
+
+/** A single combined message for form-level display, or undefined when there is nothing to show. */
+export const parameterErrorSummary = (
+  parsed: ParsedParameterErrors | null,
+): string | undefined => {
+  if (!parsed) return undefined;
+  const all = [...parsed.general, ...Object.values(parsed.byFieldPath).flat()];
+  return all.length > 0 ? all.map((i) => i.message).join(' ') : undefined;
+};
+
 export const validateConditionalFlow = (flow: Pick<SequenceFlowUpsertRequest, 'entryStepId' | 'steps' | 'links'>): string[] => {
   const errors: string[] = [];
   const stepIds = new Set(flow.steps.map((step) => step.stepId));

--- a/src/web-ui/src/pages/CommandsPage.tsx
+++ b/src/web-ui/src/pages/CommandsPage.tsx
@@ -4,6 +4,7 @@ import { ConfirmDeleteModal } from '../components/ConfirmDeleteModal';
 import { useUnsavedChangesPrompt } from '../hooks/useUnsavedChangesPrompt';
 import { useResetSignal } from '../hooks/useResetSignal';
 import { ApiError } from '../lib/api';
+import { parseParameterErrors, parameterErrorSummary } from '../lib/validation';
 import { SearchableOption } from '../components/SearchableDropdown';
 import { listCommands, getCommand, createCommand, updateCommand, deleteCommand, CommandDto, CommandStepDto } from '../services/commands';
 import { listGames, GameDto } from '../services/games';
@@ -11,7 +12,7 @@ import './CommandsPage.css';
 
 const makeId = () => (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : Math.random().toString(36).slice(2));
 
-const emptyForm: CommandFormValue = { name: '', steps: [], detection: undefined };
+const emptyForm: CommandFormValue = { name: '', steps: [], detection: undefined, parameters: [] };
 
 const stepsFromDto = (dto: CommandDto): StepEntry[] => {
   if (dto.steps && dto.steps.length > 0) {
@@ -258,9 +259,22 @@ export const CommandsPage: React.FC<CommandsPageProps> = ({ initialCreate, initi
     setForm({
       name: c.name,
       steps: stepsFromDto(c),
-      detection: detectionFromDto(c.detection)
+      detection: detectionFromDto(c.detection),
+      parameters: c.parameters ?? []
     });
     setDirty(false);
+  };
+
+  /**
+   * Turns a save rejection into the editor's field-error map (feature 078, FR-029). A parameter
+   * rejection carries `details` naming the offending field and parameter, so those are surfaced
+   * instead of a generic message; anything else falls back to the message as before.
+   */
+  const toSaveErrors = (err: unknown, fallback: string): Record<string, string> => {
+    const parameterErrors = parseParameterErrors(err);
+    const summary = parameterErrorSummary(parameterErrors);
+    if (summary) return { form: summary };
+    return { form: (err as { message?: string })?.message ?? fallback };
   };
 
   const filteredCommandOptions = useMemo(() => {
@@ -442,6 +456,7 @@ export const CommandsPage: React.FC<CommandsPageProps> = ({ initialCreate, initi
                 name: form.name.trim(),
                 steps: stepsToDto(form.steps),
                 detection: detectionResult?.value ?? undefined,
+                ...(form.parameters && form.parameters.length > 0 ? { parameters: form.parameters } : {}),
               });
               setCreating(false);
               setForm(emptyForm);
@@ -449,7 +464,9 @@ export const CommandsPage: React.FC<CommandsPageProps> = ({ initialCreate, initi
               setTableMessage('Command created successfully.');
               await reloadCommands();
             } catch (err: any) {
-              setErrors({ form: err?.message ?? 'Failed to create command' });
+              // Feature 078 (FR-029): a parameter rejection carries the offending field and name, so
+              // show that rather than a bare "Failed to create command".
+              setErrors(toSaveErrors(err, 'Failed to create command'));
             } finally {
               setSubmitting(false);
             }
@@ -486,6 +503,8 @@ export const CommandsPage: React.FC<CommandsPageProps> = ({ initialCreate, initi
                   name: form.name.trim(),
                   steps: stepsToDto(form.steps),
                   detection: detectionResult?.value ?? undefined,
+                  // Always sent on update so clearing the last declaration actually persists.
+                  parameters: form.parameters ?? [],
                 });
                 await reloadCommands();
                 setEditingId(undefined);
@@ -493,7 +512,7 @@ export const CommandsPage: React.FC<CommandsPageProps> = ({ initialCreate, initi
                 setDirty(false);
                 setTableMessage('Command updated successfully.');
               } catch (err: any) {
-                setErrors({ form: err?.message ?? 'Failed to update command' });
+                setErrors(toSaveErrors(err, 'Failed to update command'));
               } finally {
                 setSubmitting(false);
               }

--- a/src/web-ui/src/pages/Execution.tsx
+++ b/src/web-ui/src/pages/Execution.tsx
@@ -7,6 +7,8 @@ import { listSequences, executeSequence, SequenceDto } from '../services/sequenc
 import { ApiError } from '../lib/api';
 import { StatusChip } from '../features/execution/StatusChip';
 import { RunDetails } from '../features/execution/RunDetails';
+import { ParameterBindingForm } from '../components/parameters/ParameterBindingForm';
+import type { ParameterBinding } from '../components/parameters/types';
 
 export const EXECUTION_AREA_PATH = '/execution';
 export const EXECUTION_LOGS_AREA_PATH = '/execution-logs';
@@ -40,6 +42,9 @@ export const ExecutionPage: React.FC = () => {
   const [selectedSequenceId, setSelectedSequenceId] = useState<string | undefined>(undefined);
   const [sequenceMessage, setSequenceMessage] = useState<string | undefined>(undefined);
   const [sequenceError, setSequenceError] = useState<string | undefined>(undefined);
+  /** Ad-hoc parameter values, keyed by sequence id so switching selection keeps each one's entries. */
+  const [sequenceParameterValues, setSequenceParameterValues] =
+    useState<Record<string, ParameterBinding[]>>({});
   const [executingSequence, setExecutingSequence] = useState(false);
 
   const gameLookup = useMemo(() => {
@@ -138,6 +143,18 @@ export const ExecutionPage: React.FC = () => {
   // diverge: a controlled <select> would otherwise default its DOM value to the first option
   // while state lags behind a separate auto-select effect, leaving the handler reading undefined.
   const effectiveSequenceId = selectedSequenceId ?? sequences[0]?.id;
+
+  // Feature 078: the selected sequence's declarations, and the values supplied for this ad-hoc run.
+  const selectedSequence = sequences.find((s) => s.id === effectiveSequenceId);
+  const sequenceParameters = useMemo(() => selectedSequence?.parameters ?? [], [selectedSequence]);
+  const suppliedParameters = sequenceParameterValues[effectiveSequenceId ?? ''] ?? [];
+  const missingRequiredParameters = sequenceParameters
+    .filter((p) => p.required && (p.default ?? null) === null)
+    .filter((p) => {
+      const bound = suppliedParameters.find((b) => b.name === p.name);
+      return bound?.value === null || bound?.value === undefined;
+    })
+    .map((p) => p.name);
 
   const selectedRunningSession = useMemo(() => {
     if (!selectedGameId || !selectedAdbSerial) return undefined;
@@ -244,12 +261,28 @@ export const ExecutionPage: React.FC = () => {
       return;
     }
 
+    // Feature 078 (FR-031): an ad-hoc run has no queue, so nothing supplies the built-ins. Refuse
+    // locally when a required parameter has neither a value nor a default, matching the backend's
+    // 409 — better to say so before the run than to fail a step mid-way.
+    if (missingRequiredParameters.length > 0) {
+      setSequenceError(
+        `Supply a value for ${missingRequiredParameters.join(', ')} before running this sequence.`,
+      );
+      return;
+    }
+
     setExecutingSequence(true);
     setSequenceMessage(undefined);
     setSequenceError(undefined);
 
     try {
-      await executeSequence(effectiveSequenceId, cachedSession?.sessionId);
+      // Omit the argument entirely when nothing is supplied, so an unparametrized run makes exactly
+      // the call it always did — passing an explicit `undefined` would still change the arity.
+      if (suppliedParameters.length > 0) {
+        await executeSequence(effectiveSequenceId, cachedSession?.sessionId, suppliedParameters);
+      } else {
+        await executeSequence(effectiveSequenceId, cachedSession?.sessionId);
+      }
       setSequenceMessage('Sequence executed successfully.');
     } catch (err: any) {
       if (err instanceof ApiError) {
@@ -443,8 +476,38 @@ export const ExecutionPage: React.FC = () => {
           {!loadingSequences && sequences.length === 0 && <div className="form-hint">No sequences available.</div>}
         </div>
 
+        {/*
+          Feature 078 (FR-031): a run started here has no queue behind it, so the queue built-ins are
+          not in scope. Anything the sequence declares must be supplied (or defaulted) up front.
+        */}
+        {sequenceParameters.length > 0 && (
+          <div className="field">
+            <ParameterBindingForm
+              declarations={sequenceParameters}
+              bindings={suppliedParameters}
+              disabled={executingSequence || loadingSequences}
+              onChange={(bindings) => {
+                setSequenceParameterValues((prev) => ({ ...prev, [effectiveSequenceId ?? '']: bindings }));
+                setSequenceError(undefined);
+              }}
+            />
+            <div className="form-hint">
+              This run is not attached to a queue, so <code>queue.…</code> values are unavailable here.
+            </div>
+          </div>
+        )}
+
         <div className="form-actions">
-          <button type="button" onClick={handleExecuteSequence} disabled={executingSequence || loadingSequences || sequences.length === 0}>Execute sequence</button>
+          <button
+            type="button"
+            onClick={handleExecuteSequence}
+            disabled={executingSequence || loadingSequences || sequences.length === 0 || missingRequiredParameters.length > 0}
+            title={missingRequiredParameters.length > 0
+              ? `Supply a value for ${missingRequiredParameters.join(', ')} first`
+              : undefined}
+          >
+            Execute sequence
+          </button>
         </div>
       </section>
     </div>

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -5,6 +5,9 @@ import { listSequences, SequenceDto, createSequence, getSequence, updateSequence
 import { ConfirmDeleteModal } from '../components/ConfirmDeleteModal';
 import { ApiError } from '../lib/api';
 import { listCommands, CommandDto } from '../services/commands';
+import { ParameterDeclarationList } from '../components/parameters/ParameterDeclarationList';
+import { ParameterBindingForm } from '../components/parameters/ParameterBindingForm';
+import type { ParameterBinding, ParameterDeclaration } from '../components/parameters/types';
 import { FormError } from '../components/Form';
 import { FormActions, FormSection } from '../components/unified/FormLayout';
 import { SearchableDropdown, SearchableOption } from '../components/SearchableDropdown';
@@ -12,7 +15,7 @@ import type { ReorderableListItem } from '../components/ReorderableList';
 import { SortableSequenceStepList } from '../components/SortableSequenceStepList';
 import { useUnsavedChangesPrompt } from '../hooks/useUnsavedChangesPrompt';
 import { useResetSignal } from '../hooks/useResetSignal';
-import { validatePerStepConditions } from '../lib/validation';
+import { validatePerStepConditions, parseParameterErrors, parameterErrorSummary } from '../lib/validation';
 import { isLinearStepArray, toCommandStepIds, toInterStepDelayRange, toLinearSteps } from '../lib/sequenceMapping';
 import { LoopBlock } from '../components/sequences/LoopBlock';
 import { IfBlock } from '../components/sequences/IfBlock';
@@ -40,6 +43,12 @@ type SequenceStep = {
   expectedState: 'success' | 'failed' | 'skipped';
   loopEntry?: LoopStepEntry;
   ifEntry?: IfStepEntry;
+  /**
+   * Values bound for the invoked command's parameters (feature 078); meaningful only when
+   * `actionType === 'command'`. A binding with a null value means "inherit", which is the default
+   * for every row, so the common case needs no configuration at all.
+   */
+  parameterBindings?: ParameterBinding[];
   // Self-reschedule action fields (feature 065); only meaningful when actionType === 'reschedule-self'.
   rescheduleOption?: RescheduleOption;
   rescheduleTimerMode?: 'relative' | 'timeOfDay';
@@ -82,6 +91,12 @@ type SequenceFormValue = {
   useCustomDelayRange: boolean;
   delayMin: string;
   delayMax: string;
+  /**
+   * Parameters this sequence accepts (feature 078). A sequence need not declare a parameter merely
+   * to pass one through to a nested command — unbound names inherit from the enclosing run scope —
+   * so this is for values the sequence itself wants named and defaulted.
+   */
+  parameters: ParameterDeclaration[];
 };
 
 // Collision detection that uses the cursor position rather than the dragged item's
@@ -110,7 +125,8 @@ const emptyForm: SequenceFormValue = {
   steps: [],
   useCustomDelayRange: false,
   delayMin: '',
-  delayMax: ''
+  delayMax: '',
+  parameters: []
 };
 
 const createDefaultStep = (commandId: string, stepId: string, commandReference?: SequenceCommandReference): SequenceStep => ({
@@ -487,6 +503,7 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         minSimilarity: step.condition.minSimilarity == null ? '' : String(step.condition.minSimilarity),
         outcomeStepRef: '',
         expectedState: 'success' as const,
+        parameterBindings: step.parameterBindings ?? undefined,
       };
     }
 
@@ -507,12 +524,14 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
         minSimilarity: '',
         outcomeStepRef: step.condition.stepRef,
         expectedState: step.condition.expectedState,
+        parameterBindings: step.parameterBindings ?? undefined,
       };
     }
 
     return {
       ...createDefaultStep(commandId, step.stepId, step.commandReference ?? undefined),
-      stepId: step.stepId
+      stepId: step.stepId,
+      parameterBindings: step.parameterBindings ?? undefined
     };
   });
 };
@@ -682,9 +701,24 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
         }
       },
       commandReference: buildCommandReferencePayload(step.commandId, step.commandReference),
-      condition: buildConditionPayload(step)
+      condition: buildConditionPayload(step),
+      // Feature 078: only send rows that actually bind something. A row left on "inherit" carries a
+      // null value and is dropped here, so an unparametrized step stays byte-identical on the wire.
+      ...buildParameterBindingsPayload(step.parameterBindings)
     };
   });
+};
+
+/**
+ * Projects a step's bindings for the wire, omitting the member entirely when every row is left on
+ * "inherit" (feature 078). Keeping the omission here rather than server-side means an unparametrized
+ * sequence round-trips without gaining an empty array.
+ */
+const buildParameterBindingsPayload = (
+  bindings: ParameterBinding[] | undefined,
+): { parameterBindings?: ParameterBinding[] } => {
+  const bound = (bindings ?? []).filter((b) => b.value !== null && b.value !== undefined);
+  return bound.length > 0 ? { parameterBindings: bound } : {};
 };
 
 type SequencesPageProps = {
@@ -697,6 +731,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
   const [sequences, setSequences] = useState<SequenceDto[]>([]);
   const [creating, setCreating] = useState(Boolean(initialCreate));
   const [commandOptions, setCommandOptions] = useState<SearchableOption[]>([]);
+  const [commandParameters, setCommandParameters] = useState<Map<string, ParameterDeclaration[]>>(new Map());
   const [errors, setErrors] = useState<Record<string, string> | undefined>(undefined);
   const [editingId, setEditingId] = useState<string | undefined>(undefined);
   const [form, setForm] = useState<SequenceFormValue>(emptyForm);
@@ -824,12 +859,16 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         if (!mounted) return;
         setSequences(seqs);
         setCommandOptions(cmds.map((c) => ({ value: c.id, label: c.name })));
+        // Feature 078: each command's declarations, so a step's binding form renders without an
+        // extra fetch per step.
+        setCommandParameters(new Map(cmds.map((c) => [c.id, c.parameters ?? []])));
         setTableError(undefined);
       })
       .catch((err: any) => {
         if (!mounted) return;
         setSequences([]);
         setCommandOptions([]);
+        setCommandParameters(new Map());
         setTableError(err?.message ?? 'Failed to load sequences');
       })
       .finally(() => {
@@ -882,7 +921,8 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
       steps: hasPerStep ? toStepEntriesFromLinear(linearSteps) : toStepEntries(commandIds),
       useCustomDelayRange: delayRange !== null,
       delayMin: delayRange ? String(delayRange.min) : '',
-      delayMax: delayRange ? String(delayRange.max) : ''
+      delayMax: delayRange ? String(delayRange.max) : '',
+      parameters: s.parameters ?? []
     });
     setLoadedVersion(s.version ?? 1);
     setDirty(false);
@@ -907,6 +947,31 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
 
   const renderStepConditionEditor = useCallback((step: SequenceStep, index: number): React.ReactNode => (
     <div className="sequence-step-condition-editor">
+      {/*
+        Feature 078: the invoked command's parameters, every row defaulting to "inherit" so a value
+        already in scope (a queue built-in, or a template-entry value) flows down untouched. Only
+        override here when the value is a property of THIS step rather than of the instance.
+      */}
+      {step.stepType === 'Action' && step.actionType === 'command'
+        && (commandParameters.get(step.commandId)?.length ?? 0) > 0 && (
+        <div className="sequence-step-condition-field sequence-step-condition-field--parameters">
+          <ParameterBindingForm
+            declarations={commandParameters.get(step.commandId) ?? []}
+            bindings={step.parameterBindings ?? []}
+            disabled={submitting || loading}
+            onChange={(bindings) => {
+              setForm((prev) => ({
+                ...prev,
+                steps: prev.steps.map((candidate) => candidate.id === step.id
+                  ? { ...candidate, parameterBindings: bindings }
+                  : candidate)
+              }));
+              setDirty(true);
+            }}
+          />
+        </div>
+      )}
+
       {step.stepType === 'Action' && step.actionType === 'WaitForImage' && (
         <>
           <div className="sequence-step-condition-field sequence-step-condition-field--image-id">
@@ -1208,7 +1273,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         </div>
       )}
     </div>
-  ), [form.steps, submitting, loading]);
+  ), [form.steps, submitting, loading, commandParameters]);
 
   const createLoopStep = (loopType: 'count' | 'while' | 'repeatUntil'): SequenceStep => {
     const id = makeId();
@@ -1548,7 +1613,8 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                   name: linearPayload.name,
                   version: linearPayload.version,
                   steps: linearPayload.steps,
-                  interStepDelayRangeMs: linearPayload.interStepDelayRangeMs
+                  interStepDelayRangeMs: linearPayload.interStepDelayRangeMs,
+                  ...(form.parameters.length > 0 ? { parameters: form.parameters } : {})
                 }
               );
               setCreating(false);
@@ -1558,7 +1624,8 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
               setTableMessage('Sequence created successfully.');
               await reloadSequences();
             } catch (err: any) {
-              setErrors({ form: err?.message ?? 'Failed to create sequence' });
+              // Feature 078 (FR-029): surface the offending field/parameter, not a generic message.
+              setErrors({ form: parameterErrorSummary(parseParameterErrors(err)) ?? err?.message ?? 'Failed to create sequence' });
             } finally {
               setSubmitting(false);
             }
@@ -1637,6 +1704,19 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 </div>
               </>
             )}
+          </FormSection>
+
+          <FormSection
+            title="Parameters"
+            description="Values a caller supplies. A value only needs declaring here if this sequence itself names it — one passed straight through to a command is inherited automatically."
+            id="sequence-parameters"
+          >
+            <ParameterDeclarationList
+              parameters={form.parameters}
+              disabled={submitting || loading}
+              ownerLabel="This sequence"
+              onChange={(parameters) => { setForm((prev) => ({ ...prev, parameters })); setDirty(true); }}
+            />
           </FormSection>
 
           <FormSection title="Steps" description="Add commands in the order they should run and configure conditions inline." id="sequence-steps">
@@ -1769,7 +1849,10 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                     name: linearPayload.name,
                     version: linearPayload.version,
                     steps: linearPayload.steps,
-                    interStepDelayRangeMs: linearPayload.interStepDelayRangeMs
+                    interStepDelayRangeMs: linearPayload.interStepDelayRangeMs,
+                    // Always sent on update (even when empty) so clearing the last declaration
+                    // actually persists — an absent member means "leave unchanged" server-side.
+                    parameters: form.parameters
                   }
                 );
                 await reloadSequences();
@@ -1782,7 +1865,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                   setErrors({ form: `Sequence has changed on the server (version ${err.payload.currentVersion}). Reloaded latest version.` });
                   await loadSequenceIntoForm(editingId);
                 } else {
-                  setErrors({ form: err?.message ?? 'Failed to update sequence' });
+                  setErrors({ form: parameterErrorSummary(parseParameterErrors(err)) ?? err?.message ?? 'Failed to update sequence' });
                 }
               } finally {
                 setSubmitting(false);
@@ -1862,6 +1945,19 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                   </div>
                 </>
               )}
+            </FormSection>
+
+            <FormSection
+              title="Parameters"
+              description="Values a caller supplies. A value only needs declaring here if this sequence itself names it — one passed straight through to a command is inherited automatically."
+              id="sequence-edit-parameters"
+            >
+              <ParameterDeclarationList
+                parameters={form.parameters}
+                disabled={submitting || loading}
+                ownerLabel="This sequence"
+                onChange={(parameters) => { setForm((prev) => ({ ...prev, parameters })); setDirty(true); }}
+              />
             </FormSection>
 
             <FormSection title="Steps" description="Add commands in the order they should run and configure conditions inline." id="sequence-edit-steps">

--- a/src/web-ui/src/pages/__tests__/CommandsPage.detection.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/CommandsPage.detection.spec.tsx
@@ -99,6 +99,8 @@ describe('CommandsPage detection persistence', () => {
       name: 'DetectCmd',
       steps: [{ type: 'Command', targetId: 'nested1', order: 0 }],
       detection: { referenceImageId: 'tpl2', confidence: 0.9, offsetX: -4, offsetY: 7 },
+      // Feature 078: update always sends the full declaration list so clearing the last one persists.
+      parameters: [],
     }));
   });
 

--- a/src/web-ui/src/pages/__tests__/CommandsPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/CommandsPage.spec.tsx
@@ -144,6 +144,8 @@ describe('CommandsPage', () => {
       name: 'Cmd Updated',
       steps: [{ type: 'Command', targetId: 'nested1', order: 0 }],
       detection: undefined,
+      // Feature 078: update always sends the full declaration list so clearing the last one persists.
+      parameters: [],
     }));
   });
 
@@ -187,6 +189,7 @@ describe('CommandsPage', () => {
         { type: 'Command', targetId: 'nested1', order: 1 },
       ],
       detection: undefined,
+      parameters: [],
     }));
 
     uuidSpy.mockRestore();
@@ -320,6 +323,7 @@ describe('CommandsPage', () => {
         }
       }],
       detection: undefined,
+      parameters: [],
     }));
   });
 });

--- a/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.spec.tsx
@@ -118,6 +118,8 @@ describe('SequencesPage', () => {
     await waitFor(() => expect(updateSequenceMock).toHaveBeenCalledWith('s1', {
       name: 'Sequence 1',
       version: 1,
+      // Feature 078: update always sends the full declaration list so clearing the last one persists.
+      parameters: [],
       interStepDelayRangeMs: null,
       steps: [
         {
@@ -208,6 +210,7 @@ describe('SequencesPage', () => {
     await waitFor(() => expect(updateSequenceMock).toHaveBeenCalledWith('seq-wait', {
       name: 'Wait Sequence',
       version: 4,
+      parameters: [],
       interStepDelayRangeMs: null,
       steps: [
         {
@@ -279,6 +282,7 @@ describe('SequencesPage', () => {
     await waitFor(() => expect(updateSequenceMock).toHaveBeenCalledWith('seq-loop', {
       name: 'Loop Sequence',
       version: 3,
+      parameters: [],
       interStepDelayRangeMs: null,
       steps: [
         {
@@ -429,6 +433,7 @@ describe('SequencesPage', () => {
     await waitFor(() => expect(updateSequenceMock).toHaveBeenCalledWith('seq-if', {
       name: 'If In Loop',
       version: 2,
+      parameters: [],
       interStepDelayRangeMs: null,
       steps: [
         {

--- a/src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx
@@ -64,6 +64,8 @@ describe('SequencesPage unresolved commands', () => {
     await waitFor(() => expect(updateSequenceMock).toHaveBeenCalledWith('seq-missing', {
       name: 'Missing Command Sequence',
       version: 7,
+      // Feature 078: update always sends the full declaration list so clearing the last one persists.
+      parameters: [],
       interStepDelayRangeMs: null,
       steps: [
         {

--- a/src/web-ui/src/types/sequenceFlow.ts
+++ b/src/web-ui/src/types/sequenceFlow.ts
@@ -1,3 +1,5 @@
+import type { ParameterBinding } from '../components/parameters/types';
+
 export type FlowStepType = 'action' | 'command' | 'condition' | 'terminal';
 export type BranchType = 'next' | 'true' | 'false';
 export type ConditionNodeType = 'and' | 'or' | 'not' | 'operand';
@@ -128,6 +130,12 @@ export type SequenceLinearStep = {
   breakCondition?: SequenceStepCondition | null;
   if?: IfConfigDto | null;
   elseBody?: SequenceLinearStep[] | null;
+  /**
+   * Values bound for the invoked command's parameters (feature 078). Present only on a command step
+   * that binds something; a row left on "inherit" is omitted, so unparametrized steps stay unchanged
+   * on the wire.
+   */
+  parameterBindings?: ParameterBinding[] | null;
 };
 
 export type InterStepDelayRangeMs = {

--- a/tests/contract/ApiContractSnapshots/primitive-actions-routes.snapshot.json
+++ b/tests/contract/ApiContractSnapshots/primitive-actions-routes.snapshot.json
@@ -1,13 +1,15 @@
 {
-  "version": "2026-05-27",
+  "version": "2026-08-24",
   "routes": [
     "/api/commands",
     "/api/commands/{id}",
     "/api/commands/{id}/force-execute",
     "/api/commands/{id}/evaluate-and-execute",
+    "/api/commands/{id}/parameter-scope",
     "/api/sequences",
     "/api/sequences/{sequenceId}",
     "/api/sequences/{sequenceId}/execute",
+    "/api/sequences/{sequenceId}/parameter-scope",
     "/api/sessions/start",
     "/api/sessions/running",
     "/api/sessions/stop"

--- a/tests/contract/QueueTemplates/ParameterEntryContractTests.cs
+++ b/tests/contract/QueueTemplates/ParameterEntryContractTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.ContractTests.QueueTemplates;
+
+/// <summary>
+/// Feature 078: the queue-template entry's parameter members — supplied values, the override badge
+/// flag, the effective-value preview, and the one blocking error code the save can return.
+/// </summary>
+public sealed class ParameterEntryContractTests {
+  private static WebApplicationFactory<Program> CreateFactory() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    return new WebApplicationFactory<Program>();
+  }
+
+  private static System.Net.Http.HttpClient AuthedClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  /// <summary>
+  /// A template save with <c>overwrite: true</c> is create-or-replace, so it answers 201 the first
+  /// time a name is used and 200 on every later run against the same (persistent) data directory.
+  /// Asserting only 201 would make these tests pass once and fail forever after.
+  /// </summary>
+  private static void ShouldBeSaved(HttpResponseMessage response) =>
+      response.StatusCode.Should().BeOneOf(HttpStatusCode.Created, HttpStatusCode.OK);
+
+  /// <summary>Creates a sequence and returns its id, optionally declaring parameters.</summary>
+  private static async Task<string> CreateSequenceAsync(
+      System.Net.Http.HttpClient client, string name, params object[] parameters) {
+    var response = await client.PostAsJsonAsync("/api/sequences", new {
+      name,
+      version = 1,
+      parameters,
+      steps = new object[] {
+        new { stepId = "s1", stepType = "Action", primitiveAction = new { type = "tap", schemaVersion = "v1", payload = new { x = 1, y = 2 } } }
+      }
+    }).ConfigureAwait(false);
+    response.StatusCode.Should().Be(HttpStatusCode.Created);
+    return JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("id").GetString()!;
+  }
+
+  [Fact]
+  public async Task EntryParameterValuesRoundTripAndSetTheOverrideFlag() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+    var sequenceId = await CreateSequenceAsync(client, "tpl-param-seq").ConfigureAwait(false);
+
+    var save = await client.PostAsJsonAsync("/api/queue-templates", new {
+      name = "Param Template",
+      overwrite = true,
+      entries = new object[] {
+        new {
+          sequenceId,
+          scheduleType = "OncePerRun",
+          parameterValues = new object[] { new { name = "adbSerial", value = "emulator-5560" } }
+        }
+      }
+    }).ConfigureAwait(false);
+
+    ShouldBeSaved(save);
+    var entry = JsonDocument.Parse(await save.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("entries").EnumerateArray().Single();
+
+    entry.GetProperty("hasParameterOverrides").GetBoolean().Should().BeTrue();
+    var value = entry.GetProperty("parameterValues").EnumerateArray().Single();
+    value.GetProperty("name").GetString().Should().Be("adbSerial");
+    value.GetProperty("value").GetString().Should().Be("emulator-5560");
+  }
+
+  [Fact]
+  public async Task AnEntryWithNoValuesReportsNoOverrideAndOmitsTheMember() {
+    // FR-032: templates saved before the feature must not change shape.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+    var sequenceId = await CreateSequenceAsync(client, "tpl-plain-seq").ConfigureAwait(false);
+
+    var save = await client.PostAsJsonAsync("/api/queue-templates", new {
+      name = "Plain Template",
+      overwrite = true,
+      entries = new object[] { new { sequenceId, scheduleType = "OncePerRun" } }
+    }).ConfigureAwait(false);
+
+    ShouldBeSaved(save);
+    var entry = JsonDocument.Parse(await save.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("entries").EnumerateArray().Single();
+
+    entry.GetProperty("hasParameterOverrides").GetBoolean().Should().BeFalse();
+    entry.TryGetProperty("parameterValues", out _)
+        .Should().BeFalse("the member is omitted when the entry supplies nothing");
+  }
+
+  [Fact]
+  public async Task EffectiveParametersPreviewShowsTheValueAndItsOriginatingScope() {
+    // FR-028: the operator can see what a parameter resolves to, and which scope wins, without running.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+    var sequenceId = await CreateSequenceAsync(
+        client, "tpl-effective-seq",
+        new { name = "adbSerial", @default = "emulator-5558" }).ConfigureAwait(false);
+
+    var save = await client.PostAsJsonAsync("/api/queue-templates", new {
+      name = "Effective Template",
+      overwrite = true,
+      entries = new object[] {
+        new {
+          sequenceId,
+          scheduleType = "OncePerRun",
+          parameterValues = new object[] { new { name = "adbSerial", value = "emulator-5560" } }
+        }
+      }
+    }).ConfigureAwait(false);
+
+    var entry = JsonDocument.Parse(await save.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("entries").EnumerateArray().Single();
+
+    var effective = entry.GetProperty("effectiveParameters").EnumerateArray()
+        .Single(e => e.GetProperty("name").GetString() == "adbSerial");
+    effective.GetProperty("value").GetString().Should().Be("emulator-5560");
+    effective.GetProperty("originLayer").GetString().Should().Be("entry",
+        "an entry value outranks the sequence's declared default");
+  }
+
+  [Fact]
+  public async Task EffectiveParametersFallBackToTheDeclaredDefault() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+    var sequenceId = await CreateSequenceAsync(
+        client, "tpl-default-seq",
+        new { name = "adbSerial", @default = "emulator-5558" }).ConfigureAwait(false);
+
+    var save = await client.PostAsJsonAsync("/api/queue-templates", new {
+      name = "Default Template",
+      overwrite = true,
+      entries = new object[] { new { sequenceId, scheduleType = "OncePerRun" } }
+    }).ConfigureAwait(false);
+
+    var entry = JsonDocument.Parse(await save.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("entries").EnumerateArray().Single();
+
+    var effective = entry.GetProperty("effectiveParameters").EnumerateArray()
+        .Single(e => e.GetProperty("name").GetString() == "adbSerial");
+    effective.GetProperty("value").GetString().Should().Be("emulator-5558");
+    effective.GetProperty("originLayer").GetString().Should().Be("default");
+  }
+
+  [Fact]
+  public async Task TwoEntriesOnOneSequenceKeepIndependentValues() {
+    // FR-012: this is what lets several entries share a sequence and differ only by a value.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+    var sequenceId = await CreateSequenceAsync(client, "tpl-two-entries-seq").ConfigureAwait(false);
+
+    var save = await client.PostAsJsonAsync("/api/queue-templates", new {
+      name = "Two Entry Template",
+      overwrite = true,
+      entries = new object[] {
+        new { sequenceId, scheduleType = "OncePerRun", parameterValues = new object[] { new { name = "slot", value = "one" } } },
+        new { sequenceId, scheduleType = "OncePerRun", parameterValues = new object[] { new { name = "slot", value = "two" } } }
+      }
+    }).ConfigureAwait(false);
+
+    var entries = JsonDocument.Parse(await save.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("entries").EnumerateArray().ToList();
+
+    entries.Should().HaveCount(2);
+    entries[0].GetProperty("parameterValues").EnumerateArray().Single()
+        .GetProperty("value").GetString().Should().Be("one");
+    entries[1].GetProperty("parameterValues").EnumerateArray().Single()
+        .GetProperty("value").GetString().Should().Be("two");
+  }
+
+  [Fact]
+  public async Task AReservedValueNameIsRejected() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+    var sequenceId = await CreateSequenceAsync(client, "tpl-reserved-seq").ConfigureAwait(false);
+
+    var save = await client.PostAsJsonAsync("/api/queue-templates", new {
+      name = "Reserved Template",
+      overwrite = true,
+      entries = new object[] {
+        new {
+          sequenceId,
+          scheduleType = "OncePerRun",
+          parameterValues = new object[] { new { name = "iteration", value = "3" } }
+        }
+      }
+    }).ConfigureAwait(false);
+
+    save.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var root = JsonDocument.Parse(await save.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+    root.GetProperty("error").GetString().Should().Be("invalid_parameter_value_name");
+  }
+
+  [Fact]
+  public async Task AnAdHocValueNameIsAcceptedEvenThoughTheSequenceDeclaresNothing() {
+    // FR-012a: an ad-hoc name reaches a command at any depth, so it must not be rejected here.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+    var sequenceId = await CreateSequenceAsync(client, "tpl-adhoc-seq").ConfigureAwait(false);
+
+    var save = await client.PostAsJsonAsync("/api/queue-templates", new {
+      name = "AdHoc Template",
+      overwrite = true,
+      entries = new object[] {
+        new {
+          sequenceId,
+          scheduleType = "OncePerRun",
+          parameterValues = new object[] { new { name = "adbSerial", value = "emulator-5560" } }
+        }
+      }
+    }).ConfigureAwait(false);
+
+    ShouldBeSaved(save);
+  }
+}

--- a/tests/contract/Sequences/ParameterContractTests.cs
+++ b/tests/contract/Sequences/ParameterContractTests.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.ContractTests.Sequences;
+
+/// <summary>
+/// Feature 078: the additive parameter members on the command and sequence APIs — declarations,
+/// step bindings, the numeric field-template overlay, the read-only parameter-scope endpoints, and
+/// every blocking error code from contracts/api.md.
+/// </summary>
+public sealed class ParameterContractTests {
+  private static WebApplicationFactory<Program> CreateFactory() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    return new WebApplicationFactory<Program>();
+  }
+
+  private static System.Net.Http.HttpClient AuthedClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  /// <summary>A key-input command whose key comes from <paramref name="key"/>.</summary>
+  private static object KeyCommandPayload(string name, string key, params object[] parameters) => new {
+    name,
+    parameters,
+    steps = new object[] {
+      new { type = "KeyInput", order = 0, keyInput = new { key } }
+    }
+  };
+
+  private static string? ErrorCode(JsonElement root) =>
+      root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String
+          ? error.GetString()
+          : null;
+
+  // ── Declarations round-trip ──────────────────────────────────────────────
+
+  [Fact]
+  public async Task CommandDeclarationsRoundTripWithEveryField() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var create = await client.PostAsJsonAsync("/api/commands", KeyCommandPayload(
+        "param-roundtrip",
+        "{{keyName}}",
+        new {
+          name = "keyName",
+          type = "text",
+          @default = "KEYCODE_HOME",
+          required = true,
+          description = "Which key to press."
+        })).ConfigureAwait(false);
+
+    create.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = JsonDocument.Parse(await create.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+    var id = created.GetProperty("id").GetString();
+
+    var get = await client.GetAsync(new Uri($"/api/commands/{id}", UriKind.Relative)).ConfigureAwait(false);
+    var fetched = JsonDocument.Parse(await get.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+
+    var declaration = fetched.GetProperty("parameters").EnumerateArray().Single();
+    declaration.GetProperty("name").GetString().Should().Be("keyName");
+    declaration.GetProperty("type").GetString().Should().Be("text");
+    declaration.GetProperty("default").GetString().Should().Be("KEYCODE_HOME");
+    declaration.GetProperty("required").GetBoolean().Should().BeTrue();
+    declaration.GetProperty("description").GetString().Should().Be("Which key to press.");
+  }
+
+  [Fact]
+  public async Task AnUnparametrizedCommandOmitsTheParametersMember() {
+    // FR-032: pre-feature payloads must not gain a member, so nothing in the store is rewritten.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var create = await client.PostAsJsonAsync("/api/commands", new {
+      name = "no-params",
+      steps = new object[] { new { type = "KeyInput", order = 0, keyInput = new { key = "KEYCODE_HOME" } } }
+    }).ConfigureAwait(false);
+
+    var body = await create.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+    create.StatusCode.Should().Be(HttpStatusCode.Created);
+    body.Should().NotContain("\"parameters\"");
+  }
+
+  [Fact]
+  public async Task NumericFieldTemplateOverlayRoundTrips() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var create = await client.PostAsJsonAsync("/api/commands", new {
+      name = "overlay-roundtrip",
+      parameters = new object[] { new { name = "originX", type = "number" } },
+      steps = new object[] {
+        new {
+          type = "Swipe",
+          order = 0,
+          swipe = new { startX = 0, startY = 10, endX = 20, endY = 30 },
+          fieldTemplates = new Dictionary<string, string> { ["swipe.startX"] = "{{originX}}" }
+        }
+      }
+    }).ConfigureAwait(false);
+
+    create.StatusCode.Should().Be(HttpStatusCode.Created);
+    var created = JsonDocument.Parse(await create.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+    var step = created.GetProperty("steps").EnumerateArray().Single();
+    step.GetProperty("fieldTemplates").GetProperty("swipe.startX").GetString().Should().Be("{{originX}}");
+  }
+
+  // ── Blocking error codes ─────────────────────────────────────────────────
+
+  [Fact]
+  public async Task ReservedIterationNameIsRejected() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var response = await client.PostAsJsonAsync("/api/commands", KeyCommandPayload(
+        "reserved-name", "KEYCODE_HOME", new { name = "iteration" })).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+    ErrorCode(root).Should().Be("invalid_parameter_declaration");
+  }
+
+  [Fact]
+  public async Task ReservedQueueNamespaceIsRejected() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var response = await client.PostAsJsonAsync("/api/commands", KeyCommandPayload(
+        "reserved-ns", "KEYCODE_HOME", new { name = "queue.emulatorSerial" })).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    ErrorCode(JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement)
+        .Should().Be("invalid_parameter_declaration");
+  }
+
+  [Fact]
+  public async Task NumericDefaultThatIsNotAWholeNumberIsRejected() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var response = await client.PostAsJsonAsync("/api/commands", KeyCommandPayload(
+        "bad-default", "KEYCODE_HOME",
+        new { name = "waitMs", type = "number", @default = "soon" })).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    ErrorCode(JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement)
+        .Should().Be("invalid_parameter_default");
+  }
+
+  [Fact]
+  public async Task ReferenceToAnUndeclaredNameIsRejectedWithTheOffendingField() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var response = await client.PostAsJsonAsync("/api/commands",
+        KeyCommandPayload("unresolvable", "{{typo}}")).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+    ErrorCode(root).Should().Be("unresolvable_parameter_reference");
+    // FR-029: the detail names the field and the parameter so the UI can anchor the message.
+    var detail = root.GetProperty("details").EnumerateArray().First();
+    detail.GetProperty("fieldPath").GetString().Should().Be("keyInput.key");
+    detail.GetProperty("parameterName").GetString().Should().Be("typo");
+  }
+
+  [Fact]
+  public async Task AQueueBuiltInNeedsNoDeclarationAndIsAccepted() {
+    // The motivating case: referencing the queue's own serial requires nothing to be declared.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var response = await client.PostAsJsonAsync("/api/commands",
+        KeyCommandPayload("built-in-ok", "{{queue.emulatorSerial}}")).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.Created);
+  }
+
+  [Fact]
+  public async Task UnknownFieldTemplatePathIsRejected() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var response = await client.PostAsJsonAsync("/api/commands", new {
+      name = "bad-overlay",
+      parameters = new object[] { new { name = "x", type = "number" } },
+      steps = new object[] {
+        new {
+          type = "KeyInput",
+          order = 0,
+          keyInput = new { key = "KEYCODE_HOME" },
+          fieldTemplates = new Dictionary<string, string> { ["nonsense.path"] = "{{x}}" }
+        }
+      }
+    }).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    ErrorCode(JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement)
+        .Should().Be("unknown_field_template_path");
+  }
+
+  [Fact]
+  public async Task PlaceholderInACommandReferenceFieldIsRejected() {
+    // FR-007: references stay literal so the dangling-reference check keeps working.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var response = await client.PostAsJsonAsync("/api/commands", new {
+      name = "ref-placeholder",
+      parameters = new object[] { new { name = "which" } },
+      steps = new object[] { new { type = "Command", order = 0, targetId = "{{which}}" } }
+    }).ConfigureAwait(false);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    ErrorCode(JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement)
+        .Should().Be("parameter_in_reference_field");
+  }
+
+  // ── Parameter-scope endpoints ────────────────────────────────────────────
+
+  [Fact]
+  public async Task CommandParameterScopeReturnsDeclarationsAndQueueBuiltIns() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var create = await client.PostAsJsonAsync("/api/commands", KeyCommandPayload(
+        "scope-command", "{{keyName}}",
+        new { name = "keyName", description = "Which key." })).ConfigureAwait(false);
+    var id = JsonDocument.Parse(await create.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("id").GetString();
+
+    var scope = await client.GetAsync(new Uri($"/api/commands/{id}/parameter-scope", UriKind.Relative))
+        .ConfigureAwait(false);
+
+    scope.StatusCode.Should().Be(HttpStatusCode.OK);
+    var entries = JsonDocument.Parse(await scope.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("entries").EnumerateArray().ToList();
+
+    entries.Should().Contain(e => e.GetProperty("name").GetString() == "keyName"
+        && e.GetProperty("declared").GetBoolean());
+    foreach (var builtIn in new[] { "queue.emulatorSerial", "queue.instanceName", "queue.instanceIndex", "queue.gameId" }) {
+      entries.Should().Contain(e => e.GetProperty("name").GetString() == builtIn
+          && e.GetProperty("originLayer").GetString() == "queue");
+    }
+  }
+
+  [Fact]
+  public async Task CommandParameterScopeIsNotFoundForAnUnknownCommand() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var scope = await client.GetAsync(new Uri("/api/commands/does-not-exist/parameter-scope", UriKind.Relative))
+        .ConfigureAwait(false);
+
+    scope.StatusCode.Should().Be(HttpStatusCode.NotFound);
+  }
+
+  [Fact]
+  public async Task SequenceParameterScopeReportsStepCalleeDeclarations() {
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var createCommand = await client.PostAsJsonAsync("/api/commands", KeyCommandPayload(
+        "callee", "{{keyName}}", new { name = "keyName" })).ConfigureAwait(false);
+    var commandId = JsonDocument.Parse(await createCommand.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("id").GetString();
+
+    var createSequence = await client.PostAsJsonAsync("/api/sequences", new {
+      name = "scope-sequence",
+      version = 1,
+      steps = new object[] {
+        new {
+          stepId = "s1",
+          stepType = "Action",
+          primitiveAction = new { type = "command", schemaVersion = "v1", payload = new { commandId } }
+        }
+      }
+    }).ConfigureAwait(false);
+    createSequence.StatusCode.Should().Be(HttpStatusCode.Created);
+    var sequenceId = JsonDocument.Parse(await createSequence.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("id").GetString();
+
+    var scope = await client.GetAsync(new Uri($"/api/sequences/{sequenceId}/parameter-scope", UriKind.Relative))
+        .ConfigureAwait(false);
+
+    scope.StatusCode.Should().Be(HttpStatusCode.OK);
+    var root = JsonDocument.Parse(await scope.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+    var callee = root.GetProperty("stepCallees").EnumerateArray().Single();
+    callee.GetProperty("commandId").GetString().Should().Be(commandId);
+    callee.GetProperty("parameters").EnumerateArray()
+        .Should().Contain(p => p.GetProperty("name").GetString() == "keyName");
+  }
+
+  // ── Ad-hoc execute ───────────────────────────────────────────────────────
+
+  [Fact]
+  public async Task ExecutingASequenceWithAnUnsuppliedRequiredParameterIsRefused() {
+    // FR-031: an ad-hoc run has no queue, so nothing can supply a required parameter implicitly.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var create = await client.PostAsJsonAsync("/api/sequences", new {
+      name = "requires-param",
+      version = 1,
+      parameters = new object[] { new { name = "mustSupply", required = true } },
+      steps = new object[] {
+        new { stepId = "s1", stepType = "Action", primitiveAction = new { type = "tap", schemaVersion = "v1", payload = new { x = 1, y = 2 } } }
+      }
+    }).ConfigureAwait(false);
+    create.StatusCode.Should().Be(HttpStatusCode.Created);
+    var id = JsonDocument.Parse(await create.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("id").GetString();
+
+    var execute = await client.PostAsJsonAsync($"/api/sequences/{id}/execute", new { }).ConfigureAwait(false);
+
+    execute.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    var root = JsonDocument.Parse(await execute.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement;
+    ErrorCode(root).Should().Be("missing_required_parameters");
+    root.GetProperty("parameters").EnumerateArray()
+        .Select(p => p.GetString()).Should().Contain("mustSupply");
+  }
+}


### PR DESCRIPTION
## Summary

Closes every task left open when #148 merged, except the one that needs a real emulator.

| Task | What landed |
|---|---|
| **T068** | Parameters section on both sequence forms, plus a per-step binding form on command steps |
| **T072** | Ad-hoc run parameter form |
| **T071** | Backend parameter errors parsed into field-anchored messages |
| **T057/T058** | 21 contract tests; route snapshot updated |
| **T061a** | Inline-validation UI tests |
| **T073/T074** | Guide re-verified against the shipped UI |
| T075 | Still open — needs a live emulator |

## Bugs this work surfaced

- **Responses emitted `"parameters": null` and `"warnings": null`** instead of omitting the members,
  contradicting the documented contract. Confirmed against the running service, which returns
  `"parameters":null` on every command in the list. Now omitted via `JsonIgnore(WhenWritingNull)`.
- **The commands *list* endpoint dropped `parameters`.** The sequence editor renders a binding form
  per command step, so without this it would have refetched every command one at a time to learn what
  each declares.
- **Two order-dependent tests of my own**: the template-save assertions expected `201` unconditionally,
  but `overwrite: true` legitimately answers `200` on any later run against the persistent data
  directory — so they'd have passed once and failed forever after. Verified idempotent by running the
  contract project twice in a row.

## Deliberate non-changes

`executeSequence` keeps its exact arity when no parameters are supplied — passing an explicit
`undefined` third argument would still have changed the call, and the existing test rightly caught it.
Only `update` always sends the full declaration list, because clearing the last declaration has to
persist and an absent member means "leave unchanged" server-side.

## Verification

- **1,246 backend tests** (115 contract, 828 unit, 303 integration)
- **627 web-ui tests** (102 suites)
- `tsc --noEmit`, `eslint`, `vite build` all clean
- Verified in the running app: the Parameters section renders in the sequence editor; the `{ }` picker
  lists the declared parameter plus all four queue built-ins and inserts a valid reference. Nothing was
  saved to the authoring store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
