### PR TITLE
Release 1.3.0: honest delay outcomes, and two gaps in the watchdog work

### DIFF
--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "1",
-  "minor": "2",
+  "minor": "3",
   "patch": "0",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-08-24T00:00:00Z"
+  "updatedAtUtc": "2026-09-02T00:00:00Z"
 }

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -792,9 +792,12 @@ namespace GameBot.Domain.Services {
       };
 
       if (detectionTarget is null || string.IsNullOrWhiteSpace(detectionTarget.ReferenceImageId)) {
+        // A wait with no image to look for is a plain delay, not a search that failed. Reported as
+        // such so the log distinguishes "paused on purpose" from "looked for something and never
+        // found it" — the command executor draws the same distinction, and treats a delay as executed.
         await WaitUntilDeadlineAsync(deadline, ct).ConfigureAwait(false);
-        detail.ExitCondition = "timeout_elapsed";
-        return new WaitForImageStepOutcome("timeout_elapsed", detail);
+        detail.ExitCondition = "delay_elapsed";
+        return new WaitForImageStepOutcome("delay_elapsed", detail);
       }
 
       if (conditionEvaluator is null) {

--- a/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
@@ -272,6 +272,18 @@ internal static class SequencesEndpoints {
       var delayContract = JsonSerializer.Deserialize<DelayRangeMsContract>(delayProp.GetRawText(), PerStepRequestJsonOptions);
       existing.InterStepDelayRangeMs = MapDelayRangeMs(delayContract);
     }
+    // Handled at the top level too, so a body carrying only the watchdog is honoured. The per-step
+    // branch above never runs for such a body (there are no steps to read), which would otherwise make
+    // "PATCH just the watchdog" — the natural way to set it — silently do nothing. An explicit null
+    // clears it back to the queue default.
+    if (root.TryGetProperty("watchdogTimeoutMs", out var watchdogProp)) {
+      if (watchdogProp.ValueKind == System.Text.Json.JsonValueKind.Number && watchdogProp.TryGetInt32(out var watchdogMs)) {
+        existing.WatchdogTimeoutMs = watchdogMs;
+      }
+      else if (watchdogProp.ValueKind == System.Text.Json.JsonValueKind.Null) {
+        existing.WatchdogTimeoutMs = null;
+      }
+    }
     existing.Version += 1;
     existing.UpdatedAt = DateTimeOffset.UtcNow;
     var saved = await repo.UpdateAsync(existing).ConfigureAwait(false);

--- a/src/GameBot.Service/Services/CommandExecutor.cs
+++ b/src/GameBot.Service/Services/CommandExecutor.cs
@@ -485,11 +485,16 @@ internal sealed class CommandExecutor : ICommandExecutor {
     var deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
 
     if (detectionTarget is null || string.IsNullOrWhiteSpace(detectionTarget.ReferenceImageId)) {
+      // A wait with no image to look for is not a search that failed — it is a plain delay, the only
+      // way to express "pause here" in a command. Waiting it out IS the step succeeding, so it must
+      // report "executed": a command's status is failure if ANY step is not executed, so reporting a
+      // timeout here marked every command ending in a delay as failed. That mislabelled a great many
+      // commands that had done exactly what they were told, and buried the genuine failures among them.
       await WaitForTimeoutAsync(deadline, ct).ConfigureAwait(false);
       return new PrimitiveTapStepOutcome(
         step.Order,
-        "completed_timeout",
-        "timeout_elapsed",
+        "executed",
+        "delay_elapsed",
         null,
         null,
         StepType: "waitForImage",

--- a/tests/integration/Commands/WaitForImageExecutionIntegrationTests.cs
+++ b/tests/integration/Commands/WaitForImageExecutionIntegrationTests.cs
@@ -102,8 +102,10 @@ public sealed class WaitForImageExecutionIntegrationTests : IDisposable {
     outcomes.GetArrayLength().Should().Be(2);
 
     outcomes[0].GetProperty("stepType").GetString().Should().Be("waitForImage");
-    outcomes[0].GetProperty("status").GetString().Should().Be("completed_timeout");
-    outcomes[0].GetProperty("reason").GetString().Should().Be("timeout_elapsed");
+    // A wait with no image to look for is a plain delay: waiting it out is the step succeeding, so it
+    // must not drag the whole command's status down to failure.
+    outcomes[0].GetProperty("status").GetString().Should().Be("executed");
+    outcomes[0].GetProperty("reason").GetString().Should().Be("delay_elapsed");
     outcomes[0].GetProperty("effectiveTimeoutMs").GetInt32().Should().Be(25);
     if (outcomes[0].TryGetProperty("referenceImageId", out var referenceImageId)) {
       referenceImageId.ValueKind.Should().Be(JsonValueKind.Null);
@@ -196,5 +198,53 @@ public sealed class WaitForImageExecutionIntegrationTests : IDisposable {
     commandResp.EnsureSuccessStatusCode();
     var command = await commandResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(false);
     return command!["id"]!.ToString()!;
+  }
+
+  [Fact]
+  public async Task CommandEndingInADelayIsLoggedAsSuccessNotFailure() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    await UploadImageAsync(client, "tap-image").ConfigureAwait(false);
+    var sessionId = await CreateSessionAsync(client, "TrailingDelayGame").ConfigureAwait(false);
+    // Tap, then a targetless wait — the "pause after acting" idiom commands are written with.
+    var commandReq = new {
+      name = "Trailing delay command",
+      steps = new object[] {
+        new {
+          type = "PrimitiveTap",
+          order = 0,
+          primitiveTap = new {
+            detectionTarget = new {
+              referenceImageId = "tap-image",
+              confidence = 0.99,
+              offsetX = 0,
+              offsetY = 0,
+              selectionStrategy = "HighestConfidence"
+            }
+          }
+        },
+        new { type = "WaitForImage", order = 1, waitForImage = new { timeoutMs = 25 } }
+      }
+    };
+    var createResp = await client.PostAsJsonAsync(new Uri("/api/commands", UriKind.Relative), commandReq).ConfigureAwait(false);
+    createResp.EnsureSuccessStatusCode();
+    var created = await createResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(false);
+    var commandId = created!["id"]!.ToString()!;
+
+    var execResp = await client.PostAsync(new Uri($"/api/commands/{commandId}/force-execute?sessionId={sessionId}", UriKind.Relative), null).ConfigureAwait(false);
+    execResp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+    var logResp = await client.GetAsync(
+      new Uri($"/api/execution-logs?objectType=command&objectId={commandId}&pageSize=1", UriKind.Relative)).ConfigureAwait(false);
+    logResp.EnsureSuccessStatusCode();
+    using var logDoc = JsonDocument.Parse(await logResp.Content.ReadAsStringAsync().ConfigureAwait(false));
+    var items = logDoc.RootElement.GetProperty("items");
+    items.GetArrayLength().Should().Be(1);
+
+    // The command did everything it was told; a trailing pause must not report it as failed. This is
+    // what filled the logs with failure lines on commands that had worked, hiding the real ones.
+    items[0].GetProperty("finalStatus").GetString().Should().Be("success");
   }
 }

--- a/tests/integration/Queues/ForegroundGuardWiringIntegrationTests.cs
+++ b/tests/integration/Queues/ForegroundGuardWiringIntegrationTests.cs
@@ -42,4 +42,20 @@ public sealed class ForegroundGuardWiringIntegrationTests {
 
     field.GetValue(queueExecution).Should().NotBeNull("a queue run must confirm the game is in front before each firing");
   }
+
+  [Fact]
+  public void QueueExecutionServiceReceivesTheSequenceRepository() {
+    using var app = new WebApplicationFactory<Program>();
+
+    var queueExecution = app.Services.GetRequiredService<IQueueExecutionService>();
+
+    // Same silent-failure shape as the guard: without this the run cannot read a sequence's own
+    // watchdog bound, so every sequence would quietly keep the default and a slow one would be
+    // cancelled on every firing — with nothing failing to say so.
+    var field = typeof(QueueExecutionService)
+      .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+      .Single(f => f.FieldType == typeof(GameBot.Domain.Commands.ISequenceRepository));
+
+    field.GetValue(queueExecution).Should().NotBeNull("a firing's watchdog bound comes from the sequence itself");
+  }
 }

--- a/tests/integration/Sequences/SequenceWatchdogTimeoutApiIntegrationTests.cs
+++ b/tests/integration/Sequences/SequenceWatchdogTimeoutApiIntegrationTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Sequences;
+
+/// <summary>
+/// Round-trips a sequence's per-firing watchdog bound through the API. The bound is only useful if it
+/// can actually be set, and the natural way to set one on an existing sequence is a PATCH carrying
+/// nothing else — a body with no steps, which the per-step branch never reads.
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class SequenceWatchdogTimeoutApiIntegrationTests : IDisposable {
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevUseAdb;
+
+  public SequenceWatchdogTimeoutApiIntegrationTests() {
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    GC.SuppressFinalize(this);
+  }
+
+  private static HttpClient Client(WebApplicationFactory<Program> app) {
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+    return client;
+  }
+
+  private static Dictionary<string, object> SequenceBody(string name, int? watchdogTimeoutMs) {
+    var body = new Dictionary<string, object> {
+      ["name"] = name,
+      ["version"] = 1,
+      ["steps"] = new object[] {
+        new {
+          stepId = "wait",
+          primitiveAction = new { type = "WaitForImage", schemaVersion = "v1", payload = new { timeoutMs = 0 } }
+        }
+      }
+    };
+    if (watchdogTimeoutMs is not null) body["watchdogTimeoutMs"] = watchdogTimeoutMs;
+    return body;
+  }
+
+  private static async Task<string> CreateSequenceAsync(HttpClient client, int? watchdogTimeoutMs) {
+    var resp = await client.PostAsJsonAsync(
+      new Uri("/api/sequences", UriKind.Relative), SequenceBody("Watchdog sequence", watchdogTimeoutMs)).ConfigureAwait(false);
+    resp.EnsureSuccessStatusCode();
+    using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
+    return doc.RootElement.GetProperty("id").GetString()!;
+  }
+
+  private static async Task<JsonElement> GetSequenceAsync(HttpClient client, string id) {
+    var resp = await client.GetAsync(new Uri($"/api/sequences/{id}", UriKind.Relative)).ConfigureAwait(false);
+    resp.EnsureSuccessStatusCode();
+    return JsonDocument.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false)).RootElement.Clone();
+  }
+
+  [Fact]
+  public async Task WatchdogSurvivesCreateAndRead() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Client(app);
+
+    var id = await CreateSequenceAsync(client, 1_200_000).ConfigureAwait(false);
+
+    (await GetSequenceAsync(client, id).ConfigureAwait(false))
+      .GetProperty("watchdogTimeoutMs").GetInt32().Should().Be(1_200_000);
+  }
+
+  [Fact]
+  public async Task SequenceWithoutAWatchdogReportsNone() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Client(app);
+
+    var id = await CreateSequenceAsync(client, null).ConfigureAwait(false);
+
+    (await GetSequenceAsync(client, id).ConfigureAwait(false))
+      .GetProperty("watchdogTimeoutMs").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  [Fact] // The natural way to set one: a PATCH carrying only the watchdog, with no steps at all.
+  public async Task PatchCarryingOnlyTheWatchdogIsApplied() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Client(app);
+    var id = await CreateSequenceAsync(client, null).ConfigureAwait(false);
+
+    using (var patch = new HttpRequestMessage(HttpMethod.Patch, new Uri($"/api/sequences/{id}", UriKind.Relative)) {
+      Content = new StringContent("{\"watchdogTimeoutMs\":900000}", Encoding.UTF8, "application/json")
+    }) {
+      (await client.SendAsync(patch).ConfigureAwait(false)).EnsureSuccessStatusCode();
+    }
+
+    var after = await GetSequenceAsync(client, id).ConfigureAwait(false);
+    after.GetProperty("watchdogTimeoutMs").GetInt32().Should().Be(900_000);
+    // The steps must survive a PATCH that never mentioned them.
+    after.GetProperty("steps").GetArrayLength().Should().Be(1);
+  }
+
+  [Fact] // An explicit null hands the sequence back to the queue default.
+  public async Task PatchWithNullClearsTheWatchdog() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Client(app);
+    var id = await CreateSequenceAsync(client, 600_000).ConfigureAwait(false);
+
+    using (var patch = new HttpRequestMessage(HttpMethod.Patch, new Uri($"/api/sequences/{id}", UriKind.Relative)) {
+      Content = new StringContent("{\"watchdogTimeoutMs\":null}", Encoding.UTF8, "application/json")
+    }) {
+      (await client.SendAsync(patch).ConfigureAwait(false)).EnsureSuccessStatusCode();
+    }
+
+    (await GetSequenceAsync(client, id).ConfigureAwait(false))
+      .GetProperty("watchdogTimeoutMs").ValueKind.Should().Be(JsonValueKind.Null);
+  }
+
+  [Fact] // The cap keeps a typo from handing one sequence an unbounded hold on its emulator.
+  public async Task WatchdogBeyondTheCapIsRejected() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = Client(app);
+
+    var resp = await client.PostAsJsonAsync(
+      new Uri("/api/sequences", UriKind.Relative), SequenceBody("Too patient", 31 * 60 * 1000)).ConfigureAwait(false);
+
+    resp.StatusCode.Should().NotBe(HttpStatusCode.Created);
+    resp.IsSuccessStatusCode.Should().BeFalse();
+  }
+}

--- a/tests/integration/Sequences/WaitForImageSequenceExecutionIntegrationTests.cs
+++ b/tests/integration/Sequences/WaitForImageSequenceExecutionIntegrationTests.cs
@@ -92,7 +92,8 @@ public sealed class WaitForImageSequenceExecutionIntegrationTests : IDisposable 
     // honestly because its command reference does not exist.
     execution.GetProperty("status").GetString().Should().Be("Failed");
     var steps = execution.GetProperty("steps");
-    steps[0].GetProperty("actionOutcome").GetString().Should().Be("timeout_elapsed");
+    // No image to look for makes this a plain delay, not a search that timed out.
+    steps[0].GetProperty("actionOutcome").GetString().Should().Be("delay_elapsed");
     steps[1].GetProperty("actionOutcome").GetString().Should().Be("failed");
   }
 

--- a/tests/unit/Commands/CommandExecutorWaitForImageTests.cs
+++ b/tests/unit/Commands/CommandExecutorWaitForImageTests.cs
@@ -85,8 +85,10 @@ public sealed class CommandExecutorWaitForImageTests {
 
     result.Accepted.Should().Be(0);
     result.StepOutcomes.Should().HaveCount(1);
-    result.StepOutcomes[0].Status.Should().Be("completed_timeout");
-    result.StepOutcomes[0].Reason.Should().Be("timeout_elapsed");
+    // A wait with no image to look for is a plain delay, so waiting it out IS success. Reporting a
+    // timeout here marked every command ending in a delay as failed.
+    result.StepOutcomes[0].Status.Should().Be("executed");
+    result.StepOutcomes[0].Reason.Should().Be("delay_elapsed");
     stopwatch.ElapsedMilliseconds.Should().BeGreaterThanOrEqualTo(25);
   }
 

--- a/tests/unit/Sequences/SequenceRunnerWaitForImageTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerWaitForImageTests.cs
@@ -67,7 +67,9 @@ public sealed class SequenceRunnerWaitForImageTests {
 
     result.Status.Should().Be("Succeeded");
     executed.Should().ContainSingle().Which.Should().Be("cmd-after-wait");
-    result.Steps.Should().ContainSingle(step => step.ActionOutcome == "timeout_elapsed");
+    // No image to look for means this is a plain delay, reported as such rather than as a search
+    // that timed out.
+    result.Steps.Should().ContainSingle(step => step.ActionOutcome == "delay_elapsed");
     stopwatch.ElapsedMilliseconds.Should().BeGreaterThanOrEqualTo(25);
   }
 


### PR DESCRIPTION
Follow-on to #161, which merged before these two commits reached it.

## Stop reporting a deliberate delay as a timed-out search

A `WaitForImage` step with no detection target is not a search at all — it is the only way to say "pause here", and commands are written with one as a trailing beat after a tap. It reported `completed_timeout` / `timeout_elapsed`, and a command's status is failure if **any** step is not `executed`. So **every command ending in a delay was logged as failed**.

`PNS Hero Duel Wait Result` is the clearest case: all five of its recorded runs **detected the result screen and tapped it at 0.998 confidence** — then were marked `failure` by a trailing 3.5s pause. The same idiom appears in `PNS Key Back` and many others, so the logs carried a large number of failure lines on commands that had done exactly what they were told. That is what made the genuine failures so hard to pick out while diagnosing the stuck queues.

A targetless wait now reports `executed` / `delay_elapsed`, and the sequence runner reports the same `delay_elapsed` exit condition, so both layers draw the same distinction between "paused on purpose" and "looked for something and never found it". A wait **with** a target that times out is unchanged — that is a real failure and still reads as one.

Sequence flow was never affected either way (`ClassifyDispatch` only inspects input-bearing steps, and the runner always records a wait as succeeded), so this changes what the log says, not what the bot does.

The two tests covering the targetless case were already named `CompletesNormally` and `AndContinues`; their assertions now match the intent their names always stated. Added an end-to-end test that a command ending in a delay is **logged as `success`**, which is the point of the change.

## Two gaps in the watchdog work from #161

- **PATCH silently dropped `watchdogTimeoutMs`.** It was only applied inside the per-step branch, which never runs for a body with no steps — so "PATCH just the watchdog", the natural way to set one on an existing sequence, did nothing at all. Now handled at the top level, with an explicit `null` clearing it back to the queue default. Covered by tests that also assert the steps survive a PATCH that never mentioned them.
- **Pinned the sequence-repository injection** the same way #160 pinned the foreground guard. It is another optional constructor dependency, so a missing registration would fail no build and no behavioural test while quietly returning every sequence to the default bound.

## Release 1.3.0

`installer/versioning/version.override.json` moves `minor` 2 → 3. `Resolve-InstallerVersion` reads major/minor/patch from that file and appends the build number, so this alone moves the installer and the service's reported version from `1.2.0.x` to `1.3.0.x`.

A minor bump rather than a patch, because the queue engine gained behaviour this cycle rather than only fixes: the foreground guard (#160), the per-sequence watchdog bound (#161), and a new `watchdogTimeoutMs` field on the sequence API.

Verified locally — `Resolve-InstallerVersion -BuildContext local` returns `1.3.0.4` and leaves the CI build counter untouched.

## Tests

`934 unit / 322 integration / 125 contract` — all pass, re-run after rebasing onto the merged #161 rather than relied on from the pre-merge branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
