### PR TITLE
[079] Run multiple queues at once, one per emulator

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/078-sequence-parameters"
+  "feature_directory": "specs/079-concurrent-queue-execution"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/078-sequence-parameters/plan.md
+at specs/079-concurrent-queue-execution/plan.md
 <!-- SPECKIT END -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ For the *history* of how the system got here — one folder per feature, point-i
 history; this file is the current-state source of truth. When the two disagree, this file wins and
 the relevant spec should be marked superseded.
 
-_Last reviewed: 2026-08-24._
+_Last reviewed: 2026-08-30._
 
 ## What GameBot is
 
@@ -203,6 +203,12 @@ not survive a service restart; queue *configuration* and templates are persisted
   schedule option, IF-gated), a **live monitor** that shows a running queue's now/up-next plan
   (read-only, auto-refreshing) in place of the editor, a background screen-capture service reporting
   FPS, and "ensure game running" handling.
+- **Concurrent queue runs** (feature 079): several queues run at the same time, **one per emulator**.
+  Each run holds an exclusive, in-memory claim on its ADB serial (`IDeviceClaimRegistry`); starting a
+  second queue on a claimed device is refused with `409 device_in_use` naming the device and the
+  holding queue, distinct from `already_running`. The claim is released when the run ends for any
+  reason and never survives a restart. See "Device-scoped observation" below for how each run's screen
+  reads are kept to its own device.
 - **Execution Logs** (separate tab): filterable/sortable grid, expandable hierarchy reflecting
   what actually executed, deep links into authoring, snapshots and step outcomes; non-technical
   presentation (no raw JSON).
@@ -210,6 +216,28 @@ not survive a service restart; queue *configuration* and templates are persisted
   runtime per-component logging level control, jitter/retry/delay parameters.
 - **Packaging**: standalone Windows installer (EXE/MSI) with semantic-version upgrade flow
   (build auto-versioning, downgrade prohibition).
+
+### Device-scoped observation (feature 079)
+
+Every screen read is resolved against **one** device, so concurrent runs cannot observe each other:
+
+- `IScreenSourceFactory.ForSession(sessionId)` returns a `SessionScopedScreenSource` bound to one
+  session for its lifetime. Used wherever the caller already knows its session — `CommandExecutor`'s
+  detect-and-tap and wait-for-image paths, and `GameReadinessProbe`.
+- `IDeviceContextAccessor` (an `AsyncLocal<DeviceContext>`) carries "which device is this execution
+  flow acting on". `SequenceExecutionService.ExecuteAsync` pushes it for the whole sequence when given
+  a session, so nested sequences, commands, loops and trigger-based image/text conditions inherit it
+  without `ITriggerEvaluator` needing a session parameter.
+- The singleton `IScreenSource` (`BackgroundCaptureScreenSource`) resolves: **ambient context → the
+  single running session → nothing**. It previously returned the frame of the *first* running session,
+  which silently gave one queue run another run's screen.
+- Device resolution for steps follows one rule (`SessionResolver`): an explicit session always wins;
+  with none supplied, exactly one running session is used; several running sessions fail the step with
+  `"N device sessions are active; specify a sessionId for '<step>'"` rather than guessing.
+- `GET /api/emulator/screenshot` takes `sessionId` or `serial`; with several sessions and no selector
+  it returns `409 ambiguous_session` instead of an arbitrary device.
+- `Service:Sessions:MaxConcurrentSessions` defaults to **8** (was 3); exceeding it fails a run with a
+  message naming the limit and the setting.
 
 ### Break & loop execution and the execution-log status vocabulary
 

--- a/specs/051-queue-execution-runtime/spec.md
+++ b/specs/051-queue-execution-runtime/spec.md
@@ -2,7 +2,13 @@
 
 **Feature Branch**: `051-queue-execution-runtime`  
 **Created**: 2026-06-02  
-**Status**: Implemented
+**Status**: Implemented (FR-013 superseded by 079)
+
+> **FR-013 no longer describes current behaviour.** This spec allowed two queue runs to share one
+> emulator and made avoiding the resulting device-level interference the operator's responsibility.
+> Feature [079](../079-concurrent-queue-execution/spec.md) reverses that: a device is held by at most
+> one run, and a second start on a claimed emulator is refused with `device_in_use`. FR-013a (no
+> second run of the *same* queue) and every other requirement here still stand.
 **Input**: User description: "let's bring live into the queues. I want to be able to execute the queues. When the queue is executed (either via API or from the UI), first a linked template is loaded on the server side, then the queue establishes connection to the configured emulator (for now if the emulator is not available, it should stop with a failure execution log entry), and then execute sequences from loaded template one after another until the end. At the end of every execution, an execution log entry should be made, why the execution was stopped (completed full run/stopped manually/failure due to what). If the 'cycle execution' is set, it should then start from the beginning without reloading the template. When I stop the execution either via API of via UI, the execution should abort immediately, disconnect a session from the emulator and write a log entry."
 
 ## Clarifications

--- a/specs/079-concurrent-queue-execution/checklists/requirements.md
+++ b/specs/079-concurrent-queue-execution/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Concurrent Queue Execution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The "Why runs interfere today" section describes observed system behavior (the diagnosis the user
+  asked for), stated in capability terms rather than code terms, so it stays readable for
+  non-technical stakeholders while anchoring the acceptance criteria.
+- All items pass on the first validation iteration.
+- Re-validated 2026-08-30 after the clarification session (5 answers integrated): 16/16 -> 16/16 items
+  passing, no regressions.

--- a/specs/079-concurrent-queue-execution/contracts/api.md
+++ b/specs/079-concurrent-queue-execution/contracts/api.md
@@ -1,0 +1,138 @@
+# Phase 1 Contracts: Concurrent Queue Execution
+
+All changes are additive except where explicitly marked. No API version bump.
+Error bodies use the repository's existing envelope: `{ "error": "<code>", "message": "<text>" }`.
+
+---
+
+## 1. `POST /api/queues/{id}/start`
+
+### New failure: device already claimed (FR-009, FR-010)
+
+**Status**: `409 Conflict`
+
+```json
+{
+  "error": "device_in_use",
+  "message": "Emulator 'emulator-5558' is already in use by queue 'PNS Daily 5558'. Stop that queue before starting this one."
+}
+```
+
+Distinct from the existing refusal for the same queue, which is unchanged:
+
+```json
+{ "error": "already_running", "message": "The queue is already running." }
+```
+
+**Preconditions checked, in order** (unchanged order except for the new step 3):
+
+1. Queue exists -> else `404 not_found`.
+2. Feature 078 required-parameter preflight -> else `409` with the existing parameter error.
+3. **NEW** Device claim -> else `409 device_in_use`.
+4. Run registry accepts the queue -> else `409 already_running`.
+
+**Guarantees**: a `device_in_use` refusal starts no run, changes no queue's status, and does not touch
+the holding run.
+
+**Logging** (FR-017): because no run starts, there is no execution-log entry. The refusal is instead
+written to the service's application log at Warning level, naming the refused queue id, the device
+serial and the holding queue:
+
+```text
+Queue {QueueId} start refused: emulator {DeviceSerial} is held by queue {HoldingQueueId} ({HoldingQueueName}).
+```
+
+### Success
+
+Unchanged: `200 OK` with the existing queue response body.
+
+---
+
+## 2. `GET /api/queues/{id}/monitor`
+
+### New optional field (FR-018)
+
+```jsonc
+{
+  "queueId": "…",
+  "name": "PNS Daily 5558",
+  "running": true,
+  "deviceSerial": "emulator-5558",   // NEW: null when the queue is not running
+  "cycleExecution": true,
+  "runStartedAt": "2026-08-30T09:00:00+02:00",
+  "current": { /* unchanged */ },
+  "upcoming": [ /* unchanged */ ],
+  "nothingScheduled": false,
+  "lastOutcome": null
+}
+```
+
+Additive and nullable; clients that ignore it are unaffected.
+
+---
+
+## 3. `GET /api/emulators/screenshot`
+
+### Changed selector behavior (FR-022, FR-023, FR-024) - **intentionally breaking in one case**
+
+| Query | Sessions active | Before | After |
+|---|---|---|---|
+| `?sessionId=<id>` | any | that session | unchanged |
+| `?serial=<adb-serial>` | any | (not supported) | **NEW** that device's running session, else `404 session_not_found` |
+| none | 0 | `503 emulator_unavailable` | unchanged |
+| none | 1 | that session | unchanged |
+| none | >1 | **arbitrary session** | **`409 ambiguous_session`** |
+
+```json
+{
+  "error": "ambiguous_session",
+  "message": "3 device sessions are active; specify sessionId or serial."
+}
+```
+
+The previous behavior in the last row returned an unpredictable device, so nothing depended on it
+correctly. `PickSession`'s `FirstOrDefault` chain is removed.
+
+---
+
+## 4. Sequence-step failure messages (FR-006, FR-007)
+
+Not a wire contract, but these strings are user-facing in execution logs and are asserted by tests.
+
+| Situation | Before | After |
+|---|---|---|
+| Explicit session supplied, N sessions active | `no session available for '<step>' step; start a session or pass a sessionId` (**failed**) | step executes normally |
+| No session, 0 active | `no session available for '<step>' step; start a session or pass a sessionId` | unchanged |
+| No session, 1 active | (resolved silently) | unchanged |
+| No session, N > 1 active | `no session available for '<step>' step; …` | `3 device sessions are active; specify a sessionId for '<step>'` |
+
+Applies to `ensure-game-running`, `go-to-home-screen`, primitive `tap`/`swipe`/`key`, and the
+`CommandExecutor` `missing_session_context` path (whose exception message gains the same text).
+
+---
+
+## 5. Session capacity message (FR-016)
+
+`SessionManager.CreateSession` still throws `InvalidOperationException` and the API still maps it to
+the existing `capacity_exceeded` code. Only the message changes, and it is what a failed queue run
+records:
+
+```text
+session capacity reached: 8 of 8 sessions are open (Service:Sessions:MaxConcurrentSessions)
+```
+
+The queue run's execution-log failure reason becomes:
+
+```text
+emulator could not be reached ('emulator-5566'): session capacity reached: 8 of 8 sessions are open (Service:Sessions:MaxConcurrentSessions)
+```
+
+---
+
+## 6. Configuration
+
+| Key | Before | After |
+|---|---|---|
+| `Service:Sessions:MaxConcurrentSessions` | default `3` | default `8` |
+
+An explicitly configured value continues to win; only the default changes.

--- a/specs/079-concurrent-queue-execution/contracts/api.md
+++ b/specs/079-concurrent-queue-execution/contracts/api.md
@@ -1,7 +1,13 @@
 # Phase 1 Contracts: Concurrent Queue Execution
 
 All changes are additive except where explicitly marked. No API version bump.
-Error bodies use the repository's existing envelope: `{ "error": "<code>", "message": "<text>" }`.
+
+Error bodies keep each endpoint's existing envelope, which differs by area:
+
+- **Queues** (`/api/queues/*`): `{ "error": { "code": "...", "message": "...", "hint": null } }`
+- **Emulator images** (`/api/emulator/*`, `/api/images/*`): flat `{ "error": "...", "message": "..." }`
+
+Both shapes are pre-existing; this feature adds codes, not envelopes.
 
 ---
 
@@ -13,15 +19,18 @@ Error bodies use the repository's existing envelope: `{ "error": "<code>", "mess
 
 ```json
 {
-  "error": "device_in_use",
-  "message": "Emulator 'emulator-5558' is already in use by queue 'PNS Daily 5558'. Stop that queue before starting this one."
+  "error": {
+    "code": "device_in_use",
+    "message": "Emulator 'emulator-5558' is already in use by queue 'PNS Daily 5558'. Stop that queue before starting this one.",
+    "hint": null
+  }
 }
 ```
 
 Distinct from the existing refusal for the same queue, which is unchanged:
 
 ```json
-{ "error": "already_running", "message": "The queue is already running." }
+{ "error": { "code": "already_running", "message": "The queue is already running.", "hint": null } }
 ```
 
 **Preconditions checked, in order** (unchanged order except for the new step 3):
@@ -71,7 +80,7 @@ Additive and nullable; clients that ignore it are unaffected.
 
 ---
 
-## 3. `GET /api/emulators/screenshot`
+## 3. `GET /api/emulator/screenshot`
 
 ### Changed selector behavior (FR-022, FR-023, FR-024) - **intentionally breaking in one case**
 
@@ -82,6 +91,9 @@ Additive and nullable; clients that ignore it are unaffected.
 | none | 0 | `503 emulator_unavailable` | unchanged |
 | none | 1 | that session | unchanged |
 | none | >1 | **arbitrary session** | **`409 ambiguous_session`** |
+
+"Running sessions" here means every running session, including those with no bound ADB serial —
+in stub/non-ADB mode that is all of them, and excluding them would break single-session capture there.
 
 ```json
 {

--- a/specs/079-concurrent-queue-execution/data-model.md
+++ b/specs/079-concurrent-queue-execution/data-model.md
@@ -1,0 +1,143 @@
+# Phase 1 Data Model: Concurrent Queue Execution
+
+No persisted shape changes. Every type below is in-memory and dies with the process (FR-013).
+
+---
+
+## New types
+
+### `DeviceContext` (`GameBot.Domain.Sessions`)
+
+Immutable record identifying the device an execution flow is acting on.
+
+| Field | Type | Notes |
+|---|---|---|
+| `SessionId` | `string` | Non-empty. The emulator session id the run holds. |
+| `DeviceSerial` | `string?` | The ADB serial, when known. Diagnostics only; `SessionId` is the key. |
+
+Invariants: immutable; `SessionId` never blank; safe to share across threads.
+
+### `IDeviceContextAccessor` / `AsyncLocalDeviceContextAccessor` (`GameBot.Domain.Sessions`)
+
+| Member | Signature | Behavior |
+|---|---|---|
+| `Current` | `DeviceContext?` | The context of the current execution flow, or `null` outside any run. |
+| `Push` | `IDisposable Push(DeviceContext context)` | Sets `Current` for this flow; disposing restores the previous value. |
+
+Invariants:
+
+- `AsyncLocal<T>` semantics: the value flows into `await` continuations and into `Task.Run`
+  (ExecutionContext capture), and a value set inside a child flow does not leak back to the parent.
+- Push/dispose nest correctly; disposing twice is a no-op.
+- Never `null`-pushed: pushing requires a non-null context.
+
+### `IScreenSourceFactory` (`GameBot.Domain.Triggers.Evaluators`)
+
+| Member | Signature | Behavior |
+|---|---|---|
+| `ForSession` | `IScreenSource ForSession(string sessionId)` | An `IScreenSource` bound to exactly that session for its lifetime. |
+
+Invariants: the returned source never observes another session; when that session has no cached frame,
+or is no longer running, it returns `null` (FR-003) rather than substituting.
+
+### `SessionScopedScreenSource` (`GameBot.Emulator.Session`)
+
+Implements `IScreenSource` over `BackgroundScreenCaptureService.GetCachedFrame(sessionId)` for one
+fixed session id. Decodes from the frame's immutable PNG bytes exactly as
+`BackgroundCaptureScreenSource` does today, so the concurrent-disposal hazard stays handled.
+
+### `BackgroundCaptureScreenSourceFactory` (`GameBot.Emulator.Session`)
+
+Implements `IScreenSourceFactory` by constructing a `SessionScopedScreenSource` per call.
+
+### `IDeviceClaimRegistry` / `DeviceClaimRegistry` (`GameBot.Service.Services.QueueExecution`)
+
+| Member | Signature | Behavior |
+|---|---|---|
+| `TryClaim` | `bool TryClaim(string serial, string queueId, string queueName)` | Atomic. `false` when another queue holds the serial. `true` (no-op claim) when `serial` is blank. |
+| `Release` | `void Release(string serial, string queueId)` | Removes the claim only if it is still held by `queueId`. Idempotent. |
+| `TryGetHolder` | `bool TryGetHolder(string serial, out DeviceClaim claim)` | For building the refusal message. |
+
+### `DeviceClaim` (`GameBot.Service.Services.QueueExecution`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `DeviceSerial` | `string` | Normalized (trimmed) form of the claimed serial. |
+| `QueueId` | `string` | The holding queue. |
+| `QueueName` | `string` | For the operator-facing message. |
+| `ClaimedAtUtc` | `DateTimeOffset` | Diagnostics. |
+
+Invariants:
+
+- Key normalization: `serial.Trim()`, compared with `StringComparer.OrdinalIgnoreCase` (FR-008).
+- At most one claim per normalized serial at any instant (FR-008, FR-012).
+- A blank serial is never stored, so blank-serial queues never block each other (research R5).
+- Claims are never persisted and never survive a restart (FR-013).
+
+---
+
+## Changed types
+
+### `QueueStartOutcome` (`GameBot.Service.Services.QueueExecution`)
+
+Adds one member:
+
+| Member | Meaning |
+|---|---|
+| `DeviceInUse` | The queue's emulator serial is claimed by a different running queue (FR-009, FR-010). |
+
+`Started`, `NotFound` and `AlreadyRunning` keep their exact meanings, so `already_running` stays
+distinguishable from the new refusal (FR-010).
+
+### `SessionOptions` (`GameBot.Emulator.Session`)
+
+| Field | Before | After |
+|---|---|---|
+| `MaxConcurrentSessions` | `3` | `8` (FR-015) |
+
+Still bound from `Service:Sessions:MaxConcurrentSessions`; an explicit configured value wins.
+
+### `QueueMonitorSnapshot` / `QueueMonitorResponse`
+
+Adds one optional field:
+
+| Field | Type | Notes |
+|---|---|---|
+| `DeviceSerial` | `string?` | The serial the run holds; `null` when the queue is not running (FR-018). |
+
+Additive and nullable, so existing clients are unaffected.
+
+### `IGameReadinessProbe.WaitUntilReadyAsync`
+
+Gains a `string? sessionId` parameter (defaulted, so existing call sites compile) used to obtain a
+session-scoped screen source; `null` keeps the ambient/single-session resolution.
+
+---
+
+## State transitions
+
+### Device claim lifecycle
+
+```text
+        TryClaim(serial, queueA)            run ends (any reason)
+unclaimed ─────────────────────► claimed(queueA) ─────────────────────► unclaimed
+     ▲                                │
+     │       TryClaim(serial, queueB)  │
+     └────────── refused ◄─────────────┘   (DeviceInUse; queueB stays Stopped)
+```
+
+- Entry: `QueueExecutionService.StartAsync`, after the run registry accepts the queue.
+- Exit: `RunAsync`'s `finally`, which already covers completion, manual stop, failure, cancellation
+  and host shutdown (FR-011).
+- Failure-to-launch path: if the claim is refused, the run-registry entry is removed and the CTS
+  disposed before returning, leaving no residue (edge case: "run fails before it finishes starting").
+
+### Device context lifetime
+
+```text
+run starts ─► (per sequence firing) Push(DeviceContext) ─► sequence executes ─► Dispose ─► next firing
+```
+
+The context is pushed per firing rather than once per run so that a firing that spawns its own flows
+(loops, nested sequences, command execution) inherits it, while the run loop's own scheduling code
+between firings carries no context.

--- a/specs/079-concurrent-queue-execution/plan.md
+++ b/specs/079-concurrent-queue-execution/plan.md
@@ -1,0 +1,169 @@
+# Implementation Plan: Concurrent Queue Execution
+
+**Branch**: `079-concurrent-queue-execution` | **Date**: 2026-08-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/079-concurrent-queue-execution/spec.md`
+
+## Summary
+
+Two queue runs today share three things they must not share: the screen they observe, the rule they
+use to pick a device, and the physical device itself. The fix is three matching changes.
+
+1. **Observation becomes session-scoped.** `BackgroundCaptureScreenSource` currently answers
+   `GetLatestScreenshot()` with the frame of the *first* running session it finds. It is replaced by a
+   `IScreenSourceFactory.ForSession(sessionId)` used everywhere a session id is already in hand, plus
+   one ambient `IDeviceContextAccessor` (AsyncLocal) that the singleton `IScreenSource` consults so
+   trigger evaluators and condition adapters -- which cannot take a session id without changing
+   `ITriggerEvaluator` -- observe the device of the run whose execution flow they are on.
+2. **Device resolution stops guessing.** The five `runningSessions.Count != 1` fallbacks are narrowed:
+   when the caller supplies a session, it is used unconditionally; when it does not and exactly one
+   session is active, today's behavior is kept; when it does not and several are active, the step
+   fails with an actionable message instead of a bare "no session available".
+3. **A device gets an exclusive owner.** A new in-memory `IDeviceClaimRegistry` (serial -> queue)
+   is claimed atomically in `QueueExecutionService.StartAsync` and released in the run's `finally`.
+   A second queue on a claimed serial is refused with a new `QueueStartOutcome.DeviceInUse`, surfaced
+   as HTTP 409 `device_in_use` naming the serial and the holding queue.
+
+Two supporting changes complete it: the concurrent-session ceiling rises from 3 to 8 with an
+actionable capacity message, and the operator image tooling's arbitrary `PickSession` is replaced by an
+explicit selector plus an ambiguity error.
+
+Everything is behavior-preserving for a single running queue: with exactly one session active, every
+resolution path lands on the same session it does today.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9 (`net9.0`), TypeScript 5 + React 18 (Vite) for `src/web-ui`
+**Primary Dependencies**: ASP.NET Core Minimal APIs, `System.Text.Json`, OpenCvSharp (untouched),
+xUnit + FluentAssertions, Jest + React Testing Library
+**Storage**: JSON files on disk via the existing `File*Repository` classes. This feature adds **no**
+persisted state: device claims and device contexts are in-memory and die with the process (FR-013).
+**Testing**: `dotnet test` across `tests/unit`, `tests/integration`, `tests/contract`; `npm test`
+(Jest) and `npm run build` (Vite) for `src/web-ui`
+**Target Platform**: Windows 11 desktop service (`GameBot.Service`, port 8080) driving LDPlayer
+emulators over ADB
+**Project Type**: Web application -- .NET backend + React SPA in one repository
+**Performance Goals**: claim acquisition/release O(1) and < 0.05 ms (one `ConcurrentDictionary`
+operation); session-scoped frame lookup no slower than today's first-session scan; no measurable change
+to queue-run wall-clock time, which is dominated by ADB round-trips of 10-100 ms
+**Constraints**: the run loop writes run state on one thread while the monitor reads it on another, so
+every new shared structure must be concurrency-safe; `AsyncLocal` context must survive the
+`Task.Run` that launches a run and every `await` inside it; single-session behavior must be
+byte-for-byte unchanged
+**Scale/Scope**: one operator, one machine, up to 8 concurrent emulator sessions; ~20 sequences,
+~60 commands, ~6 queue templates in the live authoring store
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design -- see bottom of section.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI), implementation
+progression is blocked until failures are fixed or a documented maintainer waiver exists.
+
+| Principle | Status | How this feature satisfies it |
+|---|---|---|
+| **I. Code Quality Discipline** | PASS | The new types are small and single-purpose: `DeviceContext`, `IDeviceContextAccessor` + `AsyncLocalDeviceContextAccessor`, `IScreenSourceFactory` + `BackgroundCaptureScreenSourceFactory`, `SessionScopedScreenSource`, `IDeviceClaimRegistry` + `DeviceClaimRegistry`. Each is well under the ~50 LOC/method bar. Every new public/internal member gets XML docs with inputs, outputs and error modes. No new dependencies. The AsyncLocal accessor is the one piece of ambient state and is justified in research R2 (it replaces a *worse* global -- "the first running session"). Method names are CamelCase, no underscores. `Program.cs` is untouched, so the build-time taint analyzers stay happy. |
+| **II. Testing Standards** | PASS | Unit tests for the claim registry (atomicity, release-on-every-exit, case/whitespace normalization), the AsyncLocal accessor (flow across `await` and `Task.Run`, nested push/pop), the session-scoped screen source (own session only, no-frame path), the narrowed session-resolution rule (1 session vs N sessions vs explicit) and the capacity message. Integration tests for two concurrent runs observing distinct screens, same-device refusal, claim release after completion/stop/failure, and non-interference on stop. Contract tests for the 409 `device_in_use` body and the monitor's new device field. Target >=80% line / >=70% branch on touched areas. |
+| **III. UX Consistency** | PASS | The new refusal reuses the existing `{ error, message }` error envelope and 409 status already used by `already_running` and the 078 parameter refusal. Messages are actionable and name the device, the holding queue and the counts involved. All API changes are additive (one new error code, one new optional response field, one new optional query parameter), so no version bump. |
+| **IV. Performance** | PASS | Budget declared above. The claim registry adds one dictionary operation per run start/end. Replacing the first-session `ListSessions()` scan with a keyed lookup is neutral-to-faster. A unit benchmark under `tests/unit/Performance/` holds the claim path under budget. |
+| **V. Living Documentation** | PASS | This changes the capability set and the API surface, so `docs/architecture.md` MUST be updated with a refreshed "Last reviewed" date in the same PR, and `specs/STATUS.md` gets the 079 entry. Feature **051**'s FR-013 ("allow concurrent runs on the same emulator -- operator's responsibility, no guard") is **reversed** by FR-008: `specs/051-queue-execution-runtime/spec.md` must get a Status line noting that FR-013 is superseded by 079, and the matching XML doc on `IQueueExecutionService` must be corrected in code. FR-013a (no second run of the *same* queue) is unchanged. |
+
+**Post-Phase-1 re-check**: PASS. The design adds no project, no dependency and no constitutional
+exception. The Complexity Tracking table below is intentionally empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/079-concurrent-queue-execution/
++-- spec.md               # Feature specification (with Clarifications)
++-- plan.md               # This file
++-- research.md           # Phase 0 -- R1..R8 technical decisions
++-- data-model.md         # Phase 1 -- new/changed types and their invariants
++-- quickstart.md         # Phase 1 -- how an operator runs several queues at once
++-- contracts/
+|   +-- api.md            # Phase 1 -- additive REST contract changes
++-- checklists/
+|   +-- requirements.md   # Spec quality checklist
++-- tasks.md              # Phase 2 -- created by /speckit-tasks, not by this command
+```
+
+### Source Code (repository root)
+
+```text
+src/GameBot.Domain/
++-- Sessions/DeviceContext.cs                  NEW: (SessionId, DeviceSerial) record
++-- Sessions/IDeviceContextAccessor.cs         NEW: ambient current-device contract
++-- Sessions/AsyncLocalDeviceContextAccessor.cs NEW: AsyncLocal impl, Push returns IDisposable
++-- Triggers/Evaluators/ScreenSourceAbstractions.cs CHANGED: + IScreenSourceFactory
+
+src/GameBot.Emulator/
++-- Session/SessionScopedScreenSource.cs       NEW: frames for one fixed session id
++-- Session/BackgroundCaptureScreenSourceFactory.cs NEW: IScreenSourceFactory impl
++-- Session/BackgroundCaptureScreenSource.cs   CHANGED: ambient context -> single session ->
+|                                                       null; the FirstOrDefault scan is removed
++-- Session/SessionOptions.cs                  CHANGED: MaxConcurrentSessions default 3 -> 8
++-- Session/SessionManager.cs                  CHANGED: capacity error names active/max
+
+src/GameBot.Service/
++-- Services/QueueExecution/IDeviceClaimRegistry.cs NEW: TryClaim/Release/TryGetHolder
++-- Services/QueueExecution/DeviceClaimRegistry.cs  NEW: ConcurrentDictionary impl
++-- Services/QueueExecution/IQueueExecutionService.cs CHANGED: + QueueStartOutcome.DeviceInUse,
+|                                                              corrected same-emulator doc comment
++-- Services/QueueExecution/QueueExecutionService.cs CHANGED: claim on start, release in finally,
+|                                                             push device context per firing,
+|                                                             actionable capacity failure text
++-- Services/QueueExecution/QueueMonitorService.cs   CHANGED: project the run's device serial
++-- Services/QueueExecution/QueueMonitorSnapshot.cs  CHANGED: + DeviceSerial
++-- Services/SequenceExecution/SequenceExecutionService.cs CHANGED: push device context for the
+|                                                                   sequence; narrowed resolution
++-- Services/CommandExecutor.cs                 CHANGED: session-scoped screen source for detection;
+|                                                        narrowed resolution + actionable message
++-- Services/EnsureGameRunning/IGameReadinessProbe.cs CHANGED: + sessionId parameter
++-- Services/EnsureGameRunning/GameReadinessProbe.cs  CHANGED: resolve screen via the factory
++-- Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs CHANGED: pass its sessionId through
++-- Contracts/Queues/QueueMonitorResponse.cs    CHANGED: + deviceSerial
++-- Endpoints/QueuesEndpoints.cs                CHANGED: map DeviceInUse -> 409 device_in_use
++-- Endpoints/QueuesEndpoints.Logging.cs        CHANGED: + refused-start application-log entry
++-- Endpoints/EmulatorImageEndpoints.cs         CHANGED: explicit selector + ambiguity error
++-- GameBotServiceSetup.cs                      CHANGED: register accessor, factory, claim registry
+
+src/web-ui/src/
++-- components/queues/QueueMonitor.tsx          CHANGED: show the run's device
++-- pages/QueuesPage.tsx                        CHANGED: surface the device_in_use message on Start
++-- services/queues.ts                          CHANGED: deviceSerial on QueueMonitorDto
++-- services/images.ts                          CHANGED: always send the screenshot selector
+
+tests/
++-- unit/Sessions/DeviceContextAccessorTests.cs           NEW
++-- unit/Sessions/SessionScopedScreenSourceTests.cs       NEW
++-- unit/Sessions/SessionCapacityMessageTests.cs          NEW
++-- unit/Queues/DeviceClaimRegistryTests.cs               NEW
++-- unit/Queues/QueueExecutionServiceDeviceClaimTests.cs  NEW
++-- unit/Sequences/SessionResolutionTests.cs              NEW
++-- unit/Performance/DeviceClaimBenchmarkTests.cs         NEW
++-- integration/Queues/ConcurrentQueueRunTests.cs         NEW
++-- integration/Sessions/ConcurrentScreenIsolationTests.cs NEW
++-- integration/Queues/ConcurrentRunStateIsolationTests.cs NEW
++-- contract/QueueConcurrencyContractTests.cs             NEW
++-- contract/EmulatorScreenshotSelectorContractTests.cs   NEW
++-- src/web-ui/src/pages/__tests__/QueuesPage.execution.spec.tsx CHANGED
+
+docs/architecture.md                            CHANGED (living docs, Principle V)
+specs/STATUS.md                                 CHANGED (add 079)
+specs/051-queue-execution-runtime/spec.md        CHANGED (Status: FR-013 superseded by 079)
+```
+
+**Structure Decision**: The existing layout is kept unchanged. Device identity and the ambient
+context are pure domain concepts, so they live in `GameBot.Domain/Sessions`. Anything that touches the
+capture cache lives in `GameBot.Emulator/Session` next to the cache itself. The claim registry is a
+queue-run lifecycle concern and sits beside `QueueRunRegistry` in
+`GameBot.Service/Services/QueueExecution`, mirroring how feature 065 extracted that registry.
+
+## Complexity Tracking
+
+> No constitution violations. This table is intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | | |

--- a/specs/079-concurrent-queue-execution/quickstart.md
+++ b/specs/079-concurrent-queue-execution/quickstart.md
@@ -11,8 +11,11 @@ Each queue is bound to one ADB serial (`emulatorSerial`, immutable after creatio
 should run at the same time must have **different** serials.
 
 ```bash
-curl -s http://localhost:8080/api/queues | jq -r '.[] | "\(.name)\t\(.emulatorSerial)"'
+curl -s -H "Authorization: Bearer $GAMEBOT_AUTH_TOKEN" http://localhost:8080/api/queues | jq -r '.[] | "\(.name)\t\(.emulatorSerial)"'
 ```
+
+(Every call below needs the same `Authorization` header when `GAMEBOT_AUTH_TOKEN` is set; it is
+omitted from the remaining examples for brevity.)
 
 If two queues share a serial, split the work differently: put the sequences into one template on one
 queue, or create a second LDPlayer instance and bind the second queue to its serial.
@@ -26,16 +29,16 @@ curl -s -X POST http://localhost:8080/api/queues/<queueA-id>/start
 curl -s -X POST http://localhost:8080/api/queues/<queueB-id>/start
 ```
 
-If the second start returns:
+If the second start returns `409` with:
 
 ```json
-{ "error": "device_in_use", "message": "Emulator 'emulator-5558' is already in use by queue 'PNS Daily 5558'. Stop that queue before starting this one." }
+{ "error": { "code": "device_in_use", "message": "Emulator 'emulator-5558' is already in use by queue 'PNS Daily 5558'. Stop that queue before starting this one." } }
 ```
 
 then both queues are bound to the same emulator. Stop the holding queue, or re-point one queue at a
 different instance.
 
-`{"error":"already_running"}` is a different thing: that queue itself is already running.
+Code `already_running` is a different thing: that queue itself is already running.
 
 ## 3. Watch them
 
@@ -53,9 +56,9 @@ With more than one session active, screen capture needs to know which one you me
 
 ```bash
 # by session
-curl -s "http://localhost:8080/api/emulators/screenshot?sessionId=<id>" -o shot.png
+curl -s "http://localhost:8080/api/emulator/screenshot?sessionId=<id>" -o shot.png
 # by device serial
-curl -s "http://localhost:8080/api/emulators/screenshot?serial=emulator-5560" -o shot.png
+curl -s "http://localhost:8080/api/emulator/screenshot?serial=emulator-5560" -o shot.png
 ```
 
 Without a selector and with several sessions active you now get `409 ambiguous_session` instead of an

--- a/specs/079-concurrent-queue-execution/quickstart.md
+++ b/specs/079-concurrent-queue-execution/quickstart.md
@@ -1,0 +1,96 @@
+# Quickstart: Running Several Queues At Once
+
+After feature 079, the rule is simple: **one queue per emulator, as many emulators as you like** (up to
+the configured session limit, default 8).
+
+---
+
+## 1. Give each queue its own emulator
+
+Each queue is bound to one ADB serial (`emulatorSerial`, immutable after creation). Two queues that
+should run at the same time must have **different** serials.
+
+```bash
+curl -s http://localhost:8080/api/queues | jq -r '.[] | "\(.name)\t\(.emulatorSerial)"'
+```
+
+If two queues share a serial, split the work differently: put the sequences into one template on one
+queue, or create a second LDPlayer instance and bind the second queue to its serial.
+
+## 2. Start them
+
+Start each queue as usual. Starts are independent:
+
+```bash
+curl -s -X POST http://localhost:8080/api/queues/<queueA-id>/start
+curl -s -X POST http://localhost:8080/api/queues/<queueB-id>/start
+```
+
+If the second start returns:
+
+```json
+{ "error": "device_in_use", "message": "Emulator 'emulator-5558' is already in use by queue 'PNS Daily 5558'. Stop that queue before starting this one." }
+```
+
+then both queues are bound to the same emulator. Stop the holding queue, or re-point one queue at a
+different instance.
+
+`{"error":"already_running"}` is a different thing: that queue itself is already running.
+
+## 3. Watch them
+
+The monitor now reports which device each run holds:
+
+```bash
+curl -s http://localhost:8080/api/queues/<queueA-id>/monitor | jq '{name, running, deviceSerial, current}'
+```
+
+Each running queue shows its own device and its own current sequence. Nothing is shared between them.
+
+## 4. Take a screenshot of a specific device
+
+With more than one session active, screen capture needs to know which one you mean:
+
+```bash
+# by session
+curl -s "http://localhost:8080/api/emulators/screenshot?sessionId=<id>" -o shot.png
+# by device serial
+curl -s "http://localhost:8080/api/emulators/screenshot?serial=emulator-5560" -o shot.png
+```
+
+Without a selector and with several sessions active you now get `409 ambiguous_session` instead of an
+arbitrary device. With exactly one session active, nothing changes -- the bare call still works.
+
+**Author reference images one device at a time.** Cropping from the wrong emulator produces a
+reference image that fails everywhere else.
+
+## 5. Raise the ceiling if you need more than 8
+
+```jsonc
+// appsettings.json
+{ "Service": { "Sessions": { "MaxConcurrentSessions": 12 } } }
+```
+
+A run that hits the ceiling fails with an explicit message naming the limit, e.g.
+`session capacity reached: 8 of 8 sessions are open (Service:Sessions:MaxConcurrentSessions)`.
+
+---
+
+## What did *not* change
+
+- Single-queue behavior. With one queue running, every device-resolution path lands on the same
+  session it always did, and no call needs a new parameter.
+- Scheduling. AtQueueStart / OncePerRun / EveryStep / Timer semantics, self-reschedule, live schedules,
+  idle pause and cycling are all untouched.
+- Sequences and templates. No sequence, command or template needs editing to run concurrently. If you
+  want one template to serve several emulators, that is feature 078's queue parameters
+  (`{{queue.emulatorSerial}}` and friends) and it already works.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `device_in_use` on start | Two queues share an emulator serial | Stop the holder, or bind one queue to a different instance |
+| Step fails: `N device sessions are active; specify a sessionId for '<step>'` | A step ran outside any queue run while several sessions were open | Run it from its queue, or pass an explicit `sessionId` |
+| Run fails: `session capacity reached: N of N sessions are open` | More concurrent runs than the configured limit | Raise `Service:Sessions:MaxConcurrentSessions` |
+| `409 ambiguous_session` from screenshot | Several sessions active, no selector given | Add `?sessionId=` or `?serial=` |

--- a/specs/079-concurrent-queue-execution/research.md
+++ b/specs/079-concurrent-queue-execution/research.md
@@ -1,0 +1,167 @@
+# Phase 0 Research: Concurrent Queue Execution
+
+All decisions below were reached by reading the current implementation. Each records what the code
+does today, what was chosen, why, and what was rejected.
+
+---
+
+## R1 - Why concurrent runs interfere today
+
+**Finding (evidence in code):**
+
+| # | Defect | Where |
+|---|---|---|
+| 1 | `GetLatestScreenshot()` returns the frame of the **first** running session found by enumerating a `ConcurrentDictionary`, regardless of the caller | `src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs` |
+| 2 | Five device-resolution sites hard-fail unless **exactly one** session is running | `SequenceExecutionService.DispatchEnsureGameRunningAsync` / `DispatchGoToHomeScreenAsync` / `DispatchPrimitiveInputAsync`; `CommandExecutor.ForceExecuteStepAsync` / `ResolveSessionIdAsync` |
+| 3 | Nothing prevents two queues bound to the same serial from running at once -- explicitly allowed by 051 FR-013 | `QueueExecutionService.StartAsync`, `IQueueExecutionService` doc comment |
+| 4 | `MaxConcurrentSessions` defaults to 3 and the overflow throws a bare `InvalidOperationException("capacity_exceeded")` | `SessionOptions.cs`, `SessionManager.CreateSession` |
+| 5 | `PickSession` chooses an arbitrary running session for screen capture / crop | `EmulatorImageEndpoints.PickSession` |
+
+Defect 1 is the most damaging because it is silent: a run keeps executing, but its image and OCR
+checks are evaluated against another emulator's screen, so it taps the right coordinates on the wrong
+game. Defect 2 is the loudest: it turns the *first* queue's steps into hard failures the moment a
+second queue starts. Both must be fixed for concurrency to be usable; neither alone is sufficient.
+
+**Decision**: Treat all five as in scope; they are one bug expressed five ways ("who is *my* device?").
+
+**Alternatives considered**: Fixing only the screen source. Rejected -- defect 2 still breaks every
+primitive tap in a concurrent run, so the feature would not work.
+
+---
+
+## R2 - How a step learns which device it belongs to
+
+**Decision**: Two complementary mechanisms.
+
+- **Explicit (primary)**: a new `IScreenSourceFactory.ForSession(string sessionId)` returning an
+  `IScreenSource` permanently bound to that session. Used by every call site that already has a
+  session id in hand: `CommandExecutor`'s detect-and-tap paths and `GameReadinessProbe`.
+- **Ambient (fallback)**: a new `IDeviceContextAccessor` backed by `AsyncLocal<DeviceContext?>`.
+  `QueueExecutionService` pushes its run's context around each sequence firing;
+  `SequenceExecutionService` pushes it around a sequence executed with an explicit session. The
+  singleton `IScreenSource` registration consults the accessor first, then falls back to the
+  single-running-session rule, then returns null.
+
+**Rationale**: The trigger-based image/text condition path reaches the screen through
+`TriggerEvaluationService -> ITriggerEvaluator -> IScreenSource`. `ITriggerEvaluator.EvaluateAsync`
+has no session parameter and is also driven by the standalone `TriggerBackgroundWorker`, so threading a
+session id through it would change a shared interface and every implementation and test for the sake of
+one caller. `AsyncLocal` flows through `await` and through the `Task.Run` that launches a queue run
+(ExecutionContext is captured), so the context is correct for the whole run without touching those
+signatures.
+
+**Alternatives considered**:
+- *Ambient only.* Simpler, but leaves the paths that already know their session depending on hidden
+  state, which is harder to test and to reason about.
+- *Explicit only, threading `sessionId` through `ITriggerEvaluator`.* Rejected: a wide breaking change
+  to a shared abstraction, plus every evaluator and condition adapter, to serve one code path.
+- *Scoped DI container per run.* Rejected: the whole execution stack is registered as singletons; making
+  it scoped would ripple far beyond this feature and risk changing lifetime semantics elsewhere.
+
+---
+
+## R3 - Behavior when no session context is available
+
+**Decision**: Preserve the "exactly one running session" convenience, but only as a fallback, and make
+the multi-session case an explicit, actionable failure rather than a silent pick or a bare error:
+
+- explicit session supplied -> use it, regardless of how many sessions exist (removes the current
+  `Count != 1` failure);
+- no session supplied, exactly 1 active -> use it (today's behavior, unchanged);
+- no session supplied, 0 active -> today's "no session available; start a session" message;
+- no session supplied, N > 1 active -> fail with `"<N> device sessions are active; specify a
+  sessionId for '<step>'"`.
+
+**Rationale**: Matches the clarification, keeps every existing single-emulator workflow working, and
+turns the ambiguous case into a message that names the fix.
+
+**Alternatives considered**: Picking the most recently used session. Rejected -- it is still a guess,
+and a wrong guess taps the wrong game.
+
+---
+
+## R4 - Device claim mechanism
+
+**Decision**: `IDeviceClaimRegistry`, a singleton over
+`ConcurrentDictionary<string, DeviceClaim>` keyed by the trimmed, `OrdinalIgnoreCase`-normalized
+emulator serial. `TryClaim(serial, queueId, queueName)` uses `TryAdd`, which is atomic, so two
+simultaneous starts cannot both succeed (FR-012). `Release(serial, queueId)` removes only when the
+claim still belongs to that queue, so a late release from a finished run cannot steal a claim a newer
+run has taken.
+
+The claim is taken in `QueueExecutionService.StartAsync` **after** `QueueRunRegistry.TryAdd` succeeds
+and **before** the background run is launched. It is released in `RunAsync`'s existing `finally`
+block, which already runs on completion, manual stop, failure, cancellation and host shutdown
+(FR-011). If the claim fails, the queue is removed from the run registry, the CTS disposed and
+`QueueStartOutcome.DeviceInUse` returned -- so nothing about the refused queue changes.
+
+**Rationale**: Mirrors the existing `QueueRunRegistry` exactly, so the code is idiomatic for this
+codebase, needs no locks and cannot deadlock. In-memory only, satisfying FR-013 for free.
+
+**Alternatives considered**:
+- *Deriving the claim from the run registry* (scan running handles for a matching serial). Rejected:
+  the scan is not atomic against a concurrent start, so two starts could both pass the check.
+- *A named OS mutex per serial.* Rejected: cross-process coordination is not needed (one service
+  process) and mutex abandonment handling is a new failure mode.
+- *Claiming inside `RunAsync`.* Rejected: the start call would return `Started` and the queue would go
+  Running before the refusal was known, so the operator would see a phantom run.
+
+---
+
+## R5 - Blank and unresolvable serials
+
+**Decision**: A queue whose `EmulatorSerial` is blank claims nothing (no key), and its run proceeds to
+the existing session-creation failure path. A queue whose serial is non-blank but unknown to ADB does
+claim the serial, then fails at `CreateSession` and releases the claim in the same `finally`.
+
+**Rationale**: A blank serial has no device identity to reserve, and blocking every other blank-serial
+queue behind one shared empty key would be a new, surprising restriction. A non-blank unknown serial is
+still an intended device identity, and claiming it briefly costs nothing because the run fails within a
+second.
+
+---
+
+## R6 - Session capacity
+
+**Decision**: Raise `SessionOptions.MaxConcurrentSessions` from 3 to 8 and change
+`SessionManager.CreateSession`'s capacity exception message from the bare token `capacity_exceeded`
+to `"session capacity reached: 8 of 8 sessions are open (Service:Sessions:MaxConcurrentSessions)"`.
+The exception type and the existing `capacity_exceeded` API mapping are kept so no caller breaks; the
+message is what the queue run records in its failure log.
+
+**Rationale**: 8 covers any realistic single-machine LDPlayer setup and keeps the limit as a guard
+rail rather than the practical ceiling (FR-015, SC-006). The existing code already catches
+`InvalidOperationException` here and folds `ex.Message` into the run's failure reason, so the improved
+message reaches the execution log with no other change.
+
+**Alternatives considered**: Removing the limit. Rejected -- it is a useful guard against runaway
+session creation, and the constitution favors declared budgets.
+
+---
+
+## R7 - Operator image tooling
+
+**Decision**: `EmulatorImageEndpoints` gains an optional `sessionId` (and `serial`) selector. Resolution
+order: explicit selector -> the single running session -> ambiguity error
+`{"error":"ambiguous_session","message":"N device sessions are active; specify sessionId or serial"}`
+with HTTP 409. `PickSession`'s `FirstOrDefault` chain is deleted.
+
+**Rationale**: FR-022..FR-024. This is the only intentionally *breaking* behavior change, and only in
+the multi-session case that previously returned an arbitrary device -- an outcome that silently
+produced wrong reference images, so it has no behavior worth preserving.
+
+---
+
+## R8 - Concurrency safety of existing run state
+
+**Finding**: `QueueRunHandle` already guards its mutable state (`_currentLock`, `_idleLock`,
+`_timerLock`, concurrent collections) and `QueueRunSchedule` guards its registers with `_gate`; both
+were built for the monitor-reads-while-run-writes case. `QueueRuntimeStore` locks per queue state
+object. `FileExecutionLogRepository` serializes writes behind a `SemaphoreSlim`.
+
+**Decision**: No changes required for FR-019/FR-020/FR-021; add regression tests that exercise two runs
+concurrently rather than new synchronization. `ImageCaptureMetrics` and `TriggerEvaluationMetrics` are
+process-wide counters by design and stay as they are (they are diagnostics, not run state).
+
+**Rationale**: Adding locks where the code is already correct increases contention and risk with no
+benefit. The gap was never the per-run state; it was the shared *device* resolution.

--- a/specs/079-concurrent-queue-execution/spec.md
+++ b/specs/079-concurrent-queue-execution/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `079-concurrent-queue-execution`
 **Created**: 2026-08-30
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "I want to be able to run multiple queues at the same time. Check why these are interfereing each other now and implement a robust solution."
 
 ## Overview

--- a/specs/079-concurrent-queue-execution/spec.md
+++ b/specs/079-concurrent-queue-execution/spec.md
@@ -1,0 +1,327 @@
+# Feature Specification: Concurrent Queue Execution
+
+**Feature Branch**: `079-concurrent-queue-execution`
+**Created**: 2026-08-30
+**Status**: Draft
+**Input**: User description: "I want to be able to run multiple queues at the same time. Check why these are interfereing each other now and implement a robust solution."
+
+## Overview
+
+Today an operator can press Start on two queues and both will report themselves as Running, but the
+runs do not behave independently. The second run silently corrupts the first: screen observations are
+read from whichever device happens to be listed first, several kinds of execution step start failing
+outright with "no session available", and two queues bound to the same emulator physically fight over
+the same screen. This feature makes concurrent queue runs a first-class, correct capability: every run
+observes and acts on its own device only, and two runs may never share one device.
+
+### Why runs interfere today (investigation result)
+
+The investigation of the current implementation found five independent defects. They are recorded here
+because the acceptance criteria below are written against them.
+
+1. **Screen observation is not session-scoped.** The single shared screen provider answers every
+   "what is on screen right now" question by picking the *first* running session it finds, regardless
+   of which run is asking. Every image match, text/OCR match, wait-for-image, detect-and-tap and
+   game-readiness probe therefore reads a possibly foreign device once a second run exists, and which
+   device wins is not deterministic.
+2. **"Exactly one running session" fallbacks.** Several execution steps (foreground-the-game,
+   go-to-home-screen, primitive tap/swipe/key, force-execute-command, trigger-driven command
+   execution) resolve their device by requiring that exactly one session exists, and hard-fail when
+   the count is not one. Starting a second queue therefore breaks steps in the first.
+3. **No exclusive claim on a device.** Nothing prevents two queues configured with the same emulator
+   from running at once. Both drive the same physical screen, so navigation, back-outs and idle
+   pauses from one run corrupt the other.
+4. **A low, silent session capacity ceiling.** The number of simultaneously open device sessions is
+   capped at a small fixed number; exceeding it fails a queue run with an opaque capacity error rather
+   than an actionable message.
+5. **Arbitrary device selection in operator tooling.** Screen capture and crop tooling picks an
+   arbitrary running session, so with two runs active the operator can be shown, and can crop
+   reference images from, the wrong device.
+
+## Clarifications
+
+### Session 2026-08-30
+
+- Q: When a queue is started whose bound emulator is already claimed by a running queue, what should happen? → A: Refuse the start with an explanatory error; no auto-queueing, no waiting. (Rationale: two automations driving one screen cannot both be correct, and a silent wait would hide a misconfiguration.)
+- Q: What default limit should apply to concurrently open device sessions? → A: 8, configurable. (Rationale: today's default of 3 is below a plausible emulator count and turns a configuration limit into a surprise run failure.)
+- Q: How should a device-affecting step behave when its context carries no session and more than one session is active? → A: Fail the step with an explicit "specify a device; N sessions active" message. (Rationale: an arbitrary pick is exactly the current defect; failing loudly is diagnosable.)
+- Q: How should operator screen-capture and crop tooling behave with no explicit selector while several sessions are active? → A: Return an explicit ambiguity error; single-session behavior is unchanged. (Rationale: authoring reference images from the wrong device silently poisons every sequence that uses them.)
+- Q: What identifies a device for exclusive-claim purposes? → A: The queue's bound ADB emulator serial, trimmed and compared case-insensitively. (Rationale: the serial is already the immutable device identity on a queue, and instance name/index are optional cold-start hints rather than identity.)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Two queues on two emulators run independently (Priority: P1)
+
+An operator has two emulator instances, each with its own queue and its own template. They start both
+queues. Each run drives only its own emulator: every screen check, tap, swipe, key press and OCR read
+in queue A is evaluated against emulator A's screen, and likewise for B. Neither run's outcome changes
+because the other is running.
+
+**Why this priority**: This is the feature. Without it, concurrency produces wrong actions on the wrong
+device, which is worse than not being able to run concurrently at all.
+
+**Independent Test**: Start two queues bound to two distinct emulator serials whose screens differ, and
+have each run a sequence that waits for an image only present on its own device. Both runs succeed,
+and no run reports a detection sourced from the other device.
+
+**Acceptance Scenarios**:
+
+1. **Given** queue A bound to device A and queue B bound to device B, both linked to templates whose
+   sequences use image detection, **When** both queues are started and run concurrently, **Then** each
+   run's image detections resolve against its own device's screen and both runs complete without
+   device-related failures.
+2. **Given** two queues running concurrently, **When** a sequence step that acts on the device
+   (tap, swipe, key, foreground-the-game, go-to-home-screen) executes in either run, **Then** the step
+   executes against that run's own device and never reports "no session available".
+3. **Given** two queues running concurrently, **When** a sequence in run A performs an OCR or text
+   match, **Then** the recognized text comes from device A's screen.
+4. **Given** queue A is running, **When** queue B is started and later stopped, **Then** run A
+   continues uninterrupted and its device session is untouched.
+
+---
+
+### User Story 2 - The same emulator cannot be claimed by two runs (Priority: P1)
+
+An operator tries to start a second queue that is bound to an emulator already being driven by a
+running queue. The system refuses the start and explains which queue currently holds that emulator,
+instead of allowing both runs to fight over one screen.
+
+**Why this priority**: Same-device concurrency cannot be made correct by scoping alone. Two runs
+tapping one screen is inherently destructive, so the system must prevent it. It is equal in priority to
+Story 1 because without it "run multiple queues" silently means "corrupt one game".
+
+**Independent Test**: Configure two queues with the same emulator serial, start the first, then start
+the second and observe the refusal and its message; stop the first and confirm the second then starts.
+
+**Acceptance Scenarios**:
+
+1. **Given** queue A is running on device X, **When** the operator starts queue B, also bound to device
+   X, **Then** the start is refused with a message naming device X and the queue currently holding it,
+   and queue B's status remains Stopped.
+2. **Given** queue A is running on device X and the start of queue B was refused, **When** queue A
+   stops, **Then** starting queue B succeeds.
+3. **Given** queue A's run ends for any reason (completion, manual stop, failure, or service
+   shutdown), **When** the run finishes, **Then** its claim on device X is released so another queue
+   can claim it.
+4. **Given** two queues bound to different devices, **When** both are started, **Then** neither start
+   is refused.
+
+---
+
+### User Story 3 - Concurrency is visible and diagnosable (Priority: P2)
+
+An operator running several queues can see, at a glance, which queues are running, which device each
+one holds, and what each is doing right now. When a start is refused or a run fails for a
+concurrency-related reason, the reason is stated in plain language in both the response and the
+execution log.
+
+**Why this priority**: Correct isolation without visibility leaves the operator unable to tell whether
+concurrency is working. Valuable, but the runs are already correct without it.
+
+**Independent Test**: Start two queues, read the monitor view, and confirm each running queue shows its
+own device and its own current sequence; then attempt a same-device start and confirm the refusal is
+both returned to the caller and recorded.
+
+**Acceptance Scenarios**:
+
+1. **Given** two queues running concurrently, **When** the operator views queue monitoring, **Then**
+   each running queue reports its own bound device and its own currently-executing sequence, with no
+   cross-contamination between the two.
+2. **Given** a start refused because the device is already claimed, **When** the operator inspects the
+   result, **Then** the refusal reason distinguishes "this queue is already running" from "this queue's
+   device is in use by another queue".
+3. **Given** a run that cannot start because the concurrent-session limit is reached, **When** the run
+   is finalized, **Then** the recorded failure names the limit and the number of runs currently active
+   rather than an opaque error code.
+4. **Given** a start refused because the device is claimed, **When** the operator checks the service's
+   application log, **Then** an entry names the refused queue, the device and the holding queue.
+
+---
+
+### User Story 4 - Operator tooling targets a chosen device (Priority: P3)
+
+While multiple queues are running, an operator using the live screen view and the crop/reference-image
+tooling can specify which device to look at, and the tooling never silently substitutes another.
+
+**Why this priority**: This is authoring convenience, not run correctness. Runs are already isolated
+without it, but authoring against the wrong device produces bad reference images.
+
+**Independent Test**: With two runs active, request a screen capture for a named device and confirm the
+returned image is that device's; request one without naming a device and confirm the response is
+unambiguous rather than an arbitrary pick.
+
+**Acceptance Scenarios**:
+
+1. **Given** two running device sessions, **When** the operator requests a screen capture for an
+   explicitly named session or device, **Then** the returned image is from that device.
+2. **Given** two running device sessions, **When** the operator requests a screen capture without
+   naming one, **Then** the system responds with an explicit "which device?" style error rather than
+   arbitrarily choosing one.
+3. **Given** exactly one running device session, **When** the operator requests a screen capture
+   without naming one, **Then** the existing single-device behavior is preserved and the capture
+   succeeds.
+
+---
+
+### Edge Cases
+
+- **A run's device disappears mid-run** (emulator closed, ADB drops the device): only that run fails,
+  with a device-lost reason; other concurrent runs are unaffected and keep running.
+- **Two queues bound to the same device are started at the same instant**: exactly one wins the claim;
+  the other is refused. There is no window in which both hold the device.
+- **A run fails or throws before it finishes starting**: its device claim is released, so a retry or a
+  different queue can claim the device immediately.
+- **The service shuts down with several runs active**: every run is cancelled and every claim released;
+  no claim survives a restart.
+- **More queues are started than the concurrent-session limit allows**: the runs that fit start
+  normally; each run beyond the limit fails with a message naming the limit, and the successful runs
+  are unaffected.
+- **A queue's bound device is blank or unknown to ADB**: that run fails with the existing
+  device-not-reachable reason; it does not consume or block another queue's claim.
+- **One run enters an idle pause and backs its game out** while another run is active: the back-out
+  affects only the pausing run's own device.
+- **A sequence started manually (outside any queue) while queues are running**: it must either be given
+  an explicit device or, when exactly one device session exists, keep today's behavior; it must never
+  silently borrow a queue run's device.
+- **A run's device session is evicted for idleness while the run is still alive**: the run detects the
+  loss and fails with the existing connection-lost reason rather than silently acting on another
+  device.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Device-scoped observation
+
+- **FR-001**: Every screen observation made on behalf of a queue run (image match, text/OCR match,
+  wait-for-image, detect-and-tap, template detection, game-readiness probe) MUST be evaluated against
+  the device bound to that run, and MUST NOT be able to return another run's device screen.
+- **FR-002**: When an execution context provides a device session, the system MUST use that session for
+  screen observation; it MUST NOT fall back to "the first running session".
+- **FR-003**: When a screen observation is requested for a session that has no cached frame yet or is
+  no longer running, the system MUST report that condition to the caller (no frame available) rather
+  than substituting another session's frame.
+- **FR-004**: The existing behavior for a single running session, and for stub/test mode where no real
+  device exists, MUST be preserved.
+
+#### Device-scoped action
+
+- **FR-005**: Every device-affecting sequence step (primitive tap/swipe/key, foreground-the-game,
+  go-to-home-screen, command execution, emulator lifecycle actions) MUST act on the device session
+  supplied by its execution context.
+- **FR-006**: The system MUST remove the requirement that exactly one device session exists in order to
+  resolve a device for a step whose context already carries one. Steps invoked with an explicit session
+  MUST succeed regardless of how many other sessions are active.
+- **FR-007**: When a step has no session in its context, the system MUST resolve a device only if
+  exactly one device session is active; when more than one is active it MUST fail the step with an
+  explicit message naming the number of active sessions and stating that a device must be specified,
+  and MUST NOT select one arbitrarily.
+
+#### Exclusive device claim
+
+- **FR-008**: A device MUST be held by at most one queue run at a time. A device's identity for
+  claiming purposes is the queue's bound ADB emulator serial, trimmed of surrounding whitespace and
+  compared case-insensitively; the optional emulator instance name/index are cold-start hints and MUST
+  NOT take part in device identity.
+- **FR-009**: Starting a queue whose device is already claimed by another running queue MUST be refused
+  immediately without starting a run, without altering the claiming run, and without changing the
+  refused queue's status. The system MUST NOT wait for, auto-queue, or retry the refused start.
+- **FR-010**: The refusal MUST be distinguishable from "this same queue is already running" and MUST
+  identify the device and the queue that currently holds it.
+- **FR-011**: A run MUST release its device claim when it ends for any reason: normal completion,
+  manual stop, failure, cancellation, or host shutdown.
+- **FR-012**: Claim acquisition MUST be atomic, so that two simultaneous starts for the same device
+  cannot both succeed.
+- **FR-013**: Device claims MUST be in-memory only and MUST NOT survive a service restart.
+- **FR-014**: Queues bound to different devices MUST NOT block one another.
+
+#### Concurrency capacity and diagnostics
+
+- **FR-015**: The number of concurrently open device sessions MUST be configurable and MUST default to
+  8 (raised from today's 3), so the configured limit is not the practical ceiling on concurrent queue
+  runs for a realistic number of emulators.
+- **FR-016**: When a run cannot start because the session capacity is reached, the failure recorded and
+  returned MUST name the configured limit and the number of sessions currently open.
+- **FR-017**: Concurrency-related run **failures** (device claim lost, capacity reached, device
+  unreachable) MUST appear in the affected queue's execution log in plain language. A refused **start**
+  produces no run and therefore no execution-log entry; it MUST instead be reported in plain language
+  in the response to the caller (FR-010) and recorded in the service's application log naming the
+  queue, the device and the holding queue.
+- **FR-018**: Queue monitoring MUST report, per running queue, its own bound device and its own current
+  activity, with no values derived from another run.
+
+#### Isolation of run state
+
+- **FR-019**: Per-run state (schedule registers, self-reschedule registers, idle-pause state, current
+  sequence indicator, live schedules) MUST remain isolated per run and MUST be safe to read and write
+  concurrently across runs.
+- **FR-020**: A failure, cancellation or device loss in one run MUST NOT change the status, schedule or
+  outcome of any other run.
+- **FR-021**: Execution-log writes from concurrent runs MUST not interleave into one another's entries;
+  each run's entries MUST remain attributable to that run.
+
+#### Operator tooling
+
+- **FR-022**: Screen-capture and crop tooling MUST accept an explicit device or session selector and
+  MUST use it when supplied.
+- **FR-023**: When no selector is supplied and more than one device session is active, the tooling MUST
+  return an explicit ambiguity error instead of choosing arbitrarily.
+- **FR-024**: When no selector is supplied and exactly one device session is active, the tooling MUST
+  behave as it does today.
+
+### Key Entities
+
+- **Queue run**: One in-flight execution of one queue. Owns exactly one device session, one device
+  claim, one schedule state and one set of ephemeral registers, for the lifetime of the run.
+- **Device session**: The live binding between a run and one emulator device serial, through which all
+  observation and input for that run flows.
+- **Device claim**: The exclusive, in-memory reservation of one emulator serial by one queue run.
+  Created when a run starts, released when the run ends.
+- **Screen observation context**: The device-scoped means by which a step obtains the current screen.
+  Always derived from the run's own device session.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Two queues bound to two different emulators can run to completion at the same time, and
+  every screen observation in each run resolves against that run's own device (0 cross-device
+  observations).
+- **SC-002**: With two or more runs active, no device-affecting step fails with a "no session
+  available" or "missing session context" reason when its run holds a healthy device session.
+- **SC-003**: 100% of attempts to start a second queue on an already-claimed device are refused, with a
+  message that names the device and the holding queue.
+- **SC-004**: After any run ends (completion, stop, failure, or shutdown), its device becomes claimable
+  again within one start attempt.
+- **SC-005**: Stopping or failing one run leaves every other concurrent run's status and remaining
+  schedule unchanged.
+- **SC-006**: The number of queues that can run at once is limited only by the number of distinct
+  emulators the operator has configured, up to the configured session limit, which defaults to at least
+  eight.
+- **SC-007**: Queue monitoring shows a correct, per-run device and current activity for every running
+  queue simultaneously.
+- **SC-008**: Operator screen capture returns the requested device's screen 100% of the time when a
+  device is named, and never silently returns a different device when one is not.
+
+## Assumptions
+
+- "Multiple queues at the same time" means one queue run per emulator, with several emulators running
+  in parallel. Two runs sharing a single physical device is treated as an error to prevent, not a
+  scenario to support, because two automations driving one screen cannot both be correct.
+- Emulator serials are the identity of a device for claiming purposes; a queue's bound serial is
+  already immutable after creation.
+- The existing single-queue behavior, including feature 059/060/065/072/073/074/075/077/078 semantics,
+  is preserved unchanged; this feature only removes cross-run coupling.
+- Persistence is not required for claims: a service restart ends all runs, so all claims are naturally
+  void.
+- The background trigger worker and other non-queue consumers keep their current behavior except where
+  it depends on "the only running session"; those paths follow FR-007.
+
+## Out of Scope
+
+- Allowing two queue runs to time-share one emulator (interleaved or cooperative multitasking on one
+  device).
+- Automatically queueing or retrying a start that was refused because the device is claimed.
+- Persisting run state or claims across service restarts.
+- Multi-machine or distributed queue execution.
+- Changing the scheduling semantics of any existing schedule type.

--- a/specs/079-concurrent-queue-execution/tasks.md
+++ b/specs/079-concurrent-queue-execution/tasks.md
@@ -31,9 +31,9 @@ Web application layout per [plan.md](./plan.md): .NET backend under `src/GameBot
 
 **Purpose**: Confirm the baseline is green before changing concurrency-sensitive code.
 
-- [ ] T001 Run `dotnet build C:\src\GameBot\GameBot.sln -c Debug` and record that the pre-change build is green (Constitution: red build blocks progression)
-- [ ] T002 [P] Run `dotnet test C:\src\GameBot\GameBot.sln` and record the pre-change pass/fail baseline so new failures are attributable to this feature
-- [ ] T003 [P] Run `npm ci` then `npm run build` and `npm test` in `src/web-ui` and record the baseline (lint and `tsc --noEmit` have known pre-existing failures and are NOT the gate)
+- [X] T001 Run `dotnet build C:\src\GameBot\GameBot.sln -c Debug` and record that the pre-change build is green (Constitution: red build blocks progression)
+- [X] T002 [P] Run `dotnet test C:\src\GameBot\GameBot.sln` and record the pre-change pass/fail baseline so new failures are attributable to this feature
+- [X] T003 [P] Run `npm ci` then `npm run build` and `npm test` in `src/web-ui` and record the baseline (lint and `tsc --noEmit` have known pre-existing failures and are NOT the gate)
 
 ---
 
@@ -42,12 +42,12 @@ Web application layout per [plan.md](./plan.md): .NET backend under `src/GameBot
 **Purpose**: The device-identity primitives every user story depends on. No user story can start until
 this phase is complete.
 
-- [ ] T004 [P] Create `DeviceContext` record (`SessionId`, `DeviceSerial?`) with XML docs in `src/GameBot.Domain/Sessions/DeviceContext.cs`
-- [ ] T005 [P] Create `IDeviceContextAccessor` (`Current`, `IDisposable Push(DeviceContext)`) with XML docs in `src/GameBot.Domain/Sessions/IDeviceContextAccessor.cs`
-- [ ] T006 Implement `AsyncLocalDeviceContextAccessor` over `AsyncLocal<DeviceContext?>`, with a nested-safe disposable scope that restores the previous value, in `src/GameBot.Domain/Sessions/AsyncLocalDeviceContextAccessor.cs`
-- [ ] T007 [P] Add `IScreenSourceFactory` with `IScreenSource ForSession(string sessionId)` and XML docs to `src/GameBot.Domain/Triggers/Evaluators/ScreenSourceAbstractions.cs`
-- [ ] T008 [P] Unit-test the accessor (flows across `await`, flows into `Task.Run`, nested push/pop restores, child flow does not leak to parent, double-dispose is a no-op) in `tests/unit/Sessions/DeviceContextAccessorTests.cs`
-- [ ] T009 Register `IDeviceContextAccessor` -> `AsyncLocalDeviceContextAccessor` as a singleton in `RegisterSessionServices` in `src/GameBot.Service/GameBotServiceSetup.cs`
+- [X] T004 [P] Create `DeviceContext` record (`SessionId`, `DeviceSerial?`) with XML docs in `src/GameBot.Domain/Sessions/DeviceContext.cs`
+- [X] T005 [P] Create `IDeviceContextAccessor` (`Current`, `IDisposable Push(DeviceContext)`) with XML docs in `src/GameBot.Domain/Sessions/IDeviceContextAccessor.cs`
+- [X] T006 Implement `AsyncLocalDeviceContextAccessor` over `AsyncLocal<DeviceContext?>`, with a nested-safe disposable scope that restores the previous value, in `src/GameBot.Domain/Sessions/AsyncLocalDeviceContextAccessor.cs`
+- [X] T007 [P] Add `IScreenSourceFactory` with `IScreenSource ForSession(string sessionId)` and XML docs to `src/GameBot.Domain/Triggers/Evaluators/ScreenSourceAbstractions.cs`
+- [X] T008 [P] Unit-test the accessor (flows across `await`, flows into `Task.Run`, nested push/pop restores, child flow does not leak to parent, double-dispose is a no-op) in `tests/unit/Sessions/DeviceContextAccessorTests.cs`
+- [X] T009 Register `IDeviceContextAccessor` -> `AsyncLocalDeviceContextAccessor` as a singleton in `RegisterSessionServices` in `src/GameBot.Service/GameBotServiceSetup.cs`
 
 **Checkpoint**: Device identity primitives exist and are tested; nothing else has changed behavior yet.
 
@@ -63,23 +63,23 @@ other's screen.
 
 ### Tests for User Story 1
 
-- [ ] T010 [P] [US1] Unit-test `SessionScopedScreenSource`: returns its own session's frame, returns null when that session has no cached frame, returns null when the session stopped, never returns another session's frame — in `tests/unit/Sessions/SessionScopedScreenSourceTests.cs`
-- [ ] T011 [P] [US1] Unit-test the narrowed session resolution for `ensure-game-running`, `go-to-home-screen` and primitive `tap`/`swipe`/`key`: explicit session wins with N sessions active; 1 active resolves silently; 0 active keeps today's message; N>1 fails with `"<N> device sessions are active; specify a sessionId for '<step>'"` — in `tests/unit/Sequences/SessionResolutionTests.cs`
-- [ ] T012 [P] [US1] Unit-test `CommandExecutor.ForceExecuteStepAsync` and `ResolveSessionIdAsync` under the same four cases in `tests/unit/Commands/CommandExecutorSessionResolutionTests.cs`
-- [ ] T013 [P] [US1] Integration-test screen isolation: two sessions with distinct stub frames, two concurrent sequence executions, each observes only its own frame — in `tests/integration/Sessions/ConcurrentScreenIsolationTests.cs`
+- [X] T010 [P] [US1] Unit-test `SessionScopedScreenSource`: returns its own session's frame, returns null when that session has no cached frame, returns null when the session stopped, never returns another session's frame — in `tests/unit/Sessions/SessionScopedScreenSourceTests.cs`
+- [X] T011 [P] [US1] Unit-test the narrowed session resolution for `ensure-game-running`, `go-to-home-screen` and primitive `tap`/`swipe`/`key`: explicit session wins with N sessions active; 1 active resolves silently; 0 active keeps today's message; N>1 fails with `"<N> device sessions are active; specify a sessionId for '<step>'"` — in `tests/unit/Sequences/SessionResolutionTests.cs`
+- [X] T012 [P] [US1] Unit-test `CommandExecutor.ForceExecuteStepAsync` and `ResolveSessionIdAsync` under the same four cases in `tests/unit/Commands/CommandExecutorSessionResolutionTests.cs`
+- [X] T013 [P] [US1] Test screen isolation: two capture loops with distinct frames, two concurrent flows each pushing its own device context, each observes only its own frame; and with no context and several sessions, nothing is observed — in `tests/unit/Sessions/AmbientScreenIsolationTests.cs` (see Deviations: written as a unit test, not an integration test)
 
 ### Implementation for User Story 1
 
-- [ ] T014 [P] [US1] Implement `SessionScopedScreenSource` over `BackgroundScreenCaptureService.GetCachedFrame(sessionId)`, decoding from the frame's immutable PNG bytes (keeps the concurrent-disposal fix), in `src/GameBot.Emulator/Session/SessionScopedScreenSource.cs`
-- [ ] T015 [US1] Implement `BackgroundCaptureScreenSourceFactory : IScreenSourceFactory` returning a `SessionScopedScreenSource` per session id in `src/GameBot.Emulator/Session/BackgroundCaptureScreenSourceFactory.cs`
-- [ ] T016 [US1] Rewrite `BackgroundCaptureScreenSource.GetLatestScreenshot()` to resolve ambient context -> single running session -> null, deleting the `FirstOrDefault` first-session scan, in `src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs`
-- [ ] T017 [US1] Register `IScreenSourceFactory` -> `BackgroundCaptureScreenSourceFactory` and pass `IDeviceContextAccessor` into the `IScreenSource` singleton factory in `src/GameBot.Service/GameBotServiceSetup.cs` (both the ADB branch and the stub/test branch)
-- [ ] T018 [US1] Narrow the three `runningSessions.Count != 1` guards in `DispatchEnsureGameRunningAsync`, `DispatchGoToHomeScreenAsync` and `DispatchPrimitiveInputAsync` to the FR-007 rule, with the new multi-session message, in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
-- [ ] T019 [US1] Push the run's `DeviceContext` for the duration of a sequence execution when `sessionId` is supplied, in `SequenceExecutionService.ExecuteAsync` in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
-- [ ] T020 [US1] Narrow `ForceExecuteStepAsync` and `ResolveSessionIdAsync` to the FR-007 rule with the new message, and use `IScreenSourceFactory.ForSession(resolvedSessionId)` for the detect-and-tap and image-detection paths instead of the injected singleton `_screen`, in `src/GameBot.Service/Services/CommandExecutor.cs`
-- [ ] T021 [US1] Add a `string? sessionId` parameter to `IGameReadinessProbe.WaitUntilReadyAsync` in `src/GameBot.Service/Services/EnsureGameRunning/IGameReadinessProbe.cs`
-- [ ] T022 [US1] Resolve the screen via `IScreenSourceFactory.ForSession(sessionId)` when a session id is supplied (falling back to the injected `IScreenSource` when null) in `src/GameBot.Service/Services/EnsureGameRunning/GameReadinessProbe.cs`, and pass the handler's session id through in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs`
-- [ ] T023 [US1] Push the run's `DeviceContext` around each firing in `RunOneSequenceAsync` in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`, so loops, nested sequences and trigger-based conditions inherit it
+- [X] T014 [P] [US1] Implement `SessionScopedScreenSource` over `BackgroundScreenCaptureService.GetCachedFrame(sessionId)`, decoding from the frame's immutable PNG bytes (keeps the concurrent-disposal fix), in `src/GameBot.Emulator/Session/SessionScopedScreenSource.cs`
+- [X] T015 [US1] Implement `BackgroundCaptureScreenSourceFactory : IScreenSourceFactory` returning a `SessionScopedScreenSource` per session id in `src/GameBot.Emulator/Session/BackgroundCaptureScreenSourceFactory.cs`
+- [X] T016 [US1] Rewrite `BackgroundCaptureScreenSource.GetLatestScreenshot()` to resolve ambient context -> single running session -> null, deleting the `FirstOrDefault` first-session scan, in `src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs`
+- [X] T017 [US1] Register `IScreenSourceFactory` -> `BackgroundCaptureScreenSourceFactory` and pass `IDeviceContextAccessor` into the `IScreenSource` singleton factory in `src/GameBot.Service/GameBotServiceSetup.cs` (both the ADB branch and the stub/test branch)
+- [X] T018 [US1] Narrow the three `runningSessions.Count != 1` guards in `DispatchEnsureGameRunningAsync`, `DispatchGoToHomeScreenAsync` and `DispatchPrimitiveInputAsync` to the FR-007 rule, with the new multi-session message, in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [X] T019 [US1] Push the run's `DeviceContext` for the duration of a sequence execution when `sessionId` is supplied, in `SequenceExecutionService.ExecuteAsync` in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [X] T020 [US1] Narrow `ForceExecuteStepAsync` and `ResolveSessionIdAsync` to the FR-007 rule with the new message, and use `IScreenSourceFactory.ForSession(resolvedSessionId)` for the detect-and-tap and image-detection paths instead of the injected singleton `_screen`, in `src/GameBot.Service/Services/CommandExecutor.cs`
+- [X] T021 [US1] Add a `string? sessionId` parameter to `IGameReadinessProbe.WaitUntilReadyAsync` in `src/GameBot.Service/Services/EnsureGameRunning/IGameReadinessProbe.cs`
+- [X] T022 [US1] Resolve the screen via `IScreenSourceFactory.ForSession(sessionId)` when a session id is supplied (falling back to the injected `IScreenSource` when null) in `src/GameBot.Service/Services/EnsureGameRunning/GameReadinessProbe.cs`, and pass the handler's session id through in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs`
+- [X] T023 [US1] Ensure every queue firing runs under the run's `DeviceContext` so loops, nested sequences and trigger-based conditions inherit it — satisfied by T019 (the push happens in `SequenceExecutionService.ExecuteAsync`, which every firing goes through); `RunOneSequenceAsync` in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs` carries a comment recording that a second push there would be redundant
 
 **Checkpoint**: Two queues on two emulators observe and act only on their own devices. US1 is
 independently demonstrable.
@@ -95,22 +95,22 @@ message naming the device and the holder; stop the first; the second then starts
 
 ### Tests for User Story 2
 
-- [ ] T024 [P] [US2] Unit-test `DeviceClaimRegistry`: claim/refuse/release round trip; serial normalization (trim + case-insensitive); blank serial never blocks; `Release` by a non-holder is a no-op; concurrent `TryClaim` from many threads yields exactly one winner; a freshly constructed registry holds no claims (FR-013, in-memory only) — in `tests/unit/Queues/DeviceClaimRegistryTests.cs`
-- [ ] T025 [P] [US2] Unit-test `QueueExecutionService` claim behavior: `DeviceInUse` returned without launching a run and without changing runtime status; claim released after completion, manual stop, failure and cancellation; a refused start leaves no run-registry residue — in `tests/unit/Queues/QueueExecutionServiceDeviceClaimTests.cs`
-- [ ] T026 [P] [US2] Integration-test two concurrent runs: same-serial start refused, different-serial starts both succeed, stopping one leaves the other's status and schedule unchanged (FR-020) — in `tests/integration/Queues/ConcurrentQueueRunTests.cs`
-- [ ] T027 [P] [US2] Contract-test `POST /api/queues/{id}/start` returning `409 {"error":"device_in_use"}` with the device and holder named, and `already_running` still distinct, in `tests/contract/QueueConcurrencyContractTests.cs`
-- [ ] T027a [P] [US2] Jest-test that a 409 `device_in_use` start rejection renders its message on the queue row, alongside the existing `already_running` case, in `src/web-ui/src/pages/__tests__/QueuesPage.execution.spec.tsx`
+- [X] T024 [P] [US2] Unit-test `DeviceClaimRegistry`: claim/refuse/release round trip; serial normalization (trim + case-insensitive); blank serial never blocks; `Release` by a non-holder is a no-op; concurrent `TryClaim` from many threads yields exactly one winner; a freshly constructed registry holds no claims (FR-013, in-memory only) — in `tests/unit/Queues/DeviceClaimRegistryTests.cs`
+- [X] T025 [P] [US2] Unit-test `QueueExecutionService` claim behavior: `DeviceInUse` returned without launching a run and without changing runtime status; claim released after completion, manual stop, failure and cancellation; a refused start leaves no run-registry residue — in `tests/unit/Queues/QueueExecutionServiceDeviceClaimTests.cs`
+- [X] T026 [P] [US2] Integration-test two concurrent runs: same-serial start refused, different-serial starts both succeed, stopping one leaves the other's status and schedule unchanged (FR-020) — in `tests/integration/Queues/ConcurrentQueueRunTests.cs`
+- [X] T027 [P] [US2] Contract-test `POST /api/queues/{id}/start` returning `409 {"error":"device_in_use"}` with the device and holder named, and `already_running` still distinct, in `tests/contract/QueueConcurrencyContractTests.cs`
+- [X] T027a [P] [US2] Jest-test that a 409 `device_in_use` start rejection renders its message on the queue row, alongside the existing `already_running` case, in `src/web-ui/src/pages/__tests__/QueuesPage.execution.spec.tsx`
 
 ### Implementation for User Story 2
 
-- [ ] T028 [P] [US2] Create `DeviceClaim` record (`DeviceSerial`, `QueueId`, `QueueName`, `ClaimedAtUtc`) and `IDeviceClaimRegistry` (`TryClaim`, `Release`, `TryGetHolder`) with XML docs in `src/GameBot.Service/Services/QueueExecution/IDeviceClaimRegistry.cs`
-- [ ] T029 [US2] Implement `DeviceClaimRegistry` over `ConcurrentDictionary<string, DeviceClaim>` with `StringComparer.OrdinalIgnoreCase`, trimmed keys, `TryAdd`-based atomic claim and holder-checked release, in `src/GameBot.Service/Services/QueueExecution/DeviceClaimRegistry.cs`
-- [ ] T030 [US2] Add `QueueStartOutcome.DeviceInUse` and correct the `IQueueExecutionService` XML doc that currently states same-emulator concurrency is allowed, in `src/GameBot.Service/Services/QueueExecution/IQueueExecutionService.cs`
-- [ ] T031 [US2] Claim the device in `StartAsync` after the run registry accepts the queue and before launching the run; on refusal remove the registry entry, dispose the CTS and return `DeviceInUse`; release the claim in `RunAsync`'s `finally` — in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
-- [ ] T032 [US2] Register `IDeviceClaimRegistry` -> `DeviceClaimRegistry` as a singleton next to `IQueueRunRegistry` in `src/GameBot.Service/GameBotServiceSetup.cs`
-- [ ] T033 [US2] Map `QueueStartOutcome.DeviceInUse` to `409 device_in_use`, building the message from `IDeviceClaimRegistry.TryGetHolder`, in the `{id}/start` handler in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`
-- [ ] T033a [US2] Add a `LoggerMessage`-based application-log entry for a refused start naming the refused queue, the device and the holding queue (FR-017, second sentence) in `src/GameBot.Service/Endpoints/QueuesEndpoints.Logging.cs` and call it from the `{id}/start` handler
-- [ ] T034 [US2] Surface the `device_in_use` message on the queue Start action, reusing the existing 409 error rendering used for `already_running`, in `src/web-ui/src/pages/QueuesPage.tsx`
+- [X] T028 [P] [US2] Create `DeviceClaim` record (`DeviceSerial`, `QueueId`, `QueueName`, `ClaimedAtUtc`) and `IDeviceClaimRegistry` (`TryClaim`, `Release`, `TryGetHolder`) with XML docs in `src/GameBot.Service/Services/QueueExecution/IDeviceClaimRegistry.cs`
+- [X] T029 [US2] Implement `DeviceClaimRegistry` over `ConcurrentDictionary<string, DeviceClaim>` with `StringComparer.OrdinalIgnoreCase`, trimmed keys, `TryAdd`-based atomic claim and holder-checked release, in `src/GameBot.Service/Services/QueueExecution/DeviceClaimRegistry.cs`
+- [X] T030 [US2] Add `QueueStartOutcome.DeviceInUse` and correct the `IQueueExecutionService` XML doc that currently states same-emulator concurrency is allowed, in `src/GameBot.Service/Services/QueueExecution/IQueueExecutionService.cs`
+- [X] T031 [US2] Claim the device in `StartAsync` after the run registry accepts the queue and before launching the run; on refusal remove the registry entry, dispose the CTS and return `DeviceInUse`; release the claim in `RunAsync`'s `finally` — in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [X] T032 [US2] Register `IDeviceClaimRegistry` -> `DeviceClaimRegistry` as a singleton next to `IQueueRunRegistry` in `src/GameBot.Service/GameBotServiceSetup.cs`
+- [X] T033 [US2] Map `QueueStartOutcome.DeviceInUse` to `409 device_in_use`, building the message from `IDeviceClaimRegistry.TryGetHolder`, in the `{id}/start` handler in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`
+- [X] T033a [US2] Add a `LoggerMessage`-based application-log entry for a refused start naming the refused queue, the device and the holding queue (FR-017, second sentence) in `src/GameBot.Service/Endpoints/QueuesEndpoints.Logging.cs` and call it from the `{id}/start` handler
+- [X] T034 [US2] Surface the `device_in_use` message on the queue Start action, reusing the existing 409 error rendering used for `already_running`, in `src/web-ui/src/pages/QueuesPage.tsx`
 
 **Checkpoint**: Same-device double-start is impossible; different-device starts are unaffected. US2 is
 independently demonstrable.
@@ -128,19 +128,19 @@ runs execute and confirm no register leaks between them.
 
 ### Tests for User Story 3
 
-- [ ] T035 [P] [US3] Unit-test the capacity message shape (`session capacity reached: N of N sessions are open (Service:Sessions:MaxConcurrentSessions)`) and that the default `MaxConcurrentSessions` is 8 in `tests/unit/Sessions/SessionCapacityMessageTests.cs`
-- [ ] T036 [P] [US3] Unit-test that `QueueMonitorSnapshot`/response carries the running run's device serial and `null` when not running, in `tests/unit/Queues/QueueMonitorServiceTests.cs` (extend the existing file)
-- [ ] T037 [P] [US3] Integration-test that a capacity-exceeded run finalizes with the actionable reason in its execution-log entry (FR-016, FR-017) in `tests/integration/Queues/ConcurrentQueueRunTests.cs`
-- [ ] T037a [P] [US3] Integration-test run-state isolation under concurrency (FR-019, FR-020, and the idle-eviction edge case): two runs execute concurrently while the monitor is polled on a third thread; each run's schedule registers, self-reschedule registers, idle-pause flag and current-sequence indicator stay its own, and a session lost by one run fails only that run — in `tests/integration/Queues/ConcurrentRunStateIsolationTests.cs`
-- [ ] T037b [P] [US3] Integration-test execution-log attribution under concurrency (FR-021): two concurrent runs write interleaved entries; every entry resolves to exactly one run's root id and no entry is lost — in `tests/integration/Queues/ConcurrentRunStateIsolationTests.cs`
+- [X] T035 [P] [US3] Unit-test the capacity message shape (`session capacity reached: N of N sessions are open (Service:Sessions:MaxConcurrentSessions)`) and that the default `MaxConcurrentSessions` is 8 in `tests/unit/Sessions/SessionCapacityMessageTests.cs`
+- [X] T036 [P] [US3] Unit-test that `QueueMonitorSnapshot`/response carries the running run's device serial and `null` when not running, in `tests/unit/Queues/QueueMonitorServiceTests.cs` (extend the existing file)
+- [X] T037 [P] [US3] Integration-test that a capacity-exceeded run finalizes with the actionable reason in its execution-log entry (FR-016, FR-017) in `tests/integration/Queues/ConcurrentQueueRunTests.cs`
+- [X] T037a [P] [US3] Integration-test run-state isolation under concurrency (FR-019, FR-020, and the idle-eviction edge case): two runs execute concurrently while the monitor is polled on a third thread; each run's schedule registers, self-reschedule registers, idle-pause flag and current-sequence indicator stay its own, and a session lost by one run fails only that run — in `tests/integration/Queues/ConcurrentRunStateIsolationTests.cs`
+- [X] T037b [P] [US3] Integration-test execution-log attribution under concurrency (FR-021): two concurrent runs write interleaved entries; every entry resolves to exactly one run's root id and no entry is lost — in `tests/integration/Queues/ConcurrentRunStateIsolationTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T038 [P] [US3] Change `MaxConcurrentSessions` default from 3 to 8 in `src/GameBot.Emulator/Session/SessionOptions.cs`
-- [ ] T039 [US3] Replace the bare `capacity_exceeded` exception message with the actionable text naming active/max and the config key in `SessionManager.CreateSession` in `src/GameBot.Emulator/Session/SessionManager.cs` (keep the exception type and the existing API mapping)
-- [ ] T040 [P] [US3] Add `DeviceSerial` to `QueueMonitorSnapshot` in `src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs` and populate it from the run handle in `src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs`
-- [ ] T041 [US3] Add the nullable `deviceSerial` field to `QueueMonitorResponse` and its projection in `src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs` and `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`
-- [ ] T042 [US3] Add `deviceSerial?: string | null` to `QueueMonitorDto` in `src/web-ui/src/services/queues.ts` and render the run's device in `src/web-ui/src/components/queues/QueueMonitor.tsx`
+- [X] T038 [P] [US3] Change `MaxConcurrentSessions` default from 3 to 8 in `src/GameBot.Emulator/Session/SessionOptions.cs`
+- [X] T039 [US3] Replace the bare `capacity_exceeded` exception message with the actionable text naming active/max and the config key in `SessionManager.CreateSession` in `src/GameBot.Emulator/Session/SessionManager.cs` (keep the exception type and the existing API mapping)
+- [X] T040 [P] [US3] Add `DeviceSerial` to `QueueMonitorSnapshot` in `src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs` and populate it from the run handle in `src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs`
+- [X] T041 [US3] Add the nullable `deviceSerial` field to `QueueMonitorResponse` and its projection in `src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs` and `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`
+- [X] T042 [US3] Add `deviceSerial?: string | null` to `QueueMonitorDto` in `src/web-ui/src/services/queues.ts` and render the run's device in `src/web-ui/src/components/queues/QueueMonitor.tsx`
 
 **Checkpoint**: Concurrency state is legible in the UI and in the logs.
 
@@ -156,12 +156,12 @@ the bare call still works.
 
 ### Tests for User Story 4
 
-- [ ] T043 [P] [US4] Contract-test `GET /api/emulators/screenshot`: explicit `sessionId`, explicit `serial`, 0 sessions -> `503 emulator_unavailable`, 1 session -> unchanged success, N>1 with no selector -> `409 ambiguous_session`, unknown `serial` -> `404 session_not_found` — in `tests/contract/EmulatorScreenshotSelectorContractTests.cs`
+- [X] T043 [P] [US4] Contract-test `GET /api/emulators/screenshot`: explicit `sessionId`, explicit `serial`, 0 sessions -> `503 emulator_unavailable`, 1 session -> unchanged success, N>1 with no selector -> `409 ambiguous_session`, unknown `serial` -> `404 session_not_found` — in `tests/contract/EmulatorScreenshotSelectorContractTests.cs`
 
 ### Implementation for User Story 4
 
-- [ ] T044 [US4] Add an optional `serial` query parameter, replace `PickSession`'s `FirstOrDefault` chain with explicit-selector -> single-session -> ambiguity-error resolution, and return the `ambiguous_session` / `session_not_found` bodies, in `src/GameBot.Service/Endpoints/EmulatorImageEndpoints.cs`
-- [ ] T045 [US4] Always send the selected session/serial selector on screenshot requests from the authoring UI in `src/web-ui/src/services/images.ts` and its callers, so the ambiguity error can never be triggered from the app itself
+- [X] T044 [US4] Add an optional `serial` query parameter, replace `PickSession`'s `FirstOrDefault` chain with explicit-selector -> single-session -> ambiguity-error resolution, and return the `ambiguous_session` / `session_not_found` bodies, in `src/GameBot.Service/Endpoints/EmulatorImageEndpoints.cs`
+- [X] T045 [US4] Always send the selected session/serial selector on screenshot requests from the authoring UI in `src/web-ui/src/services/images.ts` and its callers, so the ambiguity error can never be triggered from the app itself
 
 **Checkpoint**: All four user stories complete.
 
@@ -169,13 +169,13 @@ the bare call still works.
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T046 [P] Add a micro-benchmark holding `TryClaim`/`Release` under the declared 0.05 ms budget in `tests/unit/Performance/DeviceClaimBenchmarkTests.cs` (Constitution Principle IV)
-- [ ] T047 [P] Update `docs/architecture.md` with the device-claim and session-scoped-observation model and refresh its "Last reviewed" date (Constitution Principle V, NON-NEGOTIABLE)
-- [ ] T048 [P] Add the 079 entry to `specs/STATUS.md` and set `specs/079-concurrent-queue-execution/spec.md` **Status** to `Implemented`
-- [ ] T049 [P] Update `specs/051-queue-execution-runtime/spec.md` **Status** to record that its FR-013 (same-emulator concurrency allowed, no guard) is superseded by 079; FR-013a is unchanged
-- [ ] T050 Run `dotnet build C:\src\GameBot\GameBot.sln -c Debug` and `dotnet test C:\src\GameBot\GameBot.sln` and fix every failure and every new analyzer warning (red build/test blocks completion)
-- [ ] T051 Run `npm run build` and `npm test` in `src/web-ui` and fix any failure introduced by T034/T042/T045
-- [ ] T052 Walk [quickstart.md](./quickstart.md) end to end against a running service and correct anything it gets wrong
+- [X] T046 [P] Add a micro-benchmark holding `TryClaim`/`Release` under the declared 0.05 ms budget in `tests/unit/Performance/DeviceClaimBenchmarkTests.cs` (Constitution Principle IV)
+- [X] T047 [P] Update `docs/architecture.md` with the device-claim and session-scoped-observation model and refresh its "Last reviewed" date (Constitution Principle V, NON-NEGOTIABLE)
+- [X] T048 [P] Add the 079 entry to `specs/STATUS.md` and set `specs/079-concurrent-queue-execution/spec.md` **Status** to `Implemented`
+- [X] T049 [P] Update `specs/051-queue-execution-runtime/spec.md` **Status** to record that its FR-013 (same-emulator concurrency allowed, no guard) is superseded by 079; FR-013a is unchanged
+- [X] T050 Run `dotnet build C:\src\GameBot\GameBot.sln -c Debug` and `dotnet test C:\src\GameBot\GameBot.sln` and fix every failure and every new analyzer warning (red build/test blocks completion)
+- [X] T051 Run `npm run build` and `npm test` in `src/web-ui` and fix any failure introduced by T034/T042/T045
+- [X] T052 Walk [quickstart.md](./quickstart.md) end to end against a running service and correct anything it gets wrong
 
 ---
 
@@ -226,6 +226,46 @@ implementation; T029-T033a sequential within the claim path, then T034.
 sequential after them.
 
 **Phase 7**: T046, T047, T048, T049 all parallel; T050-T052 last and sequential.
+
+---
+
+## Deviations from the plan (recorded at implementation time)
+
+1. **T013 became a unit test, not an integration test.** The integration host runs with
+   `GAMEBOT_USE_ADB=false`, where `IScreenSource` is a single stub bitmap and there are no per-device
+   frames to keep apart — an integration test there would assert nothing. The behaviour is instead
+   exercised against the real mechanism in `tests/unit/Sessions/AmbientScreenIsolationTests.cs`, which
+   drives two live capture loops with distinguishable frames.
+2. **T023 was satisfied by T019 rather than adding a second push.** Every queue firing goes through
+   `SequenceExecutionService.ExecuteAsync`, which already pushes the device context; pushing again in
+   `RunOneSequenceAsync` would be redundant nesting. A comment there records why.
+3. **The session-capacity integration test is skipped, and the requirement moved to unit level.**
+   `Service:Sessions:MaxConcurrentSessions` could not be overridden inside `WebApplicationFactory`
+   (neither an env var nor `UseSetting`/`ConfigureAppConfiguration` took effect), so the integration
+   variant asserted nothing. FR-015/FR-016 are covered by
+   `tests/unit/Sessions/SessionCapacityMessageTests.cs` (default of 8, message shape, the real
+   `SessionManager` throw) and by
+   `QueueExecutionServiceTests.ACapacityFailureIsRecordedWithTheActionableReason` (the message reaches
+   the run's execution-log summary). The skipped test carries that explanation inline, and an
+   equivalent run-level-failure integration test proves FR-017's mechanism.
+4. **T020's resolution logic was extracted rather than duplicated.** Both the sequence dispatcher and
+   the command executor now share one rule in `src/GameBot.Service/Services/SessionResolver.cs`, so
+   the FR-007 wording exists in exactly one place. T011/T012 test it there and at the
+   `CommandExecutor` boundary.
+5. **T034 needed no production change.** `QueuesPage.runAction` already renders the API error's
+   `message`, and `lib/api.ts` already prefers `error.message`. The `device_in_use` text therefore
+   surfaces as-is; T027a is the regression test that proves it.
+6. **T045 stopped short of a device-picker UI.** `fetchEmulatorScreenshot` now takes a selector and
+   `EmulatorCaptureCropper` forwards optional `sessionId`/`serial` props and renders an actionable
+   message on `ambiguous_session`. Adding a device chooser to the authoring screens is a UI feature
+   beyond this spec's scope and was not attempted.
+7. **`EmulatorImageEndpoints` counts all running sessions, not only serial-bearing ones.** The first
+   draft filtered on a non-blank `DeviceSerial`, which broke single-session capture in stub/non-ADB
+   mode (where no session has one). Recorded in contracts/api.md §3.
+
+Two documentation defects were found and fixed while walking the quickstart (T052): the queue error
+envelope is nested (`error.code` / `error.message`), not flat, and the screenshot route is
+`/api/emulator/screenshot` (singular). Both `contracts/api.md` and `quickstart.md` were corrected.
 
 ---
 

--- a/specs/079-concurrent-queue-execution/tasks.md
+++ b/specs/079-concurrent-queue-execution/tasks.md
@@ -1,0 +1,240 @@
+---
+description: "Task list for feature 079 - Concurrent Queue Execution"
+---
+
+# Tasks: Concurrent Queue Execution
+
+**Input**: Design documents from `/specs/079-concurrent-queue-execution/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/api.md](./contracts/api.md)
+
+**Tests**: REQUIRED. Constitution Principle II makes tests mandatory for executable logic, and this
+feature is a concurrency bug fix, so every defect gets a regression test that fails before the fix.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented, tested and
+delivered independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1..US4)
+
+## Path Conventions
+
+Web application layout per [plan.md](./plan.md): .NET backend under `src/GameBot.Domain`,
+`src/GameBot.Emulator`, `src/GameBot.Service`; React SPA under `src/web-ui/src`; tests under
+`tests/unit`, `tests/integration`, `tests/contract`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the baseline is green before changing concurrency-sensitive code.
+
+- [ ] T001 Run `dotnet build C:\src\GameBot\GameBot.sln -c Debug` and record that the pre-change build is green (Constitution: red build blocks progression)
+- [ ] T002 [P] Run `dotnet test C:\src\GameBot\GameBot.sln` and record the pre-change pass/fail baseline so new failures are attributable to this feature
+- [ ] T003 [P] Run `npm ci` then `npm run build` and `npm test` in `src/web-ui` and record the baseline (lint and `tsc --noEmit` have known pre-existing failures and are NOT the gate)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The device-identity primitives every user story depends on. No user story can start until
+this phase is complete.
+
+- [ ] T004 [P] Create `DeviceContext` record (`SessionId`, `DeviceSerial?`) with XML docs in `src/GameBot.Domain/Sessions/DeviceContext.cs`
+- [ ] T005 [P] Create `IDeviceContextAccessor` (`Current`, `IDisposable Push(DeviceContext)`) with XML docs in `src/GameBot.Domain/Sessions/IDeviceContextAccessor.cs`
+- [ ] T006 Implement `AsyncLocalDeviceContextAccessor` over `AsyncLocal<DeviceContext?>`, with a nested-safe disposable scope that restores the previous value, in `src/GameBot.Domain/Sessions/AsyncLocalDeviceContextAccessor.cs`
+- [ ] T007 [P] Add `IScreenSourceFactory` with `IScreenSource ForSession(string sessionId)` and XML docs to `src/GameBot.Domain/Triggers/Evaluators/ScreenSourceAbstractions.cs`
+- [ ] T008 [P] Unit-test the accessor (flows across `await`, flows into `Task.Run`, nested push/pop restores, child flow does not leak to parent, double-dispose is a no-op) in `tests/unit/Sessions/DeviceContextAccessorTests.cs`
+- [ ] T009 Register `IDeviceContextAccessor` -> `AsyncLocalDeviceContextAccessor` as a singleton in `RegisterSessionServices` in `src/GameBot.Service/GameBotServiceSetup.cs`
+
+**Checkpoint**: Device identity primitives exist and are tested; nothing else has changed behavior yet.
+
+---
+
+## Phase 3: User Story 1 - Two queues on two emulators run independently (Priority: P1)
+
+**Goal**: Every observation and every action in a run resolves against that run's own device.
+
+**Independent test**: Start two queues on two emulator serials whose screens differ, each running a
+sequence that waits for an image present only on its own device. Both succeed; neither observes the
+other's screen.
+
+### Tests for User Story 1
+
+- [ ] T010 [P] [US1] Unit-test `SessionScopedScreenSource`: returns its own session's frame, returns null when that session has no cached frame, returns null when the session stopped, never returns another session's frame — in `tests/unit/Sessions/SessionScopedScreenSourceTests.cs`
+- [ ] T011 [P] [US1] Unit-test the narrowed session resolution for `ensure-game-running`, `go-to-home-screen` and primitive `tap`/`swipe`/`key`: explicit session wins with N sessions active; 1 active resolves silently; 0 active keeps today's message; N>1 fails with `"<N> device sessions are active; specify a sessionId for '<step>'"` — in `tests/unit/Sequences/SessionResolutionTests.cs`
+- [ ] T012 [P] [US1] Unit-test `CommandExecutor.ForceExecuteStepAsync` and `ResolveSessionIdAsync` under the same four cases in `tests/unit/Commands/CommandExecutorSessionResolutionTests.cs`
+- [ ] T013 [P] [US1] Integration-test screen isolation: two sessions with distinct stub frames, two concurrent sequence executions, each observes only its own frame — in `tests/integration/Sessions/ConcurrentScreenIsolationTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T014 [P] [US1] Implement `SessionScopedScreenSource` over `BackgroundScreenCaptureService.GetCachedFrame(sessionId)`, decoding from the frame's immutable PNG bytes (keeps the concurrent-disposal fix), in `src/GameBot.Emulator/Session/SessionScopedScreenSource.cs`
+- [ ] T015 [US1] Implement `BackgroundCaptureScreenSourceFactory : IScreenSourceFactory` returning a `SessionScopedScreenSource` per session id in `src/GameBot.Emulator/Session/BackgroundCaptureScreenSourceFactory.cs`
+- [ ] T016 [US1] Rewrite `BackgroundCaptureScreenSource.GetLatestScreenshot()` to resolve ambient context -> single running session -> null, deleting the `FirstOrDefault` first-session scan, in `src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs`
+- [ ] T017 [US1] Register `IScreenSourceFactory` -> `BackgroundCaptureScreenSourceFactory` and pass `IDeviceContextAccessor` into the `IScreenSource` singleton factory in `src/GameBot.Service/GameBotServiceSetup.cs` (both the ADB branch and the stub/test branch)
+- [ ] T018 [US1] Narrow the three `runningSessions.Count != 1` guards in `DispatchEnsureGameRunningAsync`, `DispatchGoToHomeScreenAsync` and `DispatchPrimitiveInputAsync` to the FR-007 rule, with the new multi-session message, in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [ ] T019 [US1] Push the run's `DeviceContext` for the duration of a sequence execution when `sessionId` is supplied, in `SequenceExecutionService.ExecuteAsync` in `src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs`
+- [ ] T020 [US1] Narrow `ForceExecuteStepAsync` and `ResolveSessionIdAsync` to the FR-007 rule with the new message, and use `IScreenSourceFactory.ForSession(resolvedSessionId)` for the detect-and-tap and image-detection paths instead of the injected singleton `_screen`, in `src/GameBot.Service/Services/CommandExecutor.cs`
+- [ ] T021 [US1] Add a `string? sessionId` parameter to `IGameReadinessProbe.WaitUntilReadyAsync` in `src/GameBot.Service/Services/EnsureGameRunning/IGameReadinessProbe.cs`
+- [ ] T022 [US1] Resolve the screen via `IScreenSourceFactory.ForSession(sessionId)` when a session id is supplied (falling back to the injected `IScreenSource` when null) in `src/GameBot.Service/Services/EnsureGameRunning/GameReadinessProbe.cs`, and pass the handler's session id through in `src/GameBot.Service/Services/EnsureGameRunning/EnsureGameRunningActionHandler.cs`
+- [ ] T023 [US1] Push the run's `DeviceContext` around each firing in `RunOneSequenceAsync` in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`, so loops, nested sequences and trigger-based conditions inherit it
+
+**Checkpoint**: Two queues on two emulators observe and act only on their own devices. US1 is
+independently demonstrable.
+
+---
+
+## Phase 4: User Story 2 - The same emulator cannot be claimed by two runs (Priority: P1)
+
+**Goal**: One device, one run — enforced atomically, released on every exit path.
+
+**Independent test**: Two queues on one serial; start the first, watch the second be refused with a
+message naming the device and the holder; stop the first; the second then starts.
+
+### Tests for User Story 2
+
+- [ ] T024 [P] [US2] Unit-test `DeviceClaimRegistry`: claim/refuse/release round trip; serial normalization (trim + case-insensitive); blank serial never blocks; `Release` by a non-holder is a no-op; concurrent `TryClaim` from many threads yields exactly one winner; a freshly constructed registry holds no claims (FR-013, in-memory only) — in `tests/unit/Queues/DeviceClaimRegistryTests.cs`
+- [ ] T025 [P] [US2] Unit-test `QueueExecutionService` claim behavior: `DeviceInUse` returned without launching a run and without changing runtime status; claim released after completion, manual stop, failure and cancellation; a refused start leaves no run-registry residue — in `tests/unit/Queues/QueueExecutionServiceDeviceClaimTests.cs`
+- [ ] T026 [P] [US2] Integration-test two concurrent runs: same-serial start refused, different-serial starts both succeed, stopping one leaves the other's status and schedule unchanged (FR-020) — in `tests/integration/Queues/ConcurrentQueueRunTests.cs`
+- [ ] T027 [P] [US2] Contract-test `POST /api/queues/{id}/start` returning `409 {"error":"device_in_use"}` with the device and holder named, and `already_running` still distinct, in `tests/contract/QueueConcurrencyContractTests.cs`
+- [ ] T027a [P] [US2] Jest-test that a 409 `device_in_use` start rejection renders its message on the queue row, alongside the existing `already_running` case, in `src/web-ui/src/pages/__tests__/QueuesPage.execution.spec.tsx`
+
+### Implementation for User Story 2
+
+- [ ] T028 [P] [US2] Create `DeviceClaim` record (`DeviceSerial`, `QueueId`, `QueueName`, `ClaimedAtUtc`) and `IDeviceClaimRegistry` (`TryClaim`, `Release`, `TryGetHolder`) with XML docs in `src/GameBot.Service/Services/QueueExecution/IDeviceClaimRegistry.cs`
+- [ ] T029 [US2] Implement `DeviceClaimRegistry` over `ConcurrentDictionary<string, DeviceClaim>` with `StringComparer.OrdinalIgnoreCase`, trimmed keys, `TryAdd`-based atomic claim and holder-checked release, in `src/GameBot.Service/Services/QueueExecution/DeviceClaimRegistry.cs`
+- [ ] T030 [US2] Add `QueueStartOutcome.DeviceInUse` and correct the `IQueueExecutionService` XML doc that currently states same-emulator concurrency is allowed, in `src/GameBot.Service/Services/QueueExecution/IQueueExecutionService.cs`
+- [ ] T031 [US2] Claim the device in `StartAsync` after the run registry accepts the queue and before launching the run; on refusal remove the registry entry, dispose the CTS and return `DeviceInUse`; release the claim in `RunAsync`'s `finally` — in `src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs`
+- [ ] T032 [US2] Register `IDeviceClaimRegistry` -> `DeviceClaimRegistry` as a singleton next to `IQueueRunRegistry` in `src/GameBot.Service/GameBotServiceSetup.cs`
+- [ ] T033 [US2] Map `QueueStartOutcome.DeviceInUse` to `409 device_in_use`, building the message from `IDeviceClaimRegistry.TryGetHolder`, in the `{id}/start` handler in `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`
+- [ ] T033a [US2] Add a `LoggerMessage`-based application-log entry for a refused start naming the refused queue, the device and the holding queue (FR-017, second sentence) in `src/GameBot.Service/Endpoints/QueuesEndpoints.Logging.cs` and call it from the `{id}/start` handler
+- [ ] T034 [US2] Surface the `device_in_use` message on the queue Start action, reusing the existing 409 error rendering used for `already_running`, in `src/web-ui/src/pages/QueuesPage.tsx`
+
+**Checkpoint**: Same-device double-start is impossible; different-device starts are unaffected. US2 is
+independently demonstrable.
+
+---
+
+## Phase 5: User Story 3 - Concurrency is visible and diagnosable (Priority: P2)
+
+**Goal**: The operator can see which run holds which device, every concurrency refusal or failure reads
+as plain language, and per-run state is provably isolated under concurrency.
+
+**Independent test**: With two runs active, read each monitor response and confirm per-run device and
+current sequence; force a capacity failure and read the recorded reason; poll the monitor while both
+runs execute and confirm no register leaks between them.
+
+### Tests for User Story 3
+
+- [ ] T035 [P] [US3] Unit-test the capacity message shape (`session capacity reached: N of N sessions are open (Service:Sessions:MaxConcurrentSessions)`) and that the default `MaxConcurrentSessions` is 8 in `tests/unit/Sessions/SessionCapacityMessageTests.cs`
+- [ ] T036 [P] [US3] Unit-test that `QueueMonitorSnapshot`/response carries the running run's device serial and `null` when not running, in `tests/unit/Queues/QueueMonitorServiceTests.cs` (extend the existing file)
+- [ ] T037 [P] [US3] Integration-test that a capacity-exceeded run finalizes with the actionable reason in its execution-log entry (FR-016, FR-017) in `tests/integration/Queues/ConcurrentQueueRunTests.cs`
+- [ ] T037a [P] [US3] Integration-test run-state isolation under concurrency (FR-019, FR-020, and the idle-eviction edge case): two runs execute concurrently while the monitor is polled on a third thread; each run's schedule registers, self-reschedule registers, idle-pause flag and current-sequence indicator stay its own, and a session lost by one run fails only that run — in `tests/integration/Queues/ConcurrentRunStateIsolationTests.cs`
+- [ ] T037b [P] [US3] Integration-test execution-log attribution under concurrency (FR-021): two concurrent runs write interleaved entries; every entry resolves to exactly one run's root id and no entry is lost — in `tests/integration/Queues/ConcurrentRunStateIsolationTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T038 [P] [US3] Change `MaxConcurrentSessions` default from 3 to 8 in `src/GameBot.Emulator/Session/SessionOptions.cs`
+- [ ] T039 [US3] Replace the bare `capacity_exceeded` exception message with the actionable text naming active/max and the config key in `SessionManager.CreateSession` in `src/GameBot.Emulator/Session/SessionManager.cs` (keep the exception type and the existing API mapping)
+- [ ] T040 [P] [US3] Add `DeviceSerial` to `QueueMonitorSnapshot` in `src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs` and populate it from the run handle in `src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs`
+- [ ] T041 [US3] Add the nullable `deviceSerial` field to `QueueMonitorResponse` and its projection in `src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs` and `src/GameBot.Service/Endpoints/QueuesEndpoints.cs`
+- [ ] T042 [US3] Add `deviceSerial?: string | null` to `QueueMonitorDto` in `src/web-ui/src/services/queues.ts` and render the run's device in `src/web-ui/src/components/queues/QueueMonitor.tsx`
+
+**Checkpoint**: Concurrency state is legible in the UI and in the logs.
+
+---
+
+## Phase 6: User Story 4 - Operator tooling targets a chosen device (Priority: P3)
+
+**Goal**: Screen capture and cropping never silently show the wrong emulator.
+
+**Independent test**: With two sessions active, capture by `sessionId` and by `serial` and confirm the
+right device; capture with no selector and confirm `409 ambiguous_session`; with one session, confirm
+the bare call still works.
+
+### Tests for User Story 4
+
+- [ ] T043 [P] [US4] Contract-test `GET /api/emulators/screenshot`: explicit `sessionId`, explicit `serial`, 0 sessions -> `503 emulator_unavailable`, 1 session -> unchanged success, N>1 with no selector -> `409 ambiguous_session`, unknown `serial` -> `404 session_not_found` — in `tests/contract/EmulatorScreenshotSelectorContractTests.cs`
+
+### Implementation for User Story 4
+
+- [ ] T044 [US4] Add an optional `serial` query parameter, replace `PickSession`'s `FirstOrDefault` chain with explicit-selector -> single-session -> ambiguity-error resolution, and return the `ambiguous_session` / `session_not_found` bodies, in `src/GameBot.Service/Endpoints/EmulatorImageEndpoints.cs`
+- [ ] T045 [US4] Always send the selected session/serial selector on screenshot requests from the authoring UI in `src/web-ui/src/services/images.ts` and its callers, so the ambiguity error can never be triggered from the app itself
+
+**Checkpoint**: All four user stories complete.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T046 [P] Add a micro-benchmark holding `TryClaim`/`Release` under the declared 0.05 ms budget in `tests/unit/Performance/DeviceClaimBenchmarkTests.cs` (Constitution Principle IV)
+- [ ] T047 [P] Update `docs/architecture.md` with the device-claim and session-scoped-observation model and refresh its "Last reviewed" date (Constitution Principle V, NON-NEGOTIABLE)
+- [ ] T048 [P] Add the 079 entry to `specs/STATUS.md` and set `specs/079-concurrent-queue-execution/spec.md` **Status** to `Implemented`
+- [ ] T049 [P] Update `specs/051-queue-execution-runtime/spec.md` **Status** to record that its FR-013 (same-emulator concurrency allowed, no guard) is superseded by 079; FR-013a is unchanged
+- [ ] T050 Run `dotnet build C:\src\GameBot\GameBot.sln -c Debug` and `dotnet test C:\src\GameBot\GameBot.sln` and fix every failure and every new analyzer warning (red build/test blocks completion)
+- [ ] T051 Run `npm run build` and `npm test` in `src/web-ui` and fix any failure introduced by T034/T042/T045
+- [ ] T052 Walk [quickstart.md](./quickstart.md) end to end against a running service and correct anything it gets wrong
+
+---
+
+## Dependencies
+
+```text
+Phase 1 (T001-T003)  Setup / baseline
+        |
+Phase 2 (T004-T009)  Foundational  <-- BLOCKS every user story
+        |
+        +--> Phase 3 US1 (T010-T023)          device-scoped observation + action
+        |
+        +--> Phase 4 US2 (T024-T034, +T027a/T033a)  exclusive device claim
+        |
+        +--> Phase 5 US3 (T035-T042, +T037a/T037b)  visibility, capacity, state isolation
+        |                                            [T040 reads the run handle, so after T031]
+        +--> Phase 6 US4 (T043-T045)          operator tooling
+        |
+Phase 7 (T046-T052)  Polish, docs, gates
+```
+
+**Story independence**:
+
+- **US1** depends only on Phase 2. Fully deliverable alone: two queues on two emulators stop
+  corrupting each other's observations even without the claim registry.
+- **US2** depends only on Phase 2. Fully deliverable alone: same-device double-start becomes
+  impossible even before observation is scoped.
+- **US3** depends on Phase 2; T040 additionally reads the run handle's session/serial, so run it after
+  T031 if both are in flight.
+- **US4** depends only on Phase 2.
+
+**Within a story**: tests are written first and must fail before the matching implementation task.
+
+---
+
+## Parallel Execution Examples
+
+**Phase 2 (after T004/T005 exist)**: T007 and T008 in parallel with T006.
+
+**Phase 3**: T010, T011, T012, T013 are four different test files — all parallel. Then T014 in
+parallel with T018/T020/T021 (different projects and files); T015, T016, T017 are sequential because
+they touch the same registration and source pair.
+
+**Phase 4**: T024, T025, T026, T027, T027a all parallel (five files). T028 parallel with the Phase 3
+implementation; T029-T033a sequential within the claim path, then T034.
+
+**Phase 5**: T035, T036, T037, T037a, T037b parallel; T038 and T040 parallel; T039, T041, T042
+sequential after them.
+
+**Phase 7**: T046, T047, T048, T049 all parallel; T050-T052 last and sequential.
+
+---
+
+## Implementation Strategy
+
+**MVP scope**: Phase 1 + Phase 2 + **Phase 3 (US1)** + **Phase 4 (US2)**. Both are P1 and together they
+are the actual feature: correct observation plus a device that cannot be double-booked. US3 and US4
+make the result legible and safe to author against, and can land in a follow-up increment if needed.
+
+**Order of work**: baseline green -> primitives -> US1 -> US2 -> US3 -> US4 -> polish. Every phase ends
+at a checkpoint that is independently demonstrable, and no phase may be marked complete while the
+build or the test run is red.

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -86,7 +86,7 @@ Status vocabulary:
 | 048 | Edit Queue Page Layout | Implemented (iterated by 061, 062) |
 | 049 | Queue–Template Link with Auto-Load | Implemented |
 | 050 | Execution Log Grid Cleanup | Implemented |
-| 051 | Queue Execution Runtime | Implemented |
+| 051 | Queue Execution Runtime | Implemented (FR-013 superseded by 079) |
 | 052 | Ensure Game Running Primitive Action | Implemented |
 | 053 | Queue Sequence Scheduling | Implemented (iterated by 059, 060, 061) |
 | 054 | Key Input and Swipe Primitive Actions | Implemented |
@@ -113,6 +113,7 @@ Status vocabulary:
 | 075 | Deduplicate Self-Rescheduled Sequence Firings | Implemented |
 | 077 | Enable/Disable Template Sequences | Implemented |
 | 078 | Sequence & Command Parameters | Implemented |
+| 079 | Concurrent Queue Execution | Implemented |
 
 ## Numbering notes
 

--- a/src/GameBot.Domain/Sessions/AsyncLocalDeviceContextAccessor.cs
+++ b/src/GameBot.Domain/Sessions/AsyncLocalDeviceContextAccessor.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+
+namespace GameBot.Domain.Sessions;
+
+/// <summary>
+/// Default <see cref="IDeviceContextAccessor"/>: an <see cref="AsyncLocal{T}"/> holding the current
+/// <see cref="DeviceContext"/> (feature 079).
+/// </summary>
+/// <remarks>
+/// <see cref="AsyncLocal{T}"/> flows with the ExecutionContext, so the value survives every
+/// <c>await</c> inside a queue run and is captured by the <c>Task.Run</c> that launches the run. A
+/// value set inside a child flow does not leak back to its parent, so a nested push cannot outlive
+/// the scope that made it.
+/// </remarks>
+public sealed class AsyncLocalDeviceContextAccessor : IDeviceContextAccessor {
+  private static readonly AsyncLocal<DeviceContext?> Ambient = new();
+
+  /// <inheritdoc />
+  public DeviceContext? Current => Ambient.Value;
+
+  /// <inheritdoc />
+  public IDisposable Push(DeviceContext context) {
+    ArgumentNullException.ThrowIfNull(context);
+    var previous = Ambient.Value;
+    Ambient.Value = context;
+    return new Scope(previous);
+  }
+
+  /// <summary>Restores the context that was current before the matching <see cref="Push"/>.</summary>
+  private sealed class Scope : IDisposable {
+    private readonly DeviceContext? _previous;
+    private bool _disposed;
+
+    public Scope(DeviceContext? previous) => _previous = previous;
+
+    public void Dispose() {
+      if (_disposed) return;
+      _disposed = true;
+      Ambient.Value = _previous;
+    }
+  }
+}

--- a/src/GameBot.Domain/Sessions/DeviceContext.cs
+++ b/src/GameBot.Domain/Sessions/DeviceContext.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace GameBot.Domain.Sessions;
+
+/// <summary>
+/// Identifies the emulator device an execution flow is acting on (feature 079).
+/// </summary>
+/// <remarks>
+/// Carried ambiently by <see cref="IDeviceContextAccessor"/> so screen observation performed deep
+/// inside a queue run — image/text evaluators and condition adapters that take no session parameter —
+/// resolves against that run's own device instead of "whichever session happens to be first".
+/// Immutable and therefore safe to share across threads.
+/// </remarks>
+/// <param name="SessionId">The emulator session id the flow holds. Never blank.</param>
+/// <param name="DeviceSerial">The ADB serial when known; diagnostics only, the session id is the key.</param>
+public sealed record DeviceContext(string SessionId, string? DeviceSerial = null) {
+  /// <summary>Creates a context, rejecting a blank session id.</summary>
+  /// <exception cref="ArgumentException">The session id is null, empty or whitespace.</exception>
+  public static DeviceContext For(string sessionId, string? deviceSerial = null) {
+    ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+    return new DeviceContext(sessionId, string.IsNullOrWhiteSpace(deviceSerial) ? null : deviceSerial);
+  }
+}

--- a/src/GameBot.Domain/Sessions/IDeviceContextAccessor.cs
+++ b/src/GameBot.Domain/Sessions/IDeviceContextAccessor.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace GameBot.Domain.Sessions;
+
+/// <summary>
+/// Ambient "which device is this execution flow acting on" context (feature 079).
+/// </summary>
+/// <remarks>
+/// A queue run pushes its <see cref="DeviceContext"/> around each sequence firing; anything running
+/// inside that flow — nested sequences, commands, loops, trigger-based image/text conditions — sees it
+/// without the session id having to be threaded through <c>ITriggerEvaluator</c> and every evaluator.
+/// Outside any run the context is <c>null</c>, and consumers fall back to the single-running-session
+/// rule.
+/// </remarks>
+public interface IDeviceContextAccessor {
+  /// <summary>
+  /// The device context of the current execution flow, or <c>null</c> when none has been pushed.
+  /// </summary>
+  DeviceContext? Current { get; }
+
+  /// <summary>
+  /// Sets <see cref="Current"/> for the current execution flow (and every flow it starts) until the
+  /// returned scope is disposed, which restores the previous value.
+  /// </summary>
+  /// <param name="context">The context to make current. Must not be null.</param>
+  /// <returns>A scope that restores the previous context on dispose. Disposing twice is a no-op.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="context"/> is null.</exception>
+  IDisposable Push(DeviceContext context);
+}

--- a/src/GameBot.Domain/Triggers/Evaluators/ScreenSourceAbstractions.cs
+++ b/src/GameBot.Domain/Triggers/Evaluators/ScreenSourceAbstractions.cs
@@ -8,6 +8,44 @@ public interface IScreenSource {
   Bitmap? GetLatestScreenshot();
 }
 
+/// <summary>
+/// Creates <see cref="IScreenSource"/> instances bound to one specific emulator session (feature 079).
+/// </summary>
+/// <remarks>
+/// Used by every call site that already knows which session it is acting for, so concurrent queue runs
+/// can never observe one another's screen. Paths that cannot take a session id (trigger evaluators,
+/// condition adapters) keep using the singleton <see cref="IScreenSource"/>, which resolves the device
+/// from the ambient <c>IDeviceContextAccessor</c> instead.
+/// </remarks>
+public interface IScreenSourceFactory {
+  /// <summary>
+  /// Returns a screen source that observes only <paramref name="sessionId"/> for its whole lifetime.
+  /// When that session has no cached frame, or is no longer running, the source returns <c>null</c> —
+  /// it never substitutes another session's frame.
+  /// </summary>
+  /// <param name="sessionId">The emulator session to observe. Must not be blank.</param>
+  IScreenSource ForSession(string sessionId);
+}
+
+/// <summary>
+/// <see cref="IScreenSourceFactory"/> that hands the same source back for every session (feature 079).
+/// </summary>
+/// <remarks>
+/// Used in stub/test mode, where there is no real device and therefore nothing to keep separate, so
+/// callers can depend on the factory unconditionally.
+/// </remarks>
+public sealed class FixedScreenSourceFactory : IScreenSourceFactory {
+  private readonly IScreenSource _inner;
+
+  /// <summary>Creates a factory that always returns <paramref name="inner"/>.</summary>
+  public FixedScreenSourceFactory(IScreenSource inner) {
+    _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+  }
+
+  /// <inheritdoc />
+  public IScreenSource ForSession(string sessionId) => _inner;
+}
+
 [SupportedOSPlatform("windows")]
 public sealed class SingleBitmapScreenSource : IScreenSource {
   private readonly Func<Bitmap?> _provider;

--- a/src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs
+++ b/src/GameBot.Emulator/Session/BackgroundCaptureScreenSource.cs
@@ -1,5 +1,5 @@
 using System.Drawing;
-using System.IO;
+using System.Linq;
 using System.Runtime.Versioning;
 using GameBot.Domain.Sessions;
 using GameBot.Domain.Triggers.Evaluators;
@@ -7,33 +7,64 @@ using GameBot.Domain.Triggers.Evaluators;
 namespace GameBot.Emulator.Session;
 
 /// <summary>
-/// IScreenSource implementation backed by the BackgroundScreenCaptureService cache.
-/// Returns a clone of the latest cached Bitmap for the first running session.
-/// Does not call ADB directly — all captures come from the background loop.
+/// Session-agnostic <see cref="IScreenSource"/> for consumers that cannot name the session they are
+/// acting for (trigger evaluators, condition adapters, the standalone trigger worker).
 /// </summary>
+/// <remarks>
+/// Resolution order (feature 079):
+/// <list type="number">
+///   <item>the ambient <see cref="DeviceContext"/> pushed by the queue run this call is executing
+///         inside — so concurrent runs observe their own devices;</item>
+///   <item>the single running session, when exactly one exists — preserving single-emulator
+///         behaviour unchanged;</item>
+///   <item><c>null</c> when several sessions are running and none is ambient, rather than picking one
+///         arbitrarily.</item>
+/// </list>
+/// Before this feature the source always returned the frame of the <i>first</i> running session it
+/// found, which silently gave one queue run another run's screen.
+/// Does not call ADB directly — all captures come from the background loop.
+/// </remarks>
 [SupportedOSPlatform("windows")]
 public sealed class BackgroundCaptureScreenSource : IScreenSource {
   private readonly BackgroundScreenCaptureService _captureService;
   private readonly ISessionManager _sessions;
+  private readonly IDeviceContextAccessor? _deviceContext;
 
-  public BackgroundCaptureScreenSource(BackgroundScreenCaptureService captureService, ISessionManager sessions) {
+  /// <summary>Creates the source.</summary>
+  /// <param name="captureService">The per-session background capture cache.</param>
+  /// <param name="sessions">Session manager, used for the single-running-session fallback.</param>
+  /// <param name="deviceContext">
+  /// Ambient device context. When null (tests that omit it) only the single-session fallback applies.
+  /// </param>
+  public BackgroundCaptureScreenSource(
+      BackgroundScreenCaptureService captureService,
+      ISessionManager sessions,
+      IDeviceContextAccessor? deviceContext = null) {
     _captureService = captureService;
     _sessions = sessions;
+    _deviceContext = deviceContext;
   }
 
+  /// <inheritdoc />
   public Bitmap? GetLatestScreenshot() {
-    var sess = _sessions.ListSessions()
-        .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s.DeviceSerial) && s.Status == Domain.Sessions.SessionStatus.Running);
-    if (sess is null) return null;
+    var sessionId = ResolveSessionId();
+    return sessionId is null ? null : SessionScopedScreenSource.DecodeCachedFrame(_captureService, sessionId);
+  }
 
-    var frame = _captureService.GetCachedFrame(sess.Id);
-    if (frame is null) return null;
+  /// <summary>
+  /// Resolves the session to observe, or <c>null</c> when it is not unambiguously determined.
+  /// </summary>
+  private string? ResolveSessionId() {
+    // 1. The run whose execution flow we are on wins outright.
+    if (_deviceContext?.Current is { } ambient) {
+      return ambient.SessionId;
+    }
 
-    // Decode from the immutable PNG snapshot instead of cloning frame.Bitmap:
-    // the capture loop disposes the cached Bitmap when it swaps in a new frame,
-    // and reading a GDI+ Bitmap concurrently with its disposal throws.
-    using var ms = new MemoryStream(frame.PngBytes, writable: false);
-    using var tmp = new Bitmap(ms);
-    return new Bitmap(tmp); // detach from stream so the caller can dispose it independently
+    // 2. Exactly one running session: unambiguous, so keep the pre-079 single-emulator behaviour.
+    //    3. More than one (or none): ambiguous, so observe nothing rather than the wrong device.
+    var running = _sessions.ListSessions()
+      .Where(s => !string.IsNullOrWhiteSpace(s.DeviceSerial) && s.Status == Domain.Sessions.SessionStatus.Running)
+      .ToList();
+    return running.Count == 1 ? running[0].Id : null;
   }
 }

--- a/src/GameBot.Emulator/Session/BackgroundCaptureScreenSourceFactory.cs
+++ b/src/GameBot.Emulator/Session/BackgroundCaptureScreenSourceFactory.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.Versioning;
+using GameBot.Domain.Triggers.Evaluators;
+
+namespace GameBot.Emulator.Session;
+
+/// <summary>
+/// Default <see cref="IScreenSourceFactory"/>: hands out <see cref="SessionScopedScreenSource"/>
+/// instances over the shared background capture cache (feature 079).
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class BackgroundCaptureScreenSourceFactory : IScreenSourceFactory {
+  private readonly BackgroundScreenCaptureService _captureService;
+
+  /// <summary>Creates a factory over the per-session capture cache.</summary>
+  public BackgroundCaptureScreenSourceFactory(BackgroundScreenCaptureService captureService) {
+    ArgumentNullException.ThrowIfNull(captureService);
+    _captureService = captureService;
+  }
+
+  /// <inheritdoc />
+  /// <exception cref="ArgumentException"><paramref name="sessionId"/> is null, empty or whitespace.</exception>
+  public IScreenSource ForSession(string sessionId) =>
+    new SessionScopedScreenSource(_captureService, sessionId);
+}

--- a/src/GameBot.Emulator/Session/SessionManager.cs
+++ b/src/GameBot.Emulator/Session/SessionManager.cs
@@ -41,11 +41,27 @@ public sealed class SessionManager : ISessionManager {
   public int ActiveCount => _sessions.Count;
   public bool CanCreateSession => ActiveCount < _options.MaxConcurrentSessions;
 
+  /// <summary>
+  /// Builds the actionable session-capacity failure text (feature 079, FR-016). Exposed so tests and
+  /// callers assert on one wording.
+  /// </summary>
+  /// <param name="active">How many sessions are currently open.</param>
+  /// <param name="max">The configured ceiling.</param>
+  public static string CapacityExceededMessage(int active, int max) =>
+    string.Format(
+      CultureInfo.InvariantCulture,
+      "session capacity reached: {0} of {1} sessions are open (Service:Sessions:MaxConcurrentSessions)",
+      active,
+      max);
+
   public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) {
     CleanupIdleSessions();
     if (!CanCreateSession) {
       Log.CapacityExceeded(_logger, ActiveCount, _options.MaxConcurrentSessions);
-      throw new InvalidOperationException("capacity_exceeded");
+      // Feature 079 (FR-016): the message is what a failed queue run records, so it must name the
+      // limit, the current count and the setting to change — not the bare "capacity_exceeded" token.
+      // The exception type is unchanged, so the existing API mapping to that error code still works.
+      throw new InvalidOperationException(CapacityExceededMessage(ActiveCount, _options.MaxConcurrentSessions));
     }
     var id = Guid.NewGuid().ToString("N");
     var sess = new EmulatorSession {

--- a/src/GameBot.Emulator/Session/SessionOptions.cs
+++ b/src/GameBot.Emulator/Session/SessionOptions.cs
@@ -1,7 +1,16 @@
 namespace GameBot.Emulator.Session;
 
 public sealed class SessionOptions {
-  public int MaxConcurrentSessions { get; set; } = 3;
+  /// <summary>
+  /// How many emulator sessions may be open at once. Bound from
+  /// <c>Service:Sessions:MaxConcurrentSessions</c>.
+  /// </summary>
+  /// <remarks>
+  /// Raised from 3 to 8 in feature 079: with concurrent queue runs the old default was below a
+  /// plausible emulator count, so the guard rail became the practical ceiling on how many queues
+  /// could run at once. It stays a guard against runaway session creation, not a capacity plan.
+  /// </remarks>
+  public int MaxConcurrentSessions { get; set; } = 8;
   // Bind-friendly seconds value (tests can override via env Service__Sessions__IdleTimeoutSeconds)
   public int IdleTimeoutSeconds { get; set; } = 1800; // 30 minutes
 }

--- a/src/GameBot.Emulator/Session/SessionScopedScreenSource.cs
+++ b/src/GameBot.Emulator/Session/SessionScopedScreenSource.cs
@@ -1,0 +1,54 @@
+using System.Drawing;
+using System.IO;
+using System.Runtime.Versioning;
+using GameBot.Domain.Triggers.Evaluators;
+
+namespace GameBot.Emulator.Session;
+
+/// <summary>
+/// <see cref="IScreenSource"/> bound to exactly one emulator session (feature 079).
+/// </summary>
+/// <remarks>
+/// Returns the latest cached frame for that session and nothing else, so two concurrent queue runs can
+/// never observe one another's screen. Returns <c>null</c> when the session has no cached frame yet or
+/// its capture loop has stopped; it never substitutes another session's frame.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+public sealed class SessionScopedScreenSource : IScreenSource {
+  private readonly BackgroundScreenCaptureService _captureService;
+  private readonly string _sessionId;
+
+  /// <summary>Creates a source observing <paramref name="sessionId"/> for its whole lifetime.</summary>
+  /// <param name="captureService">The per-session background capture cache.</param>
+  /// <param name="sessionId">The session to observe. Must not be blank.</param>
+  public SessionScopedScreenSource(BackgroundScreenCaptureService captureService, string sessionId) {
+    ArgumentNullException.ThrowIfNull(captureService);
+    ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+    _captureService = captureService;
+    _sessionId = sessionId;
+  }
+
+  /// <summary>The session this source is bound to.</summary>
+  public string SessionId => _sessionId;
+
+  /// <inheritdoc />
+  public Bitmap? GetLatestScreenshot() => DecodeCachedFrame(_captureService, _sessionId);
+
+  /// <summary>
+  /// Decodes the session's latest cached frame into a detached <see cref="Bitmap"/>, or <c>null</c>
+  /// when no frame is cached.
+  /// </summary>
+  /// <remarks>
+  /// Decoding from the frame's immutable PNG bytes rather than cloning <c>frame.Bitmap</c> is
+  /// deliberate: the capture loop disposes the cached bitmap when it swaps in a new frame, and reading
+  /// a GDI+ bitmap concurrently with its disposal throws.
+  /// </remarks>
+  internal static Bitmap? DecodeCachedFrame(BackgroundScreenCaptureService captureService, string sessionId) {
+    var frame = captureService.GetCachedFrame(sessionId);
+    if (frame is null) return null;
+
+    using var ms = new MemoryStream(frame.PngBytes, writable: false);
+    using var tmp = new Bitmap(ms);
+    return new Bitmap(tmp); // detach from the stream so the caller can dispose it independently
+  }
+}

--- a/src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs
+++ b/src/GameBot.Service/Contracts/Queues/QueueMonitorResponse.cs
@@ -20,6 +20,12 @@ namespace GameBot.Service.Contracts.Queues {
     /// <summary>Local-clock instant the run loop started (anchor for relative timers); null when not running.</summary>
     public DateTimeOffset? RunStartedAt { get; set; }
 
+    /// <summary>
+    /// The emulator serial this run exclusively holds (feature 079); null when not running. Lets the
+    /// operator see which device each concurrently running queue is driving.
+    /// </summary>
+    public string? DeviceSerial { get; set; }
+
     /// <summary>The sequence executing right now; null when idle or not running.</summary>
     public QueueMonitorItemResponse? Current { get; set; }
 

--- a/src/GameBot.Service/Endpoints/EmulatorImageEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/EmulatorImageEndpoints.cs
@@ -17,15 +17,27 @@ internal static class EmulatorImageEndpoints {
 
   public static IEndpointRouteBuilder MapEmulatorImageEndpoints(this IEndpointRouteBuilder app) {
     // Capture emulator screenshot (served from background capture service cache)
-    app.MapGet(ApiRoutes.EmulatorScreenshot, async (HttpContext ctx, ISessionManager sessions, CaptureSessionStore captures, ILogger<EmulatorImageLoggingTag> logger, string? sessionId = null) => {
+    app.MapGet(ApiRoutes.EmulatorScreenshot, async (HttpContext ctx, ISessionManager sessions, CaptureSessionStore captures, ILogger<EmulatorImageLoggingTag> logger, string? sessionId = null, string? serial = null) => {
       var captureService = ctx.RequestServices.GetService<BackgroundScreenCaptureService>();
-      // Resolve session: use explicit sessionId or find first running session
+      // Feature 079 (FR-022..FR-024): resolve the device explicitly. Before this, an unqualified
+      // request with several sessions open returned an arbitrary one, so an operator could crop a
+      // reference image from the wrong emulator without noticing.
       GameBot.Domain.Sessions.EmulatorSession? session;
       if (!string.IsNullOrWhiteSpace(sessionId)) {
         session = sessions.GetSession(sessionId);
       }
+      else if (!string.IsNullOrWhiteSpace(serial)) {
+        session = FindSessionBySerial(sessions, serial);
+        if (session is null) {
+          return Results.Json(new { error = "session_not_found", message = $"No running session is bound to device '{serial}'." }, statusCode: StatusCodes.Status404NotFound);
+        }
+      }
       else {
-        session = PickSession(sessions);
+        var running = RunningSessions(sessions);
+        if (running.Count > 1) {
+          return Results.Json(new { error = "ambiguous_session", message = $"{running.Count} device sessions are active; specify sessionId or serial." }, statusCode: StatusCodes.Status409Conflict);
+        }
+        session = running.Count == 1 ? running[0] : null;
       }
 
       if (session is null) {
@@ -103,12 +115,22 @@ internal static class EmulatorImageEndpoints {
     return app;
   }
 
-  private static GameBot.Domain.Sessions.EmulatorSession? PickSession(ISessionManager sessions) {
-    var all = sessions.ListSessions();
-    return all.FirstOrDefault(s => !string.IsNullOrWhiteSpace(s.DeviceSerial) && s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
-        ?? all.FirstOrDefault(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
-        ?? all.FirstOrDefault();
-  }
+  /// <summary>
+  /// Every running session, in listing order (feature 079). Replaces the old <c>PickSession</c>, whose
+  /// <c>FirstOrDefault</c> chain silently chose an arbitrary emulator once more than one queue was
+  /// running. Sessions with no bound serial are included: in stub/non-ADB mode that is every session,
+  /// and excluding them would break single-session capture there.
+  /// </summary>
+  private static List<GameBot.Domain.Sessions.EmulatorSession> RunningSessions(ISessionManager sessions) =>
+    sessions.ListSessions()
+      .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
+      .ToList();
+
+  /// <summary>The running session bound to <paramref name="serial"/>, or null when there is none.</summary>
+  private static GameBot.Domain.Sessions.EmulatorSession? FindSessionBySerial(ISessionManager sessions, string serial) =>
+    RunningSessions(sessions)
+      .Find(s => !string.IsNullOrWhiteSpace(s.DeviceSerial)
+                 && string.Equals(s.DeviceSerial, serial.Trim(), StringComparison.OrdinalIgnoreCase));
 }
 
 internal sealed class CropRequest {

--- a/src/GameBot.Service/Endpoints/QueuesEndpoints.Logging.cs
+++ b/src/GameBot.Service/Endpoints/QueuesEndpoints.Logging.cs
@@ -8,4 +8,10 @@ internal static partial class QueuesEndpointsLogging {
 
   [LoggerMessage(EventId = 1101, Level = LogLevel.Information, Message = "Queue {QueueId} stopped")]
   internal static partial void LogQueueStopped(this ILogger logger, string QueueId);
+
+  // Feature 079 (FR-017): a refused start launches no run, so it produces no execution-log entry.
+  // Record it in the application log instead, naming everything needed to resolve the conflict.
+  [LoggerMessage(EventId = 1102, Level = LogLevel.Warning,
+    Message = "Queue {QueueId} start refused: emulator {DeviceSerial} is held by queue {HoldingQueueId} ({HoldingQueueName}).")]
+  internal static partial void LogQueueStartRefusedDeviceInUse(this ILogger logger, string QueueId, string DeviceSerial, string HoldingQueueId, string HoldingQueueName);
 }

--- a/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/QueuesEndpoints.cs
@@ -144,6 +144,7 @@ internal static class QueuesEndpoints {
         IQueueTemplateRepository templates,
         ISequenceRepository sequences,
         ICommandRepository commands,
+        IDeviceClaimRegistry deviceClaims,
         ILoggerFactory loggerFactory) => {
       // Feature 078 (FR-022): refuse the start BEFORE any session or device work when an enabled
       // entry has a required parameter nothing in scope can supply. Failing here beats discovering it
@@ -163,6 +164,16 @@ internal static class QueuesEndpoints {
       var outcome = await execution.StartAsync(id).ConfigureAwait(false);
       if (outcome == QueueStartOutcome.NotFound) return NotFound();
       if (outcome == QueueStartOutcome.AlreadyRunning) return Error(409, "already_running", "The queue is already running.");
+      if (outcome == QueueStartOutcome.DeviceInUse) {
+        // Feature 079 (FR-009/FR-010): a different queue holds this emulator. Name the device and the
+        // holder so the operator can act, and keep this distinct from "already_running".
+        var serial = preflightQueue.EmulatorSerial;
+        var holderId = deviceClaims.TryGetHolder(serial, out var holder) ? holder.QueueId : "another queue";
+        var holderName = holder is null || string.IsNullOrWhiteSpace(holder.QueueName) ? holderId : holder.QueueName;
+        loggerFactory.CreateLogger("Queues").LogQueueStartRefusedDeviceInUse(id, serial, holderId, holderName);
+        return Error(409, "device_in_use",
+          $"Emulator '{serial}' is already in use by queue '{holderName}'. Stop that queue before starting this one.");
+      }
       var queue = await repo.GetAsync(id).ConfigureAwait(false);
       if (queue is null) return NotFound();
       loggerFactory.CreateLogger("Queues").LogQueueStarted(id, queue.EmulatorSerial);
@@ -374,6 +385,7 @@ internal static class QueuesEndpoints {
       Running = snapshot.Running,
       CycleExecution = snapshot.CycleExecution,
       RunStartedAt = snapshot.RunStartedAt,
+      DeviceSerial = snapshot.DeviceSerial,
       Current = snapshot.Current is null ? null : ProjectMonitorItem(snapshot.Current),
       NothingScheduled = snapshot.NothingScheduled,
       LastOutcome = snapshot.LastOutcome is null

--- a/src/GameBot.Service/GameBotServiceSetup.cs
+++ b/src/GameBot.Service/GameBotServiceSetup.cs
@@ -131,6 +131,11 @@ internal static class GameBotServiceSetup {
     });
     builder.Services.AddSingleton<ISessionManager, SessionManager>();
     builder.Services.AddSingleton<ISessionContextCache, SessionContextCache>();
+    // Feature 079: ambient "which device is this execution flow acting on" context. A queue run pushes
+    // it around each firing so the singleton IScreenSource — used by trigger evaluators and condition
+    // adapters that take no session id — observes that run's own device instead of the first session.
+    builder.Services.AddSingleton<GameBot.Domain.Sessions.IDeviceContextAccessor,
+      GameBot.Domain.Sessions.AsyncLocalDeviceContextAccessor>();
     // SessionService: optionally inject BackgroundScreenCaptureService when ADB capture is enabled
     builder.Services.AddSingleton<ISessionService>(sp => {
       var sessions = sp.GetRequiredService<ISessionManager>();
@@ -148,7 +153,8 @@ internal static class GameBotServiceSetup {
           sp.GetRequiredService<GameBot.Domain.Triggers.Evaluators.IScreenSource>(),
           sp.GetRequiredService<GameBot.Domain.Triggers.Evaluators.IReferenceImageStore>(),
           sp.GetRequiredService<GameBot.Domain.Vision.ITemplateMatcher>(),
-          sp.GetRequiredService<GameBot.Domain.Config.AppConfig>()));
+          sp.GetRequiredService<GameBot.Domain.Config.AppConfig>(),
+          sp.GetService<GameBot.Domain.Triggers.Evaluators.IScreenSourceFactory>()));
     }
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureEmulatorRunning.IEmulatorControl, GameBot.Service.Services.EnsureEmulatorRunning.LdConsoleEmulatorControl>();
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureEmulatorRunning.IEmulatorDeviceProbe, GameBot.Service.Services.EnsureEmulatorRunning.AdbEmulatorDeviceProbe>();
@@ -178,6 +184,8 @@ internal static class GameBotServiceSetup {
     // Self-reschedule (feature 065): the run registry breaks the SequenceExecutionService ↔
     // QueueExecutionService DI cycle; the coordinator injects ephemeral run-scoped firings.
     builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IQueueRunRegistry, GameBot.Service.Services.QueueExecution.QueueRunRegistry>();
+    // Feature 079: exclusive per-emulator ownership, so two queues can never drive one screen.
+    builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IDeviceClaimRegistry, GameBot.Service.Services.QueueExecution.DeviceClaimRegistry>();
     builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.ISelfRescheduleCoordinator, GameBot.Service.Services.QueueExecution.SelfRescheduleCoordinator>();
     builder.Services.AddSingleton<GameBot.Service.Services.QueueExecution.IQueueExecutionService, GameBot.Service.Services.QueueExecution.QueueExecutionService>();
     // Read-only live monitor projection (feature 072): pure fold of run handle + linked template + now.
@@ -324,18 +332,29 @@ internal static class GameBotServiceSetup {
         return new GameBot.Emulator.Session.BackgroundScreenCaptureService(
           factory, appConfig.CaptureIntervalMs, sp.GetRequiredService<ILogger<GameBot.Emulator.Session.BackgroundScreenCaptureService>>());
       });
-      // IScreenSource backed by background capture cache (replaces direct ADB + TTL cache chain)
+      // IScreenSource backed by background capture cache (replaces direct ADB + TTL cache chain).
+      // Feature 079: the ambient device context decides which session it observes, so concurrent
+      // queue runs never read one another's screen.
       builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.IScreenSource>(sp => {
         var captureService = sp.GetRequiredService<GameBot.Emulator.Session.BackgroundScreenCaptureService>();
         var sessions = sp.GetRequiredService<ISessionManager>();
-        return new GameBot.Emulator.Session.BackgroundCaptureScreenSource(captureService, sessions);
+        var deviceContext = sp.GetRequiredService<GameBot.Domain.Sessions.IDeviceContextAccessor>();
+        return new GameBot.Emulator.Session.BackgroundCaptureScreenSource(captureService, sessions, deviceContext);
       });
+      // Feature 079: explicit per-session screen sources for call sites that already know their session.
+      builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.IScreenSourceFactory>(sp =>
+        new GameBot.Emulator.Session.BackgroundCaptureScreenSourceFactory(
+          sp.GetRequiredService<GameBot.Emulator.Session.BackgroundScreenCaptureService>()));
       // Keep AdbScreenSource registered for any legacy/direct consumers
       builder.Services.AddSingleton<GameBot.Emulator.Session.AdbScreenSource>();
     }
     else {
-      // Test/stub mode: optional fixed bitmap via env variable
+      // Test/stub mode: optional fixed bitmap via env variable. There is no real device, so the
+      // per-session factory hands the same stub source to every caller (feature 079).
       builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.IScreenSource>(_ => CreateTestScreenSource());
+      builder.Services.AddSingleton<GameBot.Domain.Triggers.Evaluators.IScreenSourceFactory>(sp =>
+        new GameBot.Domain.Triggers.Evaluators.FixedScreenSourceFactory(
+          sp.GetRequiredService<GameBot.Domain.Triggers.Evaluators.IScreenSource>()));
     }
   }
 

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -1,4 +1,4 @@
-using GameBot.Domain.Commands;
+﻿using GameBot.Domain.Commands;
 using GameBot.Domain.Config;
 using GameBot.Domain.Parameters;
 using GameBot.Domain.Logging;
@@ -23,6 +23,9 @@ internal sealed class CommandExecutor : ICommandExecutor {
   private readonly ILogger<CommandExecutor> _logger;
   private readonly GameBot.Domain.Triggers.Evaluators.IReferenceImageStore? _images;
   private readonly GameBot.Domain.Triggers.Evaluators.IScreenSource? _screen;
+  // Feature 079: when the executor knows which session it is acting for, detection reads that
+  // session's frames explicitly instead of relying on the ambient/singleton screen source.
+  private readonly GameBot.Domain.Triggers.Evaluators.IScreenSourceFactory? _screenFactory;
   private readonly GameBot.Domain.Vision.ITemplateMatcher? _matcher;
   private readonly ISessionContextCache _sessionCache;
   private readonly IExecutionLogService? _executionLogService;
@@ -31,7 +34,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
   private readonly IEnsureEmulatorRunningActionHandler? _ensureEmulatorRunning;
   private readonly IGameReadinessProbe? _gameReadiness;
 
-  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, AppConfig appConfig, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null, IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null, IGameReadinessProbe? gameReadiness = null) {
+  public CommandExecutor(ICommandRepository commands, ISessionManager sessions, ITriggerRepository triggers, TriggerEvaluationService triggerEval, ILogger<CommandExecutor> logger, GameBot.Domain.Triggers.Evaluators.IReferenceImageStore images, GameBot.Domain.Triggers.Evaluators.IScreenSource screen, GameBot.Domain.Vision.ITemplateMatcher matcher, ISessionContextCache sessionCache, AppConfig appConfig, IExecutionLogService? executionLogService = null, IEnsureGameRunningActionHandler? ensureGameRunning = null, IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null, IGameReadinessProbe? gameReadiness = null, GameBot.Domain.Triggers.Evaluators.IScreenSourceFactory? screenFactory = null) {
     _commands = commands;
     _sessions = sessions;
     _triggers = triggers;
@@ -39,6 +42,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _logger = logger;
     _images = images;
     _screen = screen;
+    _screenFactory = screenFactory;
     _matcher = matcher;
     _sessionCache = sessionCache;
     _appConfig = appConfig;
@@ -57,6 +61,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _logger = logger;
     _images = null;
     _screen = null;
+    _screenFactory = null;
     _matcher = null;
     _sessionCache = sessionCache;
     _appConfig = new AppConfig();
@@ -64,6 +69,21 @@ internal sealed class CommandExecutor : ICommandExecutor {
     _ensureGameRunning = ensureGameRunning;
     _ensureEmulatorRunning = ensureEmulatorRunning;
     _gameReadiness = gameReadiness;
+  }
+
+  /// <summary>
+  /// Returns the screen source detection should read for <paramref name="sessionId"/> (feature 079).
+  /// </summary>
+  /// <remarks>
+  /// Prefers an explicitly session-bound source so concurrent queue runs cannot observe one another's
+  /// device. Falls back to the injected singleton when no factory is registered (stub/test mode) or
+  /// no session is known, where the ambient device context still applies.
+  /// </remarks>
+  private GameBot.Domain.Triggers.Evaluators.IScreenSource? ResolveScreenSource(string? sessionId) {
+    if (_screenFactory is not null && !string.IsNullOrWhiteSpace(sessionId)) {
+      return _screenFactory.ForSession(sessionId);
+    }
+    return _screen;
   }
 
   public Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default)
@@ -189,6 +209,14 @@ internal sealed class CommandExecutor : ICommandExecutor {
       if (runningSessions.Count == 1) {
         resolvedSessionId = runningSessions[0].Id;
       }
+      else if (runningSessions.Count > 1) {
+        // Feature 079 (FR-007): several devices are live and the caller named none. Say so instead of
+        // acting on an arbitrary one. The sentinel stays "missing_session_context" so existing API
+        // mappings and callers keep working; the ambiguity is carried in the inner exception's text.
+        throw new InvalidOperationException(
+          "missing_session_context",
+          new InvalidOperationException(SessionResolver.Ambiguous(runningSessions.Count, "force-execute")));
+      }
       else {
         throw new InvalidOperationException("missing_session_context");
       }
@@ -258,7 +286,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
       DetectionTarget? commandLevelDetection,
       CancellationToken ct) {
     if (step.Type == CommandStepType.WaitForImage) {
-      return (0, await ExecuteWaitForImageStepAsync(step, ct).ConfigureAwait(false));
+      return (0, await ExecuteWaitForImageStepAsync(step, sessionId, ct).ConfigureAwait(false));
     }
 
     if (step.Type == CommandStepType.EnsureGameRunning) {
@@ -279,7 +307,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
           : (0, new PrimitiveTapStepOutcome(step.Order, result.ReasonCode, result.ReasonCode, null, null, StepType: "ensure-game-running"));
       }
 
-      // The game/session could not be resolved (or the platform is unsupported) — there is nothing
+      // The game/session could not be resolved (or the platform is unsupported) â€” there is nothing
       // to wait for, so surface the handler failure directly instead of spinning on the screen.
       if (result.Outcome is EnsureGameRunningOutcome.NoQueueContext
           or EnsureGameRunningOutcome.NoLinkedGame
@@ -291,7 +319,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
       // Handler has (best-effort) launched the game if it was not foreground. Now wait for it to
       // actually reach the ready screen before letting the queue proceed.
       var readinessTimeoutMs = Math.Max(0, step.EnsureGameRunning!.ReadinessTimeoutMs);
-      var readinessResult = await _gameReadiness!.WaitUntilReadyAsync(readiness!, readinessTimeoutMs, ct).ConfigureAwait(false);
+      var readinessResult = await _gameReadiness!.WaitUntilReadyAsync(readiness!, readinessTimeoutMs, sessionId, ct).ConfigureAwait(false);
       return readinessResult.Ready
         ? (1, new PrimitiveTapStepOutcome(step.Order, "executed", "game_ready", null, null, StepType: "ensure-game-running", TimeoutMs: readinessTimeoutMs, EffectiveTimeoutMs: readinessTimeoutMs, ReferenceImageId: readiness!.ReferenceImageId, ImageLoadStatus: readinessResult.ImageLoadStatus))
         : (0, new PrimitiveTapStepOutcome(step.Order, "readiness_timeout", "readiness_timeout", null, null, StepType: "ensure-game-running", TimeoutMs: readinessTimeoutMs, EffectiveTimeoutMs: readinessTimeoutMs, ReferenceImageId: readiness!.ReferenceImageId, ImageLoadStatus: readinessResult.ImageLoadStatus));
@@ -385,7 +413,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
 
       var cancelCycleTracker = 0;
       try {
-        var screenSrc = _screen;
+        var screenSrc = ResolveScreenSource(sessionId);
         var images = _images;
         var matcher = _matcher;
         if (screenSrc is null || images is null || matcher is null) {
@@ -450,7 +478,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     throw new InvalidOperationException($"Step type {step.Type} cannot be executed as a standalone step");
   }
 
-  private async Task<PrimitiveTapStepOutcome> ExecuteWaitForImageStepAsync(CommandStep step, CancellationToken ct) {
+  private async Task<PrimitiveTapStepOutcome> ExecuteWaitForImageStepAsync(CommandStep step, string sessionId, CancellationToken ct) {
     var waitConfig = step.WaitForImage ?? new WaitForImageConfig();
     var timeoutMs = Math.Max(0, waitConfig.TimeoutMs);
     var detectionTarget = waitConfig.DetectionTarget;
@@ -485,7 +513,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
         ConfiguredConfidence: detectionTarget.Confidence);
     }
 
-    var screenSrc = _screen;
+    var screenSrc = ResolveScreenSource(sessionId);
     var images = _images;
     var matcher = _matcher;
     if (screenSrc is null || images is null || matcher is null) {
@@ -591,7 +619,7 @@ internal sealed class CommandExecutor : ICommandExecutor {
     => ImageDetectionHelper.TryDetect(screenSrc, templateBmp, detectionTarget, matcher, out resolvedPoint, out detectionConfidence);
 
   /// <summary>
-  /// Attempts a single screenshot-fetch → template-match → coordinate-resolve → tap cycle.
+  /// Attempts a single screenshot-fetch â†’ template-match â†’ coordinate-resolve â†’ tap cycle.
   /// Returns true if detection succeeded and the tap was sent; false otherwise.
   /// On success, appends the outcome to <paramref name="stepOutcomes"/> and increments <paramref name="totalAccepted"/>.
   /// </summary>
@@ -681,7 +709,13 @@ internal sealed class CommandExecutor : ICommandExecutor {
       Log.SessionContextMissing(_logger, commandId);
     }
 
-    throw new InvalidOperationException("missing_session_context");
+    // Feature 079 (FR-007): distinguish "no device at all" from "several devices, none named" while
+    // keeping the "missing_session_context" sentinel every caller and API mapping already matches on.
+    throw runningSessions.Count > 1
+      ? new InvalidOperationException(
+          "missing_session_context",
+          new InvalidOperationException(SessionResolver.Ambiguous(runningSessions.Count, commandId)))
+      : new InvalidOperationException("missing_session_context");
   }
 }
 

--- a/src/GameBot.Service/Services/EnsureGameRunning/GameReadinessProbe.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/GameReadinessProbe.cs
@@ -7,18 +7,26 @@ namespace GameBot.Service.Services.EnsureGameRunning;
 
 internal sealed class GameReadinessProbe : IGameReadinessProbe {
   private readonly IScreenSource _screen;
+  // Feature 079: when the caller names its session, the probe observes only that device, so a
+  // concurrent queue run's ready screen can never satisfy this gate. Null in stub/test wiring.
+  private readonly IScreenSourceFactory? _screenFactory;
   private readonly IReferenceImageStore _images;
   private readonly ITemplateMatcher _matcher;
   private readonly AppConfig _appConfig;
 
-  public GameReadinessProbe(IScreenSource screen, IReferenceImageStore images, ITemplateMatcher matcher, AppConfig appConfig) {
+  public GameReadinessProbe(IScreenSource screen, IReferenceImageStore images, ITemplateMatcher matcher, AppConfig appConfig, IScreenSourceFactory? screenFactory = null) {
     _screen = screen;
     _images = images;
     _matcher = matcher;
     _appConfig = appConfig;
+    _screenFactory = screenFactory;
   }
 
-  public async Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, CancellationToken ct = default) {
+  public async Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, string? sessionId = null, CancellationToken ct = default) {
+    var screen = _screenFactory is not null && !string.IsNullOrWhiteSpace(sessionId)
+      ? _screenFactory.ForSession(sessionId)
+      : _screen;
+
     if (!OperatingSystem.IsWindows()) {
       return new GameReadinessResult(false, "unavailable");
     }
@@ -29,7 +37,7 @@ internal sealed class GameReadinessProbe : IGameReadinessProbe {
 
     var deadline = DateTimeOffset.UtcNow.AddMilliseconds(Math.Max(0, timeoutMs));
 
-    if (ImageDetectionHelper.TryDetect(_screen, templateBmp, readinessImage, _matcher, out _, out _)) {
+    if (ImageDetectionHelper.TryDetect(screen, templateBmp, readinessImage, _matcher, out _, out _)) {
       return new GameReadinessResult(true, "loaded");
     }
 
@@ -42,7 +50,7 @@ internal sealed class GameReadinessProbe : IGameReadinessProbe {
       var pollMs = Math.Max(1, Math.Min(_appConfig.CaptureIntervalMs, (int)Math.Ceiling(remaining.TotalMilliseconds)));
       await Task.Delay(pollMs, ct).ConfigureAwait(false);
 
-      if (ImageDetectionHelper.TryDetect(_screen, templateBmp, readinessImage, _matcher, out _, out _)) {
+      if (ImageDetectionHelper.TryDetect(screen, templateBmp, readinessImage, _matcher, out _, out _)) {
         return new GameReadinessResult(true, "loaded");
       }
     }

--- a/src/GameBot.Service/Services/EnsureGameRunning/IGameReadinessProbe.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/IGameReadinessProbe.cs
@@ -12,5 +12,14 @@ internal readonly record struct GameReadinessResult(bool Ready, string ImageLoad
 /// configured ready screen (rather than as soon as its package is foreground).
 /// </summary>
 internal interface IGameReadinessProbe {
-  Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, CancellationToken ct = default);
+  /// <summary>Polls until the readiness image is detected or the timeout elapses.</summary>
+  /// <param name="readinessImage">The reference image that means "the game is ready".</param>
+  /// <param name="timeoutMs">How long to keep polling, in milliseconds.</param>
+  /// <param name="sessionId">
+  /// The emulator session to observe (feature 079). When supplied, the probe reads only that
+  /// session's screen, so a concurrent queue run's device can never satisfy this gate. Null keeps
+  /// the ambient/single-session resolution.
+  /// </param>
+  /// <param name="ct">Cancellation token.</param>
+  Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, string? sessionId = null, CancellationToken ct = default);
 }

--- a/src/GameBot.Service/Services/QueueExecution/DeviceClaimRegistry.cs
+++ b/src/GameBot.Service/Services/QueueExecution/DeviceClaimRegistry.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// Default <see cref="IDeviceClaimRegistry"/>: a singleton owning a
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> of <see cref="DeviceClaim"/>s keyed by normalized
+/// emulator serial (feature 079).
+/// </summary>
+/// <remarks>
+/// <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/> makes claiming atomic, so two simultaneous
+/// starts for the same device cannot both succeed (FR-012) without any lock. Holds no service
+/// dependencies and no persisted state.
+/// </remarks>
+internal sealed class DeviceClaimRegistry : IDeviceClaimRegistry {
+  private readonly ConcurrentDictionary<string, DeviceClaim> _claims =
+    new(StringComparer.OrdinalIgnoreCase);
+
+  private readonly TimeProvider _timeProvider;
+
+  public DeviceClaimRegistry() : this(null) { }
+
+  /// <summary>Creates the registry; the time provider is injectable so tests can pin claim times.</summary>
+  public DeviceClaimRegistry(TimeProvider? timeProvider) {
+    _timeProvider = timeProvider ?? TimeProvider.System;
+  }
+
+  /// <inheritdoc />
+  public bool TryClaim(string? deviceSerial, string queueId, string queueName) {
+    ArgumentException.ThrowIfNullOrWhiteSpace(queueId);
+    var key = Normalize(deviceSerial);
+    // A queue with no bound serial has no device identity to reserve. Storing every such queue under
+    // one shared empty key would make them block each other for no reason (research R5).
+    if (key is null) return true;
+
+    var claim = new DeviceClaim(key, queueId, queueName ?? string.Empty, _timeProvider.GetUtcNow());
+    return _claims.TryAdd(key, claim);
+  }
+
+  /// <inheritdoc />
+  public void Release(string? deviceSerial, string queueId) {
+    var key = Normalize(deviceSerial);
+    if (key is null || string.IsNullOrWhiteSpace(queueId)) return;
+    if (!_claims.TryGetValue(key, out var existing)) return;
+    // Only the holder may release: a late release from a run that has already ended must not drop the
+    // claim a newer run has since taken on the same device.
+    if (!string.Equals(existing.QueueId, queueId, StringComparison.Ordinal)) return;
+    _claims.TryRemove(new System.Collections.Generic.KeyValuePair<string, DeviceClaim>(key, existing));
+  }
+
+  /// <inheritdoc />
+  public bool TryGetHolder(string? deviceSerial, out DeviceClaim claim) {
+    var key = Normalize(deviceSerial);
+    if (key is not null && _claims.TryGetValue(key, out var found)) {
+      claim = found;
+      return true;
+    }
+    claim = null!;
+    return false;
+  }
+
+  /// <summary>Trims the serial and maps a blank one to <c>null</c> ("no device identity").</summary>
+  private static string? Normalize(string? deviceSerial) {
+    if (string.IsNullOrWhiteSpace(deviceSerial)) return null;
+    return deviceSerial.Trim();
+  }
+}

--- a/src/GameBot.Service/Services/QueueExecution/IDeviceClaimRegistry.cs
+++ b/src/GameBot.Service/Services/QueueExecution/IDeviceClaimRegistry.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace GameBot.Service.Services.QueueExecution;
+
+/// <summary>
+/// One emulator device exclusively reserved by one queue run (feature 079).
+/// </summary>
+/// <param name="DeviceSerial">The normalized (trimmed) ADB serial that is claimed.</param>
+/// <param name="QueueId">The queue whose run holds the claim.</param>
+/// <param name="QueueName">The holding queue's display name, for the refusal message.</param>
+/// <param name="ClaimedAtUtc">When the claim was taken; diagnostics only.</param>
+internal sealed record DeviceClaim(
+  string DeviceSerial,
+  string QueueId,
+  string QueueName,
+  DateTimeOffset ClaimedAtUtc);
+
+/// <summary>
+/// Exclusive, in-memory ownership of emulator devices by queue runs (feature 079, FR-008..FR-014).
+/// </summary>
+/// <remarks>
+/// Two automations driving one screen cannot both be correct, so at most one run may hold a given
+/// device serial at a time. Feature 051 FR-013 previously allowed same-emulator concurrency and made
+/// interference the operator's problem; this registry reverses that. Claims are never persisted, so a
+/// service restart voids them all. Mirrors <see cref="IQueueRunRegistry"/> in shape and lifetime.
+/// </remarks>
+internal interface IDeviceClaimRegistry {
+  /// <summary>
+  /// Atomically claims <paramref name="deviceSerial"/> for a queue run.
+  /// </summary>
+  /// <param name="deviceSerial">
+  /// The queue's bound ADB serial. Trimmed and compared case-insensitively. A blank serial has no
+  /// device identity to reserve, so it is accepted as a no-op claim and never blocks another queue.
+  /// </param>
+  /// <param name="queueId">The claiming queue.</param>
+  /// <param name="queueName">The claiming queue's display name.</param>
+  /// <returns>
+  /// <c>true</c> when the claim was taken (or was a blank-serial no-op); <c>false</c> when a
+  /// different queue already holds the device.
+  /// </returns>
+  bool TryClaim(string? deviceSerial, string queueId, string queueName);
+
+  /// <summary>
+  /// Releases the claim on <paramref name="deviceSerial"/>, but only when <paramref name="queueId"/>
+  /// still holds it, so a late release from a finished run cannot steal a newer run's claim.
+  /// Idempotent; a blank serial or an unheld device is a no-op.
+  /// </summary>
+  void Release(string? deviceSerial, string queueId);
+
+  /// <summary>Looks up the current holder of a device, for building the refusal message.</summary>
+  /// <returns><c>false</c> when the serial is blank or unclaimed.</returns>
+  bool TryGetHolder(string? deviceSerial, out DeviceClaim claim);
+}

--- a/src/GameBot.Service/Services/QueueExecution/IQueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/IQueueExecutionService.cs
@@ -12,8 +12,15 @@ internal enum QueueStartOutcome {
   /// <summary>No queue exists with the given id.</summary>
   NotFound,
 
-  /// <summary>A run is already in progress for this queue (FR-013a).</summary>
-  AlreadyRunning
+  /// <summary>A run is already in progress for this queue (051 FR-013a).</summary>
+  AlreadyRunning,
+
+  /// <summary>
+  /// The queue's bound emulator is claimed by a <i>different</i> running queue (feature 079,
+  /// FR-009/FR-010). Deliberately distinct from <see cref="AlreadyRunning"/> so the operator can tell
+  /// "this queue is running" from "this queue's device is busy".
+  /// </summary>
+  DeviceInUse
 }
 
 /// <summary>Result of attempting to register a live relative schedule (feature 059).</summary>
@@ -30,8 +37,11 @@ internal readonly record struct LiveScheduleResult(LiveScheduleOutcome Outcome, 
 
 /// <summary>
 /// Owns the lifecycle of live queue runs: launching a background run on start, cancelling it on
-/// stop, and tracking which queues are currently running. One run at a time per queue; concurrent
-/// runs across different queues (including ones bound to the same emulator) are allowed (FR-013).
+/// stop, and tracking which queues are currently running. One run at a time per queue (051 FR-013a),
+/// and — since feature 079 — one run at a time per emulator: queues bound to <i>different</i> devices
+/// run concurrently and independently, while a start whose device is already claimed is refused with
+/// <see cref="QueueStartOutcome.DeviceInUse"/>. This reverses 051 FR-013, which allowed two runs to
+/// share one emulator and left the resulting interference to the operator.
 /// </summary>
 internal interface IQueueExecutionService {
   /// <summary>

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -46,6 +46,10 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   private readonly TimeProvider _timeProvider;
   private readonly CancellationToken _appStopping;
   private readonly IQueueRunRegistry _registry;
+  // Exclusive per-emulator ownership (feature 079): claimed before the run launches, released when it
+  // ends, so two queues can never drive one screen. When not injected (tests) the service owns a
+  // private registry, so claims are still enforced between the queues it starts.
+  private readonly IDeviceClaimRegistry _deviceClaims;
   // Foregrounds the game when an idle pause resumes (feature 073). Same handler the
   // ensure-game-running sequence step uses; reused directly here so the scheduler can bring the game
   // back without routing through a watchdog-subject sequence. Null only in tests that omit it.
@@ -86,7 +90,8 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     BackgroundScreenCaptureService? captureService = null,
     TimeProvider? timeProvider = null,
     IEnsureGameRunningActionHandler? ensureGameRunning = null,
-    IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null) {
+    IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null,
+    IDeviceClaimRegistry? deviceClaims = null) {
     _queues = queues;
     _runtime = runtime;
     _templates = templates;
@@ -100,6 +105,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     _appStopping = lifetime?.ApplicationStopping ?? CancellationToken.None;
     _ensureGameRunning = ensureGameRunning;
     _ensureEmulatorRunning = ensureEmulatorRunning;
+    _deviceClaims = deviceClaims ?? new DeviceClaimRegistry();
   }
 
   public bool IsRunning(string queueId) => _registry.IsRunning(queueId);
@@ -119,10 +125,25 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     if (queue is null) return QueueStartOutcome.NotFound;
 
     var cts = CancellationTokenSource.CreateLinkedTokenSource(_appStopping);
-    var handle = new QueueRunHandle { QueueId = queueId, Cts = cts, CycleExecution = queue.CycleExecution };
+    var handle = new QueueRunHandle {
+      QueueId = queueId,
+      Cts = cts,
+      CycleExecution = queue.CycleExecution,
+      DeviceSerial = queue.EmulatorSerial
+    };
     if (!_registry.TryAdd(queueId, handle)) {
       cts.Dispose();
       return QueueStartOutcome.AlreadyRunning;
+    }
+
+    // Feature 079 (FR-008/FR-009/FR-012): one run per device. Claim before launching, so a refusal
+    // leaves the queue Stopped with no run and no residue in the run registry. TryClaim is atomic, so
+    // two simultaneous starts for one serial cannot both win. Released in RunAsync's finally, which
+    // covers completion, manual stop, failure, cancellation and host shutdown (FR-011).
+    if (!_deviceClaims.TryClaim(queue.EmulatorSerial, queueId, queue.Name)) {
+      _registry.Remove(queueId, out _);
+      cts.Dispose();
+      return QueueStartOutcome.DeviceInUse;
     }
 
     // Resolve the linked template once and materialize its entries into the runtime store so the
@@ -130,9 +151,20 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     // display layer instead reads the runtime store, and auto-load on display is suppressed once
     // the queue is Running (see QueuesEndpoints.MaybeAutoLoadAsync). Without this, a queue started
     // before it was ever displayed reports zero entries despite a populated linked template.
-    var template = string.IsNullOrEmpty(queue.LinkedTemplateId)
-      ? null
-      : await _templates.GetAsync(queue.LinkedTemplateId).ConfigureAwait(false);
+    QueueTemplate? template;
+    try {
+      template = string.IsNullOrEmpty(queue.LinkedTemplateId)
+        ? null
+        : await _templates.GetAsync(queue.LinkedTemplateId).ConfigureAwait(false);
+    }
+    catch {
+      // The run never launched, so RunAsync's finally will not run: undo the claim and the registry
+      // entry here rather than leaking the device until the service restarts (feature 079, FR-011).
+      _deviceClaims.Release(queue.EmulatorSerial, queueId);
+      _registry.Remove(queueId, out _);
+      cts.Dispose();
+      throw;
+    }
     if (template is not null) {
       // Materialize ALL entries (including disabled ones) into the runtime store: the template
       // editor renders from these runtime entries and merges each entry's schedule/enabled state
@@ -479,6 +511,9 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
 
       _runtime.SetStatus(queue.Id, QueueExecutionStatus.Stopped);
       _registry.Remove(queue.Id, out _);
+      // Feature 079 (FR-011): the device becomes claimable again however this run ended — completed,
+      // stopped, failed, cancelled, or torn down by host shutdown.
+      _deviceClaims.Release(queue.EmulatorSerial, queue.Id);
       handle.Cts.Dispose();
     }
   }
@@ -524,6 +559,10 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     // once-per-run, every-step, timer, relative, live, self-reschedule — flows through here, so
     // set the current sequence at the top and clear it in the finally. This is purely observational
     // and does not change scheduling behavior.
+    // Feature 079: the ambient device context for this firing is established by
+    // SequenceExecutionService.ExecuteAsync from the sessionId passed below, and covers everything the
+    // firing starts (nested sequences, commands, loops, image/text conditions). Pushing it again here
+    // would be redundant, so the run loop deliberately does not.
     var trackedHandle = _registry.TryGet(queueId, out var handle) ? handle : null;
     trackedHandle?.SetCurrentSequence(sequenceId, _timeProvider.GetLocalNow());
     try {

--- a/src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueMonitorService.cs
@@ -56,7 +56,7 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
       return new QueueMonitorSnapshot(
         queueId, name, Running: false, CycleExecution: queue?.CycleExecution ?? false,
         RunStartedAt: null, Current: null, Upcoming: Array.Empty<QueueMonitorItem>(),
-        NothingScheduled: false, LastOutcome: lastOutcome);
+        NothingScheduled: false, LastOutcome: lastOutcome, DeviceSerial: null);
     }
 
     var template = string.IsNullOrEmpty(queue?.LinkedTemplateId)
@@ -86,7 +86,11 @@ internal sealed class QueueMonitorService : IQueueMonitorService {
 
     return new QueueMonitorSnapshot(
       queueId, name, Running: true, CycleExecution: cycling, RunStartedAt: handle.RunStartedAt,
-      Current: current, Upcoming: upcoming, NothingScheduled: nothingScheduled, LastOutcome: null);
+      Current: current, Upcoming: upcoming, NothingScheduled: nothingScheduled, LastOutcome: null,
+      // Feature 079 (FR-018): the device this run holds, taken from its own handle so concurrent runs
+      // never report one another's emulator. Falls back to the queue's bound serial for a handle
+      // built before the run assigned it (and in tests that hand-build one).
+      DeviceSerial: string.IsNullOrWhiteSpace(handle.DeviceSerial) ? queue?.EmulatorSerial : handle.DeviceSerial);
   }
 
   // ── Current ("now") ────────────────────────────────────────────────────────────────────────

--- a/src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueMonitorSnapshot.cs
@@ -51,7 +51,12 @@ internal sealed record QueueMonitorSnapshot(
   QueueMonitorItem? Current,
   IReadOnlyList<QueueMonitorItem> Upcoming,
   bool NothingScheduled,
-  RunOutcome? LastOutcome);
+  RunOutcome? LastOutcome,
+  /// <summary>
+  /// The emulator this run exclusively holds (feature 079, FR-018); null when not running. Read from
+  /// the run's own handle so several concurrent runs each report their own device.
+  /// </summary>
+  string? DeviceSerial = null);
 
 /// <summary>One item in the monitor's now/up-next plan.</summary>
 internal sealed record QueueMonitorItem(

--- a/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueRunHandle.cs
@@ -26,6 +26,12 @@ internal sealed class QueueRunHandle {
   /// <summary>The emulator session opened for this run; null until connected.</summary>
   public string? SessionId { get; set; }
 
+  /// <summary>
+  /// The ADB serial this run claimed at start (feature 079). Exclusively held for the run's lifetime,
+  /// and surfaced by the monitor so the operator can see which device each concurrent run drives.
+  /// </summary>
+  public string? DeviceSerial { get; set; }
+
   public DateTimeOffset StartedAtUtc { get; init; } = DateTimeOffset.UtcNow;
 
   /// <summary>

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -40,6 +40,10 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private readonly IEnsureEmulatorRunningActionHandler _ensureEmulatorRunning;
   private readonly ISessionService _sessionService;
   private readonly IOcrOffsetResolver _ocrOffsetResolver;
+  // Feature 079: pushed for the duration of a sequence run so everything the sequence starts —
+  // nested sequences, commands, loops, trigger-based image/text conditions — observes this run's own
+  // device instead of "the first running session". Null only in tests that omit it.
+  private readonly GameBot.Domain.Sessions.IDeviceContextAccessor? _deviceContext;
 
   public SequenceExecutionService(
     SequenceRunner runner,
@@ -55,7 +59,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     IEnsureGameRunningActionHandler ensureGameRunning,
     IEnsureEmulatorRunningActionHandler ensureEmulatorRunning,
     ISessionService sessionService,
-    IOcrOffsetResolver ocrOffsetResolver) {
+    IOcrOffsetResolver ocrOffsetResolver,
+    GameBot.Domain.Sessions.IDeviceContextAccessor? deviceContext = null) {
     _runner = runner;
     _evalSvc = evalSvc;
     _imageVisibleConditionAdapter = imageVisibleConditionAdapter;
@@ -70,6 +75,7 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     _ensureEmulatorRunning = ensureEmulatorRunning;
     _sessionService = sessionService;
     _ocrOffsetResolver = ocrOffsetResolver;
+    _deviceContext = deviceContext;
   }
 
   public Task<SequenceExecutionResult> ExecuteAsync(
@@ -97,6 +103,14 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       ExecutionLogContext? parentContext,
       GameBot.Domain.Parameters.ParameterScope scope,
       CancellationToken ct = default) {
+    // Feature 079: bind this whole execution flow to the caller's device, so every screen observation
+    // made anywhere beneath it resolves against that device. No session (an unbound, ad-hoc run) means
+    // no context, and consumers fall back to the single-running-session rule.
+    using var deviceScope = string.IsNullOrWhiteSpace(sessionId) || _deviceContext is null
+      ? null
+      : _deviceContext.Push(GameBot.Domain.Sessions.DeviceContext.For(
+          sessionId!, _sessionManager.GetSession(sessionId!)?.DeviceSerial));
+
     // Create the in-progress root entry up front so invoked commands can be linked to it
     // (and the sequence shows as a single top-level entry while it runs). When a parent
     // context is supplied (e.g. a queue run), the sequence is nested under it instead.
@@ -601,17 +615,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private async Task<ActionDispatchResult> DispatchEnsureGameRunningAsync(
       string? sessionId,
       CancellationToken ct) {
-    var resolvedSessionId = sessionId;
-    if (string.IsNullOrWhiteSpace(resolvedSessionId)) {
-      var runningSessions = _sessionManager.ListSessions()
-        .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
-        .ToList();
-      if (runningSessions.Count != 1) {
-        return new ActionDispatchResult(
-          "failed",
-          "no session available for 'ensure-game-running' step; start a session or pass a sessionId");
-      }
-      resolvedSessionId = runningSessions[0].Id;
+    if (!TryResolveSessionId(sessionId, "ensure-game-running", out var resolvedSessionId, out var resolveError)) {
+      return new ActionDispatchResult("failed", resolveError);
     }
 
     var result = await _ensureGameRunning.ExecuteAsync(resolvedSessionId!, ct).ConfigureAwait(false);
@@ -642,6 +647,13 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       : new ActionDispatchResult("failed", $"ensure-emulator-running failed: {result.Message}");
   }
 
+  /// <summary>
+  /// Resolves the device session a step must act on, delegating to the shared
+  /// <see cref="SessionResolver"/> rule (feature 079, FR-006/FR-007).
+  /// </summary>
+  private bool TryResolveSessionId(string? sessionId, string stepType, out string? resolved, out string error) =>
+    SessionResolver.TryResolve(_sessionManager, sessionId, stepType, out resolved, out error);
+
   // Android KEYCODE_HOME. Pressing it returns the device to the home/main screen without stopping
   // the foreground app, so the game keeps running in the background (feature 069).
   private const int AndroidKeyCodeHome = 3;
@@ -657,17 +669,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
   private async Task<ActionDispatchResult> DispatchGoToHomeScreenAsync(
       string? sessionId,
       CancellationToken ct) {
-    var resolvedSessionId = sessionId;
-    if (string.IsNullOrWhiteSpace(resolvedSessionId)) {
-      var runningSessions = _sessionManager.ListSessions()
-        .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
-        .ToList();
-      if (runningSessions.Count != 1) {
-        return new ActionDispatchResult(
-          "failed",
-          "no session available for 'go-to-home-screen' step; start a session or pass a sessionId");
-      }
-      resolvedSessionId = runningSessions[0].Id;
+    if (!TryResolveSessionId(sessionId, "go-to-home-screen", out var resolvedSessionId, out var resolveError)) {
+      return new ActionDispatchResult("failed", resolveError);
     }
 
     var input = new EmulatorInputAction("key", new Dictionary<string, object> { ["keyCode"] = AndroidKeyCodeHome });
@@ -690,17 +693,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
       return new ActionDispatchResult("failed", error);
     }
 
-    var resolvedSessionId = sessionId;
-    if (string.IsNullOrWhiteSpace(resolvedSessionId)) {
-      var runningSessions = _sessionManager.ListSessions()
-        .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
-        .ToList();
-      if (runningSessions.Count != 1) {
-        return new ActionDispatchResult(
-          "failed",
-          $"no session available for '{action.Type}' step; start a session or pass a sessionId");
-      }
-      resolvedSessionId = runningSessions[0].Id;
+    if (!TryResolveSessionId(sessionId, action.Type, out var resolvedSessionId, out var resolveError)) {
+      return new ActionDispatchResult("failed", resolveError);
     }
 
     var accepted = await _sessionManager.SendInputsAsync(resolvedSessionId!, new[] { input! }, ct).ConfigureAwait(false);

--- a/src/GameBot.Service/Services/SessionResolver.cs
+++ b/src/GameBot.Service/Services/SessionResolver.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using GameBot.Emulator.Session;
+
+namespace GameBot.Service.Services;
+
+/// <summary>
+/// The single rule for deciding which emulator session a step acts on, shared by the sequence
+/// dispatcher and the command executor (feature 079, FR-006/FR-007).
+/// </summary>
+/// <remarks>
+/// Before feature 079 each call site inlined its own "exactly one running session" check and failed
+/// whenever the count was not one — so starting a second queue broke steps in the first, even though
+/// those steps were given an explicit session. The rule now is:
+/// <list type="number">
+///   <item>an explicit session always wins, however many are running;</item>
+///   <item>with none supplied and exactly one running, use it (unchanged single-emulator behaviour);</item>
+///   <item>with none supplied and none running, ask the operator to start one;</item>
+///   <item>with none supplied and several running, fail naming the count — never guess a device.</item>
+/// </list>
+/// </remarks>
+internal static class SessionResolver {
+  /// <summary>
+  /// Resolves the session a step must act on.
+  /// </summary>
+  /// <param name="sessions">Session manager to enumerate running sessions from.</param>
+  /// <param name="sessionId">Session from the execution context; null/blank when there is none.</param>
+  /// <param name="stepType">Step or command name, used in the failure message.</param>
+  /// <param name="resolved">The resolved session id when this returns true; otherwise null.</param>
+  /// <param name="error">An actionable failure message when this returns false; otherwise empty.</param>
+  /// <returns>True when a session was unambiguously resolved.</returns>
+  internal static bool TryResolve(
+      ISessionManager sessions,
+      string? sessionId,
+      string stepType,
+      out string? resolved,
+      out string error) {
+    if (!string.IsNullOrWhiteSpace(sessionId)) {
+      resolved = sessionId;
+      error = string.Empty;
+      return true;
+    }
+
+    var running = RunningSessionCount(sessions, out var onlySessionId);
+    if (running == 1) {
+      resolved = onlySessionId;
+      error = string.Empty;
+      return true;
+    }
+
+    resolved = null;
+    error = running == 0 ? NoSession(stepType) : Ambiguous(running, stepType);
+    return false;
+  }
+
+  /// <summary>Failure text when nothing is running at all (wording unchanged since before 079).</summary>
+  internal static string NoSession(string stepType) =>
+    string.Format(
+      CultureInfo.InvariantCulture,
+      "no session available for '{0}' step; start a session or pass a sessionId",
+      stepType);
+
+  /// <summary>
+  /// Failure text for a step that supplied no session while several device sessions are active.
+  /// </summary>
+  /// <param name="activeSessionCount">How many device sessions are running (always &gt; 1).</param>
+  /// <param name="stepType">The step or command the message is about.</param>
+  internal static string Ambiguous(int activeSessionCount, string stepType) =>
+    string.Format(
+      CultureInfo.InvariantCulture,
+      "{0} device sessions are active; specify a sessionId for '{1}'",
+      activeSessionCount,
+      stepType);
+
+  /// <summary>Counts running sessions, yielding the id when there is exactly one.</summary>
+  private static int RunningSessionCount(ISessionManager sessions, out string? onlySessionId) {
+    var running = sessions.ListSessions()
+      .Where(s => s.Status == GameBot.Domain.Sessions.SessionStatus.Running)
+      .ToList();
+    onlySessionId = running.Count == 1 ? running[0].Id : null;
+    return running.Count;
+  }
+}

--- a/src/web-ui/src/components/images/EmulatorCaptureCropper.tsx
+++ b/src/web-ui/src/components/images/EmulatorCaptureCropper.tsx
@@ -9,7 +9,17 @@ type CaptureState = { captureId: string; url: string; naturalWidth: number; natu
 
 type Point = { x: number; y: number };
 
-export const EmulatorCaptureCropper: React.FC = () => {
+export type EmulatorCaptureCropperProps = {
+  /**
+   * Emulator to capture from (feature 079). Pass whenever the caller knows which device it means;
+   * with several sessions running the backend refuses an unqualified capture rather than guessing.
+   */
+  sessionId?: string | null;
+  /** ADB serial alternative to {@link EmulatorCaptureCropperProps.sessionId}. */
+  serial?: string | null;
+};
+
+export const EmulatorCaptureCropper: React.FC<EmulatorCaptureCropperProps> = ({ sessionId, serial } = {}) => {
   const [capture, setCapture] = useState<CaptureState>(null);
   const [selection, setSelection] = useState<Selection | null>(null);
   const [dragStart, setDragStart] = useState<Point | null>(null);
@@ -78,7 +88,7 @@ export const EmulatorCaptureCropper: React.FC = () => {
     setStatus(null);
     setError(null);
     try {
-      const res = await fetchEmulatorScreenshot();
+      const res = await fetchEmulatorScreenshot({ sessionId, serial });
       const url = URL.createObjectURL(res.blob);
       setNewCapture({ captureId: res.captureId, url, naturalWidth: 0, naturalHeight: 0 });
     } catch (e: any) {
@@ -86,6 +96,10 @@ export const EmulatorCaptureCropper: React.FC = () => {
         const code = resolveErrorCode(e.payload);
         if (code === 'emulator_unavailable' || e.status === 503) {
           setError('Emulator unavailable. Ensure it is running and retry capture.');
+        } else if (code === 'ambiguous_session') {
+          // Feature 079: several queues are running, so the backend will not guess a device. Cropping
+          // from the wrong emulator silently poisons every sequence that uses the reference image.
+          setError('Several emulators are running. Stop all but one, or open this from a specific emulator session.');
         } else {
           setError(e.message);
         }

--- a/src/web-ui/src/components/queues/QueueMonitor.tsx
+++ b/src/web-ui/src/components/queues/QueueMonitor.tsx
@@ -99,6 +99,13 @@ export const QueueMonitor: React.FC<QueueMonitorProps> = ({ queueId, onReturnToE
     <div className="queue-monitor" data-testid="queue-monitor">
       <div className="queue-monitor-header">
         <h4>{snapshot.name} — live monitor</h4>
+        {/* Feature 079: several queues can run at once, each on its own emulator, so name the device
+            this run holds — otherwise two open monitors are indistinguishable. */}
+        {snapshot.deviceSerial && (
+          <span className="monitor-badge" data-testid="monitor-device" title="Emulator this run holds">
+            {snapshot.deviceSerial}
+          </span>
+        )}
         {snapshot.cycleExecution && <span className="monitor-badge">cycling</span>}
       </div>
 

--- a/src/web-ui/src/pages/__tests__/QueuesPage.execution.spec.tsx
+++ b/src/web-ui/src/pages/__tests__/QueuesPage.execution.spec.tsx
@@ -80,4 +80,22 @@ describe('QueuesPage start/stop', () => {
 
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('already running'));
   });
+
+  // Feature 079: a start refused because another queue holds the emulator is a different condition
+  // from "this queue is already running", and the operator must see which device and which queue.
+  it('surfaces a device_in_use start refusal naming the emulator and the holding queue', async () => {
+    listQueuesMock.mockResolvedValueOnce([queue({ status: 'Stopped' })] as any);
+    render(<QueuesPage />);
+    await screen.findByText('Daily');
+
+    startQueueMock.mockRejectedValue(Object.assign(
+      new Error("Emulator 'emulator-5558' is already in use by queue 'PNS Daily 5558'. Stop that queue before starting this one."),
+      { status: 409 }
+    ));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('emulator-5558'));
+    expect(screen.getByRole('alert')).toHaveTextContent('PNS Daily 5558');
+  });
 });

--- a/src/web-ui/src/services/images.ts
+++ b/src/web-ui/src/services/images.ts
@@ -148,8 +148,28 @@ export const detectImage = async (referenceImageId: string, opts?: { threshold?:
   return res.json();
 };
 
-export const fetchEmulatorScreenshot = async (): Promise<EmulatorScreenshot> => {
-  const res = await fetch(buildApiUrl('/api/emulator/screenshot'), {
+/** Which emulator to capture. Feature 079: required once more than one session is running. */
+export type ScreenshotTarget = {
+  /** Explicit emulator session id. */
+  sessionId?: string | null;
+  /** ADB device serial; used when no session id is known. */
+  serial?: string | null;
+};
+
+/**
+ * Captures the current emulator screen.
+ *
+ * With several sessions running the backend refuses an unqualified request with
+ * `409 ambiguous_session` rather than picking an arbitrary device, so pass a `target` whenever the
+ * caller knows which emulator it means. With exactly one session running, omitting it still works.
+ */
+export const fetchEmulatorScreenshot = async (target?: ScreenshotTarget): Promise<EmulatorScreenshot> => {
+  const query = new URLSearchParams();
+  if (target?.sessionId) query.set('sessionId', target.sessionId);
+  else if (target?.serial) query.set('serial', target.serial);
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+
+  const res = await fetch(buildApiUrl(`/api/emulator/screenshot${suffix}`), {
     method: 'GET',
     headers: buildAuthHeaders(false)
   });

--- a/src/web-ui/src/services/queues.ts
+++ b/src/web-ui/src/services/queues.ts
@@ -133,6 +133,8 @@ export type QueueMonitorDto = {
   running: boolean;
   cycleExecution: boolean;
   runStartedAt: string | null;
+  /** Emulator this run exclusively holds (feature 079); null when the queue is not running. */
+  deviceSerial?: string | null;
   current: QueueMonitorItemDto | null;
   upcoming: QueueMonitorItemDto[];
   nothingScheduled: boolean;

--- a/tests/contract/EmulatorScreenshotSelectorContractTests.cs
+++ b/tests/contract/EmulatorScreenshotSelectorContractTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.ContractTests;
+
+/// <summary>
+/// Feature 079, contracts/api.md §3: the emulator screenshot endpoint resolves its device explicitly.
+///
+/// Before this, an unqualified request with several sessions open returned an arbitrary emulator, so an
+/// operator could crop a reference image from the wrong device without noticing. That case is now an
+/// explicit ambiguity error; the single-session behaviour is unchanged.
+/// </summary>
+public sealed class EmulatorScreenshotSelectorContractTests : IDisposable {
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+  private readonly string? _prevDataDir;
+  private readonly string _dataDir;
+
+  public EmulatorScreenshotSelectorContractTests() {
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+
+    // Isolate persistence: these tests create sessions and capture entries, and must not read or
+    // write the developer's real data directory.
+    _prevDataDir = Environment.GetEnvironmentVariable("GAMEBOT_DATA_DIR");
+    _dataDir = Path.Combine(Path.GetTempPath(), "GameBotContractTests", Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(_dataDir);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _dataDir);
+    Environment.SetEnvironmentVariable("Service__Storage__Root", _dataDir);
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _prevDataDir);
+    Environment.SetEnvironmentVariable("Service__Storage__Root", null);
+    try { Directory.Delete(_dataDir, recursive: true); }
+    catch (IOException) { /* best effort */ }
+    catch (UnauthorizedAccessException) { /* best effort */ }
+    GC.SuppressFinalize(this);
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  /// <summary>Creates a session bound to a device serial, returning its id.</summary>
+  private static async Task<string> CreateSessionAsync(HttpClient client, string gameId, string serial) {
+    var resp = await client.PostAsJsonAsync("/api/sessions", new { gameId, adbSerial = serial }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static Task<HttpResponseMessage> ScreenshotAsync(HttpClient client, string query = "") =>
+    client.GetAsync(new Uri($"/api/emulator/screenshot{query}", UriKind.Relative));
+
+  [Fact] // §3 row 4: no sessions at all is still 503, unchanged
+  public async Task WithNoSessionsTheEndpointReports503() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+
+    var resp = await ScreenshotAsync(client).ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true))
+      .RootElement.GetProperty("error").GetString().Should().Be("emulator_unavailable");
+  }
+
+  [Fact] // §3 row 5: exactly one session — the bare call keeps working
+  public async Task WithASingleSessionTheBareCallStillSucceeds() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    await CreateSessionAsync(client, "game-a", "emu-shot-a").ConfigureAwait(true);
+
+    var resp = await ScreenshotAsync(client).ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    resp.Headers.Contains("X-Capture-Id").Should().BeTrue();
+  }
+
+  [Fact] // §3 row 6: several sessions and no selector is now an explicit ambiguity error
+  public async Task WithSeveralSessionsAndNoSelectorTheEndpointReports409() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    await CreateSessionAsync(client, "game-a", "emu-shot-a").ConfigureAwait(true);
+    await CreateSessionAsync(client, "game-b", "emu-shot-b").ConfigureAwait(true);
+
+    var resp = await ScreenshotAsync(client).ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    var body = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+    body.GetProperty("error").GetString().Should().Be("ambiguous_session");
+    body.GetProperty("message").GetString().Should().Contain("2 device sessions are active");
+  }
+
+  [Fact] // §3 row 1: an explicit sessionId resolves even with several sessions open
+  public async Task AnExplicitSessionIdResolvesTheRequestedDevice() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var a = await CreateSessionAsync(client, "game-a", "emu-shot-a").ConfigureAwait(true);
+    await CreateSessionAsync(client, "game-b", "emu-shot-b").ConfigureAwait(true);
+
+    var resp = await ScreenshotAsync(client, $"?sessionId={a}").ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    resp.Headers.Contains("X-Capture-Id").Should().BeTrue();
+  }
+
+  // §3 row 2 (a `serial` that matches a live device returns that device's screen) is not exercised
+  // here: ADB is stubbed in the contract suite, so sessions carry no bound serial and no `serial`
+  // value can match. The negative half of that row — an unmatched serial must 404 rather than fall
+  // back to another device — is what actually guards against the old arbitrary pick, and is covered.
+  [Fact] // §3 row 3: an unmatched serial is a 404, never a silent substitution
+  public async Task AnUnknownSerialReports404() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    await CreateSessionAsync(client, "game-a", "emu-shot-a").ConfigureAwait(true);
+
+    var resp = await ScreenshotAsync(client, "?serial=emu-does-not-exist").ConfigureAwait(true);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true))
+      .RootElement.GetProperty("error").GetString().Should().Be("session_not_found");
+  }
+}

--- a/tests/contract/QueueConcurrencyContractTests.cs
+++ b/tests/contract/QueueConcurrencyContractTests.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.ContractTests;
+
+/// <summary>
+/// Feature 079 wire contract: the queue-start refusal when another queue holds the emulator, and the
+/// monitor's new device field (contracts/api.md sections 1 and 2).
+/// </summary>
+public sealed class QueueConcurrencyContractTests : IDisposable {
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+  private readonly string? _prevDataDir;
+  private readonly string _dataDir;
+
+  public QueueConcurrencyContractTests() {
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+
+    // Isolate persistence: these tests create queues, templates and execution-log entries, and must
+    // not read or write the developer's real data directory.
+    _prevDataDir = Environment.GetEnvironmentVariable("GAMEBOT_DATA_DIR");
+    _dataDir = Path.Combine(Path.GetTempPath(), "GameBotContractTests", Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(_dataDir);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _dataDir);
+    Environment.SetEnvironmentVariable("Service__Storage__Root", _dataDir);
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _prevDataDir);
+    Environment.SetEnvironmentVariable("Service__Storage__Root", null);
+    try { Directory.Delete(_dataDir, recursive: true); }
+    catch (IOException) { /* best effort */ }
+    catch (UnauthorizedAccessException) { /* best effort */ }
+    GC.SuppressFinalize(this);
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static async Task<string> CreateRunnableQueueAsync(HttpClient client, string name, string serial) {
+    var created = await client.PostAsJsonAsync("/api/queues",
+      new { name, emulatorSerial = serial, cycleExecution = true }).ConfigureAwait(true);
+    created.StatusCode.Should().Be(HttpStatusCode.Created);
+    var id = JsonDocument.Parse(await created.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+
+    var tplResp = await client.PostAsJsonAsync("/api/queue-templates",
+      new { name = "Tpl-" + Guid.NewGuid().ToString("N"), entries = new[] { new { sequenceId = "seq-loop" } }, overwrite = false }).ConfigureAwait(true);
+    var tpl = JsonDocument.Parse(await tplResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+    await client.PutAsJsonAsync($"/api/queues/{id}/template", new { templateId = tpl }).ConfigureAwait(true);
+    return id;
+  }
+
+  private static async Task<JsonElement> MonitorAsync(HttpClient client, string id) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}/monitor", UriKind.Relative)).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.Clone();
+  }
+
+  private static async Task WaitForRunningAsync(HttpClient client, string id, int timeoutMs = 8000) {
+    var sw = Stopwatch.StartNew();
+    while (sw.ElapsedMilliseconds < timeoutMs) {
+      if ((await MonitorAsync(client, id).ConfigureAwait(true)).GetProperty("running").GetBoolean()) return;
+      await Task.Delay(25).ConfigureAwait(true);
+    }
+  }
+
+  [Fact] // contracts/api.md §1: 409 device_in_use, naming the device and the holder
+  public async Task StartOnAClaimedDeviceReturns409DeviceInUse() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var holder = await CreateRunnableQueueAsync(client, "Holder", "emu-contract-shared").ConfigureAwait(true);
+    var other = await CreateRunnableQueueAsync(client, "Other", "emu-contract-shared").ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{holder}/start", UriKind.Relative), null).ConfigureAwait(true);
+    await WaitForRunningAsync(client, holder).ConfigureAwait(true);
+
+    var refused = await client.PostAsync(new Uri($"/api/queues/{other}/start", UriKind.Relative), null).ConfigureAwait(true);
+
+    refused.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    var error = JsonDocument.Parse(await refused.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("error");
+    error.GetProperty("code").GetString().Should().Be("device_in_use");
+    error.GetProperty("message").GetString()!
+      .Should().Contain("emu-contract-shared").And.Contain("Holder");
+
+    await client.PostAsync(new Uri($"/api/queues/{holder}/stop", UriKind.Relative), null).ConfigureAwait(true);
+  }
+
+  [Fact] // contracts/api.md §1: 'already_running' stays a distinct code
+  public async Task RestartingTheSameQueueReturns409AlreadyRunning() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateRunnableQueueAsync(client, "Solo", "emu-contract-solo").ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true);
+    await WaitForRunningAsync(client, id).ConfigureAwait(true);
+
+    var again = await client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true);
+
+    again.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    JsonDocument.Parse(await again.Content.ReadAsStringAsync().ConfigureAwait(true))
+      .RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be("already_running");
+
+    await client.PostAsync(new Uri($"/api/queues/{id}/stop", UriKind.Relative), null).ConfigureAwait(true);
+  }
+
+  [Fact] // contracts/api.md §2: deviceSerial is present, and null when the queue is not running
+  public async Task MonitorExposesDeviceSerialOnlyWhileRunning() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateRunnableQueueAsync(client, "Monitored", "emu-contract-monitor").ConfigureAwait(true);
+
+    var idle = await MonitorAsync(client, id).ConfigureAwait(true);
+    idle.TryGetProperty("deviceSerial", out var idleSerial).Should().BeTrue("the field is part of the contract");
+    idleSerial.ValueKind.Should().Be(JsonValueKind.Null);
+
+    await client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null).ConfigureAwait(true);
+    await WaitForRunningAsync(client, id).ConfigureAwait(true);
+
+    (await MonitorAsync(client, id).ConfigureAwait(true))
+      .GetProperty("deviceSerial").GetString().Should().Be("emu-contract-monitor");
+
+    await client.PostAsync(new Uri($"/api/queues/{id}/stop", UriKind.Relative), null).ConfigureAwait(true);
+  }
+}

--- a/tests/integration/Queues/ConcurrentQueueRunTests.cs
+++ b/tests/integration/Queues/ConcurrentQueueRunTests.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Queues;
+
+/// <summary>
+/// Feature 079 through the real HTTP surface: several queues run at once, one per emulator, and a
+/// second queue on an already-claimed emulator is refused rather than allowed to fight over the
+/// screen (US2, FR-008..FR-014, FR-016, FR-020).
+///
+/// ADB runs in stub mode (GAMEBOT_USE_ADB=false), so sessions are created without a real device;
+/// cycling queues hold a deterministic "Running" window.
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class ConcurrentQueueRunTests {
+  public ConcurrentQueueRunTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static async Task<string> CreateQueueAsync(HttpClient client, string name, string serial, bool cycle = true) {
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative),
+      new { name, emulatorSerial = serial, cycleExecution = cycle }).ConfigureAwait(true);
+    resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static async Task<string> CreateTemplateAsync(HttpClient client, params string[] sequenceIds) {
+    var entries = Array.ConvertAll(sequenceIds, id => new { sequenceId = id });
+    var resp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Tpl-" + Guid.NewGuid().ToString("N"), entries, overwrite = false }).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static async Task<string> CreateRunnableQueueAsync(HttpClient client, string name, string serial, bool cycle = true) {
+    var id = await CreateQueueAsync(client, name, serial, cycle).ConfigureAwait(true);
+    var tpl = await CreateTemplateAsync(client, "seq-loop").ConfigureAwait(true);
+    (await client.PutAsJsonAsync(new Uri($"/api/queues/{id}/template", UriKind.Relative), new { templateId = tpl }).ConfigureAwait(true))
+      .IsSuccessStatusCode.Should().BeTrue();
+    return id;
+  }
+
+  private static Task<HttpResponseMessage> StartAsync(HttpClient client, string id)
+    => client.PostAsync(new Uri($"/api/queues/{id}/start", UriKind.Relative), null);
+
+  private static Task<HttpResponseMessage> StopAsync(HttpClient client, string id)
+    => client.PostAsync(new Uri($"/api/queues/{id}/stop", UriKind.Relative), null);
+
+  private static async Task<string> StatusAsync(HttpClient client, string id) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}", UriKind.Relative)).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("status").GetString()!;
+  }
+
+  private static async Task<JsonElement> MonitorAsync(HttpClient client, string id) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}/monitor", UriKind.Relative)).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.Clone();
+  }
+
+  /// <summary>
+  /// Waits until the run has actually bound its device session, not merely been marked Running.
+  /// The status flips to Running in <c>StartAsync</c>, before the background run creates its session,
+  /// so tests that care about session ordering must wait for <c>runStartedAt</c>, which the run loop
+  /// sets only after a successful connect.
+  /// </summary>
+  private static async Task WaitForRunConnectedAsync(HttpClient client, string id, int timeoutMs = 8000) {
+    var sw = Stopwatch.StartNew();
+    while (sw.ElapsedMilliseconds < timeoutMs) {
+      var monitor = await MonitorAsync(client, id).ConfigureAwait(true);
+      if (monitor.GetProperty("running").GetBoolean()
+          && monitor.TryGetProperty("runStartedAt", out var started)
+          && started.ValueKind != JsonValueKind.Null) {
+        return;
+      }
+      await Task.Delay(25).ConfigureAwait(true);
+    }
+  }
+
+  private static async Task WaitForStatusAsync(HttpClient client, string id, string expected, int timeoutMs = 8000) {
+    var sw = Stopwatch.StartNew();
+    while (sw.ElapsedMilliseconds < timeoutMs) {
+      if (await StatusAsync(client, id).ConfigureAwait(true) == expected) return;
+      await Task.Delay(25).ConfigureAwait(true);
+    }
+  }
+
+  [Fact] // US1/US2: different emulators run side by side and do not interfere (FR-014, SC-001)
+  public async Task QueuesOnDifferentEmulatorsRunAtTheSameTime() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var a = await CreateRunnableQueueAsync(client, "A", "emu-5558").ConfigureAwait(true);
+    var b = await CreateRunnableQueueAsync(client, "B", "emu-5560").ConfigureAwait(true);
+
+    (await StartAsync(client, a).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+    (await StartAsync(client, b).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+    await WaitForStatusAsync(client, a, "Running").ConfigureAwait(true);
+    await WaitForStatusAsync(client, b, "Running").ConfigureAwait(true);
+
+    (await StatusAsync(client, a).ConfigureAwait(true)).Should().Be("Running");
+    (await StatusAsync(client, b).ConfigureAwait(true)).Should().Be("Running");
+
+    // FR-018: each running queue reports its own device, with no cross-contamination.
+    (await MonitorAsync(client, a).ConfigureAwait(true)).GetProperty("deviceSerial").GetString().Should().Be("emu-5558");
+    (await MonitorAsync(client, b).ConfigureAwait(true)).GetProperty("deviceSerial").GetString().Should().Be("emu-5560");
+
+    await StopAsync(client, a).ConfigureAwait(true);
+    await StopAsync(client, b).ConfigureAwait(true);
+  }
+
+  [Fact] // US3/FR-020/SC-005: stopping one run leaves every other run untouched
+  public async Task StoppingOneRunLeavesTheOtherRunning() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var a = await CreateRunnableQueueAsync(client, "A", "emu-5558").ConfigureAwait(true);
+    var b = await CreateRunnableQueueAsync(client, "B", "emu-5560").ConfigureAwait(true);
+    await StartAsync(client, a).ConfigureAwait(true);
+    await StartAsync(client, b).ConfigureAwait(true);
+    await WaitForStatusAsync(client, a, "Running").ConfigureAwait(true);
+    await WaitForStatusAsync(client, b, "Running").ConfigureAwait(true);
+
+    await StopAsync(client, a).ConfigureAwait(true);
+
+    (await StatusAsync(client, a).ConfigureAwait(true)).Should().Be("Stopped");
+    (await StatusAsync(client, b).ConfigureAwait(true)).Should().Be("Running");
+
+    await StopAsync(client, b).ConfigureAwait(true);
+  }
+
+  [Fact] // US2/FR-009/FR-010/SC-003: a second queue on a claimed emulator is refused, naming both
+  public async Task StartingASecondQueueOnAClaimedEmulatorIsRefused() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var holder = await CreateRunnableQueueAsync(client, "PNS Daily 5558", "emu-shared").ConfigureAwait(true);
+    var other = await CreateRunnableQueueAsync(client, "Events", "emu-shared").ConfigureAwait(true);
+    await StartAsync(client, holder).ConfigureAwait(true);
+    await WaitForStatusAsync(client, holder, "Running").ConfigureAwait(true);
+
+    var refused = await StartAsync(client, other).ConfigureAwait(true);
+
+    refused.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    var error = JsonDocument.Parse(await refused.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("error");
+    error.GetProperty("code").GetString().Should().Be("device_in_use");
+    error.GetProperty("message").GetString()!.Should().Contain("emu-shared").And.Contain("PNS Daily 5558");
+
+    (await StatusAsync(client, other).ConfigureAwait(true)).Should().Be("Stopped", "the refused queue must not start");
+    (await StatusAsync(client, holder).ConfigureAwait(true)).Should().Be("Running", "the holder must be untouched");
+
+    await StopAsync(client, holder).ConfigureAwait(true);
+  }
+
+  [Fact] // US2/FR-010: the same queue twice is 'already_running', a distinct condition
+  public async Task RestartingTheSameQueueIsAlreadyRunningNotDeviceInUse() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var id = await CreateRunnableQueueAsync(client, "A", "emu-5558").ConfigureAwait(true);
+    await StartAsync(client, id).ConfigureAwait(true);
+    await WaitForStatusAsync(client, id, "Running").ConfigureAwait(true);
+
+    var again = await StartAsync(client, id).ConfigureAwait(true);
+
+    again.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    JsonDocument.Parse(await again.Content.ReadAsStringAsync().ConfigureAwait(true))
+      .RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be("already_running");
+
+    await StopAsync(client, id).ConfigureAwait(true);
+  }
+
+  [Fact] // US2/FR-011/SC-004: the device is claimable again as soon as the holding run ends
+  public async Task StoppingTheHolderFreesTheDeviceForTheOtherQueue() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var holder = await CreateRunnableQueueAsync(client, "Holder", "emu-shared").ConfigureAwait(true);
+    var other = await CreateRunnableQueueAsync(client, "Other", "emu-shared").ConfigureAwait(true);
+    await StartAsync(client, holder).ConfigureAwait(true);
+    await WaitForStatusAsync(client, holder, "Running").ConfigureAwait(true);
+    (await StartAsync(client, other).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+    await StopAsync(client, holder).ConfigureAwait(true);
+    await WaitForStatusAsync(client, holder, "Stopped").ConfigureAwait(true);
+
+    (await StartAsync(client, other).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+    await StopAsync(client, other).ConfigureAwait(true);
+  }
+
+  [Fact] // US3/FR-017: a run-level failure reason reaches the queue's own execution-log entry
+  public async Task ARunLevelFailureRecordsItsReasonAgainstTheRightQueue() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    // Two queues on different devices; only one is misconfigured. The failure must land on that one.
+    var healthy = await CreateRunnableQueueAsync(client, "Healthy", "emu-5558").ConfigureAwait(true);
+    var broken = await CreateQueueAsync(client, "Broken", "emu-5560", cycle: false).ConfigureAwait(true);
+    await StartAsync(client, healthy).ConfigureAwait(true);
+    await WaitForRunConnectedAsync(client, healthy).ConfigureAwait(true);
+
+    (await StartAsync(client, broken).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+    await WaitForStatusAsync(client, broken, "Stopped").ConfigureAwait(true);
+
+    var outcome = (await MonitorAsync(client, broken).ConfigureAwait(true)).GetProperty("lastOutcome");
+    outcome.ValueKind.Should().NotBe(JsonValueKind.Null);
+    outcome.GetProperty("status").GetString().Should().Be("failure");
+    outcome.GetProperty("summary").GetString().Should().Contain("no template to run");
+
+    // FR-020: the other run is entirely unaffected by its neighbour's failure.
+    (await StatusAsync(client, healthy).ConfigureAwait(true)).Should().Be("Running");
+    await StopAsync(client, healthy).ConfigureAwait(true);
+  }
+
+  // NOTE: the session-capacity path (FR-015/FR-016) is covered at the unit level, where the limit can
+  // be set deterministically: SessionCapacityMessageTests proves the default and the message, and
+  // QueueExecutionServiceTests.ACapacityFailureIsRecordedWithTheActionableReason proves that message
+  // reaches the run's execution-log summary. Overriding Service:Sessions:MaxConcurrentSessions inside
+  // WebApplicationFactory did not take effect, so an integration variant would assert nothing.
+  [Fact(Skip = "Session limit cannot be overridden in the test host; covered by unit tests instead.")]
+  public async Task ARunBlockedByTheSessionLimitRecordsAnActionableReason() {
+    // UseSetting rather than an env var: it applies to this factory's configuration only, so the
+    // squeezed limit cannot leak into another test in the collection.
+    using var factory = new WebApplicationFactory<Program>();
+    using (var app = factory.WithWebHostBuilder(b => b.ConfigureAppConfiguration(cfg =>
+             cfg.AddInMemoryCollection(new Dictionary<string, string?> {
+               ["Service:Sessions:MaxConcurrentSessions"] = "1"
+             })))) {
+      var client = NewClient(app);
+      var first = await CreateRunnableQueueAsync(client, "First", "emu-5558").ConfigureAwait(true);
+      var second = await CreateRunnableQueueAsync(client, "Second", "emu-5560", cycle: false).ConfigureAwait(true);
+      await StartAsync(client, first).ConfigureAwait(true);
+      // Wait for the first run to actually hold the only session slot, not merely be marked Running.
+      await WaitForRunConnectedAsync(client, first).ConfigureAwait(true);
+
+      // The start itself succeeds — the device is free; the run then fails on session capacity.
+      (await StartAsync(client, second).ConfigureAwait(true)).StatusCode.Should().Be(HttpStatusCode.OK);
+      await WaitForStatusAsync(client, second, "Stopped").ConfigureAwait(true);
+
+      var monitor = await MonitorAsync(client, second).ConfigureAwait(true);
+      var outcome = monitor.GetProperty("lastOutcome");
+      outcome.ValueKind.Should().NotBe(JsonValueKind.Null);
+      var sessionsDump = await (await client.GetAsync(new Uri("/api/sessions/running", UriKind.Relative)).ConfigureAwait(true)).Content.ReadAsStringAsync().ConfigureAwait(true);
+      outcome.GetProperty("status").GetString().Should().Be("failure", "summary was '{0}'; sessions were {1}", outcome.GetProperty("summary").GetString(), sessionsDump);
+      outcome.GetProperty("summary").GetString().Should()
+        .Contain("session capacity reached: 1 of 1 sessions are open")
+        .And.Contain("Service:Sessions:MaxConcurrentSessions");
+
+      await StopAsync(client, first).ConfigureAwait(true);
+    }
+  }
+}

--- a/tests/integration/Queues/ConcurrentRunStateIsolationTests.cs
+++ b/tests/integration/Queues/ConcurrentRunStateIsolationTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Queues;
+
+/// <summary>
+/// Feature 079 (FR-019/FR-020/FR-021): with several runs in flight, each run's state stays its own and
+/// each run's execution-log entries stay attributable to it.
+///
+/// The per-run state was already lock-guarded before this feature (the monitor has always read it on a
+/// different thread than the run loop writes it); these are regression tests that exercise that under
+/// genuine multi-run concurrency, which nothing did before.
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class ConcurrentRunStateIsolationTests {
+  public ConcurrentRunStateIsolationTests() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  private static HttpClient NewClient(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static async Task<string> CreateRunnableQueueAsync(HttpClient client, string name, string serial, bool cycle = true) {
+    var created = await client.PostAsJsonAsync(new Uri("/api/queues", UriKind.Relative),
+      new { name, emulatorSerial = serial, cycleExecution = cycle }).ConfigureAwait(true);
+    created.StatusCode.Should().Be(HttpStatusCode.Created);
+    var id = JsonDocument.Parse(await created.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+
+    var tplResp = await client.PostAsJsonAsync(new Uri("/api/queue-templates", UriKind.Relative),
+      new { name = "Tpl-" + Guid.NewGuid().ToString("N"), entries = new[] { new { sequenceId = $"seq-{name}" } }, overwrite = false }).ConfigureAwait(true);
+    var tpl = JsonDocument.Parse(await tplResp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.GetProperty("id").GetString()!;
+    await client.PutAsJsonAsync(new Uri($"/api/queues/{id}/template", UriKind.Relative), new { templateId = tpl }).ConfigureAwait(true);
+    return id;
+  }
+
+  private static async Task<JsonElement> MonitorAsync(HttpClient client, string id) {
+    var resp = await client.GetAsync(new Uri($"/api/queues/{id}/monitor", UriKind.Relative)).ConfigureAwait(true);
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement.Clone();
+  }
+
+  private static async Task WaitForRunningAsync(HttpClient client, string id, int timeoutMs = 8000) {
+    var sw = Stopwatch.StartNew();
+    while (sw.ElapsedMilliseconds < timeoutMs) {
+      if ((await MonitorAsync(client, id).ConfigureAwait(true)).GetProperty("running").GetBoolean()) return;
+      await Task.Delay(25).ConfigureAwait(true);
+    }
+  }
+
+  [Fact] // FR-019/FR-020: neither run's monitor state ever shows the other's
+  public async Task ConcurrentRunsNeverReportEachOthersState() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var a = await CreateRunnableQueueAsync(client, "Alpha", "emu-5558").ConfigureAwait(true);
+    var b = await CreateRunnableQueueAsync(client, "Beta", "emu-5560").ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{a}/start", UriKind.Relative), null).ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{b}/start", UriKind.Relative), null).ConfigureAwait(true);
+    await WaitForRunningAsync(client, a).ConfigureAwait(true);
+    await WaitForRunningAsync(client, b).ConfigureAwait(true);
+
+    // Poll both monitors repeatedly and concurrently while the runs cycle, so a torn or shared read
+    // would surface as a mismatched identity.
+    for (var i = 0; i < 15; i++) {
+      var snapshots = await Task.WhenAll(MonitorAsync(client, a), MonitorAsync(client, b)).ConfigureAwait(true);
+
+      snapshots[0].GetProperty("queueId").GetString().Should().Be(a);
+      snapshots[0].GetProperty("name").GetString().Should().Be("Alpha");
+      snapshots[0].GetProperty("deviceSerial").GetString().Should().Be("emu-5558");
+
+      snapshots[1].GetProperty("queueId").GetString().Should().Be(b);
+      snapshots[1].GetProperty("name").GetString().Should().Be("Beta");
+      snapshots[1].GetProperty("deviceSerial").GetString().Should().Be("emu-5560");
+    }
+
+    await client.PostAsync(new Uri($"/api/queues/{a}/stop", UriKind.Relative), null).ConfigureAwait(true);
+    await client.PostAsync(new Uri($"/api/queues/{b}/stop", UriKind.Relative), null).ConfigureAwait(true);
+  }
+
+  [Fact] // FR-021: interleaved writes stay attributable — every entry belongs to exactly one run
+  public async Task ExecutionLogEntriesFromConcurrentRunsStayAttributable() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = NewClient(app);
+    var a = await CreateRunnableQueueAsync(client, "Alpha", "emu-5558", cycle: false).ConfigureAwait(true);
+    var b = await CreateRunnableQueueAsync(client, "Beta", "emu-5560", cycle: false).ConfigureAwait(true);
+
+    // Start together so the two runs' log writes interleave.
+    await Task.WhenAll(
+      client.PostAsync(new Uri($"/api/queues/{a}/start", UriKind.Relative), null),
+      client.PostAsync(new Uri($"/api/queues/{b}/start", UriKind.Relative), null)).ConfigureAwait(true);
+
+    var entriesA = await WaitForQueueEntriesAsync(client, a).ConfigureAwait(true);
+    var entriesB = await WaitForQueueEntriesAsync(client, b).ConfigureAwait(true);
+
+    entriesA.Should().NotBeEmpty("run A must have written its own entries");
+    entriesB.Should().NotBeEmpty("run B must have written its own entries");
+    entriesA.Should().OnlyContain(id => id == a);
+    entriesB.Should().OnlyContain(id => id == b);
+  }
+
+  /// <summary>
+  /// Polls the execution log until the queue has a finalized entry, returning the objectId of every
+  /// entry the query attributes to it.
+  /// </summary>
+  private static async Task<List<string>> WaitForQueueEntriesAsync(HttpClient client, string queueId, int timeoutMs = 10000) {
+    var sw = Stopwatch.StartNew();
+    while (sw.ElapsedMilliseconds < timeoutMs) {
+      var resp = await client.GetAsync(new Uri($"/api/execution-logs?objectType=queue&objectId={queueId}&pageSize=20", UriKind.Relative)).ConfigureAwait(true);
+      if (resp.IsSuccessStatusCode) {
+        var root = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(true)).RootElement;
+        if (root.TryGetProperty("items", out var items) && items.GetArrayLength() > 0) {
+          var ids = items.EnumerateArray()
+            .Select(e => e.GetProperty("objectRef").GetProperty("objectId").GetString() ?? string.Empty)
+            .ToList();
+          // Wait for the terminating entry so both runs have finished writing.
+          if (items.EnumerateArray().Any(e => e.TryGetProperty("finalStatus", out var s)
+                && !string.IsNullOrEmpty(s.GetString())
+                && !string.Equals(s.GetString(), "running", StringComparison.OrdinalIgnoreCase))) {
+            return ids;
+          }
+        }
+      }
+      await Task.Delay(50).ConfigureAwait(true);
+    }
+    return new List<string>();
+  }
+}

--- a/tests/unit/Commands/CommandExecutorEnsureGameRunningTests.cs
+++ b/tests/unit/Commands/CommandExecutorEnsureGameRunningTests.cs
@@ -68,8 +68,11 @@ public sealed class CommandExecutorEnsureGameRunningTests {
     private readonly GameReadinessResult _result;
     public StubReadinessProbe(bool ready, string loadStatus = "loaded") => _result = new GameReadinessResult(ready, loadStatus);
     public int CallCount { get; private set; }
-    public Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, CancellationToken ct = default) {
+    /// <summary>The session the probe was asked to observe (feature 079); null when none was passed.</summary>
+    public string? LastSessionId { get; private set; }
+    public Task<GameReadinessResult> WaitUntilReadyAsync(DetectionTarget readinessImage, int timeoutMs, string? sessionId = null, CancellationToken ct = default) {
       CallCount++;
+      LastSessionId = sessionId;
       return Task.FromResult(_result);
     }
   }

--- a/tests/unit/Commands/CommandExecutorSessionResolutionTests.cs
+++ b/tests/unit/Commands/CommandExecutorSessionResolutionTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Services;
+using GameBot.Domain.Sessions;
+using GameBot.Domain.Triggers;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Commands;
+
+/// <summary>
+/// Feature 079 (FR-006/FR-007) for the command path: an explicit session must win however many are
+/// running, and "several sessions, none named" must be reported as such instead of resolving to an
+/// arbitrary device.
+/// </summary>
+public sealed class CommandExecutorSessionResolutionTests {
+  private static Command TapCommand(string id = "cmd1") => new() {
+    Id = id,
+    Name = "Cmd",
+    Steps = new Collection<CommandStep> {
+      new() { Type = CommandStepType.PrimitiveTap, PrimitiveTap = new PrimitiveTapConfig { DetectionTarget = new DetectionTarget("template-1") }, Order = 0 }
+    }
+  };
+
+  private static CommandExecutor NewExecutor(SessionResolutionFakeSessions sessions, SessionResolutionFakeCommands? commands = null) =>
+    new(commands ?? new SessionResolutionFakeCommands(TapCommand()),
+        sessions,
+        new SessionResolutionFakeTriggers(),
+        new TriggerEvaluationService(Array.Empty<ITriggerEvaluator>()),
+        NullLogger<CommandExecutor>.Instance,
+        new SessionContextCache());
+
+  [Fact]
+  public async Task AnExplicitSessionIsUsedEvenWithSeveralSessionsRunning() {
+    var sessions = new SessionResolutionFakeSessions("s1", "s2", "s3");
+    var exec = NewExecutor(sessions);
+
+    // Before feature 079 this threw: the executor demanded exactly one running session even when the
+    // caller had already named one, so a second queue broke the first queue's command steps.
+    await exec.ForceExecuteAsync("s2", "cmd1").ConfigureAwait(false);
+
+    sessions.LastGetSessionId.Should().Be("s2");
+  }
+
+  [Fact]
+  public async Task WithNoSessionAndExactlyOneRunningThatOneIsUsed() {
+    var sessions = new SessionResolutionFakeSessions("only");
+    var exec = NewExecutor(sessions);
+
+    await exec.ForceExecuteAsync(null, "cmd1").ConfigureAwait(false);
+
+    sessions.LastGetSessionId.Should().Be("only");
+  }
+
+  [Fact]
+  public async Task WithNoSessionAndNoneRunningTheSentinelIsThrown() {
+    var exec = NewExecutor(new SessionResolutionFakeSessions());
+
+    var act = async () => await exec.ForceExecuteAsync(null, "cmd1").ConfigureAwait(false);
+
+    var thrown = await act.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*missing_session_context*").ConfigureAwait(false);
+    thrown.And.InnerException.Should().BeNull("no device at all is not an ambiguity");
+  }
+
+  [Fact]
+  public async Task WithNoSessionAndSeveralRunningTheAmbiguityIsNamed() {
+    var exec = NewExecutor(new SessionResolutionFakeSessions("s1", "s2"));
+
+    var act = async () => await exec.ForceExecuteAsync(null, "cmd1").ConfigureAwait(false);
+
+    var thrown = await act.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*missing_session_context*").ConfigureAwait(false);
+    thrown.And.InnerException!.Message.Should()
+      .Be("2 device sessions are active; specify a sessionId for 'cmd1'");
+  }
+
+  [Fact]
+  public async Task ForceExecuteStepUsesAnExplicitSessionWithSeveralRunning() {
+    var sessions = new SessionResolutionFakeSessions("s1", "s2");
+    var exec = NewExecutor(sessions);
+    var step = new CommandStep { Type = CommandStepType.PrimitiveTap, PrimitiveTap = new PrimitiveTapConfig { DetectionTarget = new DetectionTarget("t") }, Order = 0 };
+
+    await exec.ForceExecuteStepAsync("s2", step).ConfigureAwait(false);
+
+    sessions.LastGetSessionId.Should().Be("s2");
+  }
+
+  [Fact]
+  public async Task ForceExecuteStepReportsTheAmbiguityWhenNoSessionIsNamed() {
+    var exec = NewExecutor(new SessionResolutionFakeSessions("s1", "s2", "s3"));
+    var step = new CommandStep { Type = CommandStepType.PrimitiveTap, PrimitiveTap = new PrimitiveTapConfig { DetectionTarget = new DetectionTarget("t") }, Order = 0 };
+
+    var act = async () => await exec.ForceExecuteStepAsync(null, step).ConfigureAwait(false);
+
+    var thrown = await act.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*missing_session_context*").ConfigureAwait(false);
+    thrown.And.InnerException!.Message.Should()
+      .Be("3 device sessions are active; specify a sessionId for 'force-execute'");
+  }
+}
+
+/// <summary>Session manager fake holding any number of running sessions.</summary>
+internal sealed class SessionResolutionFakeSessions : ISessionManager {
+  private readonly List<EmulatorSession> _sessions;
+
+  public SessionResolutionFakeSessions(params string[] runningIds) {
+    _sessions = runningIds
+      .Select(id => new EmulatorSession { Id = id, GameId = "g", Status = SessionStatus.Running, DeviceSerial = $"dev-{id}" })
+      .ToList();
+  }
+
+  /// <summary>The session id the executor actually resolved to and acted on.</summary>
+  public string? LastGetSessionId { get; private set; }
+
+  public int ActiveCount => _sessions.Count;
+  public bool CanCreateSession => true;
+  public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) => throw new NotSupportedException();
+
+  public EmulatorSession? GetSession(string id) {
+    var found = _sessions.Find(s => s.Id == id);
+    if (found is not null) LastGetSessionId = id;
+    return found;
+  }
+
+  public IReadOnlyCollection<EmulatorSession> ListSessions() => _sessions;
+  public bool StopSession(string id) => _sessions.RemoveAll(s => s.Id == id) > 0;
+  public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+  public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+}
+
+internal sealed class SessionResolutionFakeCommands : ICommandRepository {
+  private readonly Dictionary<string, Command> _store = new(StringComparer.OrdinalIgnoreCase);
+
+  public SessionResolutionFakeCommands(params Command[] commands) {
+    foreach (var c in commands) _store[c.Id] = c;
+  }
+
+  public Task<Command> AddAsync(Command command, CancellationToken ct = default) { _store[command.Id] = command; return Task.FromResult(command); }
+  public Task<Command?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult(_store.TryGetValue(id, out var c) ? c : null);
+  public Task<IReadOnlyList<Command>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Command>)_store.Values.ToList());
+  public Task<Command?> UpdateAsync(Command command, CancellationToken ct = default) { _store[command.Id] = command; return Task.FromResult<Command?>(command); }
+  public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(_store.Remove(id));
+}
+
+internal sealed class SessionResolutionFakeTriggers : ITriggerRepository {
+  public Task<Trigger?> GetAsync(string id, CancellationToken ct = default) => Task.FromResult<Trigger?>(null);
+  public Task UpsertAsync(Trigger trigger, CancellationToken ct = default) => Task.CompletedTask;
+  public Task<bool> DeleteAsync(string id, CancellationToken ct = default) => Task.FromResult(false);
+  public Task<IReadOnlyList<Trigger>> ListAsync(CancellationToken ct = default) => Task.FromResult((IReadOnlyList<Trigger>)Array.Empty<Trigger>());
+}

--- a/tests/unit/Performance/DeviceClaimBenchmarkTests.cs
+++ b/tests/unit/Performance/DeviceClaimBenchmarkTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using FluentAssertions;
+using GameBot.Service.Services.QueueExecution;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.Tests.Unit.Performance;
+
+/// <summary>
+/// Feature 079 performance budget (Constitution Principle IV): a device claim/release pair is a single
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/> operation each and
+/// must stay under 0.05 ms, so adding it to the queue-start path costs nothing measurable next to the
+/// 10-100 ms ADB round-trips the run performs immediately afterwards.
+/// </summary>
+public sealed class DeviceClaimBenchmarkTests {
+  private const int Iterations = 20_000;
+  private const double BudgetMsPerOperation = 0.05;
+
+  [Fact]
+  public void ClaimAndReleaseStayWithinTheDeclaredBudget() {
+    var registry = new DeviceClaimRegistry();
+
+    // Warm up so JIT and first-allocation costs do not land in the measurement.
+    for (var i = 0; i < 1_000; i++) {
+      registry.TryClaim("warmup-serial", "q", "Q");
+      registry.Release("warmup-serial", "q");
+    }
+
+    var sw = Stopwatch.StartNew();
+    for (var i = 0; i < Iterations; i++) {
+      registry.TryClaim("emulator-5558", "q1", "Daily").Should().BeTrue();
+      registry.Release("emulator-5558", "q1");
+    }
+    sw.Stop();
+
+    var msPerPair = sw.Elapsed.TotalMilliseconds / Iterations;
+    msPerPair.Should().BeLessThan(BudgetMsPerOperation * 2,
+      "a claim+release pair must stay within twice the per-operation budget");
+  }
+
+  [Fact]
+  public void HolderLookupIsConstantTimeAcrossManyClaimedDevices() {
+    var registry = new DeviceClaimRegistry();
+    foreach (var i in Enumerable.Range(0, 500)) {
+      registry.TryClaim($"emulator-{i}", $"q{i}", $"Queue {i}");
+    }
+
+    var sw = Stopwatch.StartNew();
+    for (var i = 0; i < Iterations; i++) {
+      registry.TryGetHolder("emulator-499", out _).Should().BeTrue();
+    }
+    sw.Stop();
+
+    (sw.Elapsed.TotalMilliseconds / Iterations).Should().BeLessThan(BudgetMsPerOperation);
+  }
+}

--- a/tests/unit/Queues/DeviceClaimRegistryTests.cs
+++ b/tests/unit/Queues/DeviceClaimRegistryTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Service.Services.QueueExecution;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Queues;
+
+/// <summary>
+/// Feature 079: exactly one queue run may hold an emulator at a time (FR-008..FR-014). Before this,
+/// two queues bound to one serial both ran and fought over the same physical screen.
+/// </summary>
+public sealed class DeviceClaimRegistryTests {
+  [Fact]
+  public void AFreeDeviceCanBeClaimed() {
+    var registry = new DeviceClaimRegistry();
+    registry.TryClaim("emulator-5558", "q1", "Daily").Should().BeTrue();
+    registry.TryGetHolder("emulator-5558", out var holder).Should().BeTrue();
+    holder.QueueId.Should().Be("q1");
+    holder.QueueName.Should().Be("Daily");
+    holder.DeviceSerial.Should().Be("emulator-5558");
+  }
+
+  [Fact]
+  public void ASecondQueueCannotClaimTheSameDevice() {
+    var registry = new DeviceClaimRegistry();
+    registry.TryClaim("emulator-5558", "q1", "Daily").Should().BeTrue();
+
+    registry.TryClaim("emulator-5558", "q2", "Events").Should().BeFalse();
+
+    registry.TryGetHolder("emulator-5558", out var holder).Should().BeTrue();
+    holder.QueueId.Should().Be("q1", "the incumbent must keep the device");
+  }
+
+  [Fact]
+  public void ReleasingMakesTheDeviceClaimableAgain() {
+    var registry = new DeviceClaimRegistry();
+    registry.TryClaim("emulator-5558", "q1", "Daily");
+
+    registry.Release("emulator-5558", "q1");
+
+    registry.TryGetHolder("emulator-5558", out _).Should().BeFalse();
+    registry.TryClaim("emulator-5558", "q2", "Events").Should().BeTrue();
+  }
+
+  [Fact]
+  public void SerialsAreTrimmedAndComparedCaseInsensitively() {
+    var registry = new DeviceClaimRegistry();
+    registry.TryClaim("  emulator-5558  ", "q1", "Daily").Should().BeTrue();
+
+    registry.TryClaim("EMULATOR-5558", "q2", "Events").Should().BeFalse();
+    registry.TryGetHolder("emulator-5558", out var holder).Should().BeTrue();
+    holder.DeviceSerial.Should().Be("emulator-5558", "the stored serial is normalized");
+  }
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData("")]
+  [InlineData("   ")]
+  public void QueuesWithNoBoundSerialNeverBlockEachOther(string? serial) {
+    var registry = new DeviceClaimRegistry();
+
+    registry.TryClaim(serial, "q1", "One").Should().BeTrue();
+    registry.TryClaim(serial, "q2", "Two").Should().BeTrue();
+    registry.TryGetHolder(serial, out _).Should().BeFalse("a blank serial has no device identity");
+  }
+
+  [Fact]
+  public void ANonHolderCannotReleaseTheClaim() {
+    var registry = new DeviceClaimRegistry();
+    registry.TryClaim("emulator-5558", "q1", "Daily");
+
+    // A late release from a run that already ended must not drop the claim a newer run now holds.
+    registry.Release("emulator-5558", "q2");
+
+    registry.TryGetHolder("emulator-5558", out var holder).Should().BeTrue();
+    holder.QueueId.Should().Be("q1");
+  }
+
+  [Fact]
+  public void ReleaseIsIdempotentAndSafeOnUnknownDevices() {
+    var registry = new DeviceClaimRegistry();
+    registry.TryClaim("emulator-5558", "q1", "Daily");
+
+    registry.Release("emulator-5558", "q1");
+    registry.Release("emulator-5558", "q1");
+    registry.Release("never-claimed", "q1");
+    registry.Release(null, "q1");
+
+    registry.TryGetHolder("emulator-5558", out _).Should().BeFalse();
+  }
+
+  [Fact]
+  public void DifferentDevicesDoNotBlockOneAnother() {
+    var registry = new DeviceClaimRegistry();
+
+    registry.TryClaim("emulator-5558", "q1", "A").Should().BeTrue();
+    registry.TryClaim("emulator-5560", "q2", "B").Should().BeTrue();
+    registry.TryClaim("emulator-5562", "q3", "C").Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task ConcurrentClaimsOnOneDeviceYieldExactlyOneWinner() {
+    var registry = new DeviceClaimRegistry();
+    const int Contenders = 32;
+    using var gate = new Barrier(Contenders);
+
+    var results = await Task.WhenAll(Enumerable.Range(0, Contenders).Select(i => Task.Run(() => {
+      gate.SignalAndWait();
+      return registry.TryClaim("emulator-5558", $"q{i}", $"Queue {i}");
+    }))).ConfigureAwait(false);
+
+    results.Count(won => won).Should().Be(1, "TryClaim must be atomic (FR-012)");
+  }
+
+  [Fact]
+  public void AFreshRegistryHoldsNoClaims() {
+    // FR-013: claims are in-memory only, so a restart (a new registry) voids every one of them.
+    var before = new DeviceClaimRegistry();
+    before.TryClaim("emulator-5558", "q1", "Daily").Should().BeTrue();
+
+    var afterRestart = new DeviceClaimRegistry();
+
+    afterRestart.TryGetHolder("emulator-5558", out _).Should().BeFalse();
+    afterRestart.TryClaim("emulator-5558", "q2", "Events").Should().BeTrue();
+  }
+
+  [Fact]
+  public void ClaimingRequiresAQueueId() {
+    var registry = new DeviceClaimRegistry();
+    var act = () => registry.TryClaim("emulator-5558", "  ", "Daily");
+    act.Should().Throw<ArgumentException>();
+  }
+
+  [Fact]
+  public void TryGetHolderOnAnUnclaimedDeviceReturnsFalse() {
+    var registry = new DeviceClaimRegistry();
+    registry.TryGetHolder("emulator-5558", out _).Should().BeFalse();
+    registry.TryGetHolder(null, out _).Should().BeFalse();
+  }
+}

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -72,8 +72,11 @@ public sealed partial class QueueExecutionServiceTests {
     public static SequenceExecutionResult Failure(string id) { var r = SequenceExecutionResult.Start(id); r.Fail("failed"); return r; }
   }
 
+  // Feature 079: holds several sessions at once so concurrent-run tests can give each queue its own
+  // device. `Connected` is retained as the global "is the emulator link healthy" switch that
+  // connection-loss tests flip.
   private sealed class FakeSessionManager : ISessionManager {
-    private EmulatorSession? _session;
+    private readonly Dictionary<string, EmulatorSession> _sessions = new(StringComparer.Ordinal);
     public bool Connected { get; set; }
     public Exception? CreateThrows { get; set; }
     public List<string> Stopped { get; } = new();
@@ -91,19 +94,27 @@ public sealed partial class QueueExecutionServiceTests {
       }
     }
 
-    public int ActiveCount => _session is null ? 0 : 1;
+    public int ActiveCount { get { lock (_sessions) { return _sessions.Count; } } }
     public bool CanCreateSession => true;
 
     public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) {
       if (CreateThrows is not null) throw CreateThrows;
-      _session = new EmulatorSession { Id = Guid.NewGuid().ToString("N"), GameId = gameIdOrPath, DeviceSerial = preferredDeviceSerial, Status = SessionStatus.Running };
+      var session = new EmulatorSession { Id = Guid.NewGuid().ToString("N"), GameId = gameIdOrPath, DeviceSerial = preferredDeviceSerial, Status = SessionStatus.Running };
+      lock (_sessions) { _sessions[session.Id] = session; }
       Connected = true;
-      return _session;
+      return session;
     }
 
-    public EmulatorSession? GetSession(string id) => Connected && _session is not null && _session.Id == id ? _session : null;
-    public IReadOnlyCollection<EmulatorSession> ListSessions() => _session is null ? Array.Empty<EmulatorSession>() : new[] { _session };
-    public bool StopSession(string id) { Stopped.Add(id); Connected = false; return true; }
+    public EmulatorSession? GetSession(string id) {
+      if (!Connected) return null;
+      lock (_sessions) { return _sessions.TryGetValue(id, out var s) ? s : null; }
+    }
+    public IReadOnlyCollection<EmulatorSession> ListSessions() { lock (_sessions) { return _sessions.Values.ToList(); } }
+    public bool StopSession(string id) {
+      lock (Stopped) { Stopped.Add(id); }
+      lock (_sessions) { _sessions.Remove(id); if (_sessions.Count == 0) Connected = false; }
+      return true;
+    }
     public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) {
       var list = actions.ToList();
       lock (Inputs) { Inputs.AddRange(list); }
@@ -209,12 +220,17 @@ public sealed partial class QueueExecutionServiceTests {
       Service = new QueueExecutionService(Queues, Runtime, Templates, Sequences, Sessions, Log, NullLogger<QueueExecutionService>.Instance, Registry, timeProvider: clock, ensureGameRunning: EnsureGame, ensureEmulatorRunning: EnsureEmulator);
     }
 
-    public ExecutionQueue AddQueue(string id, IReadOnlyList<string> sequenceIds, bool cycle = false, bool linkTemplate = true) {
+    /// <param name="serial">
+    /// The emulator this queue binds to. Feature 079 gives a device to one run at a time, so
+    /// concurrent-run tests must give each queue a distinct serial (the default is shared on purpose,
+    /// so a same-device start is refused).
+    /// </param>
+    public ExecutionQueue AddQueue(string id, IReadOnlyList<string> sequenceIds, bool cycle = false, bool linkTemplate = true, string serial = "emu-1") {
       var templateId = $"tpl-{id}";
       var template = new QueueTemplate { Id = templateId, Name = $"T-{id}" };
       foreach (var sid in sequenceIds) template.Entries.Add(new QueueTemplateEntry { SequenceId = sid });
       Templates.Add(template);
-      var queue = new ExecutionQueue { Id = id, Name = $"Q-{id}", EmulatorSerial = "emu-1", CycleExecution = cycle, LinkedTemplateId = linkTemplate ? templateId : null };
+      var queue = new ExecutionQueue { Id = id, Name = $"Q-{id}", EmulatorSerial = serial, CycleExecution = cycle, LinkedTemplateId = linkTemplate ? templateId : null };
       Queues.Add(queue);
       return queue;
     }
@@ -389,11 +405,51 @@ public sealed partial class QueueExecutionServiceTests {
     await h.Service.StopAsync("q1");
   }
 
-  [Fact] // T020 — concurrent runs on the same emulator are allowed (FR-013/SC-009)
-  public async Task TwoQueuesOnSameEmulatorRunConcurrently() {
+  // Feature 079 reverses 051 FR-013: two runs on ONE emulator is now an error to prevent, because two
+  // automations driving one screen cannot both be correct. Two runs on DIFFERENT emulators is the
+  // supported case and must be fully independent.
+
+  [Fact] // 079 US2 — a same-device start is refused without disturbing the incumbent (FR-008/FR-009)
+  public async Task TwoQueuesOnSameEmulatorCannotRunConcurrently() {
     var h = new Harness();
-    h.AddQueue("q1", new[] { "A" });
-    h.AddQueue("q2", new[] { "B" });
+    h.AddQueue("q1", new[] { "A" }, serial: "emu-shared");
+    h.AddQueue("q2", new[] { "B" }, serial: "emu-shared");
+    h.Sequences.Handler = async (id, ct) => { await Task.Delay(Timeout.Infinite, ct); return FakeSequenceExecution.Success(id); };
+
+    (await h.Service.StartAsync("q1")).Should().Be(QueueStartOutcome.Started);
+    await WaitForAsync(() => h.Service.IsRunning("q1"));
+
+    (await h.Service.StartAsync("q2")).Should().Be(QueueStartOutcome.DeviceInUse);
+
+    h.Service.IsRunning("q2").Should().BeFalse("the refused queue must not start a run");
+    h.Service.IsRunning("q1").Should().BeTrue("the incumbent run must be untouched");
+    h.Runtime.GetStatus("q2").Should().Be(QueueExecutionStatus.Stopped);
+
+    await h.Service.StopAsync("q1");
+  }
+
+  [Fact] // 079 US2 — the device is claimable again once the holding run is stopped (FR-011, SC-004)
+  public async Task StoppingTheHoldingRunFreesTheDevice() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }, serial: "emu-shared");
+    h.AddQueue("q2", new[] { "B" }, serial: "emu-shared");
+    h.Sequences.Handler = async (id, ct) => { await Task.Delay(Timeout.Infinite, ct); return FakeSequenceExecution.Success(id); };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Service.IsRunning("q1"));
+    (await h.Service.StartAsync("q2")).Should().Be(QueueStartOutcome.DeviceInUse);
+
+    await h.Service.StopAsync("q1");
+
+    (await h.Service.StartAsync("q2")).Should().Be(QueueStartOutcome.Started);
+    await h.Service.StopAsync("q2");
+  }
+
+  [Fact] // 079 US1/US2 — different emulators never block one another (FR-014, SC-001, SC-005)
+  public async Task TwoQueuesOnDifferentEmulatorsRunConcurrently() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }, serial: "emu-5558");
+    h.AddQueue("q2", new[] { "B" }, serial: "emu-5560");
     h.Sequences.Handler = async (id, ct) => { await Task.Delay(Timeout.Infinite, ct); return FakeSequenceExecution.Success(id); };
 
     (await h.Service.StartAsync("q1")).Should().Be(QueueStartOutcome.Started);
@@ -402,9 +458,88 @@ public sealed partial class QueueExecutionServiceTests {
 
     h.Service.IsRunning("q1").Should().BeTrue();
     h.Service.IsRunning("q2").Should().BeTrue();
+    h.Sessions.ActiveCount.Should().Be(2, "each run holds its own device session");
+
+    // FR-020/SC-005: stopping one leaves the other running.
+    await h.Service.StopAsync("q1");
+    h.Service.IsRunning("q1").Should().BeFalse();
+    h.Service.IsRunning("q2").Should().BeTrue();
+
+    await h.Service.StopAsync("q2");
+  }
+
+  [Fact] // 079 US2 — a completed run releases its device (FR-011)
+  public async Task ACompletedRunReleasesItsDevice() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }, serial: "emu-shared");
+    h.AddQueue("q2", new[] { "B" }, serial: "emu-shared");
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    (await h.Service.StartAsync("q2")).Should().Be(QueueStartOutcome.Started);
+    await WaitUntilStoppedAsync(h.Service, "q2");
+    h.Sequences.Executed.Should().Equal("A", "B");
+  }
+
+  [Fact] // 079 US2 — a failed run releases its device too (FR-011)
+  public async Task AFailedRunReleasesItsDevice() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }, serial: "emu-shared");
+    h.AddQueue("q2", new[] { "B" }, serial: "emu-shared");
+    h.Sessions.CreateThrows = new InvalidOperationException("no_adb_devices");
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+    h.Log.FinalStatus.Should().Be("failure");
+
+    h.Sessions.CreateThrows = null;
+    (await h.Service.StartAsync("q2")).Should().Be(QueueStartOutcome.Started);
+    await WaitUntilStoppedAsync(h.Service, "q2");
+  }
+
+  [Fact] // 079 US3 — FR-016/FR-017: the capacity message reaches the run's execution-log summary
+  public async Task ACapacityFailureIsRecordedWithTheActionableReason() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }, serial: "emu-5558");
+    // The real SessionManager throws exactly this when the ceiling is reached.
+    h.Sessions.CreateThrows = new InvalidOperationException(SessionManager.CapacityExceededMessage(8, 8));
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Log.FinalStatus.Should().Be("failure");
+    h.Log.Summary.Should()
+      .Contain("session capacity reached: 8 of 8 sessions are open")
+      .And.Contain("Service:Sessions:MaxConcurrentSessions");
+  }
+
+  [Fact] // 079 US2 — a queue with no bound serial never blocks another (research R5)
+  public async Task QueuesWithNoBoundSerialDoNotBlockEachOther() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }, serial: string.Empty);
+    h.AddQueue("q2", new[] { "B" }, serial: string.Empty);
+    h.Sequences.Handler = async (id, ct) => { await Task.Delay(Timeout.Infinite, ct); return FakeSequenceExecution.Success(id); };
+
+    (await h.Service.StartAsync("q1")).Should().Be(QueueStartOutcome.Started);
+    (await h.Service.StartAsync("q2")).Should().Be(QueueStartOutcome.Started);
 
     await h.Service.StopAsync("q1");
     await h.Service.StopAsync("q2");
+  }
+
+  [Fact] // 079 US2 — the same queue twice is still AlreadyRunning, not DeviceInUse (FR-010)
+  public async Task RestartingTheSameQueueReportsAlreadyRunningNotDeviceInUse() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A" }, serial: "emu-shared");
+    h.Sequences.Handler = async (id, ct) => { await Task.Delay(Timeout.Infinite, ct); return FakeSequenceExecution.Success(id); };
+
+    await h.Service.StartAsync("q1");
+    await WaitForAsync(() => h.Service.IsRunning("q1"));
+
+    (await h.Service.StartAsync("q1")).Should().Be(QueueStartOutcome.AlreadyRunning);
+
+    await h.Service.StopAsync("q1");
   }
 
   [Fact] // T-not-found

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -454,7 +454,9 @@ public sealed partial class QueueExecutionServiceTests {
 
     (await h.Service.StartAsync("q1")).Should().Be(QueueStartOutcome.Started);
     (await h.Service.StartAsync("q2")).Should().Be(QueueStartOutcome.Started);
-    await WaitForAsync(() => h.Service.IsRunning("q1") && h.Service.IsRunning("q2"));
+    // IsRunning flips in StartAsync, before the background run connects, so wait for the sessions
+    // themselves — otherwise this races on a slow machine.
+    await WaitForAsync(() => h.Sessions.ActiveCount == 2);
 
     h.Service.IsRunning("q1").Should().BeTrue();
     h.Service.IsRunning("q2").Should().BeTrue();

--- a/tests/unit/Sequences/SessionResolutionTests.cs
+++ b/tests/unit/Sequences/SessionResolutionTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Sessions;
+using GameBot.Emulator.Session;
+using GameBot.Service.Services;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// Feature 079 (FR-006/FR-007): the one rule that decides which emulator a step acts on.
+///
+/// Before this feature every call site inlined "exactly one running session, else fail", so the
+/// moment a second queue started, steps in the <i>first</i> queue began failing with
+/// "no session available" even though they carried an explicit session.
+/// </summary>
+public sealed class SessionResolutionTests {
+  [Fact]
+  public void AnExplicitSessionWinsEvenWithSeveralSessionsRunning() {
+    var sessions = new FakeSessions("s1", "s2", "s3");
+
+    SessionResolver.TryResolve(sessions, "s2", "tap", out var resolved, out var error).Should().BeTrue();
+
+    resolved.Should().Be("s2");
+    error.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void AnExplicitSessionWinsWithNoSessionsListedAtAll() {
+    // The caller owns the session; the resolver must not second-guess the listing.
+    var sessions = new FakeSessions();
+
+    SessionResolver.TryResolve(sessions, "s1", "tap", out var resolved, out _).Should().BeTrue();
+
+    resolved.Should().Be("s1");
+  }
+
+  [Fact]
+  public void WithNoSessionSuppliedAndExactlyOneRunningThatOneIsUsed() {
+    var sessions = new FakeSessions("only");
+
+    SessionResolver.TryResolve(sessions, null, "tap", out var resolved, out var error).Should().BeTrue();
+
+    resolved.Should().Be("only");
+    error.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void WithNoSessionSuppliedAndNoneRunningTheMessageAsksForOne() {
+    var sessions = new FakeSessions();
+
+    SessionResolver.TryResolve(sessions, null, "go-to-home-screen", out var resolved, out var error).Should().BeFalse();
+
+    resolved.Should().BeNull();
+    error.Should().Be("no session available for 'go-to-home-screen' step; start a session or pass a sessionId");
+  }
+
+  [Fact]
+  public void WithNoSessionSuppliedAndSeveralRunningTheStepFailsNamingTheCount() {
+    var sessions = new FakeSessions("s1", "s2", "s3");
+
+    SessionResolver.TryResolve(sessions, null, "ensure-game-running", out var resolved, out var error).Should().BeFalse();
+
+    resolved.Should().BeNull("guessing a device is exactly the defect this feature fixes");
+    error.Should().Be("3 device sessions are active; specify a sessionId for 'ensure-game-running'");
+  }
+
+  [Theory]
+  [InlineData("")]
+  [InlineData("   ")]
+  public void ABlankSessionIdCountsAsNoSession(string sessionId) {
+    var sessions = new FakeSessions("only");
+
+    SessionResolver.TryResolve(sessions, sessionId, "swipe", out var resolved, out _).Should().BeTrue();
+
+    resolved.Should().Be("only");
+  }
+
+  [Fact]
+  public void StoppedSessionsDoNotCountTowardsTheRunningTotal() {
+    var sessions = new FakeSessions("live");
+    sessions.SeedStopped("dead-1", "dead-2");
+
+    SessionResolver.TryResolve(sessions, null, "key", out var resolved, out _).Should().BeTrue();
+
+    resolved.Should().Be("live");
+  }
+
+  [Fact]
+  public void TheAmbiguityMessageNamesTheStep() {
+    SessionResolver.Ambiguous(2, "waitForImage")
+      .Should().Be("2 device sessions are active; specify a sessionId for 'waitForImage'");
+  }
+}
+
+/// <summary>Minimal <see cref="ISessionManager"/> that only has to list sessions.</summary>
+file sealed class FakeSessions : ISessionManager {
+  private readonly List<EmulatorSession> _sessions = new();
+
+  public FakeSessions(params string[] runningIds) {
+    foreach (var id in runningIds) {
+      _sessions.Add(new EmulatorSession { Id = id, GameId = "g", Status = SessionStatus.Running, DeviceSerial = $"dev-{id}" });
+    }
+  }
+
+  public void SeedStopped(params string[] ids) {
+    foreach (var id in ids) {
+      _sessions.Add(new EmulatorSession { Id = id, GameId = "g", Status = SessionStatus.Stopped, DeviceSerial = $"dev-{id}" });
+    }
+  }
+
+  public int ActiveCount => _sessions.Count;
+  public bool CanCreateSession => true;
+  public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) => throw new NotSupportedException();
+  public EmulatorSession? GetSession(string id) => _sessions.Find(s => s.Id == id);
+  public IReadOnlyCollection<EmulatorSession> ListSessions() => _sessions;
+  public bool StopSession(string id) => _sessions.RemoveAll(s => s.Id == id) > 0;
+  public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+  public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+}

--- a/tests/unit/Sessions/AmbientScreenIsolationTests.cs
+++ b/tests/unit/Sessions/AmbientScreenIsolationTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Sessions;
+using GameBot.Emulator.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sessions;
+
+/// <summary>
+/// Feature 079, the core defect and its fix.
+///
+/// <c>BackgroundCaptureScreenSource</c> used to answer every "what is on screen" question with the
+/// frame of the <i>first</i> running session it found. With two queue runs active, one run's image and
+/// OCR checks therefore evaluated the other run's screen — non-deterministically, and silently, so the
+/// run kept going and tapped the right coordinates on the wrong game.
+///
+/// It now resolves: ambient device context → the single running session → nothing.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class AmbientScreenIsolationTests : IDisposable {
+  private const int WidthA = 7;
+  private const int WidthB = 13;
+
+  private readonly BackgroundScreenCaptureService _capture;
+  private readonly TwoSessionManager _sessions = new();
+  private readonly AsyncLocalDeviceContextAccessor _context = new();
+
+  public AmbientScreenIsolationTests() {
+    _capture = new BackgroundScreenCaptureService(
+      serial => new SizedCaptureProvider(string.Equals(serial, "serial-a", StringComparison.Ordinal) ? WidthA : WidthB),
+      captureIntervalMs: 50,
+      NullLogger<BackgroundScreenCaptureService>.Instance);
+  }
+
+  public void Dispose() => _capture.Dispose();
+
+  [Fact]
+  public async Task ConcurrentFlowsEachObserveTheirOwnDevice() {
+    await StartBothSessionsAsync().ConfigureAwait(false);
+    var screen = new BackgroundCaptureScreenSource(_capture, _sessions, _context);
+
+    async Task<int?> ObserveAs(string sessionId) {
+      using var scope = _context.Push(DeviceContext.For(sessionId));
+      await Task.Delay(10).ConfigureAwait(false); // interleave the two flows
+      using var frame = screen.GetLatestScreenshot();
+      return frame?.Width;
+    }
+
+    var widths = await Task.WhenAll(ObserveAs("session-a"), ObserveAs("session-b")).ConfigureAwait(false);
+
+    widths[0].Should().Be(WidthA);
+    widths[1].Should().Be(WidthB);
+  }
+
+  [Fact]
+  public async Task WithoutAContextAndSeveralSessionsNothingIsObserved() {
+    await StartBothSessionsAsync().ConfigureAwait(false);
+    var screen = new BackgroundCaptureScreenSource(_capture, _sessions, _context);
+
+    // The pre-079 behaviour returned session A's frame here, silently.
+    screen.GetLatestScreenshot().Should().BeNull();
+  }
+
+  [Fact]
+  public async Task WithASingleSessionTheContextIsNotRequired() {
+    _sessions.Add("session-a", "serial-a");
+    _capture.StartCapture("session-a", "serial-a");
+    await WaitForFrameAsync("session-a").ConfigureAwait(false);
+    var screen = new BackgroundCaptureScreenSource(_capture, _sessions, _context);
+
+    using var frame = screen.GetLatestScreenshot();
+
+    frame!.Width.Should().Be(WidthA, "single-emulator behaviour must be unchanged");
+  }
+
+  [Fact]
+  public async Task TheContextOverridesEvenTheSingleRunningSession() {
+    await StartBothSessionsAsync().ConfigureAwait(false);
+    _sessions.MarkStopped("session-a"); // only B is "running"
+    var screen = new BackgroundCaptureScreenSource(_capture, _sessions, _context);
+
+    using var scope = _context.Push(DeviceContext.For("session-a"));
+    using var frame = screen.GetLatestScreenshot();
+
+    frame!.Width.Should().Be(WidthA, "the flow's own device wins over the listing");
+  }
+
+  [Fact]
+  public void WithNoSessionsAtAllNothingIsObserved() {
+    var screen = new BackgroundCaptureScreenSource(_capture, _sessions, _context);
+    screen.GetLatestScreenshot().Should().BeNull();
+  }
+
+  private async Task StartBothSessionsAsync() {
+    _sessions.Add("session-a", "serial-a");
+    _sessions.Add("session-b", "serial-b");
+    _capture.StartCapture("session-a", "serial-a");
+    _capture.StartCapture("session-b", "serial-b");
+    await WaitForFrameAsync("session-a").ConfigureAwait(false);
+    await WaitForFrameAsync("session-b").ConfigureAwait(false);
+  }
+
+  private async Task WaitForFrameAsync(string sessionId) {
+    var sw = Stopwatch.StartNew();
+    while (sw.Elapsed < TimeSpan.FromSeconds(5)) {
+      if (_capture.GetCachedFrame(sessionId) is not null) return;
+      await Task.Delay(20).ConfigureAwait(false);
+    }
+    throw new TimeoutException($"No frame captured for '{sessionId}' within 5s.");
+  }
+}
+
+/// <summary>Session manager fake that can hold several running sessions at once.</summary>
+internal sealed class TwoSessionManager : ISessionManager {
+  private readonly List<EmulatorSession> _sessions = new();
+
+  public void Add(string id, string serial) =>
+    _sessions.Add(new EmulatorSession { Id = id, GameId = "g", Status = SessionStatus.Running, DeviceSerial = serial });
+
+  public void MarkStopped(string id) {
+    var s = _sessions.Find(x => x.Id == id);
+    if (s is not null) s.Status = SessionStatus.Stopped;
+  }
+
+  public int ActiveCount => _sessions.Count;
+  public bool CanCreateSession => true;
+  public EmulatorSession CreateSession(string gameIdOrPath, string? preferredDeviceSerial = null) => throw new NotSupportedException();
+  public EmulatorSession? GetSession(string id) => _sessions.Find(s => s.Id == id);
+  public IReadOnlyCollection<EmulatorSession> ListSessions() => _sessions;
+  public bool StopSession(string id) => _sessions.RemoveAll(s => s.Id == id) > 0;
+  public Task<int> SendInputsAsync(string id, IEnumerable<InputAction> actions, CancellationToken ct = default) => Task.FromResult(0);
+  public Task<byte[]> GetSnapshotAsync(string id, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+}
+
+/// <summary>Capture provider producing a PNG of a fixed width, so frames are attributable by size.</summary>
+[SupportedOSPlatform("windows")]
+file sealed class SizedCaptureProvider : IAdbScreenCaptureProvider {
+  private readonly byte[] _png;
+
+  public SizedCaptureProvider(int width) {
+    using var bmp = new Bitmap(width, 4);
+    using var ms = new MemoryStream();
+    bmp.Save(ms, ImageFormat.Png);
+    _png = ms.ToArray();
+  }
+
+  public Task<byte[]?> CaptureScreenshotPngAsync(CancellationToken ct) => Task.FromResult<byte[]?>(_png);
+}

--- a/tests/unit/Sessions/DeviceContextAccessorTests.cs
+++ b/tests/unit/Sessions/DeviceContextAccessorTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Sessions;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sessions;
+
+/// <summary>
+/// Feature 079: the ambient device context must flow with the execution context so a queue run's
+/// device is visible to everything it starts, and must not leak between sibling flows.
+/// </summary>
+public sealed class DeviceContextAccessorTests {
+  [Fact]
+  public void CurrentIsNullBeforeAnyPush() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+    accessor.Current.Should().BeNull();
+  }
+
+  [Fact]
+  public void PushSetsCurrentAndDisposeRestoresIt() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+
+    using (accessor.Push(DeviceContext.For("s1", "emulator-5558"))) {
+      accessor.Current!.SessionId.Should().Be("s1");
+      accessor.Current!.DeviceSerial.Should().Be("emulator-5558");
+    }
+
+    accessor.Current.Should().BeNull();
+  }
+
+  [Fact]
+  public void NestedPushesRestoreTheOuterContext() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+
+    using (accessor.Push(DeviceContext.For("outer"))) {
+      using (accessor.Push(DeviceContext.For("inner"))) {
+        accessor.Current!.SessionId.Should().Be("inner");
+      }
+      accessor.Current!.SessionId.Should().Be("outer");
+    }
+
+    accessor.Current.Should().BeNull();
+  }
+
+  [Fact]
+  public void DisposingTwiceIsANoOp() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+    var scope = accessor.Push(DeviceContext.For("s1"));
+    scope.Dispose();
+    scope.Dispose();
+    accessor.Current.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task ContextFlowsAcrossAwait() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+
+    using (accessor.Push(DeviceContext.For("s1"))) {
+      await Task.Yield();
+      await Task.Delay(1).ConfigureAwait(false);
+      accessor.Current!.SessionId.Should().Be("s1");
+    }
+  }
+
+  [Fact]
+  public async Task ContextFlowsIntoTaskRun() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+
+    using (accessor.Push(DeviceContext.For("s1"))) {
+      var observed = await Task.Run(() => accessor.Current?.SessionId).ConfigureAwait(false);
+      observed.Should().Be("s1");
+    }
+  }
+
+  [Fact]
+  public async Task AChildFlowsPushDoesNotLeakToTheParent() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+
+    await Task.Run(() => {
+      using var scope = accessor.Push(DeviceContext.For("child"));
+      accessor.Current!.SessionId.Should().Be("child");
+    }).ConfigureAwait(false);
+
+    accessor.Current.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task ConcurrentFlowsSeeTheirOwnContext() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+
+    async Task<string?> RunWith(string sessionId) {
+      using var scope = accessor.Push(DeviceContext.For(sessionId));
+      await Task.Delay(5).ConfigureAwait(false);
+      return accessor.Current?.SessionId;
+    }
+
+    var results = await Task.WhenAll(RunWith("a"), RunWith("b"), RunWith("c")).ConfigureAwait(false);
+
+    results.Should().BeEquivalentTo(new[] { "a", "b", "c" });
+    accessor.Current.Should().BeNull();
+  }
+
+  [Fact]
+  public void PushRejectsNull() {
+    var accessor = new AsyncLocalDeviceContextAccessor();
+    var act = () => accessor.Push(null!);
+    act.Should().Throw<ArgumentNullException>();
+  }
+
+  [Theory]
+  [InlineData("")]
+  [InlineData("   ")]
+  [InlineData(null)]
+  public void ForRejectsABlankSessionId(string? sessionId) {
+    var act = () => DeviceContext.For(sessionId!);
+    act.Should().Throw<ArgumentException>();
+  }
+
+  [Fact]
+  public void ForNormalizesABlankSerialToNull() {
+    DeviceContext.For("s1", "   ").DeviceSerial.Should().BeNull();
+  }
+}

--- a/tests/unit/Sessions/SessionCapacityMessageTests.cs
+++ b/tests/unit/Sessions/SessionCapacityMessageTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Runtime.Versioning;
+using FluentAssertions;
+using GameBot.Emulator.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sessions;
+
+/// <summary>
+/// Feature 079 (FR-015/FR-016): the concurrent-session ceiling must not be the practical limit on how
+/// many queues can run at once, and hitting it must say so in words an operator can act on.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class SessionCapacityMessageTests {
+  [Fact]
+  public void TheDefaultCeilingIsEight() {
+    // 3 (the pre-079 default) is below a plausible emulator count, so the guard rail became the
+    // ceiling on concurrency and failed runs with an opaque error.
+    new SessionOptions().MaxConcurrentSessions.Should().Be(8);
+  }
+
+  [Fact]
+  public void TheCapacityMessageNamesTheCountsAndTheSetting() {
+    SessionManager.CapacityExceededMessage(8, 8)
+      .Should().Be("session capacity reached: 8 of 8 sessions are open (Service:Sessions:MaxConcurrentSessions)");
+  }
+
+  [Fact]
+  public void ExceedingCapacityThrowsWithTheActionableMessage() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    try {
+      var manager = new SessionManager(
+        Options.Create(new SessionOptions { MaxConcurrentSessions = 2, IdleTimeoutSeconds = 1800 }),
+        NullLogger<SessionManager>.Instance,
+        NullLogger<GameBot.Emulator.Adb.AdbClient>.Instance);
+
+      manager.CreateSession("queue:q1", "emulator-5558");
+      manager.CreateSession("queue:q2", "emulator-5560");
+
+      var act = () => manager.CreateSession("queue:q3", "emulator-5562");
+
+      act.Should().Throw<InvalidOperationException>()
+        .WithMessage("session capacity reached: 2 of 2 sessions are open (Service:Sessions:MaxConcurrentSessions)");
+    }
+    finally {
+      Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", null);
+    }
+  }
+}

--- a/tests/unit/Sessions/SessionScopedScreenSourceTests.cs
+++ b/tests/unit/Sessions/SessionScopedScreenSourceTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Emulator.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sessions;
+
+/// <summary>
+/// Feature 079: a session-scoped screen source observes its own device and nothing else.
+///
+/// The defect it replaces: <c>BackgroundCaptureScreenSource</c> answered every screen question with
+/// the frame of the <i>first</i> running session, so with two queue runs active one run's image and
+/// OCR checks silently evaluated the other run's screen.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class SessionScopedScreenSourceTests : IDisposable {
+  // Distinct sizes make "whose frame is this?" unambiguous without pixel comparison.
+  private const int SessionAWidth = 7;
+  private const int SessionBWidth = 13;
+
+  private readonly BackgroundScreenCaptureService _capture;
+
+  public SessionScopedScreenSourceTests() {
+    _capture = new BackgroundScreenCaptureService(
+      serial => new SolidColorCaptureProvider(WidthForSerial(serial)),
+      captureIntervalMs: 50,
+      NullLogger<BackgroundScreenCaptureService>.Instance);
+  }
+
+  public void Dispose() => _capture.Dispose();
+
+  [Fact]
+  public async Task EachSessionObservesOnlyItsOwnDevice() {
+    _capture.StartCapture("session-a", "serial-a");
+    _capture.StartCapture("session-b", "serial-b");
+    await WaitForFrameAsync("session-a").ConfigureAwait(false);
+    await WaitForFrameAsync("session-b").ConfigureAwait(false);
+
+    var a = new SessionScopedScreenSource(_capture, "session-a");
+    var b = new SessionScopedScreenSource(_capture, "session-b");
+
+    using var frameA = a.GetLatestScreenshot();
+    using var frameB = b.GetLatestScreenshot();
+
+    frameA!.Width.Should().Be(SessionAWidth);
+    frameB!.Width.Should().Be(SessionBWidth);
+  }
+
+  [Fact]
+  public void AnUnknownSessionYieldsNoFrameRatherThanAnotherSessions() {
+    _capture.StartCapture("session-a", "serial-a");
+
+    var orphan = new SessionScopedScreenSource(_capture, "session-does-not-exist");
+
+    orphan.GetLatestScreenshot().Should().BeNull();
+  }
+
+  [Fact]
+  public async Task AStoppedSessionYieldsNoFrame() {
+    _capture.StartCapture("session-a", "serial-a");
+    await WaitForFrameAsync("session-a").ConfigureAwait(false);
+    var source = new SessionScopedScreenSource(_capture, "session-a");
+    source.GetLatestScreenshot().Should().NotBeNull();
+
+    _capture.StopCapture("session-a");
+
+    source.GetLatestScreenshot().Should().BeNull();
+  }
+
+  [Fact]
+  public async Task TheFactoryBindsEachSourceToItsOwnSession() {
+    _capture.StartCapture("session-a", "serial-a");
+    _capture.StartCapture("session-b", "serial-b");
+    await WaitForFrameAsync("session-a").ConfigureAwait(false);
+    await WaitForFrameAsync("session-b").ConfigureAwait(false);
+
+    var factory = new BackgroundCaptureScreenSourceFactory(_capture);
+
+    using var frameA = factory.ForSession("session-a").GetLatestScreenshot();
+    using var frameB = factory.ForSession("session-b").GetLatestScreenshot();
+
+    frameA!.Width.Should().Be(SessionAWidth);
+    frameB!.Width.Should().Be(SessionBWidth);
+  }
+
+  [Fact]
+  public void ABlankSessionIdIsRejected() {
+    var factory = new BackgroundCaptureScreenSourceFactory(_capture);
+    var act = () => factory.ForSession("   ");
+    act.Should().Throw<ArgumentException>();
+  }
+
+  /// <summary>Polls until the session's capture loop has produced its first frame.</summary>
+  private async Task WaitForFrameAsync(string sessionId) {
+    var sw = Stopwatch.StartNew();
+    while (sw.Elapsed < TimeSpan.FromSeconds(5)) {
+      if (_capture.GetCachedFrame(sessionId) is not null) return;
+      await Task.Delay(20).ConfigureAwait(false);
+    }
+    throw new TimeoutException($"No frame captured for '{sessionId}' within 5s.");
+  }
+
+  private static int WidthForSerial(string serial) =>
+    string.Equals(serial, "serial-a", StringComparison.Ordinal) ? SessionAWidth : SessionBWidth;
+}
+
+/// <summary>Capture provider returning a PNG of a fixed width, so frames are attributable by size.</summary>
+[SupportedOSPlatform("windows")]
+file sealed class SolidColorCaptureProvider : IAdbScreenCaptureProvider {
+  private readonly byte[] _png;
+
+  public SolidColorCaptureProvider(int width) {
+    using var bmp = new Bitmap(width, 4);
+    using var ms = new MemoryStream();
+    bmp.Save(ms, ImageFormat.Png);
+    _png = ms.ToArray();
+  }
+
+  public Task<byte[]?> CaptureScreenshotPngAsync(CancellationToken ct) => Task.FromResult<byte[]?>(_png);
+}


### PR DESCRIPTION
Spec: [`specs/079-concurrent-queue-execution/`](specs/079-concurrent-queue-execution/)

## Why queues interfered

Two queues could both be started and both report Running, but the second silently corrupted the
first. The investigation found five independent defects, all of them one bug — "who is *my* device?":

1. **Screen observation was not session-scoped.** `BackgroundCaptureScreenSource.GetLatestScreenshot()`
   answered every screen question with the frame of the **first** running session found by enumerating
   a `ConcurrentDictionary`. Every image match, OCR read, wait-for-image and readiness probe in a
   second run therefore evaluated a possibly foreign device — silently, and non-deterministically, so
   the run kept going and tapped the right coordinates on the wrong game.
2. **Five "exactly one running session" guards.** `ensure-game-running`, `go-to-home-screen`, primitive
   tap/swipe/key, `ForceExecuteStepAsync` and `ResolveSessionIdAsync` all hard-failed unless exactly
   one session existed — even when the step already carried an explicit session. Starting a second
   queue broke steps in the **first**.
3. **No exclusive claim on a device.** Spec 051 FR-013 explicitly allowed two runs on one emulator and
   left the interference to the operator.
4. **`MaxConcurrentSessions` defaulted to 3**, overflowing with a bare `capacity_exceeded`.
5. **`EmulatorImageEndpoints.PickSession`** chose an arbitrary session, so an operator could crop a
   reference image from the wrong emulator.

## What changed

**Session-scoped observation.** New `IScreenSourceFactory.ForSession(sessionId)` returns a
`SessionScopedScreenSource` bound to one session, used wherever a session id is already in hand
(`CommandExecutor` detection, `GameReadinessProbe`). For the paths that cannot take a session id —
trigger evaluators and condition adapters reached through `ITriggerEvaluator` — a new
`IDeviceContextAccessor` (`AsyncLocal<DeviceContext>`) is pushed by `SequenceExecutionService` for the
whole sequence, so everything it starts inherits the run's device. `BackgroundCaptureScreenSource` now
resolves **ambient context → the single running session → nothing**; the first-session scan is gone.

**One resolution rule.** `SessionResolver` replaces the five inlined guards: an explicit session always
wins; with none supplied and exactly one running, that one is used (single-emulator behaviour
unchanged); with several running it fails with `"N device sessions are active; specify a sessionId for
'<step>'"` rather than guessing.

**Exclusive device claims.** `IDeviceClaimRegistry` (atomic `TryAdd` over a `ConcurrentDictionary`
keyed by the trimmed, case-insensitive serial) gives a device to one run at a time. Claimed in
`StartAsync` before the run launches, released in `RunAsync`'s `finally` — which already covers
completion, manual stop, failure, cancellation and host shutdown. A same-device start returns
`409 device_in_use` naming the device and the holding queue, distinct from `already_running`, and is
recorded in the application log. Claims are in-memory only.

**Supporting changes.** `MaxConcurrentSessions` 3 → 8 with a message naming the limit and the setting;
the monitor reports each run's own `deviceSerial`; `GET /api/emulator/screenshot` takes `sessionId` or
`serial` and returns `409 ambiguous_session` instead of picking a device.

This reverses **051 FR-013** (same-emulator concurrency allowed). That spec's Status line and
`specs/STATUS.md` are updated; FR-013a (no second run of the same queue) is unchanged.

## Tests

| Suite | Before | After |
|---|---|---|
| Unit | 841 | **905** |
| Integration | 303 | **311** (+1 skipped, with rationale) |
| Contract | 117 | **125** |
| web-ui jest | 637 | **638** |

Build clean (0 warnings, 0 errors). `docs/architecture.md` updated with a refreshed review date, per
Constitution Principle V.

Deviations from the task plan (including one requirement moved from integration to unit level because
`Service:Sessions:*` cannot be overridden inside `WebApplicationFactory`) are recorded in
[`tasks.md`](specs/079-concurrent-queue-execution/tasks.md#deviations-from-the-plan-recorded-at-implementation-time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
