### PR TITLE
[078] Reach the per-entry parameter form from the queue template editor

### DIFF
--- a/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
@@ -294,7 +294,17 @@ internal static class SequencesEndpoints {
 
   private static async Task<IResult> ListSequencesAsync(ISequenceRepository repo) {
     var list = await repo.ListAsync().ConfigureAwait(false);
-    var resp = list.Select(s => new { id = s.Id, name = s.Name, steps = s.Steps.Select(x => x.CommandId).ToArray() });
+    // Feature 078: the list carries declarations because the queue-template editor renders a binding
+    // form per entry. Without them it would have to refetch every sequence one at a time to learn
+    // what each declares — and, before this, simply showed no parameters at all. A typed row rather
+    // than an anonymous one so the member is genuinely omitted when nothing is declared, matching
+    // every other response in the feature instead of emitting an explicit null.
+    var resp = list.Select(s => new SequenceListItemResponse {
+      Id = s.Id,
+      Name = s.Name,
+      Steps = new System.Collections.ObjectModel.Collection<string>(s.Steps.Select(x => x.CommandId).ToList()),
+      Parameters = ParameterDtoMapper.ToResponseDeclarations(s.Parameters)
+    });
     return Results.Ok(resp);
   }
 

--- a/src/GameBot.Service/Models/SequenceStepContracts.cs
+++ b/src/GameBot.Service/Models/SequenceStepContracts.cs
@@ -113,3 +113,19 @@ internal sealed record WhileLoopConfigContract : LoopConfigContract {
 internal sealed record RepeatUntilLoopConfigContract : LoopConfigContract {
   public required SequenceStepConditionContract Condition { get; init; }
 }
+
+/// <summary>One row of the sequence list.</summary>
+internal sealed record SequenceListItemResponse {
+  public required string Id { get; init; }
+  public required string Name { get; init; }
+  public required System.Collections.ObjectModel.Collection<string> Steps { get; init; }
+
+  /// <summary>
+  /// Parameters this sequence declares (feature 078). Carried in the list because the queue-template
+  /// editor renders a binding form per entry and would otherwise have to refetch every sequence.
+  /// Omitted entirely when the sequence is unparametrized, so a pre-feature client sees exactly the
+  /// payload it always saw.
+  /// </summary>
+  [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+  public System.Collections.ObjectModel.Collection<ParameterDeclarationDto>? Parameters { get; init; }
+}

--- a/src/web-ui/src/components/queues/QueueSchedulingAreas.tsx
+++ b/src/web-ui/src/components/queues/QueueSchedulingAreas.tsx
@@ -16,6 +16,7 @@ import { SequenceDto } from '../../services/sequences';
 import { ScheduleType } from '../../services/queueTemplates';
 import { EntrySchedule, TimerMode } from './QueueEntryList';
 import { SchedulingArea } from './SchedulingArea';
+import type { ParameterBinding } from '../parameters/types';
 import {
   applyDragMove,
   areaForScheduleType,
@@ -39,6 +40,12 @@ export type QueueSchedulingAreasProps = {
   onTimerModeChange?: (entryId: string, mode: TimerMode) => void;
   onTimerRelativeOffsetChange?: (entryId: string, offset: string) => void;
   onToggleEnabled?: (entryId: string, enabled: boolean) => void;
+  /**
+   * Persist an entry's supplied parameter values (feature 078). Passing this is what reveals the
+   * per-entry Parameters panel — the mechanism that lets several entries share one sequence and
+   * differ only by a value.
+   */
+  onParameterValuesChange?: (entryId: string, values: ParameterBinding[]) => void;
   disabled?: boolean;
 };
 
@@ -70,8 +77,15 @@ export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
   onTimerModeChange,
   onTimerRelativeOffsetChange,
   onToggleEnabled,
+  onParameterValuesChange,
   disabled,
 }) => {
+  // Declarations come from the sequence list the page already loaded, so opening a card's Parameters
+  // panel costs no extra request.
+  const parametersBySequenceId = useMemo(
+    () => new Map(sequences.map((s) => [s.id, s.parameters ?? []])),
+    [sequences],
+  );
   const [selected, setSelected] = useState<string | undefined>(undefined);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
@@ -167,6 +181,8 @@ export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
               onTimerModeChange={onTimerModeChange}
               onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
               onToggleEnabled={onToggleEnabled}
+              parametersBySequenceId={parametersBySequenceId}
+              onParameterValuesChange={onParameterValuesChange}
             />
           </div>
           <div className="scheduling-areas__body">
@@ -183,6 +199,8 @@ export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
                 onTimerModeChange={onTimerModeChange}
                 onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
                 onToggleEnabled={onToggleEnabled}
+                parametersBySequenceId={parametersBySequenceId}
+                onParameterValuesChange={onParameterValuesChange}
               />
               <SchedulingArea
                 areaId="scheduled"
@@ -196,6 +214,8 @@ export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
                 onTimerModeChange={onTimerModeChange}
                 onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
                 onToggleEnabled={onToggleEnabled}
+                parametersBySequenceId={parametersBySequenceId}
+                onParameterValuesChange={onParameterValuesChange}
               />
             </div>
             <div className="scheduling-areas__right">
@@ -211,6 +231,8 @@ export const QueueSchedulingAreas: React.FC<QueueSchedulingAreasProps> = ({
                 onTimerModeChange={onTimerModeChange}
                 onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
                 onToggleEnabled={onToggleEnabled}
+                parametersBySequenceId={parametersBySequenceId}
+                onParameterValuesChange={onParameterValuesChange}
               />
             </div>
           </div>

--- a/src/web-ui/src/components/queues/SchedulingArea.tsx
+++ b/src/web-ui/src/components/queues/SchedulingArea.tsx
@@ -6,6 +6,7 @@ import { ScheduleType } from '../../services/queueTemplates';
 import { TimerMode } from './QueueEntryList';
 import { SchedulingSequenceCard } from './SchedulingSequenceCard';
 import { AREA_LABELS, SchedulingAreaId, SchedulingCard } from './schedulingAreas';
+import type { ParameterBinding, ParameterDeclaration } from '../parameters/types';
 
 type SchedulingAreaProps = {
   areaId: SchedulingAreaId;
@@ -19,6 +20,9 @@ type SchedulingAreaProps = {
   onTimerModeChange?: (entryId: string, mode: TimerMode) => void;
   onTimerRelativeOffsetChange?: (entryId: string, offset: string) => void;
   onToggleEnabled?: (entryId: string, enabled: boolean) => void;
+  /** Declarations per referenced sequence id, so each card can render its own binding form. */
+  parametersBySequenceId?: Map<string, ParameterDeclaration[]>;
+  onParameterValuesChange?: (entryId: string, values: ParameterBinding[]) => void;
 };
 
 const EMPTY_HINT = 'Drop sequences here.';
@@ -35,6 +39,8 @@ export const SchedulingArea: React.FC<SchedulingAreaProps> = ({
   onTimerModeChange,
   onTimerRelativeOffsetChange,
   onToggleEnabled,
+  parametersBySequenceId,
+  onParameterValuesChange,
 }) => {
   const label = AREA_LABELS[areaId];
   // The area itself is a droppable so empty areas can receive a dragged card.
@@ -69,6 +75,8 @@ export const SchedulingArea: React.FC<SchedulingAreaProps> = ({
                     onTimerModeChange={onTimerModeChange}
                     onTimerRelativeOffsetChange={onTimerRelativeOffsetChange}
                     onToggleEnabled={onToggleEnabled}
+                    sequenceParameters={parametersBySequenceId?.get(card.sequenceId)}
+                    onParameterValuesChange={onParameterValuesChange}
                   />
                 </div>
               </React.Fragment>

--- a/src/web-ui/src/components/queues/__tests__/QueueSchedulingAreas.parameters.test.tsx
+++ b/src/web-ui/src/components/queues/__tests__/QueueSchedulingAreas.parameters.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueueSchedulingAreas } from '../QueueSchedulingAreas';
+import { EntrySchedule } from '../QueueEntryList';
+import { QueueEntryDto } from '../../../services/queues';
+import { SequenceDto } from '../../../services/sequences';
+
+/**
+ * Feature 078: the per-entry parameter binding form.
+ *
+ * The form and its card existed and were unit-tested in isolation, but SchedulingArea never accepted
+ * or forwarded the two props that reveal them, so the panel was unreachable in the running app — the
+ * declarations never travelled from the sequence list down to the card. These tests exercise the
+ * whole chain from QueueSchedulingAreas down, which is where the break was.
+ */
+const sequences = [
+  {
+    id: 'seq-pit',
+    name: 'PNS Pit Ensure Mining',
+    steps: [],
+    parameters: [
+      { name: 'sectionRowY', type: 'number', default: '569', required: false, description: 'Y of the Enter Field row.' },
+    ],
+  },
+  { id: 'seq-plain', name: 'Plain', steps: [] },
+] as unknown as SequenceDto[];
+
+const entries: QueueEntryDto[] = [
+  { entryId: 'e1', sequenceId: 'seq-pit', sequenceName: 'PNS Pit Ensure Mining', stale: false },
+  { entryId: 'e2', sequenceId: 'seq-plain', sequenceName: 'Plain', stale: false },
+];
+
+const entrySchedule: Record<string, EntrySchedule> = {
+  e1: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+  e2: { scheduleType: 'OncePerRun', timerTimeOfDay: '' },
+};
+
+const baseProps = () => ({
+  sequences,
+  onAdd: jest.fn(),
+  onRemove: jest.fn(),
+  onReorderAndReassign: jest.fn(),
+});
+
+const renderAreas = (over: Record<string, unknown> = {}) =>
+  render(
+    <QueueSchedulingAreas
+      entries={entries}
+      entrySchedule={entrySchedule}
+      {...baseProps()}
+      onParameterValuesChange={jest.fn()}
+      {...over}
+    />,
+  );
+
+describe('QueueSchedulingAreas per-entry parameters', () => {
+  it('offers a Parameters panel on each entry once a change handler is supplied', () => {
+    renderAreas();
+    expect(screen.getByLabelText('Parameters for PNS Pit Ensure Mining')).toBeInTheDocument();
+  });
+
+  it('omits the panel entirely when no handler is supplied', () => {
+    // Guards the opposite direction: a caller that does not persist values must not offer the UI.
+    renderAreas({ onParameterValuesChange: undefined });
+    expect(screen.queryByLabelText('Parameters for PNS Pit Ensure Mining')).not.toBeInTheDocument();
+  });
+
+  it("shows the referenced sequence's declarations, which is what used to never arrive", () => {
+    renderAreas();
+    fireEvent.click(screen.getByLabelText('Parameters for PNS Pit Ensure Mining'));
+    expect(screen.getByText('sectionRowY')).toBeInTheDocument();
+  });
+
+  it('reports a supplied value for the entry it was entered on', () => {
+    const onParameterValuesChange = jest.fn();
+    renderAreas({ onParameterValuesChange });
+
+    fireEvent.click(screen.getByLabelText('Parameters for PNS Pit Ensure Mining'));
+    const panel = screen.getByLabelText('Parameters for PNS Pit Ensure Mining').closest('.scheduling-card');
+    const scope = within(panel as HTMLElement);
+
+    // Every row starts on "inherit" with its value disabled, so the common case is zero clicks;
+    // supplying a value means opting out of inheritance first.
+    expect(scope.getByLabelText('Value for sectionRowY')).toBeDisabled();
+    fireEvent.click(scope.getByLabelText('Inherit sectionRowY'));
+    fireEvent.change(scope.getByLabelText('Value for sectionRowY'), { target: { value: '631' } });
+
+    expect(onParameterValuesChange).toHaveBeenCalledWith(
+      'e1',
+      expect.arrayContaining([expect.objectContaining({ name: 'sectionRowY', value: '631' })]),
+    );
+  });
+
+  it('still offers the panel for a sequence that declares nothing, so ad-hoc values are reachable', () => {
+    // FR-012a: an ad-hoc name on an entry reaches a command at any depth, so an undeclared
+    // sequence must not hide the panel.
+    renderAreas();
+    expect(screen.getByLabelText('Parameters for Plain')).toBeInTheDocument();
+  });
+});

--- a/src/web-ui/src/pages/QueuesPage.tsx
+++ b/src/web-ui/src/pages/QueuesPage.tsx
@@ -21,6 +21,7 @@ import { QueueForm, QueueFormValue } from '../components/queues/QueueForm';
 import { QueueMonitor } from '../components/queues/QueueMonitor';
 import { EntrySchedule } from '../components/queues/QueueEntryList';
 import { QueueSchedulingAreas } from '../components/queues/QueueSchedulingAreas';
+import type { ParameterBinding } from '../components/parameters/types';
 import { SchedulingAreasState } from '../components/queues/schedulingAreas';
 import { QueueLiveScheduleControl } from '../components/queues/QueueLiveScheduleControl';
 import { QueueTemplateControls } from '../components/queues/QueueTemplateControls';
@@ -150,6 +151,10 @@ export const QueuesPage: React.FC<QueuesPageProps> = ({ navResetSignal }) => {
           timerMode: tplEntry.timerRelativeOffset ? 'relative' : 'timeOfDay',
           timerRelativeOffset: tplEntry.timerRelativeOffset ?? '',
           enabled: tplEntry.enabled ?? true,
+          // Feature 078: restore supplied values and their effective-value preview, or reopening the
+          // queue would show every row back on "inherit" and the next save would erase them.
+          parameterValues: tplEntry.parameterValues ?? undefined,
+          effectiveParameters: tplEntry.effectiveParameters ?? undefined,
         };
       } else {
         schedule[entryId] = { scheduleType: 'OncePerRun', timerTimeOfDay: '' };
@@ -237,6 +242,17 @@ export const QueuesPage: React.FC<QueuesPageProps> = ({ navResetSignal }) => {
     });
   };
 
+  /**
+   * Records the values one entry supplies (feature 078). Held in the working schedule map and
+   * persisted by the next template save, matching how the schedule fields already behave.
+   */
+  const onParameterValuesChange = (entryId: string, values: ParameterBinding[]) => {
+    setEntrySchedule((prev) => ({
+      ...prev,
+      [entryId]: { ...(prev[entryId] ?? { scheduleType: 'OncePerRun', timerTimeOfDay: '' }), parameterValues: values },
+    }));
+  };
+
   const handleSaveTemplate = async (name: string, overwrite: boolean) => {
     if (!detail) return;
     // Order-aware save: persist the current linear order to the runtime queue first, then build
@@ -263,6 +279,12 @@ export const QueuesPage: React.FC<QueuesPageProps> = ({ navResetSignal }) => {
         ...(isRelative && sched.timerRelativeOffset ? { timerRelativeOffset: sched.timerRelativeOffset } : {}),
         // Only emit when disabled; omission means enabled (backend treats null/absent as true).
         ...(sched.enabled === false ? { enabled: false } : {}),
+        // Feature 078: only rows that actually bind something. A row left on "inherit" carries a
+        // null value and is dropped, so an entry that supplies nothing stays unchanged on the wire.
+        ...(() => {
+          const bound = (sched.parameterValues ?? []).filter((v) => v.value !== null && v.value !== undefined);
+          return bound.length > 0 ? { parameterValues: bound } : {};
+        })(),
       };
     });
     const saved = await saveQueueTemplate({ name, entries, overwrite });
@@ -534,6 +556,7 @@ export const QueuesPage: React.FC<QueuesPageProps> = ({ navResetSignal }) => {
                   onTimerModeChange={(eid, mode) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerMode: mode } }))}
                   onTimerRelativeOffsetChange={(eid, offset) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'Timer', timerTimeOfDay: '' }, timerMode: 'relative', timerRelativeOffset: offset } }))}
                   onToggleEnabled={(eid, en) => setEntrySchedule((prev) => ({ ...prev, [eid]: { ...prev[eid] ?? { scheduleType: 'OncePerRun', timerTimeOfDay: '' }, enabled: en } }))}
+                  onParameterValuesChange={onParameterValuesChange}
                   // No `disabled` prop: this whole section is already gated on
                   // `detail.status !== 'Running'` above, so a `status === 'Running'` test here was
                   // provably always false (TS2367) and disabled nothing.

--- a/tests/contract/Sequences/ParameterContractTests.cs
+++ b/tests/contract/Sequences/ParameterContractTests.cs
@@ -301,6 +301,62 @@ public sealed class ParameterContractTests {
         .Should().Contain(p => p.GetProperty("name").GetString() == "keyName");
   }
 
+  [Fact]
+  public async Task TheSequenceListCarriesDeclarationsSoTheTemplateEditorNeedsNoExtraFetch() {
+    // The queue-template editor renders a binding form per entry from this list. While the member
+    // was missing the panel showed no parameters at all, which made per-entry values unreachable.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var create = await client.PostAsJsonAsync("/api/sequences", new {
+      name = "listed-with-params",
+      version = 1,
+      parameters = new object[] { new { name = "sectionRowY", type = "number", @default = "569" } },
+      steps = new object[] {
+        new { stepId = "s1", stepType = "Action", primitiveAction = new { type = "tap", schemaVersion = "v1", payload = new { x = 1, y = 2 } } }
+      }
+    }).ConfigureAwait(false);
+    create.StatusCode.Should().Be(HttpStatusCode.Created);
+    var sequenceId = JsonDocument.Parse(await create.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("id").GetString();
+
+    var list = await client.GetAsync(new Uri("/api/sequences", UriKind.Relative)).ConfigureAwait(false);
+    list.StatusCode.Should().Be(HttpStatusCode.OK);
+    var listed = JsonDocument.Parse(await list.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.EnumerateArray()
+        .Single(s => s.GetProperty("id").GetString() == sequenceId);
+
+    var declaration = listed.GetProperty("parameters").EnumerateArray().Single();
+    declaration.GetProperty("name").GetString().Should().Be("sectionRowY");
+    declaration.GetProperty("type").GetString().Should().Be("number");
+    declaration.GetProperty("default").GetString().Should().Be("569");
+  }
+
+  [Fact]
+  public async Task ASequenceThatDeclaresNothingOmitsTheMemberFromTheList() {
+    // FR-032: an unparametrized sequence keeps the shape it had before the feature.
+    using var app = CreateFactory();
+    var client = AuthedClient(app);
+
+    var create = await client.PostAsJsonAsync("/api/sequences", new {
+      name = "listed-without-params",
+      version = 1,
+      steps = new object[] {
+        new { stepId = "s1", stepType = "Action", primitiveAction = new { type = "tap", schemaVersion = "v1", payload = new { x = 1, y = 2 } } }
+      }
+    }).ConfigureAwait(false);
+    var sequenceId = JsonDocument.Parse(await create.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.GetProperty("id").GetString();
+
+    var list = await client.GetAsync(new Uri("/api/sequences", UriKind.Relative)).ConfigureAwait(false);
+    var listed = JsonDocument.Parse(await list.Content.ReadAsStringAsync().ConfigureAwait(false))
+        .RootElement.EnumerateArray()
+        .Single(s => s.GetProperty("id").GetString() == sequenceId);
+
+    listed.TryGetProperty("parameters", out _)
+        .Should().BeFalse("the member is omitted when the sequence declares nothing");
+  }
+
   // ── Ad-hoc execute ───────────────────────────────────────────────────────
 
   [Fact]


### PR DESCRIPTION
Follow-up to #150. Reported from manual testing: after declaring a parameter on a sequence and referencing it from an inline action, **the queue-template editor showed no Parameters at all** — so step 3b of the quickstart could not be followed and the feature was unusable end to end.

Three separate breaks, all fixed here.

## 1. The panel was unreachable

`SchedulingSequenceCard` has a complete binding form and its own unit tests, but `SchedulingArea` neither accepted nor forwarded `sequenceParameters` or `onParameterValuesChange`. The props were exercised only by the card's isolated test, so nothing rendered in the running app.

## 2. The list endpoint omitted declarations

`GET /api/sequences` returned only `id, name, steps`. Declaring worked (the detail endpoint carries it), but the list the template editor reads did not — so even once wired, every entry would have reported "nothing here declares a parameter".

This is the **same defect fixed for the commands list in #149**; the sequences list had it too and was missed then.

The row becomes a typed `SequenceListItemResponse` rather than an anonymous type, so the member is genuinely **absent** when a sequence declares nothing instead of serializing an explicit `null` — matching every other response in the feature. A contract test pins both directions.

## 3. Values were never persisted or restored

`handleSaveTemplate` dropped `parameterValues`, and `buildScheduleFromTemplateEntries` never read them back. A value entered in the panel would have been lost on save and again on reload. Both now round-trip, using the same "omit rows left on inherit" rule as the sequence editor, so an entry supplying nothing stays byte-identical on the wire.

## Verification

Against the running app: all **20** entries of `PNS Daily 5558` now offer the Parameters panel and it opens cleanly, where before there were none. It still reports no declarations there because that service is the pre-fix binary — the contract test covers the half the old binary cannot show.

- **1,254** backend tests (834 unit, 117 contract, 303 integration)
- **637** web-ui tests (104 suites); 5 new ones drive the whole chain from `QueueSchedulingAreas` down, which is where the break was
- `tsc --noEmit`, `eslint` (0 warnings), `vite build` clean

## Notes

- No version bump: 1.2.0 landed with #150 and covers this work.
- `release-installer` will not run on this PR — it is path-filtered to `installer/**` and this change touches none of those. Build an artifact with `gh workflow run release-installer.yml --ref 078-template-entry-parameters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
