### PR TITLE
ci: build an installer on every PR into master (fix stale build-release-installer check)

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,16 +1,21 @@
 name: release-installer
 
-# PR builds run only when installer-related files change; use workflow_dispatch
-# to build an installer from any branch on demand.
+# Every PR into master builds an installer. There is deliberately no `paths`
+# filter: the installer payload is the full publish closure of
+# src/GameBot.Service (which transitively pulls in every referenced project
+# under src/**), the built src/web-ui/dist bundle, the root LICENSE, and the
+# repo-wide MSBuild/NuGet settings - see scripts/package-installer-payload.ps1.
+# Practically any source change alters what the installer contains, so a path
+# filter could never be complete, and when it skipped a run GitHub carried the
+# PREVIOUS run's conclusion into the PR status rollup: reviewers saw a green
+# `build-release-installer` produced from an older commit, next to a stale
+# artifact. Running unconditionally makes the check always match the PR head
+# commit; the job takes ~3.5 minutes on windows-latest, which is well under the
+# cost of shipping an installer built from the wrong source.
+# Use workflow_dispatch to build an installer from any branch on demand.
 on:
   pull_request:
     branches: [ master ]
-    paths:
-      - "installer/**"
-      - "scripts/installer/**"
-      - "scripts/package-installer-payload.ps1"
-      - "scripts/build-installer.ps1"
-      - ".github/workflows/release-installer.yml"
   workflow_dispatch:
 
 permissions:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -215,8 +215,15 @@ This section documents the current installer CI/release behavior and operational
 
 - Installer artifacts are produced by GitHub workflow `release-installer`.
 - `release-installer` runs on:
-  - `pull_request` targeting `master`
+  - `pull_request` targeting `master` - **every** such PR, with no `paths` filter
   - manual `workflow_dispatch`
+- There is deliberately no `paths` filter. The installer payload is the full
+  publish closure of `src/GameBot.Service` plus the built `src/web-ui/dist`
+  bundle plus the root `LICENSE`, so nearly any source change alters what the
+  installer contains. When a path filter skipped a run, GitHub carried the
+  previous run's conclusion into the PR status rollup and
+  `build-release-installer` showed a green result built from an older commit.
+  Running unconditionally guarantees the check reflects the PR head commit.
 - The workflow uses read-only permissions (`contents: read`) and does not push version files back to protected branches.
 
 ### Build/version behavior in CI
@@ -243,10 +250,10 @@ This section documents the current installer CI/release behavior and operational
 
 ### Required checks / PR gate
 
-- PRs should wait for `release-installer / build-release-installer` (installer-path changes only) plus normal CI checks to complete before merge.
+- PRs should wait for `release-installer / build-release-installer` plus normal CI checks to complete before merge.
 - Typical check set includes:
   - `.NET CI` (`build`, `web-ui-tests`) - `build` also enforces `-warnaserror` and the installer secret scan
-  - `release-installer` (`build-release-installer`) - runs only when installer-related paths change; use `workflow_dispatch` to build from any branch on demand
+  - `release-installer` (`build-release-installer`) - runs on every PR into `master`; use `workflow_dispatch` to build from a branch with no open PR
   - `CodeQL`
 
 ### Conflict resolution runbook

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -133,7 +133,12 @@ else {
   $versionResolution = Resolve-InstallerVersion -RepoRoot $repoRoot -BuildContext $buildContext
 }
 $installerVersion = $versionResolution.Version
-Write-Host "Resolved installer version: $installerVersion (source=$($versionResolution.Source), persisted=$($versionResolution.Persisted))"
+# PersistedCounterWrite - not Persisted - reports whether ci-build-counter.json
+# was actually rewritten. In CI the build number comes from GITHUB_RUN_NUMBER via
+# -BuildNumberOverride and the counter file is NOT touched, but the legacy
+# Persisted flag is hardcoded to ($BuildContext -eq "ci") and so always logged
+# True, which reads as if CI had bumped the checked-in counter.
+Write-Host "Resolved installer version: $installerVersion (source=$($versionResolution.Source), counterFileWritten=$($versionResolution.PersistedCounterWrite))"
 
 & (Join-Path $PSScriptRoot "package-installer-payload.ps1") -Configuration $Configuration -InstallerVersion $installerVersion
 if ($LASTEXITCODE -ne 0) {

--- a/src/web-ui/vite.config.ts
+++ b/src/web-ui/vite.config.ts
@@ -1,3 +1,7 @@
+// `vite build` writes src/web-ui/dist, which scripts/package-installer-payload.ps1
+// copies verbatim into the installer payload under web-ui/. Changes here and
+// anywhere else under src/** change what the installer ships, which is why
+// .github/workflows/release-installer.yml carries no `paths` filter.
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import dns from 'node:dns';


### PR DESCRIPTION
## Root cause

`release-installer` filtered its `pull_request` trigger by path:

```yaml
paths:
  - "installer/**"
  - "scripts/installer/**"
  - "scripts/package-installer-payload.ps1"
  - "scripts/build-installer.ps1"
  - ".github/workflows/release-installer.yml"
```

That filter does not describe what the installer actually contains. Reading
`scripts/package-installer-payload.ps1`, the payload is:

- `dotnet publish src/GameBot.Service/GameBot.Service.csproj` — the full publish
  closure, so every project under `src/**` that the service references
- `npm run build` in `src/web-ui` → `src/web-ui/dist`
- `payload-manifest.json`, stamped with `git rev-parse --short HEAD`

plus, from `scripts/build-installer.ps1`, the root `LICENSE` (rendered into
`installer/wix/Assets/License.generated.rtf`). None of `src/**` or `LICENSE` was
in the filter.

So a code-only PR changed what the installer contains and built no installer.
The damaging part is what GitHub does next: it carries the **previous** run's
conclusion into the PR status rollup, so `build-release-installer` shows a green
SUCCESS produced from an older commit — sitting next to a downloadable artifact
built from that older commit. A reviewer, or the repo owner downloading the
artifact to test, has no signal that anything is stale.

## Evidence (verified against the API, not assumed)

`gh run list --workflow release-installer.yml --branch 078-inline-action-editing`:

| run # | run id | head sha | event | conclusion | created |
|---|---|---|---|---|---|
| 148 | `32758250468` | `67a1660` | `pull_request` | success | 2026-08-24 |
| 150 | `32944063684` | `07ffa1d` | **`workflow_dispatch`** | success | 2026-08-26 |

- `67a1660` touched `installer/versioning/version.override.json` → matched the
  filter → automatic run 148 → artifact
  `gamebot-installer-v1.2.0.148-078-inline-action-editing-win-x64`.
- `07ffa1d` (parent `67a1660`) touches only
  `src/GameBot.Service/Endpoints/SequencesEndpoints.cs`,
  `src/GameBot.Service/Models/SequenceStepContracts.cs`, four files under
  `src/web-ui/src/**`, and `tests/contract/Sequences/ParameterContractTests.cs`
  — no installer path. It produced **no** `pull_request` run. The only run at
  that SHA is the manual `workflow_dispatch` workaround
  (`gh workflow run release-installer.yml --ref <branch>`), which is exactly the
  step nobody should have to remember.

## The fix

Drop the `paths` filter. Every PR into `master` now builds an installer from its
own head commit, so `build-release-installer` either reflects that commit or is
absent — never a stale green from an older one.

### Why not an expanded filter

To be correct the filter would have to enumerate `src/**`, `LICENSE`,
`Directory.Build.props`, `NuGet.config`, `global.json`, `GameBot.sln`, and every
future top-level input to the publish closure. That is nearly everything in the
repo, and any omission silently reintroduces the exact stale-green failure mode
this PR exists to remove — quietly, months later, with no error to notice. A
filter that must list almost the whole tree to be safe is not worth the risk of
the one entry someone forgets.

### Why not `push` on all branches, like `dotnet.yml`

`dotnet.yml` is push-on-every-branch by design (its own comment explains that the
speckit pipeline waits on that run before opening a PR), and this PR does not
change that. Mirroring it here would build an installer on every WIP push to
every branch, most of which never open a PR, for no gain on the property that
matters — the check on a PR's head commit. `pull_request` with no filter gets
that property at a fraction of the runner cost.

### Cost

The job is ~3.5 min on `windows-latest`, with NuGet and npm caches already
configured, and `concurrency: cancel-in-progress` already cancels superseded runs
on the same ref. Compared with shipping an installer built from the wrong source,
this is cheap.

`INSTALL.md` is updated in the same commit — its "Workflow and trigger model" and
"Required checks / PR gate" sections both documented the old path-filtered
behavior.

## Validation

- Workflow YAML parsed with `ConvertFrom-Yaml` (powershell-yaml): parses clean,
  `on.pull_request.branches: [master]`, no `paths` key, job and all 9 steps
  intact. `dotnet.yml` re-parsed unchanged as a control.
- **Empirical trigger check (observed, not predicted).** Commit `2f401fe` touches
  only `src/web-ui/vite.config.ts` — a path that matched **none** of the removed
  filter entries, so under the old configuration it would have produced no run at
  all. Observed instead:

  | run # | run id | head sha | event | conclusion |
  |---|---|---|---|---|
  | 153 | `32945242135` | `2f401fe` | `pull_request` | success in 3m56s |

  Artifact produced:
  `gamebot-installer-v1.2.0.153-fix-installer-workflow-triggers-win-x64` (35 MB),
  built from this PR's own head commit. Measured runtime 3m56s matches the ~3.5
  min estimate above.

  The earlier run at `d4a46cf` shows as `cancelled` — that is the existing
  `concurrency: cancel-in-progress` superseding it when `2f401fe` was pushed,
  which is the intended behavior and keeps the cost of an unfiltered trigger down.

- Build-number log line confirmed in that run:
  `Resolved installer version: 1.2.0.153 (source=ci, counterFileWritten=False)`,
  and `Artifact name: ...v1.2.0.153-...`. Build number and artifact name agree,
  and the log no longer claims a counter write that did not happen.

## Follow-up left undone: the installer build number

Investigated; **not** a real disagreement, but the logging is misleading and one
checked-in file is vestigial.

`scripts/installer/common.psm1` → `Resolve-InstallerVersion` has two paths. With
`-BuildNumberOverride` bound it uses that value and **skips**
`Set-CiBuildCounter`; without it, it computes `$counter + 1` from
`installer/versioning/ci-build-counter.json` and writes back. In CI,
`build-installer.ps1` always passes `-BuildNumberOverride $env:GITHUB_RUN_NUMBER`,
so the built version and the workflow's "Compute artifact name" step
(`$build = [int]$env:GITHUB_RUN_NUMBER`) agree. `INSTALL.md` documents this as the
intended design. Artifact `...148` = run number 148, `...150` = run number 150 —
both correct.

Two genuine problems:

1. **The log lied.** `Resolve-InstallerVersion` returns
   `Persisted = ($BuildContext -eq "ci")`, hardcoded, so CI printed
   `persisted=True` even though the override path never touched the counter file.
   The accurate flag, `PersistedCounterWrite`, already existed and was unused.
   Fixed here (log line only): CI now prints `counterFileWritten=False`.
   `common.psm1` is deliberately untouched — `tests/integration/Installer/`
   asserts on its literal strings, including `Persisted = ($BuildContext -eq "ci")`.

2. **`ci-build-counter.json` is stale and cannot self-heal** — `lastBuild: 3`,
   last written 2026-02-18. CI never writes it (correctly, `contents: read`), and
   even the pre-override behavior would have written it inside a runner and
   discarded it. It is now only a fallback for local builds when `gh` cannot
   resolve the branch's latest CI run number. Left as-is: deciding whether to
   re-baseline it, drop it, or make the fallback failure loud is a versioning
   design call for the maintainer, not a drive-by change in a CI-trigger PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)