### PR TITLE
ci: build the release installer on push to master, not on every PR

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,20 +1,21 @@
 name: release-installer
 
-# Every PR into master builds an installer. There is deliberately no `paths`
-# filter: the installer payload is the full publish closure of
-# src/GameBot.Service (which transitively pulls in every referenced project
-# under src/**), the built src/web-ui/dist bundle, the root LICENSE, and the
-# repo-wide MSBuild/NuGet settings - see scripts/package-installer-payload.ps1.
-# Practically any source change alters what the installer contains, so a path
-# filter could never be complete, and when it skipped a run GitHub carried the
-# PREVIOUS run's conclusion into the PR status rollup: reviewers saw a green
-# `build-release-installer` produced from an older commit, next to a stale
-# artifact. Running unconditionally makes the check always match the PR head
-# commit; the job takes ~3.5 minutes on windows-latest, which is well under the
-# cost of shipping an installer built from the wrong source.
-# Use workflow_dispatch to build an installer from any branch on demand.
+# Installers are release artifacts, so they are built from master: every push to
+# master - in practice, every PR merge - produces one installer for that merged
+# state. Open PRs deliberately do NOT build an installer; they are gated by
+# .NET CI and CodeQL instead. Use workflow_dispatch to build an installer from
+# any branch on demand.
+#
+# There is deliberately no `paths` filter: the installer payload is the full
+# publish closure of src/GameBot.Service (which transitively pulls in every
+# referenced project under src/**), the built src/web-ui/dist bundle, the root
+# LICENSE, and the repo-wide MSBuild/NuGet settings - see
+# scripts/package-installer-payload.ps1. Practically any source change alters
+# what the installer contains, so a path filter could never be complete, and an
+# incomplete one silently skips runs and leaves the latest master commit with no
+# installer of its own. The job takes ~3.5 minutes on windows-latest.
 on:
-  pull_request:
+  push:
     branches: [ master ]
   workflow_dispatch:
 
@@ -23,7 +24,12 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Master pushes must never cancel each other: each one is the release build for
+  # a distinct merged commit, and a cancelled run leaves that commit with no
+  # installer (and burns the github.run_number that would have versioned it).
+  # Back-to-back merges queue instead. On-demand workflow_dispatch runs are just
+  # rebuilds of a branch tip, so a newer one may still supersede an older one.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   build-release-installer:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ Use `/quiet` with installer variables:
 ### Getting installer binaries from CI
 
 - Installer packages are published by the `release-installer` workflow as GitHub Actions artifacts.
-- The workflow runs for pull requests targeting `master` and can also be started with `workflow_dispatch`.
+- The workflow runs on every push to `master` (that is, on every PR merge) and can also be started with `workflow_dispatch`.
 - Artifact name format:
 
   ```text
@@ -124,13 +124,13 @@ Example:
 - In CI, `build` is sourced from `github.run_number`.
 - `github.run_number` increments only when GitHub creates a new workflow run for `release-installer`.
 - For this repo, that means it changes on new `release-installer` runs from:
-  - pull requests targeting `master` (for example new PR, new commits pushed to the PR branch)
+  - pushes to `master` (in practice, each PR merge)
   - manual `workflow_dispatch` runs
 - Re-running a failed/successful existing run does **not** change `github.run_number`; only `github.run_attempt` increases.
 - Example timeline:
-  - Run A (new PR update): `github.run_number=57`, `github.run_attempt=1`
+  - Run A (a PR merges to `master`): `github.run_number=57`, `github.run_attempt=1`
   - Re-run Run A: `github.run_number=57`, `github.run_attempt=2`
-  - Push another commit to the same PR (new run): `github.run_number=58`, `github.run_attempt=1`
+  - Next PR merges to `master` (new run): `github.run_number=58`, `github.run_attempt=1`
 - CI does not write version counters back to protected branches.
 - Local/manual builds still support override/version files under `installer/versioning`.
 
@@ -215,15 +215,22 @@ This section documents the current installer CI/release behavior and operational
 
 - Installer artifacts are produced by GitHub workflow `release-installer`.
 - `release-installer` runs on:
-  - `pull_request` targeting `master` - **every** such PR, with no `paths` filter
-  - manual `workflow_dispatch`
+  - `push` to `master` - **every** push, with no `paths` filter. In practice that
+    means one installer build per merged PR, built from the merged master commit.
+  - manual `workflow_dispatch` - builds an installer from any branch on demand
+- Open pull requests do **not** build an installer. The installer is a release
+  artifact of merged code, not a PR gate; PRs are gated by `.NET CI` and `CodeQL`.
+  To get an installer for an unmerged branch, run `workflow_dispatch` against it.
 - There is deliberately no `paths` filter. The installer payload is the full
   publish closure of `src/GameBot.Service` plus the built `src/web-ui/dist`
   bundle plus the root `LICENSE`, so nearly any source change alters what the
-  installer contains. When a path filter skipped a run, GitHub carried the
-  previous run's conclusion into the PR status rollup and
-  `build-release-installer` showed a green result built from an older commit.
-  Running unconditionally guarantees the check reflects the PR head commit.
+  installer contains. A path filter could never be complete, and an incomplete
+  one silently skips runs, leaving the current `master` commit with no installer
+  of its own.
+- Concurrency group is `release-installer-<ref>`, but `cancel-in-progress` is
+  **false for `push` events**: back-to-back merges queue rather than cancel, so
+  every merged master commit gets its own installer. `workflow_dispatch` runs on
+  the same ref may still be superseded by a newer dispatch.
 - The workflow uses read-only permissions (`contents: read`) and does not push version files back to protected branches.
 
 ### Build/version behavior in CI
@@ -250,11 +257,15 @@ This section documents the current installer CI/release behavior and operational
 
 ### Required checks / PR gate
 
-- PRs should wait for `release-installer / build-release-installer` plus normal CI checks to complete before merge.
+- PRs should wait for all CI checks to complete before merge.
 - Typical check set includes:
   - `.NET CI` (`build`, `web-ui-tests`) - `build` also enforces `-warnaserror` and the installer secret scan
-  - `release-installer` (`build-release-installer`) - runs on every PR into `master`; use `workflow_dispatch` to build from a branch with no open PR
   - `CodeQL`
+- `release-installer` (`build-release-installer`) is **not** a PR check and will
+  not appear in a PR's status rollup. It runs after the merge, on the resulting
+  push to `master`. Its absence from a PR is expected, not a missing check.
+- After merging, check the `release-installer` run on `master` for the installer
+  build of that merge: `gh run list --workflow release-installer.yml --branch master`.
 
 ### Conflict resolution runbook
 

--- a/src/web-ui/vite.config.ts
+++ b/src/web-ui/vite.config.ts
@@ -1,7 +1,6 @@
 // `vite build` writes src/web-ui/dist, which scripts/package-installer-payload.ps1
-// copies verbatim into the installer payload under web-ui/. Changes here and
-// anywhere else under src/** change what the installer ships, which is why
-// .github/workflows/release-installer.yml carries no `paths` filter.
+// copies verbatim into the installer payload under web-ui/, so changes here ship
+// in the installer.
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import dns from 'node:dns';


### PR DESCRIPTION
## What

`release-installer` now builds on **push to `master`** (i.e. once a PR merges) instead of on every open PR. `workflow_dispatch` is kept so an installer can still be built from any branch on demand.

```yaml
on:
  push:
    branches: [ master ]
  workflow_dispatch:
```

## Why

PR #152 correctly diagnosed the stale `build-release-installer` check and removed the `paths` filter, but it landed on the wrong trigger. An installer is a release artifact of merged code, not a PR gate. On `pull_request` we spent ~3.5 min of `windows-latest` per PR update building an installer for a commit that may never land, while the commit that actually ships — the master merge commit — never got an installer of its own.

## Notes

- **No `paths` filter is reinstated**, for the same reason as #152: the payload is the full `dotnet publish` closure of `src/GameBot.Service` plus `src/web-ui/dist` plus the root `LICENSE`, so almost any change alters it and an incomplete filter is what caused the original bug.
- **`cancel-in-progress` is now `${{ github.event_name != 'push' }}`.** Under the PR trigger, cancelling a superseded run was right — only the PR head commit mattered. On master each run is the release build of a *distinct merged commit*; cancelling one loses that commit's installer and burns the `github.run_number` that versioned it. Back-to-back merges queue instead. `workflow_dispatch` reruns on the same ref may still supersede each other.
- **`build-release-installer` will not appear on this PR** (or any future PR). That is the intended outcome of removing the `pull_request` trigger, not a missing check. PRs remain gated by `.NET CI` and `CodeQL`.
- Artifact naming is unaffected: on a `push` event `GITHUB_HEAD_REF` is empty, so the workflow falls back to `GITHUB_REF_NAME` = `master` and produces the unsuffixed `gamebot-installer-v<version>-win-x64` name.
- `dotnet.yml` is untouched — push-on-every-branch is deliberate there.

## Docs

- `INSTALL.md` — rewrote "Workflow and trigger model" and "Required checks / PR gate" (both made wrong by #152), plus the `github.run_number` sources in "Version numbering in CI" and the CI-artifact blurb in section 1. Added an explicit note that `release-installer` is not a PR check and that its absence from a PR rollup is expected.
- `src/web-ui/vite.config.ts` — #152 added a comment ending with a claim about `release-installer.yml`'s paths filter. Trimmed to the fact it actually documents (`dist` is copied verbatim into the installer payload); a build config asserting things about CI trigger configuration is the coupling that just went stale.

## Verification

- Workflow YAML parsed with `ConvertFrom-Yaml` (`powershell-yaml`): `push.branches=[master]`, `workflow_dispatch`, single job `build-release-installer`.
- Post-merge check: confirm a `push`-event `release-installer` run fires on `master` and produces its artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
