### PR TITLE
Bring the game back to the foreground before each queue firing

### DIFF
--- a/src/GameBot.Service/GameBotServiceSetup.cs
+++ b/src/GameBot.Service/GameBotServiceSetup.cs
@@ -145,6 +145,11 @@ internal static class GameBotServiceSetup {
     });
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IAdbGameOperations, GameBot.Service.Services.EnsureGameRunning.AdbGameOperations>();
     builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IEnsureGameRunningActionHandler, GameBot.Service.Services.EnsureGameRunning.EnsureGameRunningActionHandler>();
+    // Keeps the game in front across a long queue run, so a game pushed out of the foreground mid-run
+    // is recovered at the next firing instead of leaving the queue running but achieving nothing.
+    builder.Services.AddSingleton<GameBot.Service.Services.EnsureGameRunning.IGameForegroundGuard>(sp =>
+      new GameBot.Service.Services.EnsureGameRunning.GameForegroundGuard(
+        sp.GetRequiredService<GameBot.Service.Services.EnsureGameRunning.IEnsureGameRunningActionHandler>()));
     // Readiness probe needs the vision stack (IScreenSource is Windows-only). Off Windows it stays
     // unregistered and the ensure-game-running step falls back to its foreground-only behavior.
     if (OperatingSystem.IsWindows()) {

--- a/src/GameBot.Service/Services/EnsureGameRunning/GameForegroundGuard.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/GameForegroundGuard.cs
@@ -1,0 +1,73 @@
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+/// <summary>
+/// Default <see cref="IGameForegroundGuard"/>, layered over the same
+/// <see cref="IEnsureGameRunningActionHandler"/> the ensure-game-running step uses, so the guard
+/// resolves the session's game and package exactly the way that step does.
+///
+/// The handler checks the foreground first and only issues a launch when the game is not in front,
+/// so the common case (game already up) costs a single ADB foreground query and the confirm loop is
+/// never entered. When the game IS out of the foreground the loop re-asks until the handler reports
+/// it back or the confirm window elapses; re-issuing a LAUNCHER intent at each poll is harmless —
+/// Android brings the existing task forward rather than restarting it, the same as tapping the app
+/// icon twice.
+/// </summary>
+internal sealed class GameForegroundGuard : IGameForegroundGuard {
+  /// <summary>
+  /// How long to keep confirming after a launch. The case this exists for is a backgrounded game
+  /// whose task is still alive, which returns within a poll or two; a genuine cold start will not
+  /// finish inside this window, and deliberately is not waited out — the firing proceeds (and most
+  /// likely fails, as it does today) and the NEXT firing's guard picks the recovery back up. That
+  /// keeps a dead game from stalling the whole queue behind one sequence's watchdog.
+  /// </summary>
+  private static readonly TimeSpan DefaultConfirmTimeout = TimeSpan.FromSeconds(15);
+  private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(2);
+
+  private readonly IEnsureGameRunningActionHandler _ensureGameRunning;
+  private readonly TimeSpan _confirmTimeout;
+  private readonly TimeSpan _pollInterval;
+  private readonly TimeProvider _timeProvider;
+
+  public GameForegroundGuard(
+      IEnsureGameRunningActionHandler ensureGameRunning,
+      TimeProvider? timeProvider = null,
+      TimeSpan? confirmTimeout = null,
+      TimeSpan? pollInterval = null) {
+    _ensureGameRunning = ensureGameRunning;
+    _timeProvider = timeProvider ?? TimeProvider.System;
+    _confirmTimeout = confirmTimeout ?? DefaultConfirmTimeout;
+    _pollInterval = pollInterval ?? DefaultPollInterval;
+  }
+
+  public async Task<GameForegroundGuardResult> EnsureForegroundAsync(string sessionId, CancellationToken ct = default) {
+    var first = await _ensureGameRunning.ExecuteAsync(sessionId, ct).ConfigureAwait(false);
+    if (first.Outcome == EnsureGameRunningOutcome.GameRunning) {
+      return new GameForegroundGuardResult(GameForegroundGuardOutcome.AlreadyForeground, first.ReasonCode);
+    }
+
+    // Anything other than "not running" means the guard cannot act here (no queue context, no linked
+    // game, no package name, non-Windows host). Report it as inapplicable so callers pass through
+    // unchanged rather than treating a configuration gap as a device problem.
+    if (first.Outcome != EnsureGameRunningOutcome.GameNotRunning) {
+      return new GameForegroundGuardResult(GameForegroundGuardOutcome.NotApplicable, first.ReasonCode);
+    }
+
+    // The first call already issued the launch. Confirm it landed.
+    var deadline = _timeProvider.GetUtcNow() + _confirmTimeout;
+    var last = first;
+    while (_timeProvider.GetUtcNow() < deadline) {
+      await Task.Delay(_pollInterval, ct).ConfigureAwait(false);
+
+      last = await _ensureGameRunning.ExecuteAsync(sessionId, ct).ConfigureAwait(false);
+      if (last.Outcome == EnsureGameRunningOutcome.GameRunning) {
+        return new GameForegroundGuardResult(GameForegroundGuardOutcome.Recovered, last.ReasonCode);
+      }
+
+      if (last.Outcome != EnsureGameRunningOutcome.GameNotRunning) {
+        return new GameForegroundGuardResult(GameForegroundGuardOutcome.NotApplicable, last.ReasonCode);
+      }
+    }
+
+    return new GameForegroundGuardResult(GameForegroundGuardOutcome.RecoveryFailed, last.ReasonCode);
+  }
+}

--- a/src/GameBot.Service/Services/EnsureGameRunning/IGameForegroundGuard.cs
+++ b/src/GameBot.Service/Services/EnsureGameRunning/IGameForegroundGuard.cs
@@ -1,0 +1,46 @@
+namespace GameBot.Service.Services.EnsureGameRunning;
+
+/// <summary>What a foreground guard pass did about the game's foreground state.</summary>
+internal enum GameForegroundGuardOutcome {
+  /// <summary>The game was already the foreground app; nothing was done.</summary>
+  AlreadyForeground,
+  /// <summary>The game was not in front; a launch was issued and the game came back within the confirm window.</summary>
+  Recovered,
+  /// <summary>The game was not in front and had not returned when the confirm window elapsed.</summary>
+  RecoveryFailed,
+  /// <summary>
+  /// The guard does not apply here — no queue context, no linked game, no package name configured,
+  /// or ADB is unavailable on this host. Callers treat this exactly like a pass.
+  /// </summary>
+  NotApplicable
+}
+
+internal sealed record GameForegroundGuardResult(GameForegroundGuardOutcome Outcome, string ReasonCode) {
+  /// <summary>True when the guard did real recovery work — the only outcome worth reporting.</summary>
+  public bool Recovered => Outcome == GameForegroundGuardOutcome.Recovered;
+
+  /// <summary>True when the game was verified absent from the foreground and did not come back.</summary>
+  public bool Failed => Outcome == GameForegroundGuardOutcome.RecoveryFailed;
+}
+
+/// <summary>
+/// Keeps the linked game in the foreground across a long-lived queue run.
+///
+/// A queue run binds one emulator for hours. Anything can push the game out of the foreground in
+/// that window — a recovery loop pressing BACK off the game's top-level screen, a crash, the user
+/// touching the emulator — and once that happens every subsequent image detection sees the device
+/// launcher instead of the game. Sequences then fail forever while the queue still reports
+/// "Running", because the only step that launches the game (a connect / ensure-game-running step)
+/// normally runs once at queue start and never again.
+///
+/// This guard closes that hole: the queue asks it to confirm the foreground before each firing, so
+/// a game that drops out is brought back at the next firing instead of never.
+/// </summary>
+internal interface IGameForegroundGuard {
+  /// <summary>
+  /// Confirms the session's linked game is the foreground app, launching it and waiting for it to
+  /// come back when it is not. Never throws for an unusable context — that surfaces as
+  /// <see cref="GameForegroundGuardOutcome.NotApplicable"/>.
+  /// </summary>
+  Task<GameForegroundGuardResult> EnsureForegroundAsync(string sessionId, CancellationToken ct = default);
+}

--- a/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
+++ b/src/GameBot.Service/Services/QueueExecution/QueueExecutionService.cs
@@ -59,6 +59,10 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
   // pre-session cold-start is skipped, degrading to the pre-074 behavior).
   private readonly IEnsureEmulatorRunningActionHandler? _ensureEmulatorRunning;
 
+  // Confirms the linked game is in front before each firing. Optional: when it is not wired the run
+  // behaves exactly as it did before the guard existed.
+  private readonly IGameForegroundGuard? _foregroundGuard;
+
   // How often a non-cyclic run re-checks pending relative/live timers while waiting for one to become
   // due. Small enough that a firing lands within roughly an iteration interval of the offset, large
   // enough to avoid a busy-wait. (feature 059)
@@ -91,7 +95,8 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     TimeProvider? timeProvider = null,
     IEnsureGameRunningActionHandler? ensureGameRunning = null,
     IEnsureEmulatorRunningActionHandler? ensureEmulatorRunning = null,
-    IDeviceClaimRegistry? deviceClaims = null) {
+    IDeviceClaimRegistry? deviceClaims = null,
+    IGameForegroundGuard? foregroundGuard = null) {
     _queues = queues;
     _runtime = runtime;
     _templates = templates;
@@ -106,6 +111,7 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     _ensureGameRunning = ensureGameRunning;
     _ensureEmulatorRunning = ensureEmulatorRunning;
     _deviceClaims = deviceClaims ?? new DeviceClaimRegistry();
+    _foregroundGuard = foregroundGuard;
   }
 
   public bool IsRunning(string queueId) => _registry.IsRunning(queueId);
@@ -566,6 +572,30 @@ internal sealed class QueueExecutionService : IQueueExecutionService {
     var trackedHandle = _registry.TryGet(queueId, out var handle) ? handle : null;
     trackedHandle?.SetCurrentSequence(sequenceId, _timeProvider.GetLocalNow());
     try {
+      // Foreground guard: a queue run holds one emulator for hours, and anything that pushes the
+      // game out of the foreground in that window (a recovery loop pressing BACK off the game's top
+      // screen, a crash, someone touching the emulator) makes every later image detection read the
+      // device launcher instead of the game. Without this, the run keeps firing sequences that can
+      // only fail — the game's launch step runs at queue start and never again — so the queue reports
+      // "Running" indefinitely while achieving nothing. Confirming the foreground here means a
+      // dropped-out game costs at most one firing instead of the rest of the run.
+      // Best-effort by design: a guard failure never fails the firing, exactly like the idle-pause
+      // foreground (FR-011). Runs under the watchdog token so a stop request cancels it promptly.
+      if (_foregroundGuard is not null) {
+        try {
+          var guard = await _foregroundGuard.EnsureForegroundAsync(sessionId, watchdog.Token).ConfigureAwait(false);
+          if (guard.Recovered) {
+            QueueExecutionLog.ForegroundGuardRecovered(_logger, queueId, sequenceId);
+          }
+          else if (guard.Failed) {
+            QueueExecutionLog.ForegroundGuardFailed(_logger, queueId, sequenceId, guard.ReasonCode);
+          }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (OperationCanceledException) { /* watchdog — fall through and let the firing try anyway */ }
+        catch (Exception ex) { QueueExecutionLog.ForegroundGuardFaulted(_logger, queueId, ex); }
+      }
+
       var parentContext = new ExecutionLogContext {
         ParentExecutionId = rootId,
         RootExecutionId = rootId,
@@ -699,4 +729,13 @@ internal static partial class QueueExecutionLog {
 
   [LoggerMessage(EventId = 1118, Level = LogLevel.Warning, Message = "Queue {QueueId} pre-session emulator ensure for instance {Instance} failed ({ReasonCode}); the run will not create a session")]
   public static partial void PreSessionEmulatorFailed(ILogger logger, string QueueId, string Instance, string ReasonCode);
+
+  [LoggerMessage(EventId = 1119, Level = LogLevel.Warning, Message = "Queue {QueueId} found the game out of the foreground before sequence {SequenceId} and brought it back")]
+  public static partial void ForegroundGuardRecovered(ILogger logger, string QueueId, string SequenceId);
+
+  [LoggerMessage(EventId = 1120, Level = LogLevel.Warning, Message = "Queue {QueueId} could not bring the game back to the foreground before sequence {SequenceId} ({ReasonCode}); the firing will run anyway and the next one retries")]
+  public static partial void ForegroundGuardFailed(ILogger logger, string QueueId, string SequenceId, string ReasonCode);
+
+  [LoggerMessage(EventId = 1121, Level = LogLevel.Warning, Message = "Queue {QueueId} foreground guard faulted; treated as non-fatal and the firing proceeds")]
+  public static partial void ForegroundGuardFaulted(ILogger logger, string QueueId, Exception ex);
 }

--- a/tests/integration/Queues/ForegroundGuardWiringIntegrationTests.cs
+++ b/tests/integration/Queues/ForegroundGuardWiringIntegrationTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using GameBot.Service.Services.EnsureGameRunning;
+using GameBot.Service.Services.QueueExecution;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+// Test-code analyzer relaxations permitted by the constitution:
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.IntegrationTests.Queues;
+
+/// <summary>
+/// The foreground guard is an OPTIONAL constructor dependency of <see cref="QueueExecutionService"/>,
+/// so a missing registration would not fail the build or any behavioral test — the queue would simply
+/// go back to running for hours without ever noticing the game had left the foreground. These tests
+/// pin the wiring itself.
+/// </summary>
+public sealed class ForegroundGuardWiringIntegrationTests {
+  [Fact]
+  public void ContainerResolvesTheForegroundGuard() {
+    using var app = new WebApplicationFactory<Program>();
+
+    var guard = app.Services.GetRequiredService<IGameForegroundGuard>();
+
+    guard.Should().BeOfType<GameForegroundGuard>();
+  }
+
+  [Fact]
+  public void QueueExecutionServiceReceivesTheForegroundGuard() {
+    using var app = new WebApplicationFactory<Program>();
+
+    var queueExecution = app.Services.GetRequiredService<IQueueExecutionService>();
+
+    // Optional ctor params are filled from the container when registered and fall back to their
+    // default (null) when not, so the injected field is the only honest evidence the guard is live.
+    var field = typeof(QueueExecutionService)
+      .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+      .Single(f => f.FieldType == typeof(IGameForegroundGuard));
+
+    field.GetValue(queueExecution).Should().NotBeNull("a queue run must confirm the game is in front before each firing");
+  }
+}

--- a/tests/unit/Queues/QueueExecutionServiceTests.cs
+++ b/tests/unit/Queues/QueueExecutionServiceTests.cs
@@ -144,6 +144,29 @@ public sealed partial class QueueExecutionServiceTests {
     }
   }
 
+  // Records every foreground-guard pass the run makes, together with how many sequences had already
+  // executed at that moment — that ordering is the whole point of the guard, so the tests assert it
+  // rather than just the call count. Optionally throws to prove a guard failure is non-fatal.
+  private sealed class FakeForegroundGuard : IGameForegroundGuard {
+    private readonly List<int> _executedCountAtCall = new();
+    public Exception? Throws { get; set; }
+    public GameForegroundGuardOutcome Outcome { get; set; } = GameForegroundGuardOutcome.AlreadyForeground;
+    public Func<int>? ExecutedCountProvider { get; set; }
+    public List<string> Sessions { get; } = new();
+
+    public IReadOnlyList<int> ExecutedCountAtCall { get { lock (_executedCountAtCall) return _executedCountAtCall.ToList(); } }
+    public int Calls { get { lock (_executedCountAtCall) return _executedCountAtCall.Count; } }
+
+    public Task<GameForegroundGuardResult> EnsureForegroundAsync(string sessionId, CancellationToken ct = default) {
+      lock (_executedCountAtCall) {
+        _executedCountAtCall.Add(ExecutedCountProvider?.Invoke() ?? -1);
+        Sessions.Add(sessionId);
+      }
+      if (Throws is not null) throw Throws;
+      return Task.FromResult(new GameForegroundGuardResult(Outcome, Outcome.ToString()));
+    }
+  }
+
   // Feature 074: fake pre-session emulator cold-start handler. Records the call count, the args it was
   // given, and how many sessions existed at the moment it ran (to prove the ensure precedes
   // CreateSession). The returned outcome is configurable to drive the behavior matrix.
@@ -210,14 +233,23 @@ public sealed partial class QueueExecutionServiceTests {
     public QueueRunRegistry Registry { get; } = new();
     public FakeEnsureGameRunning EnsureGame { get; } = new();
     public FakeEnsureEmulatorRunning EnsureEmulator { get; } = new();
+    /// <summary>
+    /// Non-null only when the harness was built with <c>foregroundGuard: true</c>. Left unwired by
+    /// default so the pre-guard tests keep asserting the exact ensure-game call counts they were
+    /// written for.
+    /// </summary>
+    public FakeForegroundGuard? ForegroundGuard { get; }
     public SelfRescheduleCoordinator Coordinator { get; }
     public QueueExecutionService Service { get; }
 
-    public Harness(FakeTimeProvider? clock = null) {
+    public Harness(FakeTimeProvider? clock = null, bool foregroundGuard = false) {
       Clock = clock;
       Coordinator = new SelfRescheduleCoordinator(Registry, clock);
       EnsureEmulator.SessionCountProvider = () => Sessions.ActiveCount;
-      Service = new QueueExecutionService(Queues, Runtime, Templates, Sequences, Sessions, Log, NullLogger<QueueExecutionService>.Instance, Registry, timeProvider: clock, ensureGameRunning: EnsureGame, ensureEmulatorRunning: EnsureEmulator);
+      if (foregroundGuard) {
+        ForegroundGuard = new FakeForegroundGuard { ExecutedCountProvider = () => Sequences.Executed.Count };
+      }
+      Service = new QueueExecutionService(Queues, Runtime, Templates, Sequences, Sessions, Log, NullLogger<QueueExecutionService>.Instance, Registry, timeProvider: clock, ensureGameRunning: EnsureGame, ensureEmulatorRunning: EnsureEmulator, foregroundGuard: ForegroundGuard);
     }
 
     /// <param name="serial">
@@ -1627,5 +1659,90 @@ public sealed partial class QueueExecutionServiceTests {
     h.EnsureGame.Calls.Should().BeGreaterThanOrEqualTo(1);
 
     await WaitUntilStoppedAsync(h.Service, "q1");
+  }
+
+  // ── Foreground guard ──────────────────────────────────────────────────
+  // A queue run holds one emulator for hours. If the game is pushed out of the foreground mid-run
+  // (a recovery loop pressing BACK off the top screen, a crash, someone touching the emulator) every
+  // later detection reads the device launcher, so every firing fails — while the queue still reports
+  // "Running". The game's launch step runs at queue start and never again, so nothing recovers it.
+  // The guard closes that hole by confirming the foreground before each firing.
+
+  [Fact]
+  public async Task ForegroundIsConfirmedBeforeEveryFiring() {
+    var h = new Harness(foregroundGuard: true);
+    h.AddQueue("q1", new[] { "A", "B", "C" });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Equal("A", "B", "C");
+    h.ForegroundGuard!.Calls.Should().Be(3);
+    // Each pass ran BEFORE its sequence: 0 sequences done at the first, 1 at the second, 2 at the third.
+    h.ForegroundGuard.ExecutedCountAtCall.Should().Equal(0, 1, 2);
+    h.ForegroundGuard.Sessions.Should().OnlyContain(s => !string.IsNullOrEmpty(s));
+  }
+
+  [Fact] // The scenario the guard exists for: the game keeps dropping out and is recovered each time.
+  public async Task RunKeepsGoingWhenTheGameHasToBeRecoveredBeforeEachFiring() {
+    var h = new Harness(foregroundGuard: true);
+    h.ForegroundGuard!.Outcome = GameForegroundGuardOutcome.Recovered;
+    h.AddQueue("q1", new[] { "A", "B" });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Equal("A", "B");
+    h.ForegroundGuard.Calls.Should().Be(2);
+  }
+
+  [Fact] // A game that cannot be brought back must not stall the run — the firing still gets its try.
+  public async Task FiringStillRunsWhenTheGameCannotBeBroughtBack() {
+    var h = new Harness(foregroundGuard: true);
+    h.ForegroundGuard!.Outcome = GameForegroundGuardOutcome.RecoveryFailed;
+    h.AddQueue("q1", new[] { "A", "B" });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Equal("A", "B");
+  }
+
+  [Fact] // Best-effort, like the idle-pause foreground: a guard fault never fails the firing.
+  public async Task GuardFailureIsNonFatal() {
+    var h = new Harness(foregroundGuard: true);
+    h.ForegroundGuard!.Throws = new InvalidOperationException("adb exploded");
+    h.AddQueue("q1", new[] { "A", "B" });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Equal("A", "B");
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  [Fact] // Hosts that cannot drive ADB report NotApplicable; the run must be untouched.
+  public async Task NotApplicableGuardLeavesTheRunUnchanged() {
+    var h = new Harness(foregroundGuard: true);
+    h.ForegroundGuard!.Outcome = GameForegroundGuardOutcome.NotApplicable;
+    h.AddQueue("q1", new[] { "A", "B" });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.Sequences.Executed.Should().Equal("A", "B");
+    h.Log.FinalStatus.Should().Be("success");
+  }
+
+  [Fact] // The guard is optional wiring: an unwired run behaves exactly as before.
+  public async Task RunWithoutAGuardIsUnaffected() {
+    var h = new Harness();
+    h.AddQueue("q1", new[] { "A", "B" });
+
+    await h.Service.StartAsync("q1");
+    await WaitUntilStoppedAsync(h.Service, "q1");
+
+    h.ForegroundGuard.Should().BeNull();
+    h.Sequences.Executed.Should().Equal("A", "B");
   }
 }

--- a/tests/unit/Services/EnsureGameRunning/GameForegroundGuardTests.cs
+++ b/tests/unit/Services/EnsureGameRunning/GameForegroundGuardTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GameBot.Service.Services.EnsureGameRunning;
+using Xunit;
+
+// Test-code analyzer relaxations permitted by the constitution:
+#pragma warning disable CA2007, CA1861, CA1859
+
+namespace GameBot.UnitTests.Services.EnsureGameRunning;
+
+public sealed class GameForegroundGuardTests {
+  // Replays a scripted sequence of handler outcomes, repeating the last one once exhausted, and
+  // counts how many times it was asked.
+  private sealed class ScriptedEnsureGameRunning : IEnsureGameRunningActionHandler {
+    private readonly Queue<EnsureGameRunningOutcome> _script;
+    private EnsureGameRunningOutcome _last;
+
+    public ScriptedEnsureGameRunning(params EnsureGameRunningOutcome[] script) {
+      _script = new Queue<EnsureGameRunningOutcome>(script);
+      _last = script.Length > 0 ? script[^1] : EnsureGameRunningOutcome.GameRunning;
+    }
+
+    public int Calls { get; private set; }
+    public string? LastSessionId { get; private set; }
+
+    public Task<EnsureGameRunningActionResult> ExecuteAsync(string sessionId, CancellationToken ct = default) {
+      Calls++;
+      LastSessionId = sessionId;
+      if (_script.Count > 0) _last = _script.Dequeue();
+      return Task.FromResult(new EnsureGameRunningActionResult(_last));
+    }
+  }
+
+  // Short windows keep the confirm loop deterministic without waiting real seconds.
+  private static GameForegroundGuard Guard(IEnsureGameRunningActionHandler handler)
+    => new(handler, confirmTimeout: TimeSpan.FromMilliseconds(200), pollInterval: TimeSpan.FromMilliseconds(5));
+
+  [Fact]
+  public async Task Game_already_in_front_passes_after_a_single_check() {
+    var handler = new ScriptedEnsureGameRunning(EnsureGameRunningOutcome.GameRunning);
+
+    var result = await Guard(handler).EnsureForegroundAsync("s-1");
+
+    result.Outcome.Should().Be(GameForegroundGuardOutcome.AlreadyForeground);
+    result.Recovered.Should().BeFalse();
+    result.Failed.Should().BeFalse();
+    // The common case must not pay for the confirm loop.
+    handler.Calls.Should().Be(1);
+    handler.LastSessionId.Should().Be("s-1");
+  }
+
+  [Fact]
+  public async Task Game_pushed_out_of_the_foreground_is_brought_back() {
+    // First check finds the launcher and fires a launch; the next confirms the game returned.
+    var handler = new ScriptedEnsureGameRunning(
+      EnsureGameRunningOutcome.GameNotRunning,
+      EnsureGameRunningOutcome.GameRunning);
+
+    var result = await Guard(handler).EnsureForegroundAsync("s-1");
+
+    result.Outcome.Should().Be(GameForegroundGuardOutcome.Recovered);
+    result.Recovered.Should().BeTrue();
+    handler.Calls.Should().Be(2);
+  }
+
+  [Fact]
+  public async Task Game_that_never_returns_reports_failure_instead_of_waiting_forever() {
+    var handler = new ScriptedEnsureGameRunning(EnsureGameRunningOutcome.GameNotRunning);
+
+    var result = await Guard(handler).EnsureForegroundAsync("s-1");
+
+    result.Outcome.Should().Be(GameForegroundGuardOutcome.RecoveryFailed);
+    result.Failed.Should().BeTrue();
+    result.ReasonCode.Should().Be("game_not_running");
+    // It kept trying rather than giving up after the first launch.
+    handler.Calls.Should().BeGreaterThan(1);
+  }
+
+  // EnsureGameRunningOutcome is internal, so it cannot be a public [Theory] parameter — these stay
+  // separate facts over a shared assertion.
+  private static async Task AssertNotApplicable(EnsureGameRunningOutcome outcome) {
+    var handler = new ScriptedEnsureGameRunning(outcome);
+
+    var result = await Guard(handler).EnsureForegroundAsync("s-1");
+
+    result.Outcome.Should().Be(GameForegroundGuardOutcome.NotApplicable);
+    result.Recovered.Should().BeFalse();
+    result.Failed.Should().BeFalse();
+    // A configuration gap must not spin the confirm loop.
+    handler.Calls.Should().Be(1);
+  }
+
+  [Fact]
+  public Task Session_outside_a_queue_context_is_not_applicable()
+    => AssertNotApplicable(EnsureGameRunningOutcome.NoQueueContext);
+
+  [Fact]
+  public Task Queue_without_a_linked_game_is_not_applicable()
+    => AssertNotApplicable(EnsureGameRunningOutcome.NoLinkedGame);
+
+  [Fact]
+  public Task Game_without_a_package_name_is_not_applicable()
+    => AssertNotApplicable(EnsureGameRunningOutcome.NoPackageName);
+
+  [Fact]
+  public Task Host_without_adb_is_not_applicable()
+    => AssertNotApplicable(EnsureGameRunningOutcome.PlatformUnsupported);
+
+  [Fact]
+  public async Task A_context_that_becomes_unusable_mid_confirm_stops_the_loop() {
+    var handler = new ScriptedEnsureGameRunning(
+      EnsureGameRunningOutcome.GameNotRunning,
+      EnsureGameRunningOutcome.NoLinkedGame);
+
+    var result = await Guard(handler).EnsureForegroundAsync("s-1");
+
+    result.Outcome.Should().Be(GameForegroundGuardOutcome.NotApplicable);
+    handler.Calls.Should().Be(2);
+  }
+
+  [Fact]
+  public async Task Cancellation_during_the_confirm_window_propagates() {
+    var handler = new ScriptedEnsureGameRunning(EnsureGameRunningOutcome.GameNotRunning);
+    using var cts = new CancellationTokenSource();
+    cts.CancelAfter(TimeSpan.FromMilliseconds(20));
+
+    var act = async () => await Guard(handler).EnsureForegroundAsync("s-1", cts.Token);
+
+    await act.Should().ThrowAsync<OperationCanceledException>();
+  }
+}


### PR DESCRIPTION
## Problem

A queue run binds one emulator for hours, and nothing was responsible for keeping the game in front during that window. The only step that launches the game (`PNS Connect` and friends) is `scheduleType: "AtQueueStart"` — it runs once and never again.

So the first thing that pushed the game out of the foreground ended the run's usefulness permanently: every later image detection read the device launcher instead of the game, every firing failed, and the queue went right on reporting `Running`.

Found live. On one queue, a sequence left the game backgrounded at 05:16 UTC and the next **4 hours were 100% failures** — every one of them the same `Loop 'recover' failed after 4 iterations`, because the recovery loop was pressing BACK against the Android launcher. The game process was alive the whole time; its task was simply in the background, one `am start` away from working.

The failure is also close to invisible: the execution-log list is roots-only and a queue row carries `ChildCount = 0`, so a queue in this state looks like a single stale "running" row rather than a broken run.

## Fix

New `IGameForegroundGuard`, consulted in `RunOneSequenceAsync` — the single funnel every firing goes through (at-start, once-per-run, every-step, timer, relative, self-reschedule).

- **Already in front** → one ADB foreground query, confirm loop never entered. This is the common path.
- **Not in front** → relaunch and confirm it came back, bounded at 15s. A backgrounded task returns in a poll or two.
- **Cold start** → deliberately *not* waited out. The firing proceeds (and most likely fails, as it does today) and the next firing's guard resumes the recovery — so one dead game cannot stall the whole queue behind a 4-minute sequence watchdog.

It layers over the same `IEnsureGameRunningActionHandler` the `ensure-game-running` step already uses, so game/package resolution is identical and no ADB logic is duplicated. That handler checks the foreground *before* it launches anything, which is what makes the common path cheap.

Best-effort throughout, matching the existing idle-pause foreground (FR-011): a guard fault never fails a firing, and an inapplicable context — no queue context, no linked game, no package name, non-Windows host — passes straight through untouched.

Net effect: **a game that drops out costs one firing instead of the rest of the run.**

## Changes

| File | |
|---|---|
| `Services/EnsureGameRunning/IGameForegroundGuard.cs` | contract + outcomes |
| `Services/EnsureGameRunning/GameForegroundGuard.cs` | check → launch → bounded confirm |
| `Services/QueueExecution/QueueExecutionService.cs` | per-firing guard + log events 1119–1121 |
| `GameBotServiceSetup.cs` | DI registration |

## Tests

`927 unit / 313 integration / 125 contract` — all pass.

New coverage:

- **Guard behaviour** — already-foreground (asserts a single handler call, so the common path cannot silently regress into the confirm loop), recovered, never-returns, four inapplicable contexts, context lost mid-confirm, cancellation.
- **Queue wiring** — the guard runs *before* each firing, asserted by the sequences-executed count at each call (`0, 1, 2`) rather than a bare call count; recovery / recovery-failure / fault paths all proven non-fatal.
- **DI wiring** — the guard is an *optional* constructor dependency, so a dropped registration would fail no build and no behavioural test while silently restoring the old behaviour. `ForegroundGuardWiringIntegrationTests` pins it by reading the injected field off the real container.

Existing queue-execution tests are untouched: the harness leaves the guard unwired by default, so the idle-pause tests keep asserting the exact `ensure-game` call counts they were written for.

## Not covered here

- The `recover` loop pressing BACK off the game's top-level screen is what pushes the game out in the first place. The guard heals it; it does not stop it happening. That is sequence authoring, not engine code.
- `PNS Hero Duel Daily` never records a terminal status (5 runs left `running`, across all three queues).
- Queue rows reporting `ChildCount = 0` in the execution-log list, which is why this class of failure is hard to spot in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
