### PR TITLE
[078] Edit inline action steps in the sequence editor (bump 1.2.0)

### DIFF
--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "1",
-  "minor": "1",
+  "minor": "2",
   "patch": "0",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-07-23T00:00:00Z"
+  "updatedAtUtc": "2026-08-24T00:00:00Z"
 }

--- a/specs/078-sequence-parameters/quickstart.md
+++ b/specs/078-sequence-parameters/quickstart.md
@@ -136,8 +136,9 @@ Commands → open → **Parameters** → **Add**:
 
 Then put the reference into the field and save.
 
-- On the **ADB serial** field of an ensure-emulator-running step, use the **{ }** picker — it lists
-  every name in scope with its description and inserts a valid reference, so you never type braces.
+- On the **ADB serial** field of an ensure-emulator-running step, and on every field of an inline
+  action step (see 3d), use the **{ }** picker — it lists every name in scope with its description
+  and inserts a valid reference, so you never type braces.
 - Other fields are plain inputs for now: type the reference yourself, exactly `{{waitMs}}`. Spelling
   matters — names are case-sensitive, and a name nothing can supply is rejected when you save, naming
   the field and the parameter.
@@ -164,6 +165,33 @@ depth.
 
 If you mistype the name, the entry saves with a warning: *"value 'adbSeril' is not used by anything
 in this entry"*. That warning is the typo detector — do not ignore it.
+
+### 3d. Parametrizing a value that lives in the sequence itself
+
+Some values are not on a command at all. A step that taps a fixed coordinate holds that coordinate in
+the sequence, in what the editor labels **Inline action**. Declare the parameter on the **sequence**
+rather than on a command, because the sequence is what consumes it.
+
+Worked example — *PNS Pit Ensure Mining* enters a fixed field row, and the row is the tap's `y`:
+
+1. Sequences → open the sequence → **Parameters** → **Add**: name `sectionRowY`, type Number,
+   default `569`, description *"Y of the Enter Field row. Row 7 = 569."*
+2. Expand the step labelled `tap (x: 448, y: 569)` — it sits inside an **If** branch — and use the
+   **{ }** picker on the **y** field to insert `{{sectionRowY}}`.
+3. Queue templates → the entry for this sequence → **Parameters** → clear **Inherit** and give each
+   entry its own row. Entries left alone keep the declared default.
+
+Two limits worth knowing before you start:
+
+- **There is no arithmetic in a reference.** You parametrize the coordinate, not the section number:
+  `sectionRowY = 569`, not `section = 7`. If you want to name the row itself, the workable variant is
+  a *string* field that embeds the reference — a detection image id `pit-row-{{section}}` resolves to
+  `pit-row-7` — which needs one reference image per row.
+- **A step's condition is not parametrizable.** Only the action's own fields are substituted, so an
+  `imageVisible` condition on the surrounding If keeps its literal image id.
+
+Fields holding a structured value — an OCR region, say — are shown read-only. They round-trip
+untouched; change them through the API if you need to.
 
 ---
 
@@ -201,6 +229,8 @@ unknown name, rather than resolving to nothing.
 
 - Which command a step runs, and which sequence a template entry runs. These stay literal so the
   "this reference is dangling" check keeps working.
+- A step's **condition** — the image id or step ref it tests. Only action fields are substituted.
+- Arithmetic of any kind inside a reference; a reference resolves to a value, nothing more.
 - `{{iteration}}` outside a loop — it has no meaning there and is rejected at save time.
 
 ### Rolling back

--- a/src/web-ui/src/components/sequences/IfBlock.tsx
+++ b/src/web-ui/src/components/sequences/IfBlock.tsx
@@ -6,6 +6,8 @@ import { IfBlockHeader } from './IfBlockHeader';
 import { BreakStepRow } from './BreakStepRow';
 import { SortableStepItem } from '../SortableStepItem';
 import { DropIndicator, dropIndicatorBefore } from '../DropIndicator';
+import { PrimitiveActionFields } from './PrimitiveActionFields';
+import type { ParameterScopeEntry } from '../parameters/types';
 
 export type CommandOption = { value: string; label: string };
 
@@ -14,6 +16,8 @@ export type IfBlockProps = {
   onChange: (updated: IfStepEntry) => void;
   onRemove: () => void;
   commandOptions?: CommandOption[];
+  /** Names the `{ }` picker may offer inside an inline action's fields. */
+  parameterScope?: ParameterScopeEntry[];
   disabled?: boolean;
   /** True when the if block sits inside a loop body; enables break steps in branches. */
   allowBreakSteps?: boolean;
@@ -35,7 +39,7 @@ type BranchName = 'then' | 'else';
  * loop-body rules (no nested loops or ifs; breaks only when the if sits inside a loop body).
  */
 export const IfBlock: React.FC<IfBlockProps> = ({
-  ifEntry, onChange, onRemove, commandOptions = [], disabled, allowBreakSteps,
+  ifEntry, onChange, onRemove, commandOptions = [], parameterScope = [], disabled, allowBreakSteps,
   isDropInvalid, activeBodyStepId, overBodyStepId,
 }) => {
   const updateBranch = (branch: BranchName, steps: StepEntry[]) => {
@@ -99,6 +103,21 @@ export const IfBlock: React.FC<IfBlockProps> = ({
                         onRemove={() => updateBranch(branch, steps.filter((_, i) => i !== index))}
                         disabled={disabled}
                       />
+                    ) : (step as ActionStepEntry).primitiveAction ? (
+                      <div className="loop-block__action-step" data-testid={`if-${branch}-action-step`}>
+                        <PrimitiveActionFields
+                          idPrefix={`if-${branch}-action-${step.id}`}
+                          action={(step as ActionStepEntry).primitiveAction!}
+                          scope={parameterScope}
+                          disabled={disabled}
+                          onChange={(action) => {
+                            const updated = steps.map((s, i) =>
+                              i === index ? { ...s, primitiveAction: action } as StepEntry : s
+                            );
+                            updateBranch(branch, updated);
+                          }}
+                        />
+                      </div>
                     ) : (
                       <div className="loop-block__action-step" data-testid={`if-${branch}-action-step`}>
                         <select

--- a/src/web-ui/src/components/sequences/LoopBlock.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlock.tsx
@@ -7,6 +7,8 @@ import { IfBlock } from './IfBlock';
 import { BreakStepRow } from './BreakStepRow';
 import { SortableStepItem } from '../SortableStepItem';
 import { DropIndicator, dropIndicatorBefore } from '../DropIndicator';
+import { PrimitiveActionFields } from './PrimitiveActionFields';
+import type { ParameterScopeEntry } from '../parameters/types';
 
 export type CommandOption = { value: string; label: string };
 
@@ -15,6 +17,8 @@ export type LoopBlockProps = {
   onChange: (updated: LoopStepEntry) => void;
   onRemove: () => void;
   commandOptions?: CommandOption[];
+  /** Names the `{ }` picker may offer inside an inline action's fields. */
+  parameterScope?: ParameterScopeEntry[];
   disabled?: boolean;
   isDropInvalid?: boolean;
   activeBodyStepId?: string | null;
@@ -27,7 +31,7 @@ const makeId = () =>
     : Math.random().toString(36).slice(2);
 
 export const LoopBlock: React.FC<LoopBlockProps> = ({
-  loop, onChange, onRemove, commandOptions = [], disabled, isDropInvalid,
+  loop, onChange, onRemove, commandOptions = [], parameterScope = [], disabled, isDropInvalid,
   activeBodyStepId, overBodyStepId,
 }) => {
   const body = loop.body;
@@ -122,12 +126,28 @@ export const LoopBlock: React.FC<LoopBlockProps> = ({
                         }}
                         onRemove={() => handleBodyDelete(index)}
                         commandOptions={commandOptions}
+                        parameterScope={parameterScope}
                         disabled={disabled}
                         allowBreakSteps
                         isDropInvalid={isDropInvalid}
                         activeBodyStepId={activeBodyStepId}
                         overBodyStepId={overBodyStepId}
                       />
+                    ) : (step as ActionStepEntry).primitiveAction ? (
+                      <div className="loop-block__action-step" data-testid="loop-action-step">
+                        <PrimitiveActionFields
+                          idPrefix={`loop-action-${step.id}`}
+                          action={(step as ActionStepEntry).primitiveAction!}
+                          scope={parameterScope}
+                          disabled={disabled}
+                          onChange={(action) => {
+                            const updated = body.map((s, i) =>
+                              i === index ? { ...s, primitiveAction: action } as StepEntry : s
+                            );
+                            onChange({ ...loop, body: updated });
+                          }}
+                        />
+                      </div>
                     ) : (
                       <div className="loop-block__action-step" data-testid="loop-action-step">
                         <select

--- a/src/web-ui/src/components/sequences/PrimitiveActionFields.tsx
+++ b/src/web-ui/src/components/sequences/PrimitiveActionFields.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import type { SequencePrimitiveActionPayload } from '../../types/sequenceFlow';
+import type { ParameterScopeEntry } from '../parameters/types';
+import { ParameterizableField } from '../parameters/ParameterizableField';
+
+/**
+ * How one payload slot is edited. Decided once from the value the sequence was loaded with, not
+ * re-derived on every keystroke: replacing `569` with `{{sectionRowY}}` turns the stored value into a
+ * string, and without a remembered kind the field would silently stop behaving as a numeric one.
+ */
+type FieldKind = 'number' | 'text' | 'boolean' | 'complex';
+
+const kindOf = (value: unknown): FieldKind => {
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'string') return 'text';
+  return 'complex';
+};
+
+const NUMERIC_LITERAL = /^-?\d+(?:\.\d+)?$/;
+
+/**
+ * Puts an edited slot back into the payload.
+ *
+ * A slot that started numeric stays numeric while it holds a plain number, so a field the operator
+ * never touched serializes byte-identically to what was loaded. Anything else — notably a
+ * `{{name}}` reference — is stored as a string, which is exactly what the runner expects: every
+ * consumer parses numeric payload slots defensively, so a reference in a numeric slot resolves.
+ */
+const coerce = (raw: string, kind: FieldKind): string | number =>
+  kind === 'number' && NUMERIC_LITERAL.test(raw.trim()) ? Number(raw.trim()) : raw;
+
+/** One-line description of an inline action, used as the step's collapsed label. */
+export const summarizePrimitiveAction = (action: SequencePrimitiveActionPayload): string => {
+  const scalars = Object.entries(action.payload ?? {})
+    .filter(([, value]) => kindOf(value) !== 'complex')
+    .map(([name, value]) => `${name}: ${String(value)}`);
+  return scalars.length > 0 ? `${action.type} (${scalars.join(', ')})` : action.type;
+};
+
+export type PrimitiveActionFieldsProps = {
+  action: SequencePrimitiveActionPayload;
+  onChange: (action: SequencePrimitiveActionPayload) => void;
+  /** Names offerable by the `{ }` picker — the sequence's declarations plus the queue built-ins. */
+  scope: ParameterScopeEntry[];
+  disabled?: boolean;
+  /** Disambiguates input ids when several of these render on one page. */
+  idPrefix: string;
+};
+
+/**
+ * Editor for a sequence step that dispatches an action inline rather than invoking a command
+ * (feature 078).
+ *
+ * Before this existed the editor understood only `command`, `WaitForImage` and `reschedule-self`
+ * steps; every other action type fell through to the command branch and was rewritten on save into a
+ * command step pointing at an id that had never existed. That made a sequence like "PNS Pit Ensure
+ * Mining" — six `tap` steps and two `reschedule-self` steps inside if-branches — unsafe to open here
+ * at all. Rendering the action's own payload keeps such steps intact and, because each scalar slot is
+ * a {@link ParameterizableField}, lets a hard-coded coordinate become a parameter reference without
+ * anyone hand-editing JSON.
+ *
+ * Slots holding an object or array (an OCR region, say) are preserved verbatim and shown read-only:
+ * they round-trip untouched, which matters more than editing them here.
+ */
+export const PrimitiveActionFields: React.FC<PrimitiveActionFieldsProps> = ({
+  action, onChange, scope, disabled, idPrefix,
+}) => {
+  const payload = action.payload ?? {};
+  const [kinds] = useState<Record<string, FieldKind>>(() =>
+    Object.fromEntries(Object.entries(payload).map(([name, value]) => [name, kindOf(value)])));
+
+  const setSlot = (name: string, value: string | number | boolean) => {
+    onChange({ ...action, payload: { ...payload, [name]: value } });
+  };
+
+  const entries = Object.entries(payload);
+
+  return (
+    <div className="primitive-action-fields" data-testid="primitive-action-fields">
+      <p className="primitive-action-fields__type">
+        Inline action: <code data-testid="primitive-action-type">{action.type}</code>
+      </p>
+
+      {entries.length === 0 && (
+        <p className="primitive-action-fields__empty">This action takes no parameters.</p>
+      )}
+
+      {entries.map(([name, value]) => {
+        const kind = kinds[name] ?? kindOf(value);
+        const fieldId = `${idPrefix}-${name}`;
+
+        if (kind === 'complex') {
+          return (
+            <div key={name} className="primitive-action-fields__field primitive-action-fields__field--complex">
+              <span className="primitive-action-fields__label">{name}</span>
+              <pre data-testid={`primitive-action-complex-${name}`}>{JSON.stringify(value, null, 2)}</pre>
+              <p className="primitive-action-fields__hint">
+                Structured values are kept exactly as saved; edit them through the API.
+              </p>
+            </div>
+          );
+        }
+
+        if (kind === 'boolean') {
+          return (
+            <div key={name} className="primitive-action-fields__field">
+              <label htmlFor={fieldId}>
+                <input
+                  id={fieldId}
+                  type="checkbox"
+                  checked={value === true}
+                  disabled={disabled}
+                  onChange={(event) => setSlot(name, event.target.checked)}
+                />
+                {name}
+              </label>
+            </div>
+          );
+        }
+
+        return (
+          <div key={name} className="primitive-action-fields__field">
+            <ParameterizableField
+              id={fieldId}
+              label={name}
+              value={String(value ?? '')}
+              numeric={kind === 'number'}
+              scope={scope}
+              disabled={disabled}
+              onChange={(next) => setSlot(name, coerce(next, kind))}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -8,6 +8,7 @@ import { listCommands, CommandDto } from '../services/commands';
 import { ParameterDeclarationList } from '../components/parameters/ParameterDeclarationList';
 import { ParameterBindingForm } from '../components/parameters/ParameterBindingForm';
 import type { ParameterBinding, ParameterDeclaration } from '../components/parameters/types';
+import { buildEditorScope } from '../components/parameters/types';
 import { FormError } from '../components/Form';
 import { FormActions, FormSection } from '../components/unified/FormLayout';
 import { SearchableDropdown, SearchableOption } from '../components/SearchableDropdown';
@@ -19,7 +20,8 @@ import { validatePerStepConditions, parseParameterErrors, parameterErrorSummary 
 import { isLinearStepArray, toCommandStepIds, toInterStepDelayRange, toLinearSteps } from '../lib/sequenceMapping';
 import { LoopBlock } from '../components/sequences/LoopBlock';
 import { IfBlock } from '../components/sequences/IfBlock';
-import type { LoopStepEntry, BreakStepEntry, IfStepEntry, StepEntry } from '../types/stepEntry';
+import { PrimitiveActionFields, summarizePrimitiveAction } from '../components/sequences/PrimitiveActionFields';
+import type { ActionStepEntry, LoopStepEntry, BreakStepEntry, IfStepEntry, StepEntry } from '../types/stepEntry';
 import type { SequenceLinearStep, LoopConfigDto, IfConfigDto, SequencePrimitiveActionPayload, SequenceCommandReference } from '../types/sequenceFlow';
 import { ImageSelectorDropdown } from '../components/images/ImageSelectorDropdown';
 
@@ -28,10 +30,17 @@ type RescheduleOption = 'AtQueueStart' | 'OncePerRun' | 'Timer' | 'EveryStep';
 type SequenceStep = {
   id: string;
   stepId: string;
+  /** Authored display name; preserved verbatim so editing a step here does not strip other labels. */
+  label?: string;
   stepType: 'Action' | 'Loop' | 'Break' | 'If';
-  actionType: 'command' | 'WaitForImage' | 'reschedule-self';
+  actionType: 'command' | 'WaitForImage' | 'reschedule-self' | 'primitive';
   commandId: string;
   commandReference?: SequenceCommandReference;
+  /**
+   * The action dispatched inline, for a step that is not a command invocation and has no dedicated
+   * editor of its own (feature 078). Carried through untouched apart from the slots edited here.
+   */
+  primitiveAction?: SequencePrimitiveActionPayload;
   waitReferenceImageId: string;
   waitConfidence: string;
   waitTimeoutMs: string;
@@ -282,6 +291,16 @@ const getPrimitiveAction = (step: SequenceLinearStep): SequencePrimitiveActionPa
   return null;
 };
 
+/**
+ * True for an action that dispatches inline rather than invoking a command.
+ *
+ * Everything the editor cannot render as a command step used to be coerced into one, which rewrote
+ * the step to point at a command id that had never existed. Recognising these instead lets them
+ * round-trip and be parametrized.
+ */
+const isInlineAction = (action: SequencePrimitiveActionPayload | null): boolean =>
+  action != null && action.type.trim().length > 0 && action.type !== 'command';
+
 const linearBodyToStepEntries = (body: SequenceLinearStep[]): StepEntry[] => {
   return body.map<StepEntry>((child) => {
     if (child.stepType === 'Break') {
@@ -289,6 +308,7 @@ const linearBodyToStepEntries = (body: SequenceLinearStep[]): StepEntry[] => {
         type: 'Break',
         id: makeId(),
         stepId: child.stepId,
+        label: child.label,
         breakCondition: child.breakCondition ?? undefined
       } satisfies BreakStepEntry;
     }
@@ -296,17 +316,22 @@ const linearBodyToStepEntries = (body: SequenceLinearStep[]): StepEntry[] => {
       return ifDtoToEntry(child);
     }
     const primitiveAction = getPrimitiveAction(child);
-    const cmdId = typeof primitiveAction?.payload?.commandId === 'string'
-      ? primitiveAction.payload.commandId
-      : typeof child.action?.parameters?.commandId === 'string'
-        ? child.action.parameters.commandId
-      : child.stepId;
+    const inline = isInlineAction(primitiveAction);
+    const cmdId = inline
+      ? ''
+      : typeof primitiveAction?.payload?.commandId === 'string'
+        ? primitiveAction.payload.commandId
+        : typeof child.action?.parameters?.commandId === 'string'
+          ? child.action.parameters.commandId
+          : child.stepId;
     return {
       type: 'Action',
       id: makeId(),
       stepId: child.stepId,
+      label: child.label,
       commandId: cmdId,
-      commandReference: child.commandReference ?? undefined,
+      commandReference: inline ? undefined : child.commandReference ?? undefined,
+      primitiveAction: inline ? primitiveAction! : undefined,
       conditionType: child.condition?.type === 'imageVisible' ? 'imageVisible'
         : child.condition?.type === 'commandOutcome' ? 'commandOutcome' : 'none',
       conditionNegate: child.condition?.negate ?? false,
@@ -322,6 +347,7 @@ const ifDtoToEntry = (step: SequenceLinearStep): IfStepEntry => ({
   type: 'If',
   id: makeId(),
   stepId: step.stepId,
+  label: step.label,
   condition: step.if?.condition,
   body: linearBodyToStepEntries(step.body ?? []),
   elseBody: step.elseBody == null ? undefined : linearBodyToStepEntries(step.elseBody)
@@ -329,7 +355,7 @@ const ifDtoToEntry = (step: SequenceLinearStep): IfStepEntry => ({
 
 const loopDtoToEntry = (step: SequenceLinearStep): LoopStepEntry => {
   const loop = step.loop!;
-  const base: Pick<LoopStepEntry, 'type' | 'id' | 'stepId'> = { type: 'Loop', id: makeId(), stepId: step.stepId };
+  const base: Pick<LoopStepEntry, 'type' | 'id' | 'stepId' | 'label'> = { type: 'Loop', id: makeId(), stepId: step.stepId, label: step.label };
   const body = linearBodyToStepEntries(step.body ?? []);
   if (loop.loopType === 'count') {
     return { ...base, loopType: 'count', count: loop.count, maxIterations: loop.maxIterations ?? undefined, body };
@@ -341,8 +367,12 @@ const loopDtoToEntry = (step: SequenceLinearStep): LoopStepEntry => {
   return { ...base, loopType: 'repeatUntil', condition: loop.condition, maxIterations: loop.maxIterations ?? undefined, body };
 };
 
-const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] => {
-  return steps.map((step) => {
+const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
+  // The label is attached here rather than in each branch below so no future branch can forget it.
+  steps.map((step) => ({ ...linearStepToFormStep(step), label: step.label }));
+
+const linearStepToFormStep = (step: SequenceLinearStep): SequenceStep => {
+  {
     if (step.stepType === 'Loop' && step.loop) {
       const loopEntry = loopDtoToEntry(step);
       return {
@@ -480,6 +510,17 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
       };
     }
 
+    // Any other inline action — a tap, a swipe, a key press. Rendered from its own payload rather
+    // than coerced into a command step, which is what used to corrupt it on save.
+    if (isInlineAction(primitiveAction)) {
+      return {
+        ...createDefaultStep('', step.stepId),
+        actionType: 'primitive' as const,
+        primitiveAction: primitiveAction!,
+        ...conditionFieldsFrom(step),
+      };
+    }
+
     const commandId = typeof primitiveAction?.payload?.commandId === 'string'
       ? primitiveAction.payload.commandId
       : typeof step.action?.parameters?.commandId === 'string'
@@ -533,7 +574,41 @@ const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
       stepId: step.stepId,
       parameterBindings: step.parameterBindings ?? undefined
     };
-  });
+  }
+};
+
+/** The condition half of a form step, shared by branches that differ only in their action fields. */
+const conditionFieldsFrom = (step: SequenceLinearStep): Pick<
+  SequenceStep, 'conditionType' | 'conditionNegate' | 'imageId' | 'minSimilarity' | 'outcomeStepRef' | 'expectedState'
+> => {
+  if (step.condition?.type === 'imageVisible') {
+    return {
+      conditionType: 'imageVisible',
+      conditionNegate: step.condition.negate ?? false,
+      imageId: step.condition.imageId,
+      minSimilarity: step.condition.minSimilarity == null ? '' : String(step.condition.minSimilarity),
+      outcomeStepRef: '',
+      expectedState: 'success',
+    };
+  }
+  if (step.condition?.type === 'commandOutcome') {
+    return {
+      conditionType: 'commandOutcome',
+      conditionNegate: step.condition.negate ?? false,
+      imageId: '',
+      minSimilarity: '',
+      outcomeStepRef: step.condition.stepRef,
+      expectedState: step.condition.expectedState,
+    };
+  }
+  return {
+    conditionType: 'none',
+    conditionNegate: false,
+    imageId: '',
+    minSimilarity: '',
+    outcomeStepRef: '',
+    expectedState: 'success',
+  };
 };
 
 const buildCommandReferencePayload = (commandId: string, commandReference: SequenceCommandReference | undefined) => {
@@ -591,6 +666,7 @@ const buildIfConfigPayload = (ifEntry: IfStepEntry): IfConfigDto | null =>
 
 const ifEntryToPayloadStep = (ifEntry: IfStepEntry, stepId: string): SequenceLinearStep => ({
   stepId: stepId.trim(),
+  label: ifEntry.label,
   stepType: 'If',
   if: buildIfConfigPayload(ifEntry),
   body: ifEntry.body.map(bodyEntryToPayloadStep),
@@ -602,6 +678,7 @@ const bodyEntryToPayloadStep = (entry: StepEntry): SequenceLinearStep => {
     const br = entry as BreakStepEntry;
     return {
       stepId: br.stepId.trim(),
+      label: br.label,
       stepType: 'Break',
       breakCondition: br.breakCondition ?? null
     };
@@ -610,14 +687,27 @@ const bodyEntryToPayloadStep = (entry: StepEntry): SequenceLinearStep => {
     return ifEntryToPayloadStep(entry, entry.stepId);
   }
   // Action body step
-  const a = entry as unknown as { stepId: string; commandId: string; commandReference?: SequenceCommandReference; conditionType: string; conditionNegate: boolean; imageId: string; minSimilarity: string; outcomeStepRef: string; expectedState: 'success' | 'failed' | 'skipped' };
+  const a = entry as ActionStepEntry;
   const cond = a.conditionType === 'imageVisible'
     ? { type: 'imageVisible' as const, imageId: a.imageId.trim(), minSimilarity: a.minSimilarity.trim() === '' ? null : Number(a.minSimilarity), negate: a.conditionNegate || undefined }
     : a.conditionType === 'commandOutcome'
       ? { type: 'commandOutcome' as const, stepRef: a.outcomeStepRef.trim(), expectedState: a.expectedState, negate: a.conditionNegate || undefined }
       : null;
+
+  // An inline action goes back exactly as it came in, apart from the slots edited in the form.
+  if (a.primitiveAction) {
+    return {
+      stepId: entry.stepId.trim(),
+      label: a.label,
+      stepType: 'Action',
+      primitiveAction: a.primitiveAction,
+      condition: cond
+    };
+  }
+
   return {
     stepId: entry.stepId.trim(),
+    label: a.label,
     stepType: 'Action',
     primitiveAction: { type: 'command', schemaVersion: 'v1', payload: { commandId: a.commandId } },
     commandReference: buildCommandReferencePayload(a.commandId, a.commandReference),
@@ -630,6 +720,7 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
     if (step.stepType === 'Loop' && step.loopEntry) {
       return {
         stepId: step.stepId.trim(),
+        label: step.label,
         stepType: 'Loop' as const,
         loop: buildLoopConfigPayload(step.loopEntry),
         body: step.loopEntry.body.map(bodyEntryToPayloadStep)
@@ -637,14 +728,25 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
     }
 
     if (step.stepType === 'If' && step.ifEntry) {
-      return ifEntryToPayloadStep(step.ifEntry, step.stepId);
+      return { ...ifEntryToPayloadStep(step.ifEntry, step.stepId), label: step.label };
     }
 
     if (step.stepType === 'Break') {
       return {
         stepId: step.stepId.trim(),
+        label: step.label,
         stepType: 'Break' as const,
         breakCondition: null // top-level breaks are unconditional
+      };
+    }
+
+    if (step.actionType === 'primitive' && step.primitiveAction) {
+      return {
+        stepId: step.stepId.trim(),
+        label: step.label,
+        stepType: 'Action' as const,
+        primitiveAction: step.primitiveAction,
+        condition: buildConditionPayload(step)
       };
     }
 
@@ -661,6 +763,7 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
       }
       return {
         stepId: step.stepId.trim(),
+        label: step.label,
         stepType: 'Action' as const,
         primitiveAction: { type: 'reschedule-self', schemaVersion: '1', payload },
         condition: buildConditionPayload(step)
@@ -677,6 +780,7 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
 
       return {
         stepId: step.stepId.trim(),
+        label: step.label,
         stepType: 'Action' as const,
         primitiveAction: {
           type: 'WaitForImage',
@@ -692,6 +796,7 @@ const toLinearPayloadSteps = (steps: SequenceStep[]): SequenceLinearStep[] => {
 
     return {
       stepId: step.stepId.trim(),
+      label: step.label,
       stepType: 'Action' as const,
       primitiveAction: {
         type: 'command',
@@ -745,6 +850,13 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
   const [activeStepId, setActiveStepId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
   const [isDragInvalid, setIsDragInvalid] = useState(false);
+
+  /**
+   * What the `{ }` picker offers inside this editor: the sequence's own declarations plus the queue
+   * built-ins. Derived from the live form rather than the saved sequence, so a parameter declared a
+   * moment ago is immediately insertable into a step.
+   */
+  const editorParameterScope = useMemo(() => buildEditorScope(form.parameters), [form.parameters]);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
@@ -964,6 +1076,26 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 ...prev,
                 steps: prev.steps.map((candidate) => candidate.id === step.id
                   ? { ...candidate, parameterBindings: bindings }
+                  : candidate)
+              }));
+              setDirty(true);
+            }}
+          />
+        </div>
+      )}
+
+      {step.stepType === 'Action' && step.actionType === 'primitive' && step.primitiveAction && (
+        <div className="sequence-step-condition-field sequence-step-condition-field--primitive-action">
+          <PrimitiveActionFields
+            idPrefix={`step-action-${step.id}`}
+            action={step.primitiveAction}
+            scope={editorParameterScope}
+            disabled={submitting || loading}
+            onChange={(action) => {
+              setForm((prev) => ({
+                ...prev,
+                steps: prev.steps.map((candidate) => candidate.id === step.id
+                  ? { ...candidate, primitiveAction: action }
                   : candidate)
               }));
               setDirty(true);
@@ -1273,7 +1405,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
         </div>
       )}
     </div>
-  ), [form.steps, submitting, loading, commandParameters]);
+  ), [form.steps, submitting, loading, commandParameters, editorParameterScope]);
 
   const createLoopStep = (loopType: 'count' | 'while' | 'repeatUntil'): SequenceStep => {
     const id = makeId();
@@ -1360,6 +1492,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 setDirty(true);
               }}
               commandOptions={editorCommandOptions}
+              parameterScope={editorParameterScope}
               disabled={submitting || loading}
               isDropInvalid={isDragInvalid}
               activeBodyStepId={branchStepIds.includes(activeStepId ?? '') ? activeStepId : null}
@@ -1389,6 +1522,7 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
                 setDirty(true);
               }}
               commandOptions={editorCommandOptions}
+              parameterScope={editorParameterScope}
               disabled={submitting || loading}
               isDropInvalid={isDragInvalid}
               activeBodyStepId={collectBodyStepIds(s.loopEntry.body).includes(activeStepId ?? '') ? activeStepId : null}
@@ -1403,11 +1537,13 @@ export const SequencesPage: React.FC<SequencesPageProps> = ({ initialCreate, ini
           ? `Wait for image: ${s.waitReferenceImageId.trim() || 'any image'}`
           : s.actionType === 'reschedule-self'
             ? `Reschedule this sequence (${RESCHEDULE_OPTIONS.find((o) => o.value === (s.rescheduleOption ?? 'OncePerRun'))?.label})`
-            : getDisplayCommandLabel(s.commandId, s.commandReference, commandLookup),
+            : s.actionType === 'primitive' && s.primitiveAction
+              ? summarizePrimitiveAction(s.primitiveAction)
+              : getDisplayCommandLabel(s.commandId, s.commandReference, commandLookup),
         details: renderStepConditionEditor(s, idx),
       };
     });
-  }, [form.steps, editorCommandOptions, commandLookup, submitting, loading, renderStepConditionEditor, isDragInvalid, activeStepId, overId]);
+  }, [form.steps, editorCommandOptions, commandLookup, submitting, loading, renderStepConditionEditor, editorParameterScope, isDragInvalid, activeStepId, overId]);
 
   const validate = (v: SequenceFormValue): Record<string, string> | undefined => {
     const next: Record<string, string> = {};

--- a/src/web-ui/src/pages/__tests__/SequencesPage.inlineActions.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.inlineActions.spec.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SequencesPage } from '../SequencesPage';
+import { getSequence, listSequences, updateSequence } from '../../services/sequences';
+import { listCommands } from '../../services/commands';
+
+jest.mock('../../services/sequences');
+jest.mock('../../services/commands');
+
+jest.mock('../../components/images/ImageSelectorDropdown', () => ({
+  ImageSelectorDropdown: ({ id, label, value, onChange, disabled }: {
+    id?: string; label?: string; value: string; onChange: (v: string) => void; disabled?: boolean;
+  }) => (
+    <>
+      {label && <label htmlFor={id}>{label}</label>}
+      <input id={id} value={value} disabled={disabled} onChange={(e) => onChange(e.target.value)} />
+    </>
+  ),
+}));
+
+const listSequencesMock = listSequences as jest.MockedFunction<typeof listSequences>;
+const getSequenceMock = getSequence as jest.MockedFunction<typeof getSequence>;
+const updateSequenceMock = updateSequence as jest.MockedFunction<typeof updateSequence>;
+const listCommandsMock = listCommands as jest.MockedFunction<typeof listCommands>;
+
+/**
+ * A cut-down "PNS Pit Ensure Mining": a top-level tap, a tap inside an if-branch, and a
+ * self-reschedule inside an if-branch whose payload carries a nested OCR region. Every one of these
+ * shapes used to be rewritten into a command step on save, because the editor understood only
+ * command / WaitForImage / reschedule-self steps at the top level and only command steps in bodies.
+ */
+const pitLikeSequence = () => ({
+  id: 'seq-pit',
+  name: 'PNS Pit Ensure Mining',
+  version: 7,
+  parameters: [
+    { name: 'sectionRowY', type: 'number', default: '569', required: false, description: 'Y of the Enter Field row.' },
+  ],
+  steps: [
+    {
+      stepId: 'open-rail',
+      label: 'Open the side rail',
+      stepType: 'Action',
+      primitiveAction: { type: 'tap', schemaVersion: 'v1', payload: { x: 37, y: 358 } },
+    },
+    {
+      stepId: 'enter7',
+      label: 'Enter field row 7',
+      stepType: 'If',
+      if: { condition: { type: 'imageVisible', imageId: 'rare-earth-title', minSimilarity: 0.8 } },
+      body: [
+        {
+          stepId: 'enter7-tap',
+          label: 'Tap Enter Field row7',
+          stepType: 'Action',
+          primitiveAction: { type: 'tap', schemaVersion: 'v1', payload: { x: 448, y: 569 } },
+        },
+      ],
+    },
+    {
+      stepId: 'success',
+      label: 'Reschedule on success',
+      stepType: 'If',
+      if: { condition: { type: 'imageVisible', imageId: 'gather-ok', minSimilarity: null } },
+      body: [
+        {
+          stepId: 'resched-success',
+          label: 'Reschedule from the OCR countdown',
+          stepType: 'Action',
+          primitiveAction: {
+            type: 'reschedule-self',
+            schemaVersion: '1',
+            payload: {
+              option: 'Timer',
+              ocrOffset: { region: { x: 2, y: 228, width: 78, height: 18 }, fallback: '02:05:00' },
+            },
+          },
+        },
+      ],
+    },
+  ],
+});
+
+const openEditor = async () => {
+  render(<SequencesPage />);
+  await screen.findByText('PNS Pit Ensure Mining');
+  fireEvent.click(screen.getByText('PNS Pit Ensure Mining'));
+  await screen.findByText('Edit Sequence');
+};
+
+const savedSteps = () => (updateSequenceMock.mock.calls[0][1] as { steps: any[] }).steps;
+
+describe('SequencesPage inline (non-command) action steps', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    listCommandsMock.mockResolvedValue([{ id: 'cmd-back', name: 'Back' }] as any);
+    listSequencesMock.mockResolvedValue([{ id: 'seq-pit', name: 'PNS Pit Ensure Mining', steps: [] }] as any);
+    getSequenceMock.mockResolvedValue(pitLikeSequence() as any);
+    updateSequenceMock.mockResolvedValue({ id: 'seq-pit', name: 'PNS Pit Ensure Mining', steps: [] } as any);
+  });
+
+  it('renders an inline action from its own payload rather than as a command step', async () => {
+    await openEditor();
+
+    // Top-level tap: both coordinates are editable fields, not a command dropdown.
+    expect(screen.getAllByLabelText('x')[0]).toHaveValue('37');
+    expect(screen.getAllByLabelText('y')[0]).toHaveValue('358');
+    expect(screen.getAllByTestId('primitive-action-type').map((n) => n.textContent))
+      .toEqual(expect.arrayContaining(['tap', 'reschedule-self']));
+  });
+
+  it('round-trips every step untouched when nothing is edited', async () => {
+    await openEditor();
+
+    fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'PNS Pit Ensure Mining' } });
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(updateSequenceMock).toHaveBeenCalled());
+
+    const steps = savedSteps();
+    expect(steps[0]).toMatchObject({
+      stepId: 'open-rail',
+      label: 'Open the side rail',
+      primitiveAction: { type: 'tap', payload: { x: 37, y: 358 } },
+    });
+
+    // The if-branch tap survives with numeric coordinates, not as a command id of 'enter7-tap'.
+    expect(steps[1].body[0]).toMatchObject({
+      stepId: 'enter7-tap',
+      label: 'Tap Enter Field row7',
+      primitiveAction: { type: 'tap', payload: { x: 448, y: 569 } },
+    });
+    expect(steps[1].body[0].primitiveAction.payload).not.toHaveProperty('commandId');
+
+    // The nested OCR region is carried through byte-for-byte; the editor never reshapes it.
+    expect(steps[2].body[0].primitiveAction).toMatchObject({
+      type: 'reschedule-self',
+      payload: {
+        option: 'Timer',
+        ocrOffset: { region: { x: 2, y: 228, width: 78, height: 18 }, fallback: '02:05:00' },
+      },
+    });
+  });
+
+  it('replaces a hard-coded coordinate with a parameter reference', async () => {
+    await openEditor();
+
+    // The two taps both expose a 'y'; the second is the one inside the if-branch.
+    const yFields = screen.getAllByLabelText('y');
+    fireEvent.change(yFields[1], { target: { value: '{{sectionRowY}}' } });
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(updateSequenceMock).toHaveBeenCalled());
+
+    const tap = savedSteps()[1].body[0].primitiveAction;
+    // A reference goes out as a string in the numeric slot — the runner parses these defensively.
+    expect(tap.payload.y).toBe('{{sectionRowY}}');
+    expect(tap.payload.x).toBe(448);
+  });
+
+  it('offers the sequence parameters and queue built-ins in an inline action field', async () => {
+    await openEditor();
+
+    fireEvent.click(screen.getAllByLabelText('Insert parameter into y')[1]);
+    expect(screen.getByRole('option', { name: /sectionRowY/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /queue\.emulatorSerial/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('option', { name: /sectionRowY/ }));
+    expect(screen.getAllByLabelText('y')[1]).toHaveValue('{{sectionRowY}}');
+  });
+
+  it('preserves step labels on steps the operator never opened', async () => {
+    await openEditor();
+
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(updateSequenceMock).toHaveBeenCalled());
+
+    expect(savedSteps().map((s: any) => s.label))
+      .toEqual(['Open the side rail', 'Enter field row 7', 'Reschedule on success']);
+  });
+});

--- a/src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/SequencesPage.unresolvedCommand.spec.tsx
@@ -70,6 +70,8 @@ describe('SequencesPage unresolved commands', () => {
       steps: [
         {
           stepId: 'step-1',
+          // The authored label survives a save; it used to be stripped by any edit made here.
+          label: 'Deleted command step',
           stepType: 'Action',
           primitiveAction: {
             type: 'command',

--- a/src/web-ui/src/types/stepEntry.ts
+++ b/src/web-ui/src/types/stepEntry.ts
@@ -1,4 +1,4 @@
-import type { SequenceCommandReference, SequenceStepCondition } from './sequenceFlow';
+import type { SequenceCommandReference, SequencePrimitiveActionPayload, SequenceStepCondition } from './sequenceFlow';
 
 /** Discriminated union for all step types in the sequence form editor. */
 export type StepEntry =
@@ -11,9 +11,18 @@ export type ActionStepEntry = {
   type: 'Action';
   id: string;
   stepId: string;
+  /** Authored display name; preserved on save so opening a sequence here does not strip labels. */
+  label?: string;
   commandId: string;
   commandReference?: SequenceCommandReference;
+  /**
+   * Set when the step dispatches an action inline (a tap, a self-reschedule) instead of invoking a
+   * command. The payload is carried through untouched so a body step the editor has no rich form for
+   * still round-trips, and its scalar slots stay parametrizable.
+   */
+  primitiveAction?: SequencePrimitiveActionPayload;
   conditionType: 'none' | 'imageVisible' | 'commandOutcome';
+  conditionNegate?: boolean;
   imageId: string;
   minSimilarity: string;
   outcomeStepRef: string;
@@ -24,6 +33,7 @@ export type LoopStepEntry = {
   type: 'Loop';
   id: string;
   stepId: string;
+  label?: string;
   loopType: 'count' | 'while' | 'repeatUntil';
   count?: number;
   condition?: SequenceStepCondition;
@@ -35,6 +45,7 @@ export type BreakStepEntry = {
   type: 'Break';
   id: string;
   stepId: string;
+  label?: string;
   breakCondition?: SequenceStepCondition;
 };
 
@@ -42,6 +53,7 @@ export type IfStepEntry = {
   type: 'If';
   id: string;
   stepId: string;
+  label?: string;
   /** Same condition shape as while/repeat-until loop conditions. */
   condition?: SequenceStepCondition;
   /** Then branch; behaves like a loop body (no nested loops or ifs). */

--- a/tests/unit/Sequences/SequenceRunnerScopeTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerScopeTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Parameters;
+using GameBot.Domain.Services;
+using Xunit;
+
+// Test-code analyzer relaxations (permitted by the constitution for test code).
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Feature 078: parameter substitution inside a sequence's own <b>inline action payloads</b> — the
+/// shape that carries tap coordinates.
+/// <para>
+/// This is the real-world case behind the Pit "which section to enter" question: the section is not a
+/// numeric field anywhere, it is a fixed tap coordinate in an inline action step. A numeric payload
+/// slot accepts a <c>{{name}}</c> string because every consumer parses defensively, so no schema
+/// change is needed — these tests pin that down so it cannot regress.
+/// </para>
+/// </summary>
+public sealed class SequenceRunnerScopeTests {
+  private sealed class StubRepo : ISequenceRepository {
+    private readonly CommandSequence _sequence;
+    public StubRepo(CommandSequence sequence) => _sequence = sequence;
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_sequence);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() => Task.FromResult<IReadOnlyList<CommandSequence>>(new List<CommandSequence> { _sequence });
+    public Task<CommandSequence> CreateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<CommandSequence> UpdateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+  }
+
+  /// <summary>A sequence with one inline tap whose Y comes from <paramref name="yValue"/>.</summary>
+  private static CommandSequence TapSequence(object yValue, params ParameterDeclaration[] declarations) {
+    var sequence = new CommandSequence { Id = "pit", Name = "Pit Ensure Mining" };
+    foreach (var declaration in declarations) sequence.Parameters.Add(declaration);
+    sequence.SetSteps(new[] {
+      new SequenceStep {
+        Order = 0,
+        StepId = "enter-row",
+        StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload {
+          Type = ActionTypes.Tap,
+          Parameters = { ["x"] = 448, ["y"] = yValue }
+        }
+      }
+    });
+    return sequence;
+  }
+
+  private static async Task<SequenceActionPayload?> RunCapturingPayloadAsync(
+      CommandSequence sequence, ParameterScope scope) {
+    var runner = new SequenceRunner(new StubRepo(sequence));
+    SequenceActionPayload? captured = null;
+
+    await runner.ExecuteAsync(
+      sequence.Id,
+      (_, _) => Task.CompletedTask,
+      actionDispatcher: (payload, _) => {
+        captured = payload;
+        return Task.FromResult(new ActionDispatchResult("executed", null));
+      },
+      scope: scope,
+      ct: CancellationToken.None);
+
+    return captured;
+  }
+
+  [Fact]
+  public async Task InlineTapCoordinateResolvesFromASequenceParameter() {
+    // The Pit case: the row to tap is supplied per queue-template entry rather than hard-coded.
+    var sequence = TapSequence("{{sectionRowY}}", new ParameterDeclaration {
+      Name = "sectionRowY", Type = ParameterValueType.Number
+    });
+    var scope = ParameterScope.Empty
+        .Child(ParameterScopeLayers.Entry,
+            new Collection<ParameterBinding> { new() { Name = "sectionRowY", Value = "569" } },
+            null);
+
+    var payload = await RunCapturingPayloadAsync(sequence, scope);
+
+    payload.Should().NotBeNull();
+    payload!.Parameters["y"].Should().Be("569");
+    payload.Parameters["x"].Should().Be(448, "an unparametrized slot keeps its stored numeric value");
+  }
+
+  [Fact]
+  public async Task InlineTapCoordinateFallsBackToTheDeclaredDefault() {
+    var sequence = TapSequence("{{sectionRowY}}", new ParameterDeclaration {
+      Name = "sectionRowY", Type = ParameterValueType.Number, Default = "569"
+    });
+
+    var payload = await RunCapturingPayloadAsync(sequence, ParameterScope.Empty);
+
+    payload!.Parameters["y"].Should().Be("569");
+  }
+
+  [Fact]
+  public async Task EntryValueOverridesTheDeclaredDefaultForAnInlineTap() {
+    var sequence = TapSequence("{{sectionRowY}}", new ParameterDeclaration {
+      Name = "sectionRowY", Type = ParameterValueType.Number, Default = "569"
+    });
+    var scope = ParameterScope.Empty
+        .Child(ParameterScopeLayers.Entry,
+            new Collection<ParameterBinding> { new() { Name = "sectionRowY", Value = "631" } },
+            null);
+
+    var payload = await RunCapturingPayloadAsync(sequence, scope);
+
+    payload!.Parameters["y"].Should().Be("631");
+  }
+
+  [Fact]
+  public async Task AQueueBuiltInResolvesInsideAnInlineActionPayload() {
+    var sequence = new CommandSequence { Id = "s", Name = "S" };
+    sequence.SetSteps(new[] {
+      new SequenceStep {
+        Order = 0,
+        StepId = "connect",
+        StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload {
+          Type = ActionTypes.EnsureEmulatorRunning,
+          Parameters = { ["adbSerial"] = "{{queue.emulatorSerial}}" }
+        }
+      }
+    });
+    var scope = ParameterScope.FromQueue(new GameBot.Domain.Queues.ExecutionQueue {
+      Id = "q", Name = "Q", EmulatorSerial = "emulator-5560"
+    });
+
+    var payload = await RunCapturingPayloadAsync(sequence, scope);
+
+    payload!.Parameters["adbSerial"].Should().Be("emulator-5560");
+  }
+
+  [Fact]
+  public async Task AnUnparametrizedPayloadIsDispatchedUnchanged() {
+    // FR-032: the overwhelmingly common case must behave exactly as before the feature.
+    var sequence = TapSequence(569);
+
+    var payload = await RunCapturingPayloadAsync(sequence, ParameterScope.Empty);
+
+    payload!.Parameters["y"].Should().Be(569);
+    payload.Parameters["x"].Should().Be(448);
+  }
+
+  [Fact]
+  public async Task TopLevelStepsAreSubstituted() {
+    // Substitution used to run only inside loop bodies; a top-level step like this one is the
+    // ordinary case for a parametrized sequence.
+    var sequence = TapSequence("{{sectionRowY}}", new ParameterDeclaration { Name = "sectionRowY" });
+    var scope = ParameterScope.Empty
+        .Child(ParameterScopeLayers.Entry,
+            new Collection<ParameterBinding> { new() { Name = "sectionRowY", Value = "700" } },
+            null);
+
+    var payload = await RunCapturingPayloadAsync(sequence, scope);
+
+    payload!.Parameters["y"].Should().Be("700");
+  }
+}


### PR DESCRIPTION
## The problem

The sequence editor understood three step kinds — `command`, `WaitForImage`, `reschedule-self`. Every other primitive action fell through to the command branch, where `commandId` came from the payload's (absent) `commandId` and defaulted to the **step id**.

Concretely, opening `PNS Pit Ensure Mining` and pressing Save would have:

- rewritten **all 6 `tap` steps** into command steps pointing at ids that never existed (`enter7-tap`, `gold-check`, …);
- done the same to **both `reschedule-self` steps nested in if-branches** — the body loader had no reschedule branch at all — discarding the nested `ocrOffset` payload;
- **stripped every step label**, on every step type.

So the sequence most in need of a parameter was the one sequence you could not safely open. This was pre-existing, not introduced by #148 / #149.

## The fix

`PrimitiveActionFields` renders any inline action from its own payload. Every scalar slot is a `ParameterizableField`, so the `{ }` picker inserts a reference rather than anyone hand-editing JSON — which is what feature 078 was for. Wired at the top level and inside **loop and if bodies**, since that is where these steps actually live.

Two details carry the round-trip guarantee:

- A slot that loaded as a number **stays** a number while it holds a plain number, so an untouched field serializes byte-identically. The field's kind is remembered from load rather than re-derived per keystroke — otherwise replacing `569` with `{{sectionRowY}}` would silently demote it to a text field.
- Structured values (an OCR region) are preserved verbatim and shown read-only.

Labels now survive a save on every step type.

`installer/versioning/version.override.json` → **1.2.0**.

## Worked case this unblocks

The Pit sequence's "section 7" is not a field on any command — it is `tap { x: 448, y: 569 }` inside an if-branch. You can now declare `sectionRowY` (Number, default 569) on the sequence, insert `{{sectionRowY}}` into the tap's `y` with the picker, and set the value per queue-template entry. Documented as [quickstart §3d](specs/078-sequence-parameters/quickstart.md), including the two honest limits: **no arithmetic** in a reference (so you parametrize the coordinate, not the section number), and **conditions are not parametrizable**.

## Notes on the test change

`SequencesPage.unresolvedCommand.spec.tsx` asserts on an exact payload. Its own fixture carried a label the old save was silently dropping, so the expectation gains that label — the assertion now pins label preservation rather than the previous loss.

## Verification

Against the running service: all 6 taps and both reschedules render with their real values, `ocrOffset` intact, **no console errors**. Nothing was saved to the authoring store.

- **632/632** web-ui tests (103 suites), 5 new in `SequencesPage.inlineActions.spec.tsx`
- **834/834** backend unit tests, 6 new in `SequenceRunnerScopeTests.cs`
- `tsc --noEmit`, `eslint` (**0 warnings** — two `exhaustive-deps` findings were real: without the new dep, a freshly declared parameter would not appear in a step's picker), `vite build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
