### PR TITLE
Let a recovery guard give up without taking the sequence down

### DIFF
--- a/installer/versioning/version.override.json
+++ b/installer/versioning/version.override.json
@@ -1,7 +1,7 @@
 {
   "major": "1",
   "minor": "3",
-  "patch": "0",
+  "patch": "1",
   "updatedBy": "Anton Kuvsinov",
-  "updatedAtUtc": "2026-09-02T00:00:00Z"
+  "updatedAtUtc": "2026-09-03T00:00:00Z"
 }

--- a/src/GameBot.Domain/Commands/LoopConfig.cs
+++ b/src/GameBot.Domain/Commands/LoopConfig.cs
@@ -17,6 +17,22 @@ public abstract class LoopConfig {
   /// Must be greater than zero when present.
   /// </summary>
   public int? MaxIterations { get; set; }
+
+  /// <summary>
+  /// <para>
+  /// When <c>true</c>, running out of iterations ends the loop as an ordinary exit instead of
+  /// failing the step and aborting the rest of the sequence.
+  /// </para>
+  /// <para>
+  /// The default (<c>false</c>) keeps the ceiling as a hard error, which is what a loop that is
+  /// meant to converge — draining a list, waiting for a state — wants. A best-effort guard such
+  /// as "press BACK until the city is on screen" is different: giving up after N presses is a
+  /// disappointing outcome, not a broken one, and the steps that follow are still worth running.
+  /// Opting such a loop out is what stops one screen the guard could not escape from taking the
+  /// whole sequence down with it.
+  /// </para>
+  /// </summary>
+  public bool ExitOnMaxIterations { get; set; }
 }
 
 /// <summary>

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -1038,6 +1038,12 @@ namespace GameBot.Domain.Services {
 
         iterations++;
         if (iterations > maxIterations) {
+          if (cfg.ExitOnMaxIterations) {
+            var gaveUp = $"Loop '{stepKey}' gave up after {maxIterations} iterations with its condition still true.";
+            result.AddLoopStep(stepKey, "exhausted", iterResults, gaveUp);
+            stepOutcomes[stepKey] = "not_executed";
+            return false;
+          }
           result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
           result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
           stepOutcomes[stepKey] = "failed";
@@ -1113,6 +1119,12 @@ namespace GameBot.Domain.Services {
         if (breakTriggered) break;
 
         if (iterations >= maxIterations) {
+          if (cfg.ExitOnMaxIterations) {
+            var gaveUp = $"Loop '{stepKey}' gave up after {maxIterations} iterations with its exit condition still false.";
+            result.AddLoopStep(stepKey, "exhausted", iterResults, gaveUp);
+            stepOutcomes[stepKey] = "not_executed";
+            return false;
+          }
           result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
           result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
           stepOutcomes[stepKey] = "failed";

--- a/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
+++ b/src/GameBot.Service/Endpoints/SequencesEndpoints.cs
@@ -606,17 +606,20 @@ internal static class SequencesEndpoints {
       CountLoopConfig count => new {
         loopType = "count",
         count = count.Count,
-        maxIterations = count.MaxIterations
+        maxIterations = count.MaxIterations,
+        exitOnMaxIterations = count.ExitOnMaxIterations ? true : (bool?)null
       },
       WhileLoopConfig while_ => new {
         loopType = "while",
         condition = MapPerStepConditionToDto(while_.Condition),
-        maxIterations = while_.MaxIterations
+        maxIterations = while_.MaxIterations,
+        exitOnMaxIterations = while_.ExitOnMaxIterations ? true : (bool?)null
       },
       RepeatUntilLoopConfig repeatUntil => new {
         loopType = "repeatUntil",
         condition = MapPerStepConditionToDto(repeatUntil.Condition),
-        maxIterations = repeatUntil.MaxIterations
+        maxIterations = repeatUntil.MaxIterations,
+        exitOnMaxIterations = repeatUntil.ExitOnMaxIterations ? true : (bool?)null
       },
       _ => null
     };
@@ -940,9 +943,21 @@ internal static class SequencesEndpoints {
 
   private static LoopConfig? MapLoopConfig(LoopConfigContract? contract) {
     return contract switch {
-      CountLoopConfigContract count => new CountLoopConfig { Count = count.Count, MaxIterations = count.MaxIterations },
-      WhileLoopConfigContract while_ => new WhileLoopConfig { Condition = MapPerStepCondition(while_.Condition)!, MaxIterations = while_.MaxIterations },
-      RepeatUntilLoopConfigContract repeatUntil => new RepeatUntilLoopConfig { Condition = MapPerStepCondition(repeatUntil.Condition)!, MaxIterations = repeatUntil.MaxIterations },
+      CountLoopConfigContract count => new CountLoopConfig {
+        Count = count.Count,
+        MaxIterations = count.MaxIterations,
+        ExitOnMaxIterations = count.ExitOnMaxIterations ?? false
+      },
+      WhileLoopConfigContract while_ => new WhileLoopConfig {
+        Condition = MapPerStepCondition(while_.Condition)!,
+        MaxIterations = while_.MaxIterations,
+        ExitOnMaxIterations = while_.ExitOnMaxIterations ?? false
+      },
+      RepeatUntilLoopConfigContract repeatUntil => new RepeatUntilLoopConfig {
+        Condition = MapPerStepCondition(repeatUntil.Condition)!,
+        MaxIterations = repeatUntil.MaxIterations,
+        ExitOnMaxIterations = repeatUntil.ExitOnMaxIterations ?? false
+      },
       _ => null
     };
   }

--- a/src/GameBot.Service/Models/SequenceStepContracts.cs
+++ b/src/GameBot.Service/Models/SequenceStepContracts.cs
@@ -114,6 +114,12 @@ internal sealed record CommandOutcomeConditionContract : SequenceStepConditionCo
 [JsonDerivedType(typeof(RepeatUntilLoopConfigContract), typeDiscriminator: "repeatUntil")]
 internal abstract record LoopConfigContract {
   public int? MaxIterations { get; init; }
+
+  /// <summary>
+  /// When true, running out of iterations ends the loop as an ordinary exit instead of failing
+  /// the step and aborting the sequence. Omitted from responses when false.
+  /// </summary>
+  public bool? ExitOnMaxIterations { get; init; }
 }
 
 internal sealed record CountLoopConfigContract : LoopConfigContract {

--- a/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
+++ b/src/GameBot.Service/Services/ExecutionLog/ExecutionLogService.cs
@@ -475,7 +475,10 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       null,
       step.StepOrder,
       ResolveStepLabel(step),
-      step.ConditionTrace is not null ? (step.ConditionTrace.FinalResult ? "success" : "failure") : MapStepStatus(step.Outcome),
+      // A condition step IS its verdict, so a false result is that step's failure. Every other
+      // kind of step merely carries the trace that explains a gate decision — a command whose
+      // gate was false was skipped, not broken — so there its own outcome decides the status.
+      IsConditionStep(step) ? (step.ConditionTrace!.FinalResult ? "success" : "failure") : MapStepStatus(step.Outcome),
       step.ReasonText ?? step.ReasonCode,
       step.AppliedDelayMs,
       step.CommandName,
@@ -483,6 +486,10 @@ internal sealed class ExecutionLogService : IExecutionLogService {
       step.ConditionTrace,
       BuildDeepLink(entry, step),
       Array.Empty<ExecutionTreeNodeProjection>());
+
+  private static bool IsConditionStep(ExecutionStepOutcome step)
+    => step.ConditionTrace is not null
+       && string.Equals(step.StepType, "condition", StringComparison.OrdinalIgnoreCase);
 
   private static string MapStepKind(string? stepType)
     => (stepType ?? string.Empty).ToLowerInvariant() switch {
@@ -498,6 +505,18 @@ internal sealed class ExecutionLogService : IExecutionLogService {
   internal static string MapStepStatus(string? outcome)
     => (outcome ?? string.Empty).ToLowerInvariant() switch {
       "executed" or "success" or "image_detected" or "true" or "break" => "success",
+      // A while loop whose condition finally goes false, and a count loop that runs every
+      // iteration, have both done exactly what they were asked. Without these the runner's own
+      // "false"/"Succeeded" loop statuses fell through to the failure default and painted a
+      // healthy guard red on every single run.
+      "false" or "succeeded" => "success",
+      // A loop that ran out of iterations while opted out of failing (LoopConfig.ExitOnMaxIterations):
+      // the body ran, the goal was not reached, and the sequence continued.
+      "exhausted" => "not_executed",
+      "failed" => "failure",
+      // feature 065: self-reschedule outcomes. Scheduling the next firing is the step working.
+      "scheduled" => "success",
+      "noop" => "skipped",
       // feature 067: if-step branch decisions — a taken branch is a success, a no-op is skipped.
       "then" or "else" => "success",
       "none" => "skipped",

--- a/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
+++ b/src/GameBot.Service/Services/SequenceExecution/SequenceExecutionService.cs
@@ -344,9 +344,13 @@ internal sealed class SequenceExecutionService : ISequenceExecutionService {
 
       if (step.LoopIterations is not null) {
         var iterCount = step.LoopIterations.Count;
+        // A loop that carries its own message (it hit its iteration ceiling) says something the
+        // generated "<status> after N iterations" line cannot, so let it speak for itself.
         detailItems.Add(new ExecutionDetailItem(
           "step",
-          $"Loop '{stepLabel}' {step.Status.ToLowerInvariant()} after {iterCount} iteration{(iterCount == 1 ? "" : "s")}.",
+          !string.IsNullOrWhiteSpace(step.Message)
+            ? step.Message!
+            : $"Loop '{stepLabel}' {step.Status.ToLowerInvariant()} after {iterCount} iteration{(iterCount == 1 ? "" : "s")}.",
           new Dictionary<string, object?> {
             ["stepOrder"] = stepOrder++,
             ["stepType"] = "loop",

--- a/src/web-ui/src/components/sequences/LoopBlock.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlock.tsx
@@ -86,9 +86,11 @@ export const LoopBlock: React.FC<LoopBlockProps> = ({
           count={loop.count}
           condition={loop.condition}
           maxIterations={loop.maxIterations}
+          exitOnMaxIterations={loop.exitOnMaxIterations}
           disabled={disabled}
           onCountChange={(count) => onChange({ ...loop, count })}
           onMaxIterationsChange={(maxIterations) => onChange({ ...loop, maxIterations })}
+          onExitOnMaxIterationsChange={(exitOnMaxIterations) => onChange({ ...loop, exitOnMaxIterations })}
           onConditionChange={(condition: SequenceStepCondition) => onChange({ ...loop, condition })}
         />
         <button type="button" onClick={onRemove} disabled={disabled} data-testid="loop-remove">Remove Loop</button>

--- a/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
+++ b/src/web-ui/src/components/sequences/LoopBlockHeader.tsx
@@ -7,9 +7,11 @@ export type LoopBlockHeaderProps = {
   count?: number;
   condition?: SequenceStepCondition;
   maxIterations?: number;
+  exitOnMaxIterations?: boolean;
   disabled?: boolean;
   onCountChange?: (count: number) => void;
   onMaxIterationsChange?: (maxIterations: number | undefined) => void;
+  onExitOnMaxIterationsChange?: (exitOnMaxIterations: boolean) => void;
   onConditionChange?: (condition: SequenceStepCondition) => void;
 };
 
@@ -20,8 +22,8 @@ const loopTypeBadge: Record<string, string> = {
 };
 
 export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
-  loopType, count, condition, maxIterations, disabled,
-  onCountChange, onMaxIterationsChange, onConditionChange,
+  loopType, count, condition, maxIterations, exitOnMaxIterations, disabled,
+  onCountChange, onMaxIterationsChange, onExitOnMaxIterationsChange, onConditionChange,
 }) => {
   const badge = loopTypeBadge[loopType] ?? loopType;
 
@@ -67,6 +69,21 @@ export const LoopBlockHeader: React.FC<LoopBlockHeaderProps> = ({
             }}
             style={{ width: '60px' }}
           />
+        </label>
+      )}
+
+      {/* Reaching the cap normally fails the step and stops the sequence. A best-effort guard —
+          "press BACK until the city is on screen" — wants the opposite: give up, carry on. */}
+      {loopType !== 'count' && (
+        <label className="loop-block-header__limit-field" title="Reaching Max ends the loop instead of failing the sequence">
+          <input
+            type="checkbox"
+            data-testid="loop-exit-on-max"
+            checked={exitOnMaxIterations ?? false}
+            disabled={disabled}
+            onChange={(e) => onExitOnMaxIterationsChange?.(e.target.checked)}
+          />{' '}
+          Give up at Max
         </label>
       )}
     </div>

--- a/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
+++ b/src/web-ui/src/components/sequences/__tests__/LoopBlock.test.tsx
@@ -146,6 +146,27 @@ describe('LoopBlockHeader', () => {
     const input = screen.getByTestId('loop-max-iterations') as HTMLInputElement;
     expect(input.value).toBe('');
   });
+
+  it('toggles the give-up-at-max option for while/repeat-until loops', () => {
+    const onExitChange = jest.fn();
+    render(
+      <LoopBlockHeader
+        loopType="while"
+        condition={{ type: 'imageVisible', imageId: '', minSimilarity: null }}
+        maxIterations={4}
+        onExitOnMaxIterationsChange={onExitChange}
+      />
+    );
+    const toggle = screen.getByTestId('loop-exit-on-max') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    fireEvent.click(toggle);
+    expect(onExitChange).toHaveBeenCalledWith(true);
+  });
+
+  it('hides the give-up-at-max option for a count loop', () => {
+    render(<LoopBlockHeader loopType="count" count={3} />);
+    expect(screen.queryByTestId('loop-exit-on-max')).not.toBeInTheDocument();
+  });
 });
 
 describe('BreakStepRow', () => {

--- a/src/web-ui/src/pages/SequencesPage.tsx
+++ b/src/web-ui/src/pages/SequencesPage.tsx
@@ -357,14 +357,15 @@ const loopDtoToEntry = (step: SequenceLinearStep): LoopStepEntry => {
   const loop = step.loop!;
   const base: Pick<LoopStepEntry, 'type' | 'id' | 'stepId' | 'label'> = { type: 'Loop', id: makeId(), stepId: step.stepId, label: step.label };
   const body = linearBodyToStepEntries(step.body ?? []);
+  const exitOnMaxIterations = loop.exitOnMaxIterations ?? undefined;
   if (loop.loopType === 'count') {
-    return { ...base, loopType: 'count', count: loop.count, maxIterations: loop.maxIterations ?? undefined, body };
+    return { ...base, loopType: 'count', count: loop.count, maxIterations: loop.maxIterations ?? undefined, exitOnMaxIterations, body };
   }
   if (loop.loopType === 'while') {
-    return { ...base, loopType: 'while', condition: loop.condition, maxIterations: loop.maxIterations ?? undefined, body };
+    return { ...base, loopType: 'while', condition: loop.condition, maxIterations: loop.maxIterations ?? undefined, exitOnMaxIterations, body };
   }
   // repeatUntil
-  return { ...base, loopType: 'repeatUntil', condition: loop.condition, maxIterations: loop.maxIterations ?? undefined, body };
+  return { ...base, loopType: 'repeatUntil', condition: loop.condition, maxIterations: loop.maxIterations ?? undefined, exitOnMaxIterations, body };
 };
 
 const toStepEntriesFromLinear = (steps: SequenceLinearStep[]): SequenceStep[] =>
@@ -649,14 +650,16 @@ const buildConditionPayload = (step: SequenceStep) => {
 };
 
 const buildLoopConfigPayload = (loop: LoopStepEntry): LoopConfigDto | null => {
+  // Carried only when opted in, so a loop that never touched the flag keeps its payload identical.
+  const exit = loop.exitOnMaxIterations ? { exitOnMaxIterations: true } : {};
   if (loop.loopType === 'count') {
-    return { loopType: 'count', count: loop.count ?? 1, maxIterations: loop.maxIterations ?? null };
+    return { loopType: 'count', count: loop.count ?? 1, maxIterations: loop.maxIterations ?? null, ...exit };
   }
   if (loop.loopType === 'while' && loop.condition) {
-    return { loopType: 'while', condition: loop.condition, maxIterations: loop.maxIterations ?? null };
+    return { loopType: 'while', condition: loop.condition, maxIterations: loop.maxIterations ?? null, ...exit };
   }
   if (loop.loopType === 'repeatUntil' && loop.condition) {
-    return { loopType: 'repeatUntil', condition: loop.condition, maxIterations: loop.maxIterations ?? null };
+    return { loopType: 'repeatUntil', condition: loop.condition, maxIterations: loop.maxIterations ?? null, ...exit };
   }
   return null;
 };

--- a/src/web-ui/src/types/sequenceFlow.ts
+++ b/src/web-ui/src/types/sequenceFlow.ts
@@ -111,9 +111,9 @@ export type SequenceCommandReference = {
 };
 
 export type LoopConfigDto =
-  | { loopType: 'count'; count: number; maxIterations?: number | null }
-  | { loopType: 'while'; condition: SequenceStepCondition; maxIterations?: number | null }
-  | { loopType: 'repeatUntil'; condition: SequenceStepCondition; maxIterations?: number | null };
+  | { loopType: 'count'; count: number; maxIterations?: number | null; exitOnMaxIterations?: boolean | null }
+  | { loopType: 'while'; condition: SequenceStepCondition; maxIterations?: number | null; exitOnMaxIterations?: boolean | null }
+  | { loopType: 'repeatUntil'; condition: SequenceStepCondition; maxIterations?: number | null; exitOnMaxIterations?: boolean | null };
 
 export type IfConfigDto = { condition: SequenceStepCondition };
 

--- a/src/web-ui/src/types/stepEntry.ts
+++ b/src/web-ui/src/types/stepEntry.ts
@@ -38,6 +38,8 @@ export type LoopStepEntry = {
   count?: number;
   condition?: SequenceStepCondition;
   maxIterations?: number;
+  // When set, running out of iterations ends the loop instead of failing the sequence.
+  exitOnMaxIterations?: boolean;
   body: StepEntry[];
 };
 

--- a/tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionLogServiceMapStepStatusTests.cs
@@ -28,4 +28,37 @@ public sealed class ExecutionLogServiceMapStepStatusTests {
     // Failure counts/health/alerts key on the "failure" node status; no_break must never map to it.
     ExecutionLogService.MapStepStatus("no_break").Should().NotBe("failure");
   }
+
+  // A while loop whose condition finally goes false, and a count loop that runs every iteration,
+  // have each done exactly what they were asked. These runner statuses used to fall through to the
+  // failure default, which painted a healthy recovery guard red on every single run.
+  [Theory]
+  [InlineData("false")]
+  [InlineData("Succeeded")]
+  [InlineData("true")]
+  public void MapsNormalLoopExitsToSuccess(string outcome) {
+    ExecutionLogService.MapStepStatus(outcome).Should().Be("success");
+  }
+
+  [Fact]
+  public void MapsFailedLoopToFailure() {
+    ExecutionLogService.MapStepStatus("Failed").Should().Be("failure");
+  }
+
+  [Fact]
+  public void MapsExhaustedLoopToNotExecuted() {
+    // The loop opted out of failing at its ceiling: the body ran, the goal was not reached, and
+    // the sequence carried on. That is neither a success nor a failure.
+    var status = ExecutionLogService.MapStepStatus("exhausted");
+    status.Should().Be("not_executed");
+    status.Should().NotBe("failure");
+  }
+
+  // Feature 065: a self-reschedule that booked the next firing is the step working, and one that
+  // declined because its queue run had ended is a no-op — neither is a failure.
+  [Fact]
+  public void MapsSelfRescheduleOutcomes() {
+    ExecutionLogService.MapStepStatus("scheduled").Should().Be("success");
+    ExecutionLogService.MapStepStatus("noop").Should().Be("skipped");
+  }
 }

--- a/tests/unit/ExecutionLogs/ExecutionSubtreeProjectionTests.cs
+++ b/tests/unit/ExecutionLogs/ExecutionSubtreeProjectionTests.cs
@@ -44,6 +44,32 @@ public sealed class ExecutionSubtreeProjectionTests {
   }
 
   [Fact]
+  public void BuildSubtreeRendersAGatedOutCommandAsSkippedNotFailed() {
+    // A command step carries the trace explaining why its gate declined to run it. The step was
+    // skipped, exactly as authored — reading the false verdict as the step's own status is what
+    // painted hundreds of healthy "tap it if it is there" steps red.
+    var root = SequenceEntry("root-4", "Gated", "success", new[] { GatedOutCommandStep(1) });
+
+    var subtree = ExecutionLogService.BuildSubtree(root, new[] { root });
+
+    var node = subtree.Root.Children[0];
+    node.NodeKind.Should().Be("command");
+    node.Status.Should().Be("skipped");
+    node.ConditionTrace.Should().NotBeNull();
+  }
+
+  [Fact]
+  public void BuildSubtreeStillRendersAFalseConditionStepAsFailure() {
+    // A condition step IS its verdict, so false remains that step's failure.
+    var root = SequenceEntry("root-5", "Conditional", "failure", new[] { FalseConditionStep(1) });
+
+    var subtree = ExecutionLogService.BuildSubtree(root, new[] { root });
+
+    subtree.Root.Children[0].NodeKind.Should().Be("condition");
+    subtree.Root.Children[0].Status.Should().Be("failure");
+  }
+
+  [Fact]
   public void BuildSubtreeNestsChildSequenceWithoutExtraTopLevelNode() {
     // Sequence-invoking-sequence: a child entry that is itself a sequence with its own command child.
     var root = SequenceEntry("root-3", "Outer", "success", new[] { CommandStep(1, "seq-inner", "Inner") });
@@ -117,6 +143,17 @@ public sealed class ExecutionSubtreeProjectionTests {
       CommandName = commandName,
       CommandId = commandId
     };
+
+  private static ExecutionStepOutcome GatedOutCommandStep(int order)
+    => new(order, "command", "skipped", "skipped", "Step ran command 'Claim' with outcome 'skipped'.", "seq", $"step-{order}", "Seq", $"Step {order}",
+      new ConditionEvaluationTrace(false, "false", null, Array.Empty<Dictionary<string, object?>>(), Array.Empty<Dictionary<string, object?>>())) {
+      CommandName = "Claim",
+      CommandId = "cmd-claim"
+    };
+
+  private static ExecutionStepOutcome FalseConditionStep(int order)
+    => new(order, "condition", "executed", "executed", "Condition evaluated to false.", "seq", $"step-{order}", "Seq", $"Step {order}",
+      new ConditionEvaluationTrace(false, "false", null, Array.Empty<Dictionary<string, object?>>(), Array.Empty<Dictionary<string, object?>>()));
 
   private static ExecutionStepOutcome ConditionStep(int order)
     => new(order, "condition", "executed", "executed", "Condition evaluated to true.", "seq", $"step-{order}", "Seq", $"Step {order}",

--- a/tests/unit/Sequences/SequenceRunnerLoopTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerLoopTests.cs
@@ -210,6 +210,43 @@ public sealed class SequenceRunnerLoopTests {
   }
 
   [Fact]
+  public async Task WhileLoopExitOnMaxIterationsGivesUpWithoutFailingTheSequence() {
+    // A best-effort guard ("press BACK until the city is on screen") that runs out of attempts
+    // has produced a disappointing outcome, not a broken one — the steps after it still run.
+    var executed = new List<string>();
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "recover",
+      StepType = SequenceStepType.Loop,
+      Loop = new WhileLoopConfig {
+        Condition = new ImageVisibleStepCondition { ImageId = "img" },
+        MaxIterations = 3,
+        ExitOnMaxIterations = true
+      },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+    var afterStep = new SequenceStep {
+      Order = 1,
+      StepId = "after",
+      CommandId = "after-cmd",
+      StepType = SequenceStepType.Action,
+      Action = new SequenceActionPayload { Type = "tap" }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep, afterStep })));
+    var result = await runner.ExecuteAsync("s",
+        (id, _) => { executed.Add(id); return Task.CompletedTask; },
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    result.Status.Should().Be("Succeeded");
+    executed.Should().HaveCount(4);
+    executed.Should().Contain("after-cmd");
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.Status.Should().Be("exhausted");
+    loopResult.Message.Should().Contain("gave up after 3 iterations");
+  }
+
+  [Fact]
   public async Task WhileLoopConditionThrowsLoopFails() {
     var executed = new List<string>();
     var loopStep = new SequenceStep {
@@ -303,6 +340,33 @@ public sealed class SequenceRunnerLoopTests {
 
     result.Status.Should().Be("Failed");
     executed.Should().HaveCount(3);
+  }
+
+  [Fact]
+  public async Task RepeatUntilLoopExitOnMaxIterationsGivesUpWithoutFailingTheSequence() {
+    var executed = new List<string>();
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "cleanup",
+      StepType = SequenceStepType.Loop,
+      Loop = new RepeatUntilLoopConfig {
+        Condition = new ImageVisibleStepCondition { ImageId = "img" },
+        MaxIterations = 3,
+        ExitOnMaxIterations = true
+      },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (id, _) => { executed.Add(id); return Task.CompletedTask; },
+        conditionEvaluator: (_, _) => Task.FromResult(false));
+
+    result.Status.Should().Be("Succeeded");
+    executed.Should().HaveCount(3);
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.Status.Should().Be("exhausted");
+    loopResult.Message.Should().Contain("gave up after 3 iterations");
   }
 
   [Fact]


### PR DESCRIPTION
## What this fixes

A full comparison of the three live queues over one overnight run (606 sequence firings, 2026-09-02 19:24 → 2026-09-03 08:57 local) found that **every one of the 17 sequence failures had the same cause**, and that the execution log was hiding it behind ~1,671 false alarms.

| | Monday (5554) | PNS Daily 5558 | Exo (5556) |
|---|---|---|---|
| Sequence runs | 184 | 242 | 180 |
| Hard failures | 5 | 3 | 9 |

## 1. Recovery guards took the whole sequence down

Every failure was a `recover` or `cleanup` while-loop — `while NOT imageVisible(world-nav) { BACK }`, `maxIterations: 4` — hitting its ceiling. `SequenceRunner` treats exhaustion as `result.Fail()`, a hard abort. Nothing else stopped a sequence all night.

The iteration histogram shows the cap, not the game, was the binding constraint:

```
recover:  0 BACKs x160   1 x60   2 x46   3 x16   4 x6   |  hit cap x11
cleanup:  0 x100         1 x136  2 x33   3 x13          |  hit cap x6
```

Sixteen seconds after Exo's Radio Quiz gave up at 4 presses, Alliance Help All's identical guard succeeded on its own.

Worse, a failed *trailing* `cleanup` leaves the game deep in a modal, so the next sequence's `recover` starts four presses behind and also dies. Both overnight failure clusters are exactly that cascade:

- Exo 22:30 Daily Quest Chests → 22:33 Help All → 22:37 Mystery Shop → 23:03 Radio Quiz → 23:34 Help All
- Monday 03:05 Hero Duel → 03:10 Tavern → 03:20 Praise

`LoopConfig.ExitOnMaxIterations` lets a loop opt out. Running out of iterations then ends it as `exhausted` and the sequence carries on. A loop that is meant to converge — draining a list, waiting for a state — keeps the hard failure by default.

## 2. The log called ~1,671 healthy nodes failures

This is why the success rates *looked* more varied than they were. Only 17 of the red nodes were real.

- `BuildStepNode` derived a node's status from its condition trace whenever one was present, so a correctly gated-out "tap it if it is there" step rendered as a failure (581 command nodes + 483 if nodes). A condition step is its own verdict; every other step now uses its own outcome.
- `MapStepStatus` had no case for the runner's `"false"` / `"Succeeded"` loop exits or for `"scheduled"` / `"noop"` self-reschedules, so all four fell through to the `_ => "failure"` default (341 + 243 nodes). Every self-reschedule in the system showed red on every single run.

## Scope

The flag is plumbed through the domain model, the REST contract (request and response), and the authoring UI, which gains a "Give up at Max" checkbox on while / repeat-until loops so an edit cannot silently drop it. The save payload omits the field unless set, so untouched loops stay byte-identical.

No sequence data is changed here. Turning the flag on for the 46 live `recover`/`cleanup` loops is a follow-up against the running service.

## Tests

10 new tests; full suite green — 944 unit, 125 contract, 322 integration, 640 web-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
