### PR TITLE
Stop reporting a command step as executed when nothing reached the device

### DIFF
--- a/src/GameBot.Domain/Commands/SequenceStep.cs
+++ b/src/GameBot.Domain/Commands/SequenceStep.cs
@@ -48,6 +48,26 @@ namespace GameBot.Domain.Commands {
     public RetryPolicy? Retry { get; set; }
     public GateConfig? Gate { get; set; }
 
+    /// <summary>
+    /// Opt-in strictness for a command step: when <c>true</c>, the step FAILS (and so aborts the
+    /// sequence) if the command it invoked dispatched no input to the device — typically an
+    /// image-anchored tap whose template was not found within its retries.
+    /// <para>
+    /// Defaults to <c>false</c>, which keeps the long-standing behavior of carrying on, because
+    /// "tap it if it happens to be there" is a deliberate and widespread authoring pattern: loops
+    /// that drain a list until nothing matches, and retry loops that expect early misses, both
+    /// rely on a missed tap being survivable. Turning that into a failure by default would abort
+    /// those sequences on the very iteration that is supposed to end them.
+    /// </para>
+    /// <para>
+    /// Set it on steps that guard a screen transition, where a missed tap means every later step
+    /// is running against the wrong screen. Regardless of this flag, a step that dispatched
+    /// nothing now reports <c>not_executed</c> rather than <c>executed</c>, so the miss is always
+    /// visible in the execution log and available to a <c>commandOutcome</c> condition.
+    /// </para>
+    /// </summary>
+    public bool RequireDispatch { get; set; }
+
     // Loop-step properties (StepType == Loop)
     /// <summary>Loop configuration (count, while, or repeat-until). Required when <see cref="StepType"/> is <see cref="SequenceStepType.Loop"/>.</summary>
     public LoopConfig? Loop { get; set; }

--- a/src/GameBot.Domain/Services/CommandDispatchOutcome.cs
+++ b/src/GameBot.Domain/Services/CommandDispatchOutcome.cs
@@ -1,0 +1,27 @@
+namespace GameBot.Domain.Services;
+
+/// <summary>
+/// Result of invoking a command from a sequence step through the optional command dispatcher
+/// supplied to <see cref="SequenceRunner.ExecuteAsync"/>.
+/// <para>
+/// The runner previously had no way to see what a command actually did: the invoking callback
+/// returned a bare <c>Task</c>, so a command that completed without throwing always recorded
+/// <c>executed</c> on its step — even when the only thing it contained was an image-anchored tap
+/// that never found its template and so sent nothing to the device. That made a failed recovery
+/// guard indistinguishable in the log from a successful one.
+/// </para>
+/// </summary>
+/// <param name="Dispatched">
+/// <c>false</c> when the command completed but no input reached the device — every input-bearing
+/// step in it was skipped (template not detected, unresolved parameter, invalid configuration).
+/// Observational steps (waiting for an image) and lifecycle steps (ensuring the emulator or game
+/// is running) are not input-bearing and never, on their own, make this false.
+/// </param>
+/// <param name="Reason">
+/// Reason code from the first step that failed to dispatch (e.g. <c>detection_failed_after_3_retries</c>),
+/// recorded on the sequence step so the miss is legible without opening the command's own subtree.
+/// </param>
+public sealed record CommandDispatchOutcome(bool Dispatched, string? Reason) {
+  /// <summary>The ordinary case: the command ran and its input reached the device.</summary>
+  public static readonly CommandDispatchOutcome Executed = new(true, null);
+}

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -82,6 +82,7 @@ namespace GameBot.Domain.Services {
     public async Task<SequenceExecutionResult> ExecuteAsync(
         string sequenceId,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher = null,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator = null,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator = null,
         Func<SequenceActionPayload, CancellationToken, Task<ActionDispatchResult>>? actionDispatcher = null,
@@ -102,7 +103,7 @@ namespace GameBot.Domain.Services {
       if (_logger != null) LogSequenceStart(_logger, sequenceId, null);
 
       if (!string.IsNullOrWhiteSpace(sequence.EntryStepId) && sequence.FlowSteps.Count > 0) {
-        await ExecuteFlowGraphAsync(sequence, executeCommandAsync, conditionEvaluator, result, ct).ConfigureAwait(false);
+        await ExecuteFlowGraphAsync(sequence, executeCommandAsync, commandDispatcher, conditionEvaluator, result, ct).ConfigureAwait(false);
         if (_logger != null) LogSequenceEnd(_logger, sequenceId, result.Status, null);
         return result;
       }
@@ -117,6 +118,7 @@ namespace GameBot.Domain.Services {
         var earlyStop = await ExecuteSingleStepAsync(
             step,
             executeCommandAsync,
+            commandDispatcher,
             gateEvaluator,
             conditionEvaluator,
             delayRange,
@@ -151,6 +153,7 @@ namespace GameBot.Domain.Services {
     private async Task ExecuteFlowGraphAsync(
         CommandSequence sequence,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         SequenceExecutionResult result,
         CancellationToken ct) {
@@ -431,6 +434,7 @@ namespace GameBot.Domain.Services {
     private async Task<bool> ExecuteSingleStepAsync(
         SequenceStep originalStep,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         DelayRangeMs interStepDelayRange,
@@ -453,6 +457,7 @@ namespace GameBot.Domain.Services {
         return await ExecuteLoopStepAsync(
             step,
             executeCommandAsync,
+            commandDispatcher,
             gateEvaluator,
             conditionEvaluator,
             interStepDelayRange,
@@ -470,6 +475,7 @@ namespace GameBot.Domain.Services {
         var (ifEarlyStop, _) = await ExecuteIfStepAsync(
             step,
             executeCommandAsync,
+            commandDispatcher,
             gateEvaluator,
             conditionEvaluator,
             interStepDelayRange,
@@ -671,6 +677,7 @@ namespace GameBot.Domain.Services {
 
       if (_logger != null) LogCommandStart(_logger, step.CommandId, null);
       var cmdStart = DateTimeOffset.UtcNow;
+      var cmdDispatch = CommandDispatchOutcome.Executed;
       try {
         // The step's bindings become an inner layer, so the invoked command sees them ahead of
         // anything inherited. The command's own declarations are layered on by the caller, which is
@@ -678,7 +685,10 @@ namespace GameBot.Domain.Services {
         var commandScope = originalStep.ParameterBindings is { Count: > 0 }
             ? scope.Child(ParameterScopeLayers.Command, originalStep.ParameterBindings, null)
             : scope;
-        await executeCommandAsync(step.CommandId, commandScope).ConfigureAwait(false);
+        cmdDispatch = commandDispatcher is not null
+            ? await commandDispatcher(step.CommandId, commandScope).ConfigureAwait(false)
+            : CommandDispatchOutcome.Executed;
+        if (commandDispatcher is null) await executeCommandAsync(step.CommandId, commandScope).ConfigureAwait(false);
       }
       catch (Exception ex) {
         var reason = !string.IsNullOrWhiteSpace(ex.Message) ? ex.Message : $"step '{stepKey}' command execution failed";
@@ -695,6 +705,46 @@ namespace GameBot.Domain.Services {
         return true;
       }
       var durationMs = (int)(DateTimeOffset.UtcNow - cmdStart).TotalMilliseconds;
+
+      // The command ran without throwing, but nothing it contained reached the device — an
+      // image-anchored tap that never found its template is the usual cause. Reporting "executed"
+      // here is what let a recovery guard look successful while changing nothing on screen, so the
+      // miss is always recorded honestly. Whether it also STOPS the sequence is the author's call:
+      // "tap it if it is there" is a legitimate and common pattern (loops that drain a list until
+      // nothing matches end precisely on a miss), so only a step marked RequireDispatch fails.
+      if (!cmdDispatch.Dispatched) {
+        var missReason = !string.IsNullOrWhiteSpace(cmdDispatch.Reason)
+            ? cmdDispatch.Reason!
+            : "command dispatched no input to the device";
+        if (originalStep.RequireDispatch) {
+          var failure = $"step '{stepKey}' requires dispatch but {missReason}";
+          result.AddStep(
+              step.CommandId,
+              appliedDelay,
+              "Failed",
+              conditionType: step.Condition is null ? null : step.Condition.Type,
+              conditionResult: step.Condition is null ? null : "true",
+              actionOutcome: "not_executed",
+              message: failure);
+          result.Fail(failure);
+          if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "failed";
+          if (_logger != null) LogCommandEnd(_logger, step.CommandId, durationMs, null);
+          return true;
+        }
+
+        result.AddStep(
+            step.CommandId,
+            appliedDelay,
+            "Succeeded",
+            conditionType: step.Condition is null ? null : step.Condition.Type,
+            conditionResult: step.Condition is null ? null : "true",
+            actionOutcome: "not_executed",
+            message: missReason);
+        if (!string.IsNullOrWhiteSpace(stepKey)) stepOutcomes[stepKey] = "not_executed";
+        if (_logger != null) LogCommandEnd(_logger, step.CommandId, durationMs, null);
+        return false;
+      }
+
       result.AddStep(
           step.CommandId,
           appliedDelay,
@@ -811,6 +861,7 @@ namespace GameBot.Domain.Services {
     private Task<bool> ExecuteSingleStepAsync(
         SequenceStep step,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         SequenceExecutionResult result,
         string sequenceId,
@@ -818,6 +869,7 @@ namespace GameBot.Domain.Services {
       return ExecuteSingleStepAsync(
           step,
           executeCommandAsync,
+          commandDispatcher,
           gateEvaluator,
           conditionEvaluator: null,
           interStepDelayRange: new DelayRangeMs { Min = DefaultInterStepDelayMinMs, Max = DefaultInterStepDelayMaxMs },
@@ -843,6 +895,7 @@ namespace GameBot.Domain.Services {
     private async Task<bool> ExecuteLoopStepAsync(
         SequenceStep step,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         DelayRangeMs interStepDelayRange,
@@ -859,17 +912,17 @@ namespace GameBot.Domain.Services {
       switch (step.Loop) {
         case CountLoopConfig countCfg:
           return await ExecuteCountLoopAsync(step, stepKey, countCfg,
-              executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+              executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
               stepOutcomes, result, sequenceId, actionDispatcher, scope, ct).ConfigureAwait(false);
 
         case WhileLoopConfig whileCfg:
           return await ExecuteWhileLoopAsync(step, stepKey, whileCfg, maxIterations,
-              executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+              executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
               stepOutcomes, result, sequenceId, actionDispatcher, scope, ct).ConfigureAwait(false);
 
         case RepeatUntilLoopConfig ruCfg:
           return await ExecuteRepeatUntilLoopAsync(step, stepKey, ruCfg, maxIterations,
-              executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+              executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
               stepOutcomes, result, sequenceId, actionDispatcher, scope, ct).ConfigureAwait(false);
 
         default:
@@ -886,6 +939,7 @@ namespace GameBot.Domain.Services {
         string stepKey,
         CountLoopConfig cfg,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         DelayRangeMs interStepDelayRange,
@@ -910,7 +964,7 @@ namespace GameBot.Domain.Services {
 
         var iterCtx = scope.WithIteration(i + 1);
         var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
-            step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+            step.Body, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
             stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
         iterResults.Add(new LoopIterResult { IterationIndex = i + 1, BreakTriggered = breakTriggered, StepCount = stepCount });
@@ -936,6 +990,7 @@ namespace GameBot.Domain.Services {
         WhileLoopConfig cfg,
         int maxIterations,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         DelayRangeMs interStepDelayRange,
@@ -988,7 +1043,7 @@ namespace GameBot.Domain.Services {
 
         var iterCtx = scope.WithIteration(iterations);
         var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
-            step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+            step.Body, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
             stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
         iterResults.Add(new LoopIterResult { IterationIndex = iterations, BreakTriggered = breakTriggered, StepCount = stepCount });
@@ -1014,6 +1069,7 @@ namespace GameBot.Domain.Services {
         RepeatUntilLoopConfig cfg,
         int maxIterations,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         DelayRangeMs interStepDelayRange,
@@ -1040,7 +1096,7 @@ namespace GameBot.Domain.Services {
 
         var iterCtx = scope.WithIteration(iterations);
         var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
-            step.Body, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+            step.Body, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
             stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
         iterResults.Add(new LoopIterResult { IterationIndex = iterations, BreakTriggered = breakTriggered, StepCount = stepCount });
@@ -1093,6 +1149,7 @@ namespace GameBot.Domain.Services {
     private async Task<(bool EarlyStop, bool BreakTriggered)> ExecuteIfStepAsync(
         SequenceStep step,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         DelayRangeMs interStepDelayRange,
@@ -1148,7 +1205,7 @@ namespace GameBot.Domain.Services {
       }
 
       var (earlyStop, breakTriggered, _) = await ExecuteLoopBodyAsync(
-          branch, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+          branch, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
           stepOutcomes, result, sequenceId, iterScope, actionDispatcher, ct).ConfigureAwait(false);
 
       if (earlyStop) {
@@ -1169,6 +1226,7 @@ namespace GameBot.Domain.Services {
     private async Task<(bool EarlyStop, bool BreakTriggered, int StepCount)> ExecuteLoopBodyAsync(
         IReadOnlyList<SequenceStep> bodySteps,
         Func<string, ParameterScope, Task> executeCommandAsync,
+        Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
         Func<SequenceStep, CancellationToken, Task<bool>>? gateEvaluator,
         Func<Condition, CancellationToken, Task<bool>>? conditionEvaluator,
         DelayRangeMs interStepDelayRange,
@@ -1251,7 +1309,7 @@ namespace GameBot.Domain.Services {
           // Nested if: executed with the current iteration context so branch steps keep
           // {{iteration}} substitution, and a break inside a branch exits the enclosing loop.
           var (ifEarlyStop, ifBreakTriggered) = await ExecuteIfStepAsync(
-              step, executeCommandAsync, gateEvaluator, conditionEvaluator, interStepDelayRange,
+              step, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
               stepOutcomes, result, sequenceId, iterScope, actionDispatcher, ct).ConfigureAwait(false);
           stepsExecuted++;
 
@@ -1271,6 +1329,7 @@ namespace GameBot.Domain.Services {
         var earlyStop = await ExecuteSingleStepAsync(
             step,
             executeCommandAsync,
+            commandDispatcher,
             gateEvaluator,
             conditionEvaluator,
             interStepDelayRange,
@@ -1544,7 +1603,7 @@ namespace GameBot.Domain.Services {
             }
             else if (se.ValueKind == JsonValueKind.Object) {
               var step = ToSequenceStep(se);
-              var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
+              var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, null, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
               if (earlyStop) {
                 var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
                 result.AddBlock(new BlockResult { BlockType = "while", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
@@ -1633,7 +1692,7 @@ namespace GameBot.Domain.Services {
           }
           else if (se.ValueKind == JsonValueKind.Object) {
             var step = ToSequenceStep(se);
-            var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
+            var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, null, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
             if (earlyStop) return;
           }
         }
@@ -1713,7 +1772,7 @@ namespace GameBot.Domain.Services {
             }
             else if (se.ValueKind == JsonValueKind.Object) {
               var step = ToSequenceStep(se);
-              var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
+              var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, null, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
               if (earlyStop) {
                 var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
                 result.AddBlock(new BlockResult { BlockType = "repeatUntil", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });
@@ -1864,7 +1923,7 @@ namespace GameBot.Domain.Services {
             }
             else if (se.ValueKind == JsonValueKind.Object) {
               var step = ToSequenceStep(se);
-              var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
+              var earlyStop = await ExecuteSingleStepAsync(step, executeCommandAsync, null, gateEvaluator, result, sequenceId, ct).ConfigureAwait(false);
               if (earlyStop) {
                 var dur = (int)(DateTimeOffset.UtcNow - start).TotalMilliseconds;
                 result.AddBlock(new BlockResult { BlockType = "repeatCount", Iterations = iterations, Evaluations = evals, DurationMs = dur, Status = "Failed" });

--- a/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
@@ -542,6 +542,7 @@ internal static class SequencesEndpoints {
       stepType,
       commandReference = MapCommandReferenceToDto(step, commandLookup),
       parameterBindings = ParameterDtoMapper.ToResponseBindings(step.ParameterBindings),
+      requireDispatch = step.RequireDispatch ? true : (bool?)null,
       primitiveAction = step.Action is null
         ? null
         : new {
@@ -871,6 +872,7 @@ internal static class SequencesEndpoints {
           Action = step.PrimitiveAction is not null ? new SequenceActionPayload { Type = step.PrimitiveAction.Type, SchemaVersion = step.PrimitiveAction.SchemaVersion } : null,
           WaitForImage = MapWaitForImageConfig(step.PrimitiveAction),
           Condition = MapPerStepCondition(step.Condition),
+          RequireDispatch = step.RequireDispatch ?? false,
           // Feature 078: normalize an empty list to null so unparametrized steps stay byte-identical.
           ParameterBindings = step.ParameterBindings is { Count: > 0 }
             ? new System.Collections.ObjectModel.Collection<GameBot.Domain.Parameters.ParameterBinding>(

--- a/src/GameBot.Service/Models/SequenceStepContracts.cs
+++ b/src/GameBot.Service/Models/SequenceStepContracts.cs
@@ -51,6 +51,14 @@ internal sealed record SequenceStepContract {
   /// step; a binding with a null value means "inherit", which is the default for every row.
   /// </summary>
   public IReadOnlyList<ParameterBindingDto>? ParameterBindings { get; init; }
+
+  /// <summary>
+  /// Opt-in strictness: when <c>true</c>, this step fails (aborting the sequence) if the command it
+  /// invokes puts no input on the device — typically an image-anchored tap that never found its
+  /// template. Defaults to <c>false</c>, matching the long-standing "carry on" behavior that loops
+  /// draining a list, and retry loops, depend on. Omitted from responses when false.
+  /// </summary>
+  public bool? RequireDispatch { get; init; }
 }
 
 /// <summary>

--- a/src/GameBot.Service/Services/ICommandExecutor.cs
+++ b/src/GameBot.Service/Services/ICommandExecutor.cs
@@ -13,6 +13,14 @@ internal interface ICommandExecutor {
   /// invoked as part of a sequence is recorded as a linked child rather than a top-level entry.
   /// </summary>
   Task<CommandForceExecutionResult> ForceExecuteDetailedAsync(string? sessionId, string commandId, ExecutionLogContext context, CancellationToken ct = default);
+
+  /// <summary>
+  /// Force-executes a command with a parameter scope and returns its per-step outcomes, so a caller
+  /// can tell whether the command actually put input on the device rather than only that it did not
+  /// throw. The sequence runner needs this to avoid recording <c>executed</c> for a command whose
+  /// image-anchored tap never found its template.
+  /// </summary>
+  Task<CommandForceExecutionResult> ForceExecuteDetailedAsync(string? sessionId, string commandId, ExecutionLogContext context, ParameterScope scope, CancellationToken ct = default);
   Task<int> ForceExecuteAsync(string? sessionId, string commandId, CancellationToken ct = default);
   Task<int> ForceExecuteAsync(string? sessionId, string commandId, ExecutionLogContext context, CancellationToken ct = default);
 

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -129,9 +129,10 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     // the extra firing is attributable in the execution log (feature 065, FR-014).
     var selfRescheduleOriginActionId = parentContext?.SelfRescheduleOriginActionId;
 
-    var res = await _runner.ExecuteAsync(
-      sequenceId,
-      async (commandId, stepScope) => {
+    // Invokes one command step and reports whether its input actually reached the device, so the
+    // runner can record an honest outcome instead of assuming "executed" whenever nothing threw.
+    async Task<GameBot.Domain.Services.CommandDispatchOutcome> DispatchCommandAsync(string commandId, GameBot.Domain.Parameters.ParameterScope stepScope) {
+      {
         try {
           var childContext = new ExecutionLogContext {
             ParentExecutionId = rootExecutionId,
@@ -142,7 +143,8 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
             SequenceLabel = startSequenceName,
             OriginatingQueueId = originatingQueueId
           };
-          await _commandExecutor.ForceExecuteAsync(sessionId, commandId, childContext, stepScope, ct).ConfigureAwait(false);
+          var detailed = await _commandExecutor.ForceExecuteDetailedAsync(sessionId, commandId, childContext, stepScope, ct).ConfigureAwait(false);
+          return ClassifyDispatch(detailed, ct);
         }
         catch (KeyNotFoundException ex) when (ex.Message == "cached_session_not_found") {
           throw new InvalidOperationException($"No cached session found for command '{commandId}'. Start a session first.");
@@ -160,7 +162,15 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
             : $"Command '{commandId}' could not be executed: {ex.Message}.";
           throw new InvalidOperationException(reason);
         }
-      },
+      }
+    }
+
+    var res = await _runner.ExecuteAsync(
+      sequenceId,
+      // Never reached in production — the runner prefers the dispatcher below — but kept a real
+      // call rather than a throwing stub so the legacy contract stays honest.
+      async (commandId, stepScope) => await DispatchCommandAsync(commandId, stepScope).ConfigureAwait(false),
+      commandDispatcher: DispatchCommandAsync,
       gateEvaluator: (step, token) => {
         // Temporary evaluator for integration tests:
         // TargetId "always" => gate passes; "never" => gate fails
@@ -804,6 +814,38 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
     }
 
     return await imageVisibleConditionAdapter.EvaluateAsync(cond, token).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  /// Command step types that put input on the device. Only these can make a command "dispatch
+  /// nothing": waiting for an image is observational, and the ensure-emulator/ensure-game steps
+  /// carry their own reason codes (a deliberately optional readiness gate among them), so neither
+  /// says anything about whether a tap landed.
+  /// </summary>
+  private static bool IsInputBearing(PrimitiveTapStepOutcome outcome) =>
+    outcome.StepType is null                       // primitive tap: the only kind that leaves StepType unset
+    || string.Equals(outcome.StepType, "key", StringComparison.OrdinalIgnoreCase)
+    || string.Equals(outcome.StepType, "swipe", StringComparison.OrdinalIgnoreCase)
+    || string.Equals(outcome.StepType, "go-to-home-screen", StringComparison.OrdinalIgnoreCase);
+
+  /// <summary>
+  /// Decides whether a finished command actually put input on the device. A command with no
+  /// input-bearing steps at all (a pure wait, say) counts as dispatched: it did everything it was
+  /// asked to. Cancellation is deliberately NOT reported as a miss — a stopped queue or a tripped
+  /// watchdog must keep surfacing as cancellation rather than as a sequence failure.
+  /// </summary>
+  private static CommandDispatchOutcome ClassifyDispatch(CommandForceExecutionResult result, CancellationToken ct) {
+    if (ct.IsCancellationRequested) return CommandDispatchOutcome.Executed;
+
+    var inputSteps = result.StepOutcomes.Where(IsInputBearing).ToList();
+    if (inputSteps.Count == 0) return CommandDispatchOutcome.Executed;
+    if (inputSteps.Any(o => string.Equals(o.Status, "executed", StringComparison.OrdinalIgnoreCase)))
+      return CommandDispatchOutcome.Executed;
+    if (inputSteps.Any(o => string.Equals(o.Status, "cancelled", StringComparison.OrdinalIgnoreCase)))
+      return CommandDispatchOutcome.Executed;
+
+    var first = inputSteps[0];
+    return new CommandDispatchOutcome(false, first.Reason ?? first.Status);
   }
 
   private static IEnumerable<SequenceStep> FlattenSequenceSteps(IEnumerable<SequenceStep> steps) {

--- a/tests/unit/Sequences/SequenceRunnerCommandDispatchOutcomeTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerCommandDispatchOutcomeTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Domain.Commands;
+using GameBot.Domain.Parameters;
+using GameBot.Domain.Services;
+using Xunit;
+
+// Test-code analyzer relaxations (permitted by the constitution for test code).
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Sequences;
+
+/// <summary>
+/// A command step that dispatched no input to the device must stop reporting <c>executed</c>.
+/// It reports <c>not_executed</c> instead, and fails the step only when the author opted in with
+/// <see cref="SequenceStep.RequireDispatch"/> — because "tap it if it is there" is a deliberate
+/// pattern that loops draining a list, and retry loops, depend on.
+/// </summary>
+public sealed class SequenceRunnerCommandDispatchOutcomeTests {
+  private sealed class StubRepo : ISequenceRepository {
+    private readonly CommandSequence _sequence;
+    public StubRepo(CommandSequence sequence) => _sequence = sequence;
+    public Task<CommandSequence?> GetAsync(string id) => Task.FromResult<CommandSequence?>(_sequence);
+    public Task<IReadOnlyList<CommandSequence>> ListAsync() => Task.FromResult<IReadOnlyList<CommandSequence>>(new List<CommandSequence> { _sequence });
+    public Task<CommandSequence> CreateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<CommandSequence> UpdateAsync(CommandSequence sequence) => Task.FromResult(sequence);
+    public Task<bool> DeleteAsync(string id) => Task.FromResult(true);
+  }
+
+  private static SequenceStep CommandStep(string id, bool requireDispatch = false) => new() {
+    StepId = id,
+    CommandId = id,
+    StepType = SequenceStepType.Action,
+    RequireDispatch = requireDispatch
+  };
+
+  private static SequenceRunner RunnerFor(params SequenceStep[] steps) {
+    var sequence = new CommandSequence { Id = "seq", Name = "Seq" };
+    sequence.SetSteps(steps.Select((s, i) => { s.Order = i; return s; }).ToArray());
+    sequence.InterStepDelayRangeMs = new DelayRangeMs { Min = 0, Max = 0 };
+    return new SequenceRunner(new StubRepo(sequence));
+  }
+
+  private static Func<string, ParameterScope, Task<CommandDispatchOutcome>> Dispatcher(
+      params (string Command, bool Dispatched)[] outcomes) {
+    var map = outcomes.ToDictionary(o => o.Command, o => o.Dispatched, StringComparer.Ordinal);
+    return (commandId, _) => Task.FromResult(
+      map.TryGetValue(commandId, out var ok) && !ok
+        ? new CommandDispatchOutcome(false, "detection_failed_after_3_retries")
+        : CommandDispatchOutcome.Executed);
+  }
+
+  [Fact]
+  public async Task DispatchedCommandStillReportsExecuted() {
+    var runner = RunnerFor(CommandStep("a"));
+
+    var res = await runner.ExecuteAsync("seq", (_, _) => Task.CompletedTask,
+        commandDispatcher: Dispatcher(("a", true)), ct: CancellationToken.None);
+
+    res.Status.Should().Be("Succeeded");
+    res.Steps.Single().ActionOutcome.Should().Be("executed");
+  }
+
+  [Fact] // The reported bug: a missed anchored tap used to be indistinguishable from a real one.
+  public async Task CommandThatDispatchedNothingReportsNotExecutedInsteadOfExecuted() {
+    var runner = RunnerFor(CommandStep("a"));
+
+    var res = await runner.ExecuteAsync("seq", (_, _) => Task.CompletedTask,
+        commandDispatcher: Dispatcher(("a", false)), ct: CancellationToken.None);
+
+    res.Steps.Single().ActionOutcome.Should().Be("not_executed");
+    res.Steps.Single().Message.Should().Contain("detection_failed_after_3_retries");
+  }
+
+  [Fact] // Default stays lenient: the sequence carries on and still succeeds.
+  public async Task WithoutRequireDispatchAMissDoesNotFailTheSequence() {
+    var runner = RunnerFor(CommandStep("a"), CommandStep("b"));
+    var ran = new List<string>();
+
+    var res = await runner.ExecuteAsync("seq", (_, _) => Task.CompletedTask,
+        commandDispatcher: (id, _) => {
+          ran.Add(id);
+          return Task.FromResult(id == "a"
+            ? new CommandDispatchOutcome(false, "detection_failed_after_3_retries")
+            : CommandDispatchOutcome.Executed);
+        },
+        ct: CancellationToken.None);
+
+    res.Status.Should().Be("Succeeded");
+    ran.Should().Equal("a", "b"); // the miss did not stop the run
+  }
+
+  [Fact] // Opt-in strict: the guard case — a missed tap must abort rather than carry on blindly.
+  public async Task RequireDispatchFailsTheStepAndStopsTheSequence() {
+    var runner = RunnerFor(CommandStep("a", requireDispatch: true), CommandStep("b"));
+    var ran = new List<string>();
+
+    var res = await runner.ExecuteAsync("seq", (_, _) => Task.CompletedTask,
+        commandDispatcher: (id, _) => {
+          ran.Add(id);
+          return Task.FromResult(id == "a"
+            ? new CommandDispatchOutcome(false, "detection_failed_after_3_retries")
+            : CommandDispatchOutcome.Executed);
+        },
+        ct: CancellationToken.None);
+
+    res.Status.Should().Be("Failed");
+    res.Steps.Single().ActionOutcome.Should().Be("not_executed");
+    ran.Should().Equal("a"); // "b" never ran — no acting on the wrong screen
+  }
+
+  [Fact] // RequireDispatch is irrelevant while the command keeps dispatching.
+  public async Task RequireDispatchIsANoOpWhenTheCommandDispatches() {
+    var runner = RunnerFor(CommandStep("a", requireDispatch: true), CommandStep("b"));
+
+    var res = await runner.ExecuteAsync("seq", (_, _) => Task.CompletedTask,
+        commandDispatcher: Dispatcher(("a", true), ("b", true)), ct: CancellationToken.None);
+
+    res.Status.Should().Be("Succeeded");
+    res.Steps.Should().HaveCount(2);
+  }
+
+  [Fact] // Callers that supply no dispatcher (every existing one) keep the old contract exactly.
+  public async Task WithoutADispatcherBehaviourIsUnchanged() {
+    var runner = RunnerFor(CommandStep("a", requireDispatch: true));
+    var ran = 0;
+
+    var res = await runner.ExecuteAsync("seq", (_, _) => { ran++; return Task.CompletedTask; },
+        ct: CancellationToken.None);
+
+    ran.Should().Be(1);
+    res.Status.Should().Be("Succeeded");
+    res.Steps.Single().ActionOutcome.Should().Be("executed");
+  }
+
+  [Fact] // The drain-until-empty loop: the terminating iteration misses, and that must be survivable.
+  public async Task ALoopThatDrainsUntilNothingMatchesStillCompletes() {
+    var loop = new SequenceStep {
+      StepId = "drain",
+      StepType = SequenceStepType.Loop,
+      Loop = new CountLoopConfig { Count = 3 },
+      Body = new[] { CommandStep("claim") }
+    };
+    var runner = RunnerFor(loop);
+    var calls = 0;
+
+    var res = await runner.ExecuteAsync("seq", (_, _) => Task.CompletedTask,
+        commandDispatcher: (_, _) => {
+          calls++;
+          // Two items to claim, then nothing left to tap.
+          return Task.FromResult(calls <= 2
+            ? CommandDispatchOutcome.Executed
+            : new CommandDispatchOutcome(false, "detection_failed_after_3_retries"));
+        },
+        ct: CancellationToken.None);
+
+    res.Status.Should().Be("Succeeded");
+    calls.Should().Be(3); // the loop ran to completion instead of aborting on the empty iteration
+  }
+}


### PR DESCRIPTION
## The bug

A sequence step that invokes a command was marked `Succeeded` / `"executed"` purely because the call did not throw. [SequenceExecutionService.cs:145](https://github.com/bbqf/GameBotAI/blob/master/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs#L145) called `ForceExecuteAsync` and **discarded its return value**, so the command's own step outcomes never reached the runner — an image-anchored tap that never found its template was indistinguishable from one that landed.

That is how `PNS Update Popup Guard` failed silently twice on emulator-5556. The `If` matched the popup, the tap inside it reported `detection_failed_after_3_retries`, and the step still logged:

```
command [success] PNS Dismiss Blocking Popup | ... with outcome 'executed'.
  tap [not_executed] primitiveTap | detection_failed_after_3_retries
```

…while the modal stayed on screen. The primitive-action path immediately above already had this right — *"a primitive step must never report success when nothing reached the device"* — the command path just never did.

## The change

- **`CommandDispatchOutcome`** — what a command step actually achieved. Threaded through the modern runner path as an optional `commandDispatcher`, so every existing caller (and all the runner tests) keeps compiling against the old `Func<…, Task>` callback with unchanged behavior.
- **Classification** lives in `SequenceExecutionService`: a command "dispatched nothing" only when it *has* input-bearing steps (tap / key / swipe / go-to-home) and none executed. Waiting for an image is observational, and `ensure-emulator` / `ensure-game` steps carry their own reason codes (including a deliberately optional readiness gate), so neither can trigger it. **Cancellation is never reported as a miss** — a stopped queue or a tripped watchdog must keep surfacing as cancellation, not as a sequence failure.
- A miss records `actionOutcome: "not_executed"` with the reason, and sets the step outcome to `not_executed` so a `commandOutcome` condition can branch on it.

## Why failing is opt-in, not the default

This is the part worth reviewing. I surveyed the live library before choosing:

- **86 of 90 commands** contain image-anchored taps.
- **14 of them sit inside loops with no guarding condition, where missing IS the mechanism.**

| Sequence | Step | Why a miss is normal |
|---|---|---|
| PNS Daily Quest Chests | Claim one quest | drains until no quest remains |
| PNS Mystery Shop Daily | Exchange top-most resource item | drains until nothing left |
| Hero Duel / Cmdr Duel / Campaign / Prison | Open Daily To-Do | retries until the screen appears |

A failed step early-stops its loop and aborts the sequence ([SequenceRunner.cs:920](https://github.com/bbqf/GameBotAI/blob/master/src/GameBot.Domain/Services/SequenceRunner.cs#L920)). So "missed tap ⇒ sequence fails" would break those on the very iteration meant to end them — and they succeed daily today.

Hence `SequenceStep.RequireDispatch`, **default `false`**. It round-trips through the sequence API and is omitted from responses when false, so untouched sequences serialise byte-identically. Set it on steps that guard a screen transition, where a missed tap means every later step runs against the wrong screen — the popup guard being the motivating case.

The queue is unaffected either way: a failed sequence is already non-fatal there (`failed++`, run continues), which is the behavior asked for — the sequence fails, the queue does not.

## Tests

7 new cases: executed vs. miss reporting, the lenient default, opt-in failure and its stop-the-sequence effect, unchanged no-dispatcher behavior, and a drain-until-empty loop that must survive a miss.

- 913 unit ✅ (+7)
- 311 integration ✅ (1 pre-existing skip)
- 125 contract ✅

## Follow-up after deploy

Nothing sets `RequireDispatch` yet — it wants a live edit to the guard once this ships, plus a look at three condition/tap threshold mismatches this survey turned up in `PNS Campaign Daily` (condition `0.80` vs tap `0.85` on the same image), which are the same latent class of bug that bit the guard.

Independent of PR #158; branched from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
