### PR TITLE
ci: bump upload-artifact to v6 to clear the Node 20 deprecation warning

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -88,7 +88,7 @@ jobs:
           "INSTALLER_ARTIFACT_NAME=$artifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Artifact name: $artifactName"
       - name: Upload installer artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.INSTALLER_ARTIFACT_NAME }}
           if-no-files-found: error


### PR DESCRIPTION
## Problem

Every `release-installer` run finished with this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v5.

Nothing was broken — the runner force-ran the action on Node 24 — but the warning is noise on every release build.

## Audit

Every `uses:` in both workflows, with the runtime each pinned version actually declares (`runs.using` in the action's own `action.yml` at that ref):

| Action | Version | `runs.using` | Change |
| --- | --- | --- | --- |
| `actions/checkout` | v5 | `node24` | none needed |
| `actions/setup-dotnet` | v5 | `node24` | none needed |
| `actions/setup-node` | v5 | `node24` | none needed |
| `actions/cache` | v5 | `node24` | none needed |
| `actions/upload-artifact` | v5 | **`node20`** | bumped to **v6** (`node24`) |

`upload-artifact` is the only offender. `v5.0.0` is the only release on the `v5` line, so no patch bump fixes it; `v6.0.0` is the lowest release that sets `runs.using: node24`.

## Breaking changes

None applicable. Diffing `action.yml` between `v5.0.0` and `v6.0.0` shows exactly one changed line — `using: 'node20'` to `using: 'node24'`. Inputs and defaults are identical, so `name`, `path` and `if-no-files-found: error` behave as before. The artifact-immutability / hidden-file / overwrite behaviour changes landed in v4 and v5 and are already baked into what this workflow does today.

The v6 release notes add one requirement: Actions Runner >= 2.327.1. This job runs on GitHub-hosted `windows-latest`, which is well past that. (Relevant only to self-hosted runners, of which this repo has none.)

`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` was deliberately **not** used — it silences the warning by opting back into the deprecated runtime rather than fixing it.

## Verification

`release-installer` no longer runs on pull requests (#153), so its absence from this PR's checks is expected. It was verified by `workflow_dispatch` against this branch instead; the run id, conclusion and post-change annotation state are posted in a comment below.

Triggers, `concurrency` and `permissions` blocks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)