### PR TITLE
[078] Substitute placeholders stored as JsonElement, not just string

### DIFF
--- a/src/GameBot.Domain/Utils/TemplateSubstitutor.cs
+++ b/src/GameBot.Domain/Utils/TemplateSubstitutor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using GameBot.Domain.Commands;
 
@@ -91,11 +92,11 @@ public static class TemplateSubstitutor {
   }
 
   /// <summary>
-  /// Returns a new <see cref="SequenceActionPayload"/> where every <em>string</em> parameter
-  /// value has had its <c>{{key}}</c> placeholders substituted from <paramref name="context"/>.
-  /// Non-string values are copied unchanged.
+  /// Returns a new <see cref="SequenceActionPayload"/> where every textual parameter value has had
+  /// its <c>{{key}}</c> placeholders substituted from <paramref name="context"/>. Values that are not
+  /// text are copied unchanged.
   /// </summary>
-  /// <param name="payload">The payload whose string parameters should be substituted.</param>
+  /// <param name="payload">The payload whose textual parameters should be substituted.</param>
   /// <param name="context">Substitution map from placeholder key to replacement value.</param>
   public static SequenceActionPayload SubstitutePayload(
       SequenceActionPayload payload,
@@ -103,9 +104,44 @@ public static class TemplateSubstitutor {
     ArgumentNullException.ThrowIfNull(payload);
     var result = new SequenceActionPayload { Type = payload.Type, SchemaVersion = payload.SchemaVersion };
     foreach (var (key, value) in payload.Parameters) {
-      result.Parameters[key] = value is string str ? Substitute(str, context) : value;
+      result.Parameters[key] = SubstituteValue(value, context);
     }
 
     return result;
+  }
+
+  /// <summary>
+  /// Substitutes one payload slot.
+  /// <para>
+  /// Handling <see cref="JsonElement"/> is not a nicety: <see cref="SequenceActionPayload.Parameters"/>
+  /// is a <c>Dictionary&lt;string, object?&gt;</c>, so a payload loaded from disk holds
+  /// <see cref="JsonElement"/> values and <em>never</em> <see cref="string"/>. Matching only on
+  /// <see cref="string"/> meant every stored placeholder was copied through untouched — a tap with
+  /// <c>"y": "{{sectionRowY}}"</c> reached the device layer as that literal text and failed with
+  /// "requires numeric 'x' and 'y'". Only payloads built in memory (that is, in tests) ever
+  /// substituted, which is precisely why this survived a green suite.
+  /// </para>
+  /// <para>
+  /// The substituted result is returned as a plain <see cref="string"/>; every consumer parses numeric
+  /// slots defensively from text, so a resolved <c>"569"</c> reads back as the number 569.
+  /// </para>
+  /// <para>
+  /// Objects and arrays are copied unchanged — placeholders nested inside a structured value (an OCR
+  /// region, say) are not substituted, matching the feature's "string and numeric leaf fields" scope.
+  /// </para>
+  /// </summary>
+  /// <param name="value">The stored slot value.</param>
+  /// <param name="context">Substitution map from placeholder key to replacement value.</param>
+  private static object? SubstituteValue(object? value, IReadOnlyDictionary<string, string> context) {
+    switch (value) {
+      case string str:
+        return Substitute(str, context);
+      case JsonElement { ValueKind: JsonValueKind.String } element: {
+        var text = element.GetString();
+        return text is null ? value : Substitute(text, context);
+      }
+      default:
+        return value;
+    }
   }
 }

--- a/tests/unit/Sequences/SequenceRunnerIfBodyScopeTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerIfBodyScopeTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Actions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Parameters;
+using GameBot.Domain.Services;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Reproduction of a live failure: "PNS Pit Ensure Mining" logged
+/// <c>Step 'Tap Enter Field row7' failed: tap step requires numeric 'x' and 'y' parameters</c>
+/// while the sibling top-level tap (literal coordinates) succeeded in the same run.
+/// <para>
+/// The shape is exactly the stored one: a <b>top-level If</b> whose then-branch holds an inline tap
+/// whose <c>y</c> is <c>{{sectionRowY}}</c>, with the parameter declared on the sequence with a
+/// default and no caller supplying anything.
+/// </para>
+/// </summary>
+public sealed class SequenceRunnerIfBodyScopeTests {
+  private sealed class StubRepo : ISequenceRepository {
+    private readonly CommandSequence _sequence;
+    public StubRepo(CommandSequence sequence) => _sequence = sequence;
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_sequence);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() => Task.FromResult<IReadOnlyList<CommandSequence>>(new List<CommandSequence> { _sequence });
+    public Task<CommandSequence> CreateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<CommandSequence> UpdateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+  }
+
+  /// <summary>The stored Pit shape: If(imageVisible) → body[ tap(448, {{sectionRowY}}) ].</summary>
+  private static CommandSequence PitSequence() {
+    var sequence = new CommandSequence { Id = "pit", Name = "PNS Pit Ensure Mining" };
+    sequence.Parameters.Add(new ParameterDeclaration {
+      Name = "sectionRowY", Type = ParameterValueType.Number, Default = "569"
+    });
+    sequence.SetSteps(new[] {
+      new SequenceStep {
+        Order = 0,
+        StepId = "enter7",
+        StepType = SequenceStepType.If,
+        If = new IfConfig {
+          Condition = new ImageVisibleStepCondition { ImageId = "rare-earth-title", MinSimilarity = 0.8 }
+        },
+        Body = new[] {
+          new SequenceStep {
+            Order = 0,
+            StepId = "enter7-tap",
+            Label = "Tap Enter Field row7",
+            StepType = SequenceStepType.Action,
+            Action = new SequenceActionPayload {
+              Type = ActionTypes.Tap,
+              Parameters = { ["x"] = 448, ["y"] = "{{sectionRowY}}" }
+            }
+          }
+        }
+      }
+    });
+    return sequence;
+  }
+
+  private static async Task<SequenceActionPayload?> RunAsync(ParameterScope scope) {
+    var sequence = PitSequence();
+    var runner = new SequenceRunner(new StubRepo(sequence));
+    SequenceActionPayload? captured = null;
+
+    await runner.ExecuteAsync(
+      sequence.Id,
+      (_, _) => Task.CompletedTask,
+      conditionEvaluator: (_, _) => Task.FromResult(true), // the image is visible, as in the live run
+      actionDispatcher: (payload, _) => {
+        captured = payload;
+        return Task.FromResult(new ActionDispatchResult("executed", null));
+      },
+      scope: scope,
+      ct: CancellationToken.None);
+
+    return captured;
+  }
+
+  [Fact]
+  public async Task ATapInsideAnIfBranchResolvesTheSequencesDeclaredDefault() {
+    var payload = await RunAsync(ParameterScope.Empty);
+
+    payload.Should().NotBeNull("the then-branch runs when the condition is true");
+    payload!.Parameters["y"].Should().Be("569");
+    payload.Parameters["x"].Should().Be(448);
+  }
+
+  /// <summary>
+  /// The same sequence after a persistence round-trip, which is what actually runs.
+  /// <para>
+  /// <see cref="SequenceActionPayload.Parameters"/> is a <c>Dictionary&lt;string, object?&gt;</c>, so
+  /// System.Text.Json materializes every value as a <see cref="JsonElement"/> — never a
+  /// <see cref="string"/>. A test that builds the payload in memory therefore exercises a type the
+  /// runner never sees at run time, and passes while production fails.
+  /// </para>
+  /// </summary>
+  private static CommandSequence RoundTripped() {
+    var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    var json = JsonSerializer.Serialize(PitSequence(), options);
+    return JsonSerializer.Deserialize<CommandSequence>(json, options)!;
+  }
+
+  [Fact]
+  public async Task ATapLoadedFromPersistenceResolvesTheParameter() {
+    var sequence = RoundTripped();
+    sequence.Steps[0].Body![0].Action!.Parameters["y"]
+        .Should().BeOfType<JsonElement>("persistence yields JsonElement, not string — this is the gap");
+
+    var runner = new SequenceRunner(new StubRepo(sequence));
+    SequenceActionPayload? captured = null;
+    await runner.ExecuteAsync(
+      sequence.Id,
+      (_, _) => Task.CompletedTask,
+      conditionEvaluator: (_, _) => Task.FromResult(true),
+      actionDispatcher: (payload, _) => {
+        captured = payload;
+        return Task.FromResult(new ActionDispatchResult("executed", null));
+      },
+      scope: ParameterScope.Empty,
+      ct: CancellationToken.None);
+
+    captured.Should().NotBeNull();
+    // Must be a value a numeric slot can parse — not the literal placeholder.
+    captured!.Parameters["y"].Should().NotBeNull();
+    captured.Parameters["y"]!.ToString().Should().Be("569");
+  }
+
+  [Fact]
+  public async Task AnEntryValueOverridesTheDefaultForATapInsideAnIfBranch() {
+    var scope = ParameterScope.Empty
+        .Child(ParameterScopeLayers.Entry,
+            new Collection<ParameterBinding> { new() { Name = "sectionRowY", Value = "631" } },
+            null);
+
+    var payload = await RunAsync(scope);
+
+    payload!.Parameters["y"].Should().Be("631");
+  }
+}

--- a/tests/unit/Sequences/TemplateSubstitutorTests.cs
+++ b/tests/unit/Sequences/TemplateSubstitutorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using FluentAssertions;
 using GameBot.Domain.Commands;
 using GameBot.Domain.Utils;
@@ -176,5 +177,66 @@ public sealed class TemplateSubstitutorTests {
     result.Parameters["first"].Should().Be("alpha");
     result.Parameters["second"].Should().Be("beta");
     result.Parameters["third"].Should().Be(42);
+  }
+
+  /// <summary>
+  /// Builds a payload slot the way persistence does. <see cref="SequenceActionPayload.Parameters"/> is
+  /// a <c>Dictionary&lt;string, object?&gt;</c>, so a stored payload holds <see cref="JsonElement"/>
+  /// values — never <see cref="string"/>.
+  /// </summary>
+  private static JsonElement Stored(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+  [Fact]
+  public void SubstitutePayloadReplacesAPlaceholderStoredAsAJsonElement() {
+    // Regression: matching only on `string` meant a placeholder loaded from disk was copied through
+    // untouched, so a stored tap reached the device layer as the literal text "{{sectionRowY}}".
+    var payload = new SequenceActionPayload { Type = "tap" };
+    payload.Parameters["x"] = Stored("448");
+    payload.Parameters["y"] = Stored("\"{{sectionRowY}}\"");
+
+    var result = TemplateSubstitutor.SubstitutePayload(
+        payload,
+        new Dictionary<string, string> { ["sectionRowY"] = "569" });
+
+    // Returned as text, which is what a numeric slot parses.
+    result.Parameters["y"].Should().Be("569");
+  }
+
+  [Fact]
+  public void SubstitutePayloadLeavesAStoredNumberUntouched() {
+    var payload = new SequenceActionPayload { Type = "tap" };
+    payload.Parameters["x"] = Stored("448");
+
+    var result = TemplateSubstitutor.SubstitutePayload(
+        payload,
+        new Dictionary<string, string> { ["sectionRowY"] = "569" });
+
+    result.Parameters["x"].Should().BeOfType<JsonElement>();
+    ((JsonElement)result.Parameters["x"]!).GetInt32().Should().Be(448);
+  }
+
+  [Fact]
+  public void SubstitutePayloadLeavesAStoredObjectUntouched() {
+    // A structured slot (an OCR region) round-trips unchanged; nested placeholders are out of scope.
+    var payload = new SequenceActionPayload { Type = "reschedule-self" };
+    payload.Parameters["ocrOffset"] = Stored("{\"region\":{\"x\":2},\"fallback\":\"02:05:00\"}");
+
+    var result = TemplateSubstitutor.SubstitutePayload(
+        payload,
+        new Dictionary<string, string> { ["x"] = "999" });
+
+    ((JsonElement)result.Parameters["ocrOffset"]!).GetProperty("region").GetProperty("x").GetInt32()
+        .Should().Be(2);
+  }
+
+  [Fact]
+  public void SubstitutePayloadLeavesAnUnknownStoredPlaceholderInPlace() {
+    // Lenient by contract: an outer scope may resolve it later, so it must not become empty text.
+    var payload = new SequenceActionPayload { Type = "tap" };
+    payload.Parameters["y"] = Stored("\"{{notInScope}}\"");
+
+    var result = TemplateSubstitutor.SubstitutePayload(payload, new Dictionary<string, string>());
+
+    result.Parameters["y"].Should().Be("{{notInScope}}");
   }
 }


### PR DESCRIPTION
Found while manually testing the queue-template parameter form from #151: a stored sequence **never** resolved a parameter inside an inline action payload.

`PNS Pit Ensure Mining` failed live with

```
Step 'Tap Enter Field row7' failed: tap step requires numeric 'x' and 'y' parameters
```

while the sibling tap with literal coordinates succeeded in the same run.

## Root cause

`TemplateSubstitutor.SubstitutePayload` matched on `value is string`:

```csharp
result.Parameters[key] = value is string str ? Substitute(str, context) : value;
```

`SequenceActionPayload.Parameters` is a `Dictionary<string, object?>`, so System.Text.Json materializes every slot as a **`JsonElement`** and never as a `string`. The match failed for every payload loaded from disk, the placeholder was copied through untouched, and the literal text `{{sectionRowY}}` reached the device layer where the numeric parse failed.

Substitution only ever worked for payloads **constructed in memory** — that is, in tests.

## Why the suite stayed green

Every existing test built its payload with a real C# string, so the whole suite exercised a type the runner never sees at run time. Six tests added in #150 asserted on exactly this behaviour and all passed while the feature was broken end to end. That is a testing defect as much as a code one, so this PR fixes it at both levels:

- `SequenceRunnerIfBodyScopeTests` round-trips the sequence through JSON exactly as `FileSequenceRepository` does, then runs it. **It fails before this change.** It asserts up front that the slot really is a `JsonElement`, so the test cannot silently drift back to the in-memory shape.
- Four `TemplateSubstitutorTests` cover the unit directly: a stored placeholder resolves, a stored number is untouched, a stored object is untouched, and an unknown stored placeholder stays in place rather than becoming empty text.

## Scope

This was never working for stored sequences — `{{iteration}}` inside a loop body's action payload included. The same one-line cause covers both.

Structured slots are deliberately left alone: an object or array is copied unchanged, so a `reschedule-self` `ocrOffset` region round-trips byte-for-byte, and placeholders nested inside a structured value stay out of scope as the feature specifies.

The substituted result is returned as plain text; every consumer parses numeric slots defensively, so a resolved `"569"` reads back as the number 569.

## Verification

- **841** unit, **117** contract, **303** integration tests pass.
- Confirmed against the running service that the authoring side was already correct: the stored step is `{"x":448,"y":"{{sectionRowY}}"}`, the sequence declares `sectionRowY` with default `569`, and `/parameter-scope` resolves it to `569` from `default`. The defect was purely in substitution at dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
