### PR TITLE
Add loop exit reason and nested commandOutcome stepRef resolution (FR-001)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/080-fix-api-bugs"}
+{"feature_directory": "specs/081-loop-exit-reason-and-nested-steprefs"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/080-fix-api-bugs/plan.md
+at specs/081-loop-exit-reason-and-nested-steprefs/plan.md
 <!-- SPECKIT END -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -270,6 +270,31 @@ tree node kind `if` (web-ui grid label "If"). Branch steps log themselves like l
 `elseBody: [...]` (null/absent = no else; `[]` = present but empty). See
 `specs/067-sequence-if-conditions/contracts/sequences-api.md`.
 
+**Loop exit reason** (feature 081): a `Loop` step's `StepResult` carries a structured
+`ExitReason { BrokeVia: string?, ExhaustedMaxIterations: bool }` alongside the existing
+`LoopIterations`, populated identically across all three loop kinds (count/while/repeat-until) and
+correct even when the firing `Break` is nested inside an `If` body within the loop. `BrokeVia` is
+the firing `Break` step's own `StepId` (never an enclosing `If`'s), or `null` if none fired.
+`ExhaustedMaxIterations` reports whether the loop ran its full configured `MaxIterations` without
+any `Break` firing, independent of `ExitOnMaxIterations` (so it stays `true` even when
+`ExitOnMaxIterations: false` also fails the loop for that reason). Both are `false`/`null` when the
+loop finished its body/condition normally. Purely additive on the existing `/api/sequences/{id}/execute`
+response — no separate contract to update.
+
+**Widened `commandOutcome` `stepRef` scope** (feature 081): `SequenceStepValidationService`
+resolves a `commandOutcome` condition's `stepRef` against every step reachable from the sequence
+root — root steps plus every nested `Loop.Body` and `If.Body`/`ElseBody`, recursively — using the
+sequence's authored (document) order to keep enforcing "must reference a prior step," rather than
+only the condition's immediate sibling list as before. `expectedState` additionally accepts
+`break`/`no_break` (alongside `success`/`failed`/`skipped`), and `SequenceRunner` now records a
+`Break` step's fired/not-fired outcome into its runtime outcome map so such a reference actually
+resolves at execution time (previously unset, so even an already-legal same-body reference to a
+`Break` step's outcome always failed with "reference unavailable"). A reference that is now
+validation-legal (reachable + prior) but names a step that did not execute during a given run (an
+`If` branch not taken, a loop body that ran zero iterations) still fails the referencing step and
+the run with that same "unavailable" error — unchanged, deliberately not softened into a silent
+skip. See `specs/081-loop-exit-reason-and-nested-steprefs/contracts/loop-exit-reason-and-stepref-scope.md`.
+
 ## REST API surface
 
 Minimal-API endpoint groups under `src/GameBot.Service/Endpoints/` (all under `/api`):
@@ -310,6 +335,14 @@ Feature 080 fixed three platform bugs, additively/tightening only (no route remo
   `400 invalid_input_actions` when none of the actions dispatched, or keeps the existing
   `202 Accepted` (extended with a per-action `results` array) when some/all did; `409` is reserved
   for a session that genuinely isn't found/running.
+
+Feature 081 added, additively (see "Loop exit reason" / "Widened `commandOutcome` `stepRef` scope"
+above for detail):
+
+- A `Loop` step's execution result gains `exitReason: { brokeVia, exhaustedMaxIterations }`.
+- `POST /api/sequences` / `PUT /api/sequences/{id}` now accept a `commandOutcome` condition's
+  `stepRef` naming any structurally prior step reachable from the sequence root, not only an
+  immediate sibling, and accept `break`/`no_break` as `expectedState` values.
 
 ## Legacy / removed (don't be misled by old specs)
 

--- a/specs/081-loop-exit-reason-and-nested-steprefs/checklists/requirements.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Loop Exit Reason & Nested Step-Outcome References
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a platform-API feature (the "user" is an API-consuming sequence author,
+  same framing as `specs/080-fix-api-bugs/spec.md`), so field/step-type names like
+  `Loop`, `Break`, `If`, `stepRef`, and `commandOutcome` are the domain vocabulary,
+  not implementation detail — consistent with the precedent set by feature 080.
+- All items pass on first draft; no clarification iterations were needed. The one
+  genuine design choice (how "prior" is determined once reference scope spans the
+  whole sequence, not just the immediate sibling list) is resolved as an explicit
+  requirement (FR-007: authored/structural order) rather than left ambiguous,
+  because a clear default exists and the alternative (runtime-order-dependent
+  "prior") would make static validation impossible.

--- a/specs/081-loop-exit-reason-and-nested-steprefs/contracts/loop-exit-reason-and-stepref-scope.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/contracts/loop-exit-reason-and-stepref-scope.md
@@ -1,0 +1,122 @@
+# Contract: Loop Exit Reason & Widened `stepRef` Scope
+
+This feature adds **no new HTTP endpoint**. It extends an existing response field
+(`/api/sequences/{id}/execute`'s per-step result) and widens acceptance on an
+existing request field: a sequence step's own `condition` (the per-step gate
+deciding whether that step executes at all — `SequenceStepContract.Condition`,
+distinct from an `If` step's branch-selector `if.condition`), when it is a
+`commandOutcome` condition, accepted by `POST /api/sequences` and
+`PUT /api/sequences/{id}`. Both changes are additive: every request/response shape
+that is valid today remains valid and unchanged in meaning.
+
+Note: an `If` step's own branch-selector condition (`if.condition`) is a separate,
+pre-existing code path (`SequenceStepValidationService.ValidateIfCondition`) that
+does not perform stepRef existence/ordering checks today and is unchanged by this
+feature — only the per-step `condition` gate's resolution (`ValidateStepCondition`)
+is widened here.
+
+## Response addition: `Loop` step result `exitReason`
+
+A `Loop` step's entry in the `steps` array of a sequence-execution result gains one
+new, optional field:
+
+```json
+{
+  "commandId": "collect-loop",
+  "status": "Succeeded",
+  "loopIterations": [ /* unchanged */ ],
+  "exitReason": {
+    "brokeVia": "cluster-not-found-break",
+    "exhaustedMaxIterations": false
+  }
+}
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `exitReason.brokeVia` | `string \| null` | `stepId` of the `Break` step that fired, or `null` if none fired. |
+| `exitReason.exhaustedMaxIterations` | `boolean` | `true` iff the loop ran its full configured `maxIterations` without any `Break` firing. |
+
+Present only on `Loop` step entries (wherever `loopIterations` is present today).
+A consumer that does not read `exitReason` sees no change to any field it already
+parses.
+
+## Request acceptance: `commandOutcome.stepRef` scope
+
+**Before**: `stepRef` must name a step that is an immediate sibling of the
+condition's own step, within the same top-level `steps` array, `Loop.body`, or
+`If.body`/`elseBody` list the condition itself lives in. Any other reference —
+including a step nested in a *different* `Loop`/`If` body — is rejected at
+`POST /api/sequences` / `PUT /api/sequences/{id}` time with:
+
+```json
+{ "message": "...", "errors": ["Step 'gate' commandOutcome references unknown prior step 'nested-break'."] }
+```
+
+**After**: `stepRef` may name any `stepId` reachable from the sequence root —
+including one nested inside a `Loop`/`If` body other than the condition's own —
+provided it is structurally prior in the sequence's authored order. A reference to
+a step that is reachable but not prior (e.g. it appears later in the sequence)
+continues to be rejected, now with the same message but evaluated against the
+whole sequence rather than only the immediate list:
+
+```json
+{ "message": "...", "errors": ["Step 'gate' commandOutcome stepRef 'later-step' must reference a prior step."] }
+```
+
+## Request acceptance: `commandOutcome.expectedState` vocabulary
+
+**Before**: `"success" | "failed" | "skipped"` (case-insensitive); anything else,
+including `"break"`/`"no_break"`, is rejected:
+
+```json
+{ "message": "...", "errors": ["Step 'gate' commandOutcome expectedState must be one of success|failed|skipped."] }
+```
+
+**After**: `"success" | "failed" | "skipped" | "break" | "no_break"`
+(case-insensitive). `"break"`/`"no_break"` are meaningful only when `stepRef`
+names a `Break` step; naming a non-`Break` step whose recorded outcome is always
+`success`/`failed`/`skipped` and expecting `"break"`/`"no_break"` is accepted by
+validation (the vocabulary is not tied to the referenced step's type) but will
+never match at runtime — this mirrors today's existing behavior for any
+`expectedState` that can never match a given step's actual outcome tokens (not a
+new class of authoring foot-gun introduced by this feature).
+
+## Unchanged execution-time failure mode
+
+Referencing a step that is now validation-legal (reachable + prior) but did not
+actually execute during a specific run (e.g. it lives in an `If` branch not taken
+that run, or a loop body that ran zero iterations) continues to fail the
+referencing step and the sequence run at execution time with the existing message
+shape:
+
+```json
+{ "status": "Failed", "message": "Step 'gate' commandOutcome reference 'other-branch-step' is unavailable" }
+```
+
+This is unchanged behavior (see [research.md](../research.md) R-004) — only newly
+*reachable* through the API because it was previously blocked at validation for an
+unrelated reason (any cross-scope reference was rejected outright).
+
+## Invariants (MUST hold — asserted by tests)
+
+1. Every sequence and condition accepted before this feature is still accepted,
+   with unchanged validation errors for genuinely invalid input.
+2. Every `Loop` step result's existing fields (`status`, `loopIterations`,
+   `message`, etc.) are unchanged; `exitReason` is purely additive.
+3. `exitReason.brokeVia` and `exitReason.exhaustedMaxIterations: true` never both
+   hold for the same result.
+4. A `stepRef` that is reachable but not prior (by authored order) is rejected at
+   creation/replace time — widening scope never widens past "prior."
+5. A `Break` step's fired/not-fired outcome resolves via `commandOutcome` at any
+   validation-legal scope, including its own loop body (previously legal but
+   always broken at runtime).
+
+## Out of scope (explicitly unchanged)
+
+- Persisted sequence-definition JSON schema — no field added or removed.
+- `Break` step authoring, firing semantics, or execution-log entry shape (feature
+  066's outcome vocabulary is reused, not altered).
+- Non-`Break` step outcome recording/resolution semantics for
+  `success`/`failed`/`skipped` — unchanged, only now resolvable from a wider set of
+  referencing scopes.

--- a/specs/081-loop-exit-reason-and-nested-steprefs/data-model.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/data-model.md
@@ -1,0 +1,60 @@
+# Phase 1 Data Model: Loop Exit Reason & Nested Step-Outcome References
+
+No new persisted entities and no change to any stored sequence-definition schema.
+This feature touches two in-memory shapes: the execution-result type returned per
+run, and the internal outcome map the execution engine consults while running.
+
+## `LoopExitReason` (new, `GameBot.Domain.Services.SequenceRunner` / `StepResult`)
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `BrokeVia` | `string?` | The `StepId` of the `Break` step that fired during this loop's execution, or `null` if none fired. |
+| `ExhaustedMaxIterations` | `bool` | `true` iff the loop ran its full configured `MaxIterations` without any `Break` firing; independent of the `ExitOnMaxIterations` flag and of the loop's overall status. |
+
+Invariants:
+- `BrokeVia` and `ExhaustedMaxIterations: true` are mutually exclusive — a loop
+  either broke, exhausted, or did neither (finished its body/condition normally);
+  it cannot do more than one.
+- When the firing `Break` is nested inside an `If` body within the loop body,
+  `BrokeVia` is that `Break` step's own `StepId`, never the enclosing `If` step's.
+- Present only on a `StepResult` for a `Loop` step (i.e., wherever
+  `LoopIterations` is non-null today); absent/irrelevant for non-loop steps.
+
+## `StepResult` (existing, extended)
+
+Adds one new nullable property, `ExitReason: LoopExitReason?`, alongside the
+existing `LoopIterations: IReadOnlyList<LoopIterResult>?`. No existing field
+changes meaning or is removed. Serializes as-is through
+`/api/sequences/{id}/execute`'s existing response — no separate DTO/contract
+layer to update (see [research.md](research.md) R-006).
+
+## Runtime outcome map (`stepOutcomes: Dictionary<string, string>`, existing)
+
+No shape change — still a flat `stepId → outcome-token` map built up as steps
+execute. Extended in **coverage**, not shape: a `Break` step now writes its own
+`brokeVia`/outcome token (`"break"` or `"no_break"`) into this dictionary, which
+it previously never did (see [research.md](research.md) R-005). This is what
+makes a widened `stepRef` actually resolve to a meaningful value at runtime for a
+`Break` step, not just pass validation.
+
+## `CommandOutcomeStepCondition` (existing, validation behavior changed)
+
+No field changes. Two validation-time behavior changes in
+`SequenceStepValidationService.ValidateStepCondition`:
+
+1. `StepRef` resolution scope widens from "the condition's immediate sibling
+   list" to "every `StepId` reachable from the sequence root, in authored
+   (document) order" — see [research.md](research.md) R-003.
+2. `ExpectedState`'s allowed-values set gains `"break"` and `"no_break"` alongside
+   the existing `"success"`/`"failed"`/`"skipped"`.
+
+## Flattened step index (new, internal validation helper — not a persisted or
+returned entity)
+
+A single ordered list, built once per top-level `Validate(...)` call, of every
+step reachable from the sequence root: root `steps` in authored order, with each
+`Loop`'s `Body` and each `If`'s `Body`/`ElseBody` recursively expanded in place at
+its authored position. Used only to answer "is stepId X reachable, and does it
+appear before stepId Y in authored order" during validation. Never serialized,
+never exposed via any endpoint — a pure internal computation aid for R-003's
+resolution rule.

--- a/specs/081-loop-exit-reason-and-nested-steprefs/plan.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/plan.md
@@ -1,0 +1,145 @@
+# Implementation Plan: Loop Exit Reason & Nested Step-Outcome References
+
+**Branch**: `081-loop-exit-reason-and-nested-steprefs` | **Date**: 2026-09-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/081-loop-exit-reason-and-nested-steprefs/spec.md`
+
+## Summary
+
+Deliver FR-001 from the PNS project's feature-request tracker
+(`C:\src\PNS\docs\api-feature-requests.md`), two additive changes to sequence
+authoring/execution:
+
+1. **Loop exit reason** — a `Loop` step's `StepResult` gains a structured
+   `ExitReason { BrokeVia: string?, ExhaustedMaxIterations: bool }`, populated by
+   every loop-execution path (count/while/repeat-until), including when the firing
+   `Break` is nested inside an `If` body within the loop.
+2. **Nested `stepRef` resolution** — `SequenceStepValidationService.ValidateStepCondition`
+   resolves a `commandOutcome` condition's `stepRef` against every step reachable
+   from the sequence root (not just the condition's immediate sibling list), using
+   the sequence's authored (document) order to keep enforcing "must reference a
+   prior step" without needing runtime information. This requires two pieces of
+   supporting plumbing, both necessary for the feature to deliver its stated value
+   (querying whether a nested `Break` fired), not optional extras:
+   - `Break` step outcomes (`"break"`/`"no_break"`) must actually be recorded into
+     `SequenceRunner`'s runtime `stepOutcomes` dictionary — today they are written
+     only to the execution log, never to the dictionary `commandOutcome` resolves
+     against, so even an already-legal same-body reference to a `Break` step always
+     fails at runtime with "reference unavailable."
+   - `break`/`no_break` must be added to `SequenceStepValidationService`'s allowed
+     `commandOutcome` `expectedState` values (currently only
+     `success|failed|skipped`).
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9.0
+**Primary Dependencies**: ASP.NET Core Minimal APIs (GameBot.Service), no new
+third-party dependencies required
+**Storage**: File-backed repositories (`FileSequenceRepository` et al.) — unchanged;
+no schema migration (the `Loop` `StepResult` is serialized as-is with no persisted
+contract to migrate)
+**Testing**: xUnit 2.7.1 across `tests/unit`, `tests/integration`, `tests/contract`
+(GameBot.UnitTests / GameBot.IntegrationTests / GameBot.ContractTests)
+**Target Platform**: Windows service host (existing GameBot.Service)
+**Project Type**: Backend web service (single solution, layered: Domain / Emulator /
+Service)
+**Performance Goals**: No new performance budget — additive fields on an existing
+per-step result object and a widened (still O(sequence size), still validation-time
+only) lookup; no measurable latency/throughput change expected on the low-frequency
+sequence-authoring and execution paths this touches.
+**Constraints**: MUST NOT change behavior for any already-valid sequence, condition,
+or Loop/Break execution result (regression-free per spec FR-012); MUST NOT weaken
+the existing "reference must be prior" ordering rule, only widen its search scope
+(FR-007); MUST NOT change the existing "reference to a step that didn't execute this
+run fails the run" semantics (FR-011).
+**Scale/Scope**: Two related, additive defect-adjacent changes confined to
+`GameBot.Domain/Services/SequenceRunner.cs`,
+`GameBot.Domain/Services/SequenceStepValidationService.cs`,
+plus their existing test counterparts. No new endpoints, entities, or persisted
+schema changes — the widened result shape flows through the existing
+`/api/sequences/{id}/execute` response with no separate contract to update (per
+research; the Service layer consumes `StepResult` fields directly).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*NON-NEGOTIABLE*: If `build` or required `test` runs are failing (local or CI),
+implementation progression is blocked until failures are fixed or a documented
+maintainer waiver exists.
+
+- **I. Code Quality Discipline**: No new lint/static-analysis suppressions
+  anticipated; changes are additive fields/logic in existing, already-modular
+  services (`SequenceRunner`, `SequenceStepValidationService`). No underscores in
+  new method names. PASS.
+- **II. Testing Standards**: Each behavior change requires a failing test added
+  first that reproduces the gap through the real execution/validation path (not a
+  hand-built result bypassing the engine) — mirrors the precedent set by feature
+  080. PASS (gate honored by task design, not yet executed).
+- **III. UX Consistency**: The new `ExitReason` field is additive JSON on an
+  existing result shape (no breaking change, no new error-response shape to
+  invent); the relaxed `stepRef` validation reuses the existing error-message
+  format, only changing which references are accepted. PASS.
+- **IV. Performance**: No hot-path change; walking the full step tree at
+  sequence-creation validation time is bounded by sequence size (already small,
+  authoring-time only, not executed per-run). No new benchmark required. PASS.
+- **V. Living Documentation**: `docs/architecture.md` §"Break & loop execution and
+  the execution-log status vocabulary" documents today's `Loop`/`Break` status
+  vocabulary and will be updated in the same PR to describe `ExitReason` and the
+  widened `stepRef` scope; spec Status line will be set to `Implemented` once
+  implementation lands.
+
+No violations requiring Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/081-loop-exit-reason-and-nested-steprefs/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── GameBot.Domain/
+    └── Services/
+        ├── SequenceRunner.cs                    # Loop ExitReason (all 3 loop kinds
+        │                                         # + Break-through-If), Break outcome
+        │                                         # recording into stepOutcomes
+        └── SequenceStepValidationService.cs      # Whole-tree stepRef resolution +
+                                                    # break/no_break expectedState
+
+tests/
+├── unit/Sequences/
+│   ├── SequenceRunnerLoopTests.cs                # ExitReason: count loop
+│   ├── SequenceRunnerWhileBreakOnTests.cs        # ExitReason: while loop
+│   ├── SequenceRunnerIfTests.cs / SequenceRunnerIfBodyScopeTests.cs
+│   │                                              # ExitReason: Break nested in If
+│   │                                              # within a Loop body
+│   └── LoopValidationTests.cs / IfValidationTests.cs
+│                                                  # nested stepRef acceptance,
+│                                                  # ordering-still-enforced, and
+│                                                  # break/no_break expectedState
+└── integration/Sequences/
+    └── (new) NestedStepOutcomeReferenceIntegrationTests.cs
+                                                    # real HTTP-through-repository:
+                                                    # cross-scope Break reference,
+                                                    # end-to-end break vs no_break run
+```
+
+**Structure Decision**: Existing single-solution layered structure
+(`GameBot.Domain` / `GameBot.Emulator` / `GameBot.Service`, with `tests/unit`,
+`tests/integration`, `tests/contract`) is unchanged. This feature adds no new
+projects or top-level directories — both changes land in existing files, per the
+research below.
+
+## Complexity Tracking
+
+*No Constitution Check violations — table intentionally omitted.*

--- a/specs/081-loop-exit-reason-and-nested-steprefs/quickstart.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/quickstart.md
@@ -1,0 +1,72 @@
+# Quickstart: Verifying Loop Exit Reason & Nested `stepRef` Resolution
+
+Run against a local `GameBot.Service` instance (`GAMEBOT_USE_ADB=false` is fine —
+both changes are pure sequence-authoring/execution-engine behavior, no device I/O
+involved).
+
+## Part A — a Loop's result reveals why it stopped
+
+Create a sequence with a `Loop(maxIterations: 3)` whose body has a conditional
+`Break` that fires once a counter parameter reaches a threshold, run it twice (once
+with input that makes the break fire, once that exhausts the loop), then inspect
+each run's result:
+
+```bash
+curl -s http://localhost:8080/api/sequences/{id}/executions/{executionId}
+# Break-fired run — expect the Loop step's entry to include:
+#   "exitReason": { "brokeVia": "<break-step-id>", "exhaustedMaxIterations": false }
+# Exhausted run — expect:
+#   "exitReason": { "brokeVia": null, "exhaustedMaxIterations": true }
+```
+
+## Part B — a condition can reference a nested `Break` from anywhere in the sequence
+
+Author a sequence where a `Break` step lives inside one `Loop` body, and a separate
+top-level step's own `condition` gate (not its `if.condition` — see
+[contracts/loop-exit-reason-and-stepref-scope.md](contracts/loop-exit-reason-and-stepref-scope.md)
+for why that distinction matters) — not a sibling of that `Break` — checks whether
+it fired:
+
+```bash
+curl -s -X POST http://localhost:8080/api/sequences \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "quickstart-fr001-partb",
+        "steps": [
+          { "stepId": "loop-1", "loop": { "loopType": "count", "count": 3 },
+            "body": [
+              { "stepId": "cluster-not-found-break", "stepType": "Break",
+                "breakCondition": { "type": "imageVisible", "imageId": "no-cluster" } }
+            ] },
+          { "stepId": "gate",
+            "condition": { "type": "commandOutcome", "stepRef": "cluster-not-found-break", "expectedState": "break" },
+            "primitiveAction": { "type": "Command", "payload": { "commandId": "fail-c4" } } }
+        ]
+      }'
+# Before this feature: 400, errors mentions "gate" references unknown prior step
+#   "cluster-not-found-break"
+# After this feature: 201 Created — the reference resolves
+```
+
+```bash
+curl -s http://localhost:8080/api/sequences/{id}/executions/{executionId}
+# Break fired this run   -> gate's condition evaluates true  -> gate's action runs
+# Break did not fire     -> gate's condition evaluates false -> gate is skipped
+```
+
+## Regression check — ordering is still enforced
+
+The same request with `stepRef` pointed at a step that appears **after** `gate` in
+the sequence must still be rejected:
+
+```bash
+curl -s -X POST http://localhost:8080/api/sequences \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "quickstart-fr001-ordering", "steps": [
+        { "stepId": "gate",
+          "condition": { "type": "commandOutcome", "stepRef": "later-step", "expectedState": "success" },
+          "primitiveAction": { "type": "Command", "payload": { "commandId": "noop" } } },
+        { "stepId": "later-step", "primitiveAction": { "type": "Command", "payload": { "commandId": "noop" } } }
+      ] }'
+# Expect: 400, errors mentions "gate" ... stepRef 'later-step' must reference a prior step
+```

--- a/specs/081-loop-exit-reason-and-nested-steprefs/research.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/research.md
@@ -1,0 +1,163 @@
+# Phase 0 Research: Loop Exit Reason & Nested Step-Outcome References
+
+## R-001: Where `ExitReason` is constructed and threaded
+
+**Decision**: Add a `LoopExitReason` record (`BrokeVia: string?`,
+`ExhaustedMaxIterations: bool`) alongside `LoopIterations` on `StepResult`, and add
+a `brokeVia`/`exhaustedMaxIterations`-carrying overload to
+`SequenceExecutionResult.AddLoopStep(...)`. `ExecuteLoopBodyAsync`'s return tuple
+gains a fourth element, `string? BrokeVia`, populated with the firing `Break`
+step's own `StepId` (not `brkKey`'s derived fallback unless `StepId` truly is
+empty) at both firing sites (unconditional and conditional break, ~line 1266 and
+~1297 in `SequenceRunner.cs`). `ExecuteIfStepAsync`'s existing `BreakTriggered`
+`bool` return also gains this string alongside it, since a `Break` reached through
+a nested `If` inside a loop body must still surface its own id, not the `If`
+step's id. All three loop-kind executors (`ExecuteCountLoopAsync`,
+`ExecuteWhileLoopAsync`, `ExecuteRepeatUntilLoopAsync`) already branch on
+break-fired vs. exhausted vs. plain-completion to pick a status string — the same
+branches supply `ExitReason` at each of their existing `AddLoopStep` call sites, so
+no new control flow is introduced, only additional values captured at points that
+already know them.
+
+**Rationale**: `AddLoopStep` is already the single, exclusive construction site for
+a `Loop` step's `StepResult` (per exploration, confirmed at `SequenceRunner.cs:2156`
+in the current tree) — every one of the 6 call sites across the three loop kinds
+independently has the break-fired/exhausted/neither fact in hand at the moment it
+calls `AddLoopStep`, so threading one more value through is a narrow, additive
+change with no new state machine.
+
+**Alternatives considered**: A separate lookup/derived property computed from
+`LoopIterations` after the fact was rejected — `LoopIterResult` only records
+`BreakTriggered: bool` and `StepCount`, not the firing step's id, so deriving
+`BrokeVia` after construction would still require passing the id through anyway,
+just later and less directly.
+
+## R-002: `ExhaustedMaxIterations` semantics independent of `ExitOnMaxIterations`
+
+**Decision**: `ExhaustedMaxIterations` is `true` iff the loop actually ran its
+full configured `MaxIterations` without any `Break` firing — computed purely from
+iteration-count-reached-without-break, never from the `ExitOnMaxIterations` flag or
+the resulting status string. This holds even when `ExitOnMaxIterations: false`
+today produces an overall `"Failed"` loop status (a case that is presently
+indistinguishable, from the result alone, from a genuine mid-body error).
+
+**Rationale**: Spec FR-004 explicitly requires this independence, because the
+consumer's use case (a structural "did we run out of tries" gate) needs the fact
+regardless of whether the platform is also configured to fail the loop over it —
+conflating the two would silently drop exactly the signal FR-001 exists to expose.
+
+**Alternatives considered**: Deriving `ExhaustedMaxIterations` solely from status
+`== "exhausted"` was rejected because that status string is only emitted for the
+`ExitOnMaxIterations: true` path (per `SequenceRunner.cs` ~1043/1124); the
+`ExitOnMaxIterations: false` path reuses the generic `"Failed"` status (~1047-1050),
+which would make the new field blind to exactly the case where the underlying
+platform behavior most needs a structural explanation.
+
+## R-003: Whole-tree `stepRef` resolution and "prior" ordering
+
+**Decision**: Replace `ValidateStepCondition`'s sibling-scoped lookup
+(`siblings.Select(...).FirstOrDefault(...)`) with a lookup against a flattened,
+document-order index of every step reachable from the sequence root — root `steps`
+in order, with each `Loop`'s `Body` and each `If`'s `Body`/`ElseBody` expanded
+in place at its authored position, recursively. Build this flattened index once per
+top-level `Validate(...)` call and pass it down through the existing recursive
+`ValidateLoopStep`/`ValidateIfBranch` calls (replacing the `siblings`/
+`indexInSiblings` parameters used only for this check) rather than reassembling it
+per condition. "Prior" is redefined as "appears earlier in this flattened,
+authored-order index" instead of "has a lower index within the immediate sibling
+list" — a strict generalization that still rejects same-list forward references
+exactly as today.
+
+**Rationale**: This requires no runtime/branch-taken information (validation is
+static, authored-structure-only, matching how it already only has the authored
+tree available), and it is a direct, minimal generalization of the exact rule
+already in place — every currently-valid reference (a sibling with a lower
+same-list index) also has a lower flattened index than its referencer, since a
+list's own steps are contiguous and ordered within the flattened walk. No existing
+acceptance/rejection changes for any request that was already valid or already
+correctly rejected for being non-prior within its own list.
+
+**Alternatives considered**: (a) Resolving purely by reachability with no ordering
+check was rejected — spec FR-007 explicitly requires "prior" to keep being
+enforced, since dropping it would let a condition reference a step that
+provably cannot have executed yet by construction (e.g. a later top-level step),
+which is a strictly worse authoring experience than today, not merely a widened
+one. (b) Deferring the "prior" check to runtime (resolve at validation, only fail
+at execution if the dictionary lookup misses) was rejected because it would let a
+sequence pass creation validation while carrying a reference that can never
+possibly succeed for a purely structural reason (referencing a step that appears
+later in every possible execution order) — validation is supposed to catch exactly
+this class of authoring mistake fast, per the existing "must reference a prior
+step" rule's own stated purpose.
+
+## R-004: Referencing a reachable-but-not-executed step stays a hard failure
+
+**Decision**: No change to `SequenceRunner`'s existing behavior when a
+`commandOutcome` condition's `stepRef` resolves against the (now wider) validation
+allow-list but the named step did not actually run during a given execution (e.g.
+it lives in the untaken branch of an `If`, or inside a loop body that ran zero
+iterations): the step and the sequence run continue to fail with today's
+`"...commandOutcome reference '<id>' is unavailable"` message (`SequenceRunner.cs`
+~544-558). This case was previously unreachable through the API (validation
+rejected any cross-scope reference outright); Part B's widened validation makes it
+reachable for the first time, but the runtime code path and its failure message
+already exist and are unchanged.
+
+**Rationale**: Spec FR-011 requires this explicitly — a "did this step run" gap
+should fail loudly (matching the platform's existing convention for an
+unresolvable reference), not silently resolve to `skipped`/`false`, since a silent
+resolution would reintroduce exactly the kind of unprovable, guessable outcome
+FR-001 exists to eliminate.
+
+**Alternatives considered**: Treating a not-yet-executed reachable step as an
+implicit `skipped`/false-match was considered (it would let an author build an
+"if the other branch ran and it broke" OR-style gate without a hard failure) but
+rejected as out of scope — it is a new runtime semantic FR-001 does not ask for
+and would change behavior for a case the spec's edge cases section explicitly
+pins to today's failure behavior.
+
+## R-005: Making a `Break` step's outcome actually resolvable
+
+**Decision**: `ExecuteLoopBodyAsync` must additionally write
+`stepOutcomes[brkKey] = BreakOutcomes.Break` or `BreakOutcomes.NoBreak` at each of
+its four `result.AddStep(brkKey, ...)` call sites (unconditional-fired,
+conditional-fired, conditional-not-fired, and the eval-error-treated-as-no-break
+path) — today only the execution-log entry is written; the runtime dictionary
+`commandOutcome` conditions resolve against is never updated for a `Break` step.
+Additionally, `SequenceStepValidationService`'s `AllowedCommandOutcomeStates` gains
+`"break"` and `"no_break"` (matching `BreakOutcomes.Break`/`BreakOutcomes.NoBreak`'s
+existing string constants exactly, so no new vocabulary is invented).
+
+**Rationale**: Without this, Part B's headline use case — asking "did that nested
+`Break` fire?" — cannot work at all, at any scope, including the same-body sibling
+reference that is already technically legal today: the dictionary key for a
+`Break` step's id is simply never set, so any reference to it already fails with
+"unavailable" before this feature and would continue to after, defeating the
+feature's stated purpose. This is the same expressiveness gap flagged informally
+in the consumer's bug tracker (B-006: "no way to query whether a specific nested
+`Break` step fired... `break`/`no_break` are not valid `expectedState` values").
+
+**Alternatives considered**: Scoping this feature to only the literal two words in
+FR-001's proposed shape (exit reason + relaxed `stepRef`) and leaving `Break`
+outcomes unresolvable was rejected — it would ship a feature that cannot deliver
+its own stated motivation (a provable "did this loop's `Break` fire" gate),
+directly contradicting the "why" section of the request being implemented.
+
+## R-006: No persisted-schema or OpenAPI contract migration needed
+
+**Decision**: No change to `FileSequenceRepository`'s persisted sequence-definition
+schema (the new fields are execution-result-only, never part of a stored sequence
+document) and no separate result-DTO contract to update — `StepResult` is returned
+directly by `/api/sequences/{id}/execute` (per exploration: Service-layer
+`SequenceExecutionService.cs` consumes `StepResult` fields directly, no mapping
+layer sits between the domain result and the HTTP response), so the new
+`ExitReason` property is exposed automatically once added to the domain type.
+
+**Rationale**: Keeps the change confined to `GameBot.Domain`, matching the
+"additive, no breaking change" requirement (FR-012) — existing consumers that
+don't read the new field see no shape change to anything they already parse.
+
+**Alternatives considered**: Introducing a dedicated response contract/DTO for
+`ExitReason` was rejected as unnecessary indirection — the project's existing
+convention (per feature 080's precedent) is to extend the domain result type
+directly when no separate contract already exists for that shape.

--- a/specs/081-loop-exit-reason-and-nested-steprefs/spec.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/spec.md
@@ -1,0 +1,257 @@
+# Feature Specification: Loop Exit Reason & Nested Step-Outcome References
+
+**Feature Branch**: `081-loop-exit-reason-and-nested-steprefs`
+**Created**: 2026-09-11
+**Status**: Implemented
+**Input**: User description: "Implement FR-001 from C:\src\PNS\docs\api-feature-requests.md: two related, additive changes to the sequence execution/authoring API — expose why a Loop step ended (brokeVia vs. exhaustedMaxIterations), and let commandOutcome/stepRef reference a step nested inside a Loop/If body, not only a top-level sibling."
+
+## Background
+
+An external consumer of the GameBotAI platform API (the PNS project) maintains a
+feature-request tracker at `C:\src\PNS\docs\api-feature-requests.md`. Its first
+entry, FR-001, documents a real, paid authoring cost: because a `Loop` step's
+result never reveals *why* it stopped iterating, and because a condition can only
+reference a step that is its own immediate sibling, two downstream features had to
+fall back on weaker designs —
+
+- `PNS.CollectResources` shipped without a hard "cluster not found" failure gate,
+  because there was no structural way to ask "did the exhaustion-detection loop's
+  Break fire?" from outside that loop.
+- The alliance-donation feature's exhaustion gate had to guess whether a rejection
+  had occurred using a fragile ~2.0-3.3 second screenshot-timing window instead of
+  a provable check, and that heuristic is documented as unreliable and
+  best-effort-only.
+
+This feature closes that gap with two additive changes to sequence authoring and
+execution, plus the minimal supporting plumbing needed for the second change to
+actually be usable for its stated purpose (querying a `Break` step's fired/not-fired
+outcome):
+
+1. A `Loop` step's execution result reports a structured reason it stopped
+   iterating: which `Break` step fired (if any), or whether it ran out of
+   iterations.
+2. A condition elsewhere in the sequence can reference any step's outcome by id,
+   regardless of which `Loop`/`If` body that step lives in — not only a step in its
+   own immediate scope — including asking whether a specific `Break` step fired.
+
+Neither change alters the meaning or result of any sequence or condition that is
+already valid today.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A Loop's result reveals why it stopped (Priority: P1)
+
+A sequence author (or the tooling that inspects a sequence run's result) looks at a
+`Loop` step's own execution result and needs to know, structurally, whether the loop
+stopped because a specific `Break` fired, because it ran out of iterations, or
+because it simply finished its body/condition normally — instead of having to infer
+this from timing or from the coarse pass/fail status alone.
+
+**Why this priority**: This is useful on its own even before any condition can
+reference it — a caller inspecting a completed run's JSON result already gains a
+provable signal, cutting the exact "can't tell if my safety loop actually broke"
+cost documented in FR-001. It requires no other part of this feature to deliver
+value.
+
+**Independent Test**: Run a sequence containing a `Loop` whose body has a
+conditional `Break`, once with an input that makes the `Break` fire and once with an
+input that makes the loop exhaust its configured max iterations; inspect the `Loop`
+step's own result in both runs and confirm the reported reason matches which path
+actually happened. Fully testable without any condition/stepRef change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `Loop` whose body contains a `Break` step with a condition that
+   evaluates true on some iteration, **When** the sequence runs and the `Break`
+   fires, **Then** the `Loop` step's result reports the firing `Break` step's id and
+   reports that max iterations was not exhausted.
+2. **Given** the same `Loop`, **When** the sequence runs with an input that never
+   satisfies the `Break` condition and the loop reaches its configured maximum
+   iteration count, **Then** the `Loop` step's result reports no firing `Break` step
+   and reports that max iterations was exhausted.
+3. **Given** a `Break` step nested inside an `If` body that is itself nested inside
+   the `Loop` body, **When** that `Break` fires, **Then** the `Loop` step's result
+   reports the `Break` step's own id (not the enclosing `If` step's id).
+4. **Given** a `Loop` that completes without exhausting its max iterations and
+   without any `Break` ever firing (e.g. a body with no `Break` step, or a
+   while/repeat-until loop whose own condition ends the loop), **When** the sequence
+   runs, **Then** the `Loop` step's result reports no firing `Break` step and reports
+   that max iterations was not exhausted (neither state applies).
+5. **Given** any sequence run that existed and passed before this feature, **When**
+   it is run again unmodified, **Then** its existing status, message, and iteration
+   fields are unchanged — the new information is additive.
+
+---
+
+### User Story 2 - A condition can ask "did that Break fire?" from anywhere in the sequence (Priority: P1)
+
+A sequence author builds an `If` (or another `Loop`'s `Break`) condition that needs
+to check whether a specific `Break` step — nested inside some `Loop` or `If` body
+elsewhere in the sequence, not necessarily the condition's own immediate body —
+fired during this run, so they can gate later steps on that structural fact instead
+of a screenshot-timing guess.
+
+**Why this priority**: This is the specific, evidenced use case that forced the
+alliance-donation feature's timing-based workaround. Equal priority to Story 1
+because together they are what actually lets that workaround be replaced.
+
+**Independent Test**: Author a sequence with a `Break` step nested inside one
+`Loop`/`If` body, and a separate `If` step elsewhere in the sequence (not a sibling
+of that `Break`) whose condition references the `Break` step's id and checks whether
+it fired. Run the sequence once with an input that fires the `Break` and once with
+an input that does not; confirm the referencing `If` step's condition result differs
+correctly between the two runs. Independently testable once Story 1's execution
+plumbing exists, without needing the general non-Break stepRef case from Story 3.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sequence-creation request whose `If` condition's `stepRef` names a
+   step nested inside a `Loop`/`If` body that is not the condition's own sibling,
+   **When** the sequence is submitted, **Then** creation succeeds (today it is
+   rejected with `400 "references unknown prior step"`).
+2. **Given** that sequence, **When** it runs and the referenced `Break` step fires,
+   **Then** a condition checking for the `break` outcome evaluates true (and a
+   condition checking for `no_break` evaluates false).
+3. **Given** the same sequence, **When** it runs and the referenced `Break` step
+   does not fire, **Then** a condition checking for `no_break` evaluates true (and
+   one checking for `break` evaluates false).
+4. **Given** a `stepRef` naming a step that appears later in the sequence's authored
+   structure than the referencing condition, **When** the sequence is submitted,
+   **Then** creation is still rejected as referencing a step that is not prior —
+   relaxing scope does not relax ordering.
+
+---
+
+### User Story 3 - A condition can reference any nested step's outcome, not just Break (Priority: P2)
+
+A sequence author builds a condition that checks the success/failed/skipped outcome
+of an ordinary (non-`Break`) step nested inside a different `Loop`/`If` body than
+the condition's own, to combine several nested checks into one gate.
+
+**Why this priority**: Lower priority than Stories 1-2 because the specifically
+evidenced, paid cost (the donation-exhaustion gate) is a `Break`-detection use case,
+but the platform's own condition contract makes no distinction between referencing a
+`Break` step and referencing any other step type, so the relaxed resolution
+inherently covers this too and it should be verified explicitly.
+
+**Independent Test**: Author a sequence with an ordinary `Command`-typed step nested
+inside one `Loop` body and a separate `If` step elsewhere whose condition references
+that step's id and expected `success`/`failed`/`skipped` outcome; confirm it
+resolves correctly. Testable independently of the `Break`-specific scenarios in
+Story 2.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `commandOutcome` condition elsewhere in the sequence that references
+   a non-`Break` step nested inside a `Loop`/`If` body, **When** the sequence is
+   submitted and run, **Then** the condition resolves against that step's actual
+   outcome exactly as it would for a top-level reference today.
+2. **Given** a `commandOutcome` condition whose `stepRef` names a step that is
+   structurally prior and reachable but did not actually execute during this run
+   (e.g. it lives in an `If` branch that was not taken this run), **When** the
+   sequence runs, **Then** the referencing step and the sequence are reported as
+   failed with an "unavailable reference" error, exactly as an unresolvable
+   reference is reported today — no new silent-success or silent-skip behavior is
+   introduced by widening scope.
+
+### Edge Cases
+
+- A `Loop` reaches its configured max iterations with `ExitOnMaxIterations` set to
+  `false` (today reported as an overall `"Failed"` loop status rather than
+  `"exhausted"`): `exitReason.exhaustedMaxIterations` still reports `true`, because
+  it reports the structural fact independent of whether that fact is also
+  configured to fail the loop.
+- A `while`/`repeat-until` loop whose condition is false on the very first check
+  (the body never executes): `exitReason` reports no firing `Break` and
+  `exhaustedMaxIterations: false` — it simply never had a chance to do either.
+- A `commandOutcome` condition inside a `Loop` body references a `Break` step that
+  is its own sibling in the same body (already structurally permitted before this
+  feature, but never actually resolvable at runtime because a `Break` step's
+  fired/not-fired outcome was never recorded for lookup): this now resolves
+  correctly, since recording that outcome is required plumbing for Story 2 and
+  applies uniformly regardless of scope.
+- Two `Break` steps share the same `stepId` string in different, unrelated loop
+  bodies: existing sequence-wide `stepId` uniqueness validation already prevents
+  this; nested-reference resolution does not need to disambiguate duplicates.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A `Loop` step's execution result MUST include a structured exit
+  reason with two fields: the id of the `Break` step that fired during this run (or
+  no value, if none fired), and whether the loop's configured maximum iteration
+  count was reached without any `Break` firing.
+- **FR-002**: The exit reason in FR-001 MUST be populated consistently across every
+  loop kind the platform supports today (count-based, while, and repeat-until).
+- **FR-003**: When the firing `Break` step is nested inside an `If` body that is
+  itself nested inside the `Loop` body, the exit reason MUST report the `Break`
+  step's own id, not an enclosing step's id.
+- **FR-004**: The "max iterations exhausted" fact in FR-001 MUST reflect whether the
+  loop actually ran its full configured iteration count without a `Break` firing,
+  regardless of whether the loop is configured to fail or succeed when that happens.
+- **FR-005**: When a loop finishes without any `Break` firing and without exhausting
+  its configured max iterations, the exit reason MUST report neither condition as
+  true (no firing `Break` id, `exhaustedMaxIterations: false`).
+- **FR-006**: The platform MUST accept a `commandOutcome` condition's `stepRef`
+  naming any step reachable from the sequence root — including a step nested inside
+  a `Loop`/`If` body other than the condition's own — not only a step within the
+  condition's immediate sibling list.
+- **FR-007**: The platform MUST continue to reject a `commandOutcome` `stepRef` that
+  names a step which is not structurally prior to the referencing condition (using
+  the sequence's authored structure to determine "prior," now spanning the whole
+  sequence rather than only the immediate sibling list).
+- **FR-008**: The platform MUST accept `break` and `no_break` as valid
+  `commandOutcome` `expectedState` values, in addition to the existing
+  `success`/`failed`/`skipped`.
+- **FR-009**: The sequence execution engine MUST record whether each `Break` step
+  fired or did not fire, keyed by that step's id, so that any in-scope
+  `commandOutcome` condition referencing it (at any nesting depth permitted by
+  FR-006) resolves to `break`/`no_break` rather than failing as an unavailable
+  reference.
+- **FR-010**: The platform MUST continue to accept and resolve a `commandOutcome`
+  condition referencing a non-`Break` step nested inside a `Loop`/`If` body other
+  than the condition's own, using the same `success`/`failed`/`skipped` semantics
+  that already apply to a top-level reference today.
+- **FR-011**: When a `commandOutcome` `stepRef` names a step that is structurally
+  reachable and prior but did not execute during a given run (for example, a step in
+  an `If` branch that was not taken), the platform MUST continue to fail the
+  referencing step and the sequence run with the existing "reference unavailable"
+  error — widening reference scope MUST NOT introduce a new silent-success or
+  silent-skip outcome for this case.
+- **FR-012**: The platform MUST continue to accept and execute, unchanged, every
+  sequence and condition that is valid under today's rules (top-level references,
+  same-body sibling references, `success`/`failed`/`skipped` expected states, and
+  existing `Loop`/`Break` status/message reporting) — this feature is additive only.
+
+### Key Entities
+
+- **Loop step result**: The per-run outcome record for a `Loop` step, already
+  carrying a status and per-iteration detail; gains a structured exit reason
+  describing which `Break` fired (if any) and whether max iterations was exhausted.
+- **Break step**: A step nested inside a `Loop` body (directly, or inside an `If`
+  body within that `Loop`) that conditionally or unconditionally ends the loop's
+  iteration; gains a recorded fired/not-fired outcome resolvable by id from
+  elsewhere in the sequence.
+- **`commandOutcome` condition**: A condition (on an `If` or `Break` step) that
+  gates on a named prior step's recorded outcome; its `stepRef` resolution scope
+  widens from "immediate siblings only" to "anywhere reachable and prior in the
+  sequence," and its accepted outcome vocabulary gains `break`/`no_break`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of automated tests covering count/while/repeat-until `Loop`
+  execution assert a correct, structured exit reason (firing `Break` id, or
+  max-iterations-exhausted, or neither) for every tested termination path.
+- **SC-002**: A `commandOutcome` condition can reference a `Break` step nested
+  anywhere else in the sequence and correctly distinguish `break` from `no_break`
+  in 100% of the automated regression tests added for this feature.
+- **SC-003**: A sequence-creation request that today is rejected with `400
+  "references unknown prior step"` solely because its `stepRef` names a step outside
+  its immediate sibling list, but which does name a structurally prior, reachable
+  step, is accepted after this feature ships.
+- **SC-004**: All pre-existing automated tests covering sequence validation, `Loop`
+  execution, and condition evaluation continue to pass unmodified in their
+  well-formed-input assertions (no regression to any documented working case).

--- a/specs/081-loop-exit-reason-and-nested-steprefs/tasks.md
+++ b/specs/081-loop-exit-reason-and-nested-steprefs/tasks.md
@@ -1,0 +1,229 @@
+---
+
+description: "Task list for Loop Exit Reason & Nested Step-Outcome References"
+---
+
+# Tasks: Loop Exit Reason & Nested Step-Outcome References
+
+**Input**: Design documents from `/specs/081-loop-exit-reason-and-nested-steprefs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md,
+contracts/loop-exit-reason-and-stepref-scope.md, quickstart.md
+
+**Tests**: Included — Constitution Principle II requires tests for all executable
+logic and a failing-test-first approach for the bug-adjacent behavior this feature
+fixes as necessary plumbing (Break outcomes never being recorded for lookup).
+
+**Organization**: Tasks are grouped by user story (US1 = Loop exit reason, US2 =
+cross-scope `Break`-outcome reference, US3 = cross-scope non-`Break` reference).
+US1 is fully independent (touches only `SequenceRunner`'s loop-completion sites).
+US2 and US3 share the same whole-tree `stepRef` resolution mechanism in
+`SequenceStepValidationService`; US2 (P1) builds it plus the `Break`-outcome
+recording it needs, and US3 (P2) is additional test coverage confirming the same
+mechanism already generalizes to non-`Break` references with no further code.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1/US2/US3)
+
+## Phase 1: Setup
+
+No new project, dependency, or tooling setup is required — this feature adds no
+new projects and no new third-party dependencies (plan.md Technical Context).
+
+## Phase 2: Foundational
+
+None strictly blocking. US1 and US2 touch different methods in
+`SequenceRunner.cs` and can proceed independently or in parallel; US3 depends only
+on US2's validation mechanism, not on new foundational work of its own.
+
+---
+
+## Phase 3: User Story 1 - A Loop's result reveals why it stopped (Priority: P1) 🎯 MVP
+
+**Goal**: Every `Loop` step's execution result includes a structured
+`exitReason` (`brokeVia` / `exhaustedMaxIterations`) populated correctly for all
+three loop kinds, including when the firing `Break` is nested inside an `If`
+within the loop body.
+
+**Independent Test**: Run a `Loop(maxIterations: 3)` with a conditional `Break`
+once with input that fires the break and once that exhausts iterations; confirm
+`exitReason` correctly distinguishes the two runs, with no dependency on any
+`stepRef`/condition change.
+
+### Tests for User Story 1 ⚠️
+
+> Write these first; confirm they FAIL against current code before implementing.
+
+- [X] T001 [P] [US1] Add failing unit test(s) in `tests/unit/Sequences/SequenceRunnerLoopTests.cs` asserting a count `Loop`'s `StepResult.ExitReason.BrokeVia` equals the firing `Break` step's `StepId` when a conditional break fires, and is `null` with `ExhaustedMaxIterations: true` when the loop exhausts `MaxIterations` without any break firing (cover both `ExitOnMaxIterations: true` and `ExitOnMaxIterations: false`, since spec FR-004 requires `ExhaustedMaxIterations` to be `true` in both cases even though overall status differs)
+- [X] T002 [P] [US1] Add failing unit test(s) in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`'s existing "T018: While loop" section asserting the same `exitReason` semantics for a `while` loop: break-fired case, condition-became-false-normally case (`brokeVia: null`, `exhaustedMaxIterations: false`), and max-iterations-exhausted case — NOT `SequenceRunnerWhileBreakOnTests.cs`, which covers the unrelated legacy block-based `while`/`breakOn` mechanism
+- [X] T003 [P] [US1] Add failing unit test(s) covering a `repeat-until` loop's equivalent three cases (break-fired / normal-condition-true completion / exhausted) in `tests/unit/Sequences/SequenceRunnerLoopTests.cs`'s existing "T020: Repeat-until loop" section, alongside `RepeatUntilLoopConditionNeverTrueFailsAtLimit`/`RepeatUntilLoopExitOnMaxIterationsGivesUpWithoutFailingTheSequence` — NOT `tests/unit/Sequences/BlocksLoopTests.cs`, which tests an unrelated legacy JSON-block execution path (`SequenceRunner.Blocks`/`BlockResult`), not the `SequenceStep`/`RepeatUntilLoopConfig` model this feature changes
+- [X] T004 [P] [US1] Add failing unit test in `tests/unit/Sequences/SequenceRunnerIfBodyScopeTests.cs` (or `SequenceRunnerIfTests.cs`) asserting that when the firing `Break` is nested inside an `If` body within the `Loop` body, `exitReason.brokeVia` is the `Break` step's own `StepId`, not the enclosing `If` step's id (spec FR-003)
+- [X] T005 [P] [US1] Add a regression test confirming a `Loop` with a body containing no `Break` step at all, completing normally under its max iterations, reports `exitReason: { brokeVia: null, exhaustedMaxIterations: false }` (spec FR-005) — covers the "neither" case
+- [X] T006 [P] [US1] Add a regression test confirming every pre-existing assertion on `Loop` `StepResult.Status`/`Message`/`LoopIterations` in `SequenceRunnerLoopTests.cs` and sibling files is unaffected by the new field (spec FR-012) — run the full existing suite for these files and confirm no existing assertion needs to change
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] In `src/GameBot.Domain/Services/SequenceRunner.cs`, add a `LoopExitReason` record (`BrokeVia: string?`, `ExhaustedMaxIterations: bool`) and an `ExitReason` property on `StepResult`, alongside the existing `LoopIterations` property
+- [X] T008 [US1] In the same file, extend `SequenceExecutionResult.AddLoopStep(...)` to accept and store the new `LoopExitReason` (additive overload or additional parameter — do not change any existing call site's other arguments)
+- [X] T009 [US1] In the same file, change `ExecuteLoopBodyAsync`'s return tuple to also carry `string? BrokeVia` (the firing `Break` step's own `StepId`, captured at both the unconditional-break and conditional-break-fired call sites, ~lines 1266 and 1297) and thread it through `ExecuteIfStepAsync`'s existing `BreakTriggered` return path so a break fired inside a nested `If` still surfaces its own id
+- [X] T010 [US1] In `ExecuteCountLoopAsync`, `ExecuteWhileLoopAsync`, and `ExecuteRepeatUntilLoopAsync`, compute and pass `LoopExitReason` at each existing `AddLoopStep` call site using the break-fired/exhausted/neither fact each site already branches on (per research.md R-001/R-002) — `ExhaustedMaxIterations` MUST be computed from "ran full configured MaxIterations without a break firing," independent of the `ExitOnMaxIterations` flag or resulting status string
+
+**Checkpoint**: Run T001-T006 — all must now pass. User Story 1 is independently
+complete and testable; `exitReason` is visible in `/api/sequences/{id}/execute`
+responses with no dependency on Part B.
+
+---
+
+## Phase 4: User Story 2 - A condition can ask "did that Break fire?" from anywhere in the sequence (Priority: P1)
+
+**Goal**: A `commandOutcome` condition can reference a `Break` step nested inside
+any `Loop`/`If` body elsewhere in the sequence (not just its own immediate
+sibling list) and correctly resolve `break`/`no_break`, while a non-prior
+reference is still rejected at creation time.
+
+**Independent Test**: Author a sequence with a `Break` nested in one `Loop` body
+and a separate top-level `If` gating on `commandOutcome { stepRef: <break-id>,
+expectedState: "break" }`; confirm creation succeeds and the condition correctly
+tracks whether the break fired across two runs.
+
+### Tests for User Story 2 ⚠️
+
+> Write these first; confirm they FAIL against current code before implementing.
+
+- [X] T011 [P] [US2] Add failing unit test in `tests/unit/Sequences/LoopValidationTests.cs` (or a new `SequenceStepValidationServiceNestedRefTests.cs` alongside it) asserting `SequenceStepValidationService.Validate` accepts a `commandOutcome` condition on a top-level `If` step whose `stepRef` names a `Break` step nested inside a **different**, earlier top-level `Loop`'s body (today rejected as "references unknown prior step")
+- [X] T012 [P] [US2] Add a failing unit test in the same file asserting `expectedState: "break"` and `expectedState: "no_break"` are now accepted (not rejected as "must be one of success|failed|skipped") on a `commandOutcome` condition
+- [X] T013 [P] [US2] Add a regression test in the same file confirming a `stepRef` naming a step that appears **later** in the sequence's authored structure than the referencing condition is still rejected with the existing "must reference a prior step" error, now using whole-sequence order (spec FR-007) — construct this so the referenced step is reachable (exists somewhere in the tree) but structurally after the referencer, to prove ordering — not just reachability — is still enforced
+- [X] T014 [P] [US2] Add a failing integration test in `tests/integration/Sequences/` (new file `NestedStepOutcomeReferenceIntegrationTests.cs`) that POSTs a sequence via the real HTTP path with a `Break` nested in a `Loop` body and a separate top-level `If` step referencing it with `expectedState: "break"`, asserts `201 Created` (today `400`), then runs the sequence twice (break-firing input, non-firing input) and asserts the `If` step's condition result differs correctly between the two runs — this is the end-to-end proof that `Break` outcomes are actually recorded for lookup (research.md R-005), not just validation-legal
+- [X] T015 [P] [US2] Add a regression test in the same integration file confirming a `commandOutcome` condition referencing a `Break` step **within its own loop body** (already validation-legal before this feature) now actually resolves at runtime instead of always failing with "reference unavailable" (research.md R-005's latent-gap fix)
+- [X] T016 [P] [US2] Add a regression test in the same integration file confirming a `stepRef` that is validation-legal (reachable + prior) but names a step that did not execute during a given run (e.g. an `If` branch not taken) still fails the referencing step and the sequence with the existing "commandOutcome reference '...' is unavailable" error (spec FR-011) — proves widened scope does not introduce a new silent-success/silent-skip path
+
+### Implementation for User Story 2
+
+- [X] T017 [US2] In `src/GameBot.Domain/Services/SequenceStepValidationService.cs`, build a flattened, authored-order index of every step reachable from the sequence root (root `steps` plus every nested `Loop.Body` and `If.Body`/`ElseBody`, recursively expanded in place) once per top-level `Validate(...)` call, per research.md R-003 / data-model.md's "Flattened step index"
+- [X] T018 [US2] In the same file, change `ValidateStepCondition`'s `commandOutcome` `stepRef` resolution to look up against the flattened index from T017 instead of the immediate `siblings` list, and redefine "prior" as "appears earlier in the flattened index" instead of "has a lower same-list index" — thread the flattened index down through the existing `ValidateLoopStep`/`ValidateIfBranch` recursion in place of (or alongside) the current `siblings`/`indexInSiblings` parameters
+- [X] T019 [US2] In the same file, add `"break"` and `"no_break"` to `AllowedCommandOutcomeStates` (matching `SequenceRunner.BreakOutcomes.Break`/`BreakOutcomes.NoBreak`'s existing string constants exactly)
+- [X] T020 [US2] In `src/GameBot.Domain/Services/SequenceRunner.cs`'s `ExecuteLoopBodyAsync`, write `stepOutcomes[brkKey] = BreakOutcomes.Break` or `BreakOutcomes.NoBreak` at each of the four existing `result.AddStep(brkKey, ...)` call sites for a `Break` step (unconditional-fired, conditional-fired, conditional-not-fired, eval-error-treated-as-no-break) — today only the execution-log entry is written, never the runtime dictionary `commandOutcome` resolves against (research.md R-005)
+
+**Checkpoint**: Run T011-T016 — all must now pass. User Stories 1 AND 2 both work
+independently; the alliance-donation-style "did this loop's Break fire" gate is
+now buildable as a structural check.
+
+---
+
+## Phase 5: User Story 3 - A condition can reference any nested step's outcome, not just Break (Priority: P2)
+
+**Goal**: Confirm the whole-tree `stepRef` resolution built for US2 generalizes,
+with no further code, to a `commandOutcome` condition referencing an ordinary
+(non-`Break`) step nested inside a different `Loop`/`If` body.
+
+**Independent Test**: Author a sequence with an ordinary `Command`-typed step
+nested in one `Loop` body and a separate `If` step elsewhere referencing its
+`success`/`failed`/`skipped` outcome; confirm it resolves correctly using only
+US2's mechanism, no additional implementation.
+
+### Tests for User Story 3 ⚠️
+
+> Write these first; confirm they FAIL against current code before implementing
+> (they exercise the pre-US2 code path, so they fail the same way US2's tests do
+> until Phase 4 is implemented — if run only after Phase 4, confirm they pass
+> without needing new implementation, proving generality).
+
+- [X] T021 [P] [US3] Add failing (pre-US2) / passing (post-US2) unit test in `tests/unit/Sequences/LoopValidationTests.cs` (or the new file from T011) asserting a `commandOutcome` condition's `stepRef` naming a non-`Break`, `Command`-typed step nested inside a different `Loop`/`If` body is accepted at validation time
+- [X] T022 [P] [US3] Add a failing/passing integration test in `tests/integration/Sequences/NestedStepOutcomeReferenceIntegrationTests.cs` (from T014) that POSTs and runs a sequence where a top-level `If` step's `commandOutcome` condition references a non-`Break` step nested inside a different `Loop`'s body, using `expectedState: "success"`, and asserts the condition resolves against that step's actual runtime outcome exactly as a top-level reference does today
+
+### Implementation for User Story 3
+
+- [X] T023 [US3] No new implementation expected — if T021/T022 fail after Phase 4 is complete, that indicates T017/T018's resolution logic is accidentally `Break`-specific; fix `ValidateStepCondition`/`SequenceRunner` so the whole-tree resolution and existing runtime `stepOutcomes` dictionary lookup (already scope-agnostic per research.md R-003's exploration finding) apply uniformly regardless of the referenced step's type
+
+**Checkpoint**: All three user stories are independently functional; nested
+`stepRef` resolution is proven general, not `Break`-specific.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T024 Update `docs/architecture.md` §"Break & loop execution and the
+  execution-log status vocabulary" to document `exitReason` and the widened
+  `commandOutcome` `stepRef` scope, refreshing the "Last reviewed" date
+  (Constitution Principle V)
+- [X] T025 Run `dotnet build` and the full `dotnet test` suite (unit + integration
+  + contract projects) and confirm zero failures/regressions
+- [X] T026 Manually validate quickstart.md's scenarios (Part A, Part B, and the
+  ordering-regression check) against a locally running `GameBot.Service`
+- [X] T027 Update spec.md's Status line to `Implemented` once all tasks above are
+  verified complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup / Foundational**: None — skipped, no shared prerequisites.
+- **User Story 1 (Phase 3)**: Fully independent — touches only loop-completion
+  sites in `SequenceRunner.cs`, disjoint from US2/US3's files/methods.
+- **User Story 2 (Phase 4)**: Independent of US1; builds the whole-tree
+  resolution mechanism and `Break`-outcome recording that US3 reuses.
+- **User Story 3 (Phase 5)**: Depends on US2's implementation (T017-T020) being
+  in place — its tests specifically verify US2's mechanism generalizes, and its
+  one implementation task (T023) is a contingency, not new work, if it doesn't.
+- **Polish (Phase 6)**: Depends on all three user stories being complete.
+
+### Within Each User Story
+
+- Tests (T001-T006 / T011-T016 / T021-T022) MUST be written and confirmed
+  FAILING before their story's implementation tasks.
+- T007 before T008 before T009 before T010 (US1): result-shape fields first,
+  then the `AddLoopStep` plumbing to carry them, then threading the firing
+  `Break`'s id up through body/if execution, then wiring each loop kind's call
+  sites.
+- T017 before T018 (US2): build the flattened index before changing the lookup
+  to use it. T019 and T020 can proceed in parallel with T017/T018 (different
+  concerns: allow-list vs. runtime recording) but all four must land before
+  T014-T016's integration tests can pass.
+
+### Parallel Opportunities
+
+- T001-T006, T011-T016, and T021-T022 are each independently parallelizable
+  within their story (distinct test files or distinct assertions), except where
+  a task explicitly says "in the same file" as a preceding task in this list —
+  those should be authored together rather than truly concurrently to avoid
+  merge conflicts in one new file.
+- US1's implementation (T007-T010) can proceed in parallel with US2's
+  (T017-T020) — disjoint methods in the same file (`SequenceRunner.cs`) for
+  T009/T010 vs. T020, and a fully separate file for T017-T019
+  (`SequenceStepValidationService.cs`); coordinate merges if worked by different
+  people since T009/T010/T020 land in the same file.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. T001-T010 (US1). **STOP and VALIDATE**: run the new tests, confirm no
+   regression in existing `Loop`/`Break` execution tests. This alone already
+   exposes the exit-reason signal FR-001 asks for, usable by any caller
+   inspecting a run's result directly.
+
+### Incremental Delivery
+
+1. US1 (T001-T010) → validate → `exitReason` ships, independently useful.
+2. US2 (T011-T020) → validate → closes the specifically evidenced
+   donation-exhaustion-gate gap (cross-scope `Break` reference).
+3. US3 (T021-T023) → validate → confirms the mechanism is general, not a
+   `Break`-only special case.
+4. Phase 6 polish once all three are in.
+
+## Notes
+
+- US1 is purely additive to an execution-result type with no persisted schema —
+  lowest-risk slice, ship first.
+- US2's implementation is deliberately three small, independent changes
+  (T017-T018 resolution scope, T019 allow-list, T020 outcome recording) because
+  research.md R-005 established that *all three* are required for the feature's
+  stated motivation to actually work — a widened `stepRef` alone (skipping T020)
+  would still validate but always fail at runtime with "reference unavailable"
+  for any `Break` reference, defeating the point.
+- Commit after each user story's checkpoint, not after every individual task.

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -115,6 +115,7 @@ Status vocabulary:
 | 078 | Sequence & Command Parameters | Implemented |
 | 079 | Concurrent Queue Execution | Implemented |
 | 080 | Fix Sequence & Session-Input API Bugs | Implemented |
+| 081 | Loop Exit Reason & Nested Step-Outcome References | Implemented |
 
 ## Numbering notes
 

--- a/src/GameBot.Domain/Services/SequenceRunner.cs
+++ b/src/GameBot.Domain/Services/SequenceRunner.cs
@@ -472,7 +472,7 @@ namespace GameBot.Domain.Services {
 
       // ── If step dispatch (top level: no iteration context, break cannot occur) ──
       if (step.StepType == SequenceStepType.If) {
-        var (ifEarlyStop, _) = await ExecuteIfStepAsync(
+        var (ifEarlyStop, _, _) = await ExecuteIfStepAsync(
             step,
             executeCommandAsync,
             commandDispatcher,
@@ -955,6 +955,7 @@ namespace GameBot.Domain.Services {
       var iterResults = new List<LoopIterResult>();
       var priorIterationExecutedSteps = false;
       var breakFired = false;
+      string? brokeVia = null;
 
       for (var i = 0; i < cfg.Count; i++) {
         ct.ThrowIfCancellationRequested();
@@ -966,7 +967,7 @@ namespace GameBot.Domain.Services {
         }
 
         var iterCtx = scope.WithIteration(i + 1);
-        var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
+        var (earlyStop, breakTriggered, stepCount, iterBrokeVia) = await ExecuteLoopBodyAsync(
             step.Body, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
             stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
@@ -978,10 +979,11 @@ namespace GameBot.Domain.Services {
           stepOutcomes[stepKey] = "failed";
           return true;
         }
-        if (breakTriggered) { breakFired = true; break; }
+        if (breakTriggered) { breakFired = true; brokeVia = iterBrokeVia; break; }
       }
 
-      result.AddLoopStep(stepKey, breakFired ? "true" : "Succeeded", iterResults);
+      result.AddLoopStep(stepKey, breakFired ? "true" : "Succeeded", iterResults,
+          exitReason: new LoopExitReason { BrokeVia = brokeVia, ExhaustedMaxIterations = false });
       stepOutcomes[stepKey] = "success";
       return false;
     }
@@ -1006,6 +1008,7 @@ namespace GameBot.Domain.Services {
       var iterResults = new List<LoopIterResult>();
       var iterations = 0;
       var priorIterationExecutedSteps = false;
+      string? brokeVia = null;
 
       while (true) {
         ct.ThrowIfCancellationRequested();
@@ -1025,7 +1028,8 @@ namespace GameBot.Domain.Services {
         if (!condResult) {
           // condition false on entry (or after last iteration)
           var status = iterations == 0 ? "Skipped" : "false";
-          result.AddLoopStep(stepKey, status, iterResults);
+          result.AddLoopStep(stepKey, status, iterResults,
+              exitReason: new LoopExitReason { BrokeVia = null, ExhaustedMaxIterations = false });
           stepOutcomes[stepKey] = iterations == 0 ? "skipped" : "success";
           return false;
         }
@@ -1040,18 +1044,20 @@ namespace GameBot.Domain.Services {
         if (iterations > maxIterations) {
           if (cfg.ExitOnMaxIterations) {
             var gaveUp = $"Loop '{stepKey}' gave up after {maxIterations} iterations with its condition still true.";
-            result.AddLoopStep(stepKey, "exhausted", iterResults, gaveUp);
+            result.AddLoopStep(stepKey, "exhausted", iterResults, gaveUp,
+                exitReason: new LoopExitReason { BrokeVia = null, ExhaustedMaxIterations = true });
             stepOutcomes[stepKey] = "not_executed";
             return false;
           }
-          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).",
+              exitReason: new LoopExitReason { BrokeVia = null, ExhaustedMaxIterations = true });
           result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
           stepOutcomes[stepKey] = "failed";
           return true;
         }
 
         var iterCtx = scope.WithIteration(iterations);
-        var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
+        var (earlyStop, breakTriggered, stepCount, iterBrokeVia) = await ExecuteLoopBodyAsync(
             step.Body, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
             stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
@@ -1063,10 +1069,11 @@ namespace GameBot.Domain.Services {
           stepOutcomes[stepKey] = "failed";
           return true;
         }
-        if (breakTriggered) break;
+        if (breakTriggered) { brokeVia = iterBrokeVia; break; }
       }
 
-      result.AddLoopStep(stepKey, "true", iterResults);
+      result.AddLoopStep(stepKey, "true", iterResults,
+          exitReason: new LoopExitReason { BrokeVia = brokeVia, ExhaustedMaxIterations = false });
       stepOutcomes[stepKey] = "success";
       return false;
     }
@@ -1091,6 +1098,7 @@ namespace GameBot.Domain.Services {
       var iterResults = new List<LoopIterResult>();
       var iterations = 0;
       var priorIterationExecutedSteps = false;
+      string? brokeVia = null;
 
       while (true) {
         ct.ThrowIfCancellationRequested();
@@ -1104,7 +1112,7 @@ namespace GameBot.Domain.Services {
         iterations++;
 
         var iterCtx = scope.WithIteration(iterations);
-        var (earlyStop, breakTriggered, stepCount) = await ExecuteLoopBodyAsync(
+        var (earlyStop, breakTriggered, stepCount, iterBrokeVia) = await ExecuteLoopBodyAsync(
             step.Body, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
             stepOutcomes, result, sequenceId, iterCtx, actionDispatcher, ct).ConfigureAwait(false);
 
@@ -1116,16 +1124,18 @@ namespace GameBot.Domain.Services {
           stepOutcomes[stepKey] = "failed";
           return true;
         }
-        if (breakTriggered) break;
+        if (breakTriggered) { brokeVia = iterBrokeVia; break; }
 
         if (iterations >= maxIterations) {
           if (cfg.ExitOnMaxIterations) {
             var gaveUp = $"Loop '{stepKey}' gave up after {maxIterations} iterations with its exit condition still false.";
-            result.AddLoopStep(stepKey, "exhausted", iterResults, gaveUp);
+            result.AddLoopStep(stepKey, "exhausted", iterResults, gaveUp,
+                exitReason: new LoopExitReason { BrokeVia = null, ExhaustedMaxIterations = true });
             stepOutcomes[stepKey] = "not_executed";
             return false;
           }
-          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
+          result.AddLoopStep(stepKey, "Failed", iterResults, $"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).",
+              exitReason: new LoopExitReason { BrokeVia = null, ExhaustedMaxIterations = true });
           result.Fail($"Loop '{stepKey}' exceeded maximum iterations ({maxIterations}).");
           stepOutcomes[stepKey] = "failed";
           return true;
@@ -1147,7 +1157,8 @@ namespace GameBot.Domain.Services {
         if (exitCond) break;
       }
 
-      result.AddLoopStep(stepKey, "true", iterResults);
+      result.AddLoopStep(stepKey, "true", iterResults,
+          exitReason: new LoopExitReason { BrokeVia = brokeVia, ExhaustedMaxIterations = false });
       stepOutcomes[stepKey] = "success";
       return false;
     }
@@ -1161,7 +1172,7 @@ namespace GameBot.Domain.Services {
     /// (<c>earlyStop</c>, <c>breakTriggered</c>); a break inside a branch propagates to the
     /// enclosing loop.
     /// </summary>
-    private async Task<(bool EarlyStop, bool BreakTriggered)> ExecuteIfStepAsync(
+    private async Task<(bool EarlyStop, bool BreakTriggered, string? BrokeVia)> ExecuteIfStepAsync(
         SequenceStep step,
         Func<string, ParameterScope, Task> executeCommandAsync,
         Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
@@ -1180,7 +1191,7 @@ namespace GameBot.Domain.Services {
         result.AddStep(stepKey, 0, "Failed", message: $"If step '{stepKey}' has missing if configuration.");
         result.Fail($"If step '{stepKey}' has missing if configuration.");
         stepOutcomes[stepKey] = "failed";
-        return (true, false);
+        return (true, false, null);
       }
 
       var condDesc = DescribeBreakCondition(step.If.Condition);
@@ -1198,7 +1209,7 @@ namespace GameBot.Domain.Services {
             message: $"If '{stepKey}' condition evaluation failed: {ex.Message}");
         result.Fail($"If '{stepKey}' condition evaluation failed: {ex.Message}");
         stepOutcomes[stepKey] = "failed";
-        return (true, false);
+        return (true, false, null);
       }
 
       var branch = condResult ? step.Body : step.ElseBody ?? Array.Empty<SequenceStep>();
@@ -1216,29 +1227,31 @@ namespace GameBot.Domain.Services {
 
       if (!hasBranchSteps) {
         stepOutcomes[stepKey] = "skipped";
-        return (false, false);
+        return (false, false, null);
       }
 
-      var (earlyStop, breakTriggered, _) = await ExecuteLoopBodyAsync(
+      var (earlyStop, breakTriggered, _, brokeVia) = await ExecuteLoopBodyAsync(
           branch, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
           stepOutcomes, result, sequenceId, iterScope, actionDispatcher, ct).ConfigureAwait(false);
 
       if (earlyStop) {
         stepOutcomes[stepKey] = "failed";
-        return (true, false);
+        return (true, false, null);
       }
 
       stepOutcomes[stepKey] = "success";
-      return (false, breakTriggered);
+      return (false, breakTriggered, brokeVia);
     }
 
     /// <summary>
     /// Executes the body steps for one loop iteration.  Returns
-    /// (<c>earlyStop</c>, <c>breakTriggered</c>, <c>stepsExecuted</c>).
+    /// (<c>earlyStop</c>, <c>breakTriggered</c>, <c>stepsExecuted</c>, <c>brokeVia</c>).
+    /// <c>brokeVia</c> is the firing Break step's own StepId (even when reached through a
+    /// nested If), or null when no break fired.
     /// A break step whose condition cannot be evaluated is recorded as a neutral "No break"
     /// (feature 066, FR-002a) and the loop continues — it does not set earlyStop.
     /// </summary>
-    private async Task<(bool EarlyStop, bool BreakTriggered, int StepCount)> ExecuteLoopBodyAsync(
+    private async Task<(bool EarlyStop, bool BreakTriggered, int StepCount, string? BrokeVia)> ExecuteLoopBodyAsync(
         IReadOnlyList<SequenceStep> bodySteps,
         Func<string, ParameterScope, Task> executeCommandAsync,
         Func<string, ParameterScope, Task<CommandDispatchOutcome>>? commandDispatcher,
@@ -1268,7 +1281,8 @@ namespace GameBot.Domain.Services {
                 conditionResult: "true",
                 actionOutcome: BreakOutcomes.Break,
                 message: "Unconditional break triggered");
-            return (false, true, stepsExecuted);
+            stepOutcomes[brkKey] = BreakOutcomes.Break;
+            return (false, true, stepsExecuted, brkKey);
           }
 
           var condDesc = DescribeBreakCondition(step.BreakCondition);
@@ -1290,6 +1304,7 @@ namespace GameBot.Domain.Services {
                 conditionResult: "error",
                 actionOutcome: BreakOutcomes.NoBreak,
                 message: $"No break: {condDesc.Detail} could not be evaluated ({ex.Message})");
+            stepOutcomes[brkKey] = BreakOutcomes.NoBreak;
           }
 
           if (breakCond) {
@@ -1299,7 +1314,8 @@ namespace GameBot.Domain.Services {
                 conditionResult: "true",
                 actionOutcome: BreakOutcomes.Break,
                 message: $"Break triggered: {condDesc.Detail} evaluated to true");
-            return (false, true, stepsExecuted);
+            stepOutcomes[brkKey] = BreakOutcomes.Break;
+            return (false, true, stepsExecuted, brkKey);
           }
 
           if (!evalError) {
@@ -1310,6 +1326,7 @@ namespace GameBot.Domain.Services {
                 conditionResult: "false",
                 actionOutcome: BreakOutcomes.NoBreak,
                 message: $"No break: {condDesc.Detail} evaluated to false");
+            stepOutcomes[brkKey] = BreakOutcomes.NoBreak;
           }
 
           if (bodyIndex < orderedBodySteps.Count - 1) {
@@ -1323,13 +1340,13 @@ namespace GameBot.Domain.Services {
         if (step.StepType == SequenceStepType.If) {
           // Nested if: executed with the current iteration context so branch steps keep
           // {{iteration}} substitution, and a break inside a branch exits the enclosing loop.
-          var (ifEarlyStop, ifBreakTriggered) = await ExecuteIfStepAsync(
+          var (ifEarlyStop, ifBreakTriggered, ifBrokeVia) = await ExecuteIfStepAsync(
               step, executeCommandAsync, commandDispatcher, gateEvaluator, conditionEvaluator, interStepDelayRange,
               stepOutcomes, result, sequenceId, iterScope, actionDispatcher, ct).ConfigureAwait(false);
           stepsExecuted++;
 
-          if (ifEarlyStop) return (true, false, stepsExecuted);
-          if (ifBreakTriggered) return (false, true, stepsExecuted);
+          if (ifEarlyStop) return (true, false, stepsExecuted, null);
+          if (ifBreakTriggered) return (false, true, stepsExecuted, ifBrokeVia);
 
           if (bodyIndex < orderedBodySteps.Count - 1) {
             var ifDelayMs = SampleInterStepDelay(interStepDelayRange);
@@ -1356,7 +1373,7 @@ namespace GameBot.Domain.Services {
             ct).ConfigureAwait(false);
         stepsExecuted++;
 
-        if (earlyStop) return (true, false, stepsExecuted);
+        if (earlyStop) return (true, false, stepsExecuted, null);
 
         if (bodyIndex < orderedBodySteps.Count - 1) {
           var delayMs = SampleInterStepDelay(interStepDelayRange);
@@ -1365,7 +1382,7 @@ namespace GameBot.Domain.Services {
         }
       }
 
-      return (false, false, stepsExecuted);
+      return (false, false, stepsExecuted, null);
     }
 
     /// <summary>
@@ -2157,13 +2174,15 @@ namespace GameBot.Domain.Services {
         string stepId,
         string status,
         IReadOnlyList<LoopIterResult> iterResults,
-        string? message = null) {
+        string? message = null,
+        LoopExitReason? exitReason = null) {
       _steps.Add(new StepResult {
         CommandId = stepId,
         Status = status,
         Attempts = 1,
         LoopIterations = iterResults,
-        Message = message
+        Message = message,
+        ExitReason = exitReason
       });
     }
 
@@ -2202,6 +2221,21 @@ namespace GameBot.Domain.Services {
     public WaitForImageStepResultDetails? WaitForImageDetails { get; set; }
     /// <summary>Per-iteration results for loop steps; null for non-loop steps.</summary>
     public IReadOnlyList<LoopIterResult>? LoopIterations { get; set; }
+    /// <summary>Why a loop step stopped iterating; null for non-loop steps.</summary>
+    public LoopExitReason? ExitReason { get; set; }
+  }
+
+  /// <summary>
+  /// Structural reason a <see cref="SequenceStepType.Loop"/> step stopped iterating (feature 081 /
+  /// FR-001). <see cref="BrokeVia"/> and <see cref="ExhaustedMaxIterations"/> = true are mutually
+  /// exclusive; both are null/false when the loop finished its body/condition normally without
+  /// either happening.
+  /// </summary>
+  public sealed class LoopExitReason {
+    /// <summary>The StepId of the Break step that fired, or null if none fired.</summary>
+    public string? BrokeVia { get; set; }
+    /// <summary>True iff the loop ran its full configured MaxIterations without any Break firing.</summary>
+    public bool ExhaustedMaxIterations { get; set; }
   }
 
   public sealed class WaitForImageStepResultDetails {

--- a/src/GameBot.Domain/Services/SequenceStepValidationService.cs
+++ b/src/GameBot.Domain/Services/SequenceStepValidationService.cs
@@ -3,7 +3,6 @@ using GameBot.Domain.Commands.SelfReschedule;
 using GameBot.Domain.Actions;
 using GameBot.Domain.Parameters;
 using GameBot.Domain.Utils;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Text.Json;
 
@@ -14,7 +13,9 @@ public sealed class SequenceStepValidationService {
   private static readonly HashSet<string> AllowedCommandOutcomeStates = new(StringComparer.OrdinalIgnoreCase) {
     "success",
     "failed",
-    "skipped"
+    "skipped",
+    "break",
+    "no_break"
   };
   private static readonly HashSet<string> AllowedPrimitiveActionTypes = new(PrimitiveActionTypes.All, StringComparer.OrdinalIgnoreCase);
 
@@ -23,6 +24,15 @@ public sealed class SequenceStepValidationService {
 
     var errors = new List<string>();
     var seenStepIds = new HashSet<string>(_stepIdComparer);
+
+    // FR-006/FR-007 (feature 081): a commandOutcome condition's stepRef may reference any step
+    // reachable from the sequence root, not only an immediate sibling — resolved against a
+    // flattened, authored-order index built once up front, so "prior" means "appears earlier in
+    // this document-order walk" rather than "has a lower index within the immediate list."
+    var ownPosition = new Dictionary<SequenceStep, int>();
+    var positionByStepId = new Dictionary<string, int>(_stepIdComparer);
+    var positionCounter = 0;
+    BuildStepPositionIndex(steps, ownPosition, positionByStepId, ref positionCounter);
 
     for (var index = 0; index < steps.Count; index++) {
       var step = steps[index];
@@ -42,12 +52,12 @@ public sealed class SequenceStepValidationService {
       }
 
       if (step.StepType == SequenceStepType.Loop) {
-        ValidateLoopStep(step, stepLabel, steps, index, errors, insideLoop: false);
+        ValidateLoopStep(step, stepLabel, ownPosition, positionByStepId, errors, insideLoop: false);
         continue;
       }
 
       if (step.StepType == SequenceStepType.If) {
-        ValidateIfStep(step, stepLabel, errors, insideLoop: false);
+        ValidateIfStep(step, stepLabel, ownPosition, positionByStepId, errors, insideLoop: false);
         continue;
       }
 
@@ -55,17 +65,44 @@ public sealed class SequenceStepValidationService {
         errors.Add($"Step '{stepLabel}' requires action payload.");
       }
 
-      ValidateStepCondition(step, stepLabel, steps, index, errors, insideLoop: false);
+      ValidateStepCondition(step, stepLabel, ownPosition, positionByStepId, errors, insideLoop: false);
     }
 
     return errors;
   }
 
+  // Preorder walk (root steps in order; each Loop's Body and each If's Body/ElseBody expanded in
+  // place, recursively) recording every step's position in that document order. First occurrence
+  // wins for a duplicate stepId (duplicates are already flagged as a separate error).
+  private static void BuildStepPositionIndex(
+      IReadOnlyList<SequenceStep> steps,
+      Dictionary<SequenceStep, int> ownPosition,
+      Dictionary<string, int> positionByStepId,
+      ref int counter) {
+    foreach (var step in steps) {
+      ownPosition[step] = counter;
+      if (!string.IsNullOrWhiteSpace(step.StepId)) {
+        positionByStepId.TryAdd(step.StepId, counter);
+      }
+      counter++;
+
+      if (step.StepType == SequenceStepType.Loop) {
+        BuildStepPositionIndex(step.Body, ownPosition, positionByStepId, ref counter);
+      }
+      else if (step.StepType == SequenceStepType.If) {
+        BuildStepPositionIndex(step.Body, ownPosition, positionByStepId, ref counter);
+        if (step.ElseBody is not null) {
+          BuildStepPositionIndex(step.ElseBody, ownPosition, positionByStepId, ref counter);
+        }
+      }
+    }
+  }
+
   private void ValidateLoopStep(
       SequenceStep step,
       string stepLabel,
-      IReadOnlyList<SequenceStep> siblings,
-      int indexInSiblings,
+      Dictionary<SequenceStep, int> ownPosition,
+      Dictionary<string, int> positionByStepId,
       List<string> errors,
       bool insideLoop) {
 
@@ -105,7 +142,7 @@ public sealed class SequenceStepValidationService {
 
       // Feature 067: loop bodies may contain if steps (whose branches may then use breaks).
       if (bodyStep.StepType == SequenceStepType.If) {
-        ValidateIfStep(bodyStep, bodyLabel, errors, insideLoop: true);
+        ValidateIfStep(bodyStep, bodyLabel, ownPosition, positionByStepId, errors, insideLoop: true);
         continue;
       }
 
@@ -124,7 +161,7 @@ public sealed class SequenceStepValidationService {
       // FR-002a: {{iteration}} (or any template placeholder) is only valid inside a loop body —
       // validate that top-level steps do NOT contain placeholders (done in Validate()). Here
       // we just validate the body step's condition references.
-      ValidateStepCondition(bodyStep, bodyLabel, step.Body, bi, errors, insideLoop: true);
+      ValidateStepCondition(bodyStep, bodyLabel, ownPosition, positionByStepId, errors, insideLoop: true);
     }
   }
 
@@ -134,6 +171,8 @@ public sealed class SequenceStepValidationService {
   private void ValidateIfStep(
       SequenceStep step,
       string stepLabel,
+      Dictionary<SequenceStep, int> ownPosition,
+      Dictionary<string, int> positionByStepId,
       List<string> errors,
       bool insideLoop) {
 
@@ -144,9 +183,9 @@ public sealed class SequenceStepValidationService {
       ValidateIfCondition(step.If.Condition, stepLabel, errors);
     }
 
-    ValidateIfBranch(step.Body, "then", stepLabel, errors, insideLoop);
+    ValidateIfBranch(step.Body, "then", stepLabel, ownPosition, positionByStepId, errors, insideLoop);
     if (step.ElseBody is not null) {
-      ValidateIfBranch(step.ElseBody, "else", stepLabel, errors, insideLoop);
+      ValidateIfBranch(step.ElseBody, "else", stepLabel, ownPosition, positionByStepId, errors, insideLoop);
     }
   }
 
@@ -171,6 +210,8 @@ public sealed class SequenceStepValidationService {
       IReadOnlyList<SequenceStep> branch,
       string branchName,
       string stepLabel,
+      Dictionary<SequenceStep, int> ownPosition,
+      Dictionary<string, int> positionByStepId,
       List<string> errors,
       bool insideLoop) {
 
@@ -212,15 +253,15 @@ public sealed class SequenceStepValidationService {
         errors.Add($"Branch step '{branchLabel}' inside if '{stepLabel}' requires action payload.");
       }
 
-      ValidateStepCondition(branchStep, branchLabel, branch, bi, errors, insideLoop: insideLoop);
+      ValidateStepCondition(branchStep, branchLabel, ownPosition, positionByStepId, errors, insideLoop: insideLoop);
     }
   }
 
   private static void ValidateStepCondition(
       SequenceStep step,
       string stepLabel,
-      IReadOnlyList<SequenceStep> siblings,
-      int indexInSiblings,
+      Dictionary<SequenceStep, int> ownPosition,
+      Dictionary<string, int> positionByStepId,
       List<string> errors,
       bool insideLoop) {
 
@@ -260,24 +301,21 @@ public sealed class SequenceStepValidationService {
       if (string.IsNullOrWhiteSpace(commandOutcome.StepRef)) {
         errors.Add($"Step '{stepLabel}' commandOutcome condition requires stepRef.");
       }
-      else {
-        var referencedIndex = siblings
-          .Select((candidate, candidateIndex) => new { candidate.StepId, candidateIndex })
-          .FirstOrDefault(candidate => string.Equals(candidate.StepId, commandOutcome.StepRef, StringComparison.Ordinal))
-          ?.candidateIndex ?? -1;
-
-        if (referencedIndex < 0) {
-          errors.Add($"Step '{stepLabel}' commandOutcome references unknown prior step '{commandOutcome.StepRef}'.");
-        }
-        else if (referencedIndex >= indexInSiblings) {
-          // FR-006: inside a loop body a commandOutcome must not forward-reference within the same body.
-          errors.Add($"Step '{stepLabel}' commandOutcome stepRef '{commandOutcome.StepRef}' must reference a prior step.");
-        }
+      else if (!positionByStepId.TryGetValue(commandOutcome.StepRef, out var referencedPosition)) {
+        // Feature 081 (FR-006): resolved against every step reachable from the sequence root —
+        // not only this condition's immediate sibling list — so "unknown" now means genuinely
+        // absent from the whole sequence, not merely outside this condition's own scope.
+        errors.Add($"Step '{stepLabel}' commandOutcome references unknown prior step '{commandOutcome.StepRef}'.");
+      }
+      else if (!ownPosition.TryGetValue(step, out var ownPos) || referencedPosition >= ownPos) {
+        // FR-007: "prior" is now authored (document) order across the whole sequence, a strict
+        // generalization of the old same-list-index check.
+        errors.Add($"Step '{stepLabel}' commandOutcome stepRef '{commandOutcome.StepRef}' must reference a prior step.");
       }
 
       if (string.IsNullOrWhiteSpace(commandOutcome.ExpectedState)
           || !AllowedCommandOutcomeStates.Contains(commandOutcome.ExpectedState)) {
-        errors.Add($"Step '{stepLabel}' commandOutcome expectedState must be one of success|failed|skipped.");
+        errors.Add($"Step '{stepLabel}' commandOutcome expectedState must be one of success|failed|skipped|break|no_break.");
       }
     }
 

--- a/tests/integration/Sequences/NestedStepOutcomeReferenceIntegrationTests.cs
+++ b/tests/integration/Sequences/NestedStepOutcomeReferenceIntegrationTests.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace GameBot.IntegrationTests.Sequences;
+
+/// <summary>
+/// Integration tests for feature 081 (FR-001, Part B): a <c>commandOutcome</c> condition's
+/// <c>stepRef</c> may reference any step reachable from the sequence root — including one nested
+/// inside a <c>Loop</c>/<c>If</c> body other than the condition's own — not only an immediate
+/// sibling, and can query a <c>Break</c> step's fired/not-fired outcome (<c>break</c>/<c>no_break</c>).
+/// Before this feature, creation of these sequences was rejected with
+/// <c>400 "references unknown prior step"</c>.
+///
+/// Break/no-break is controlled deterministically via a plain dispatching command step's
+/// <c>success</c> outcome and a mismatching <c>expectedState</c> on the Break's own condition —
+/// deliberately avoiding <c>imageVisible</c>, which requires a capture session started via
+/// <c>POST /api/sessions/start</c> to ever evaluate true (see pns-account-state / gamebot-api-notes
+/// memory: a plain <c>POST /api/sessions</c> session always reports images absent).
+/// </summary>
+[Collection("ConfigIsolation")]
+public sealed class NestedStepOutcomeReferenceIntegrationTests : IDisposable {
+  private readonly string? _prevUseAdb;
+  private readonly string? _prevDynamicPort;
+  private readonly string? _prevAuthToken;
+  private readonly string? _prevDataDir;
+
+  public NestedStepOutcomeReferenceIntegrationTests() {
+    _prevUseAdb = Environment.GetEnvironmentVariable("GAMEBOT_USE_ADB");
+    _prevDynamicPort = Environment.GetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT");
+    _prevAuthToken = Environment.GetEnvironmentVariable("GAMEBOT_AUTH_TOKEN");
+    _prevDataDir = Environment.GetEnvironmentVariable("GAMEBOT_DATA_DIR");
+
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", "false");
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", "true");
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", "test-token");
+    TestEnvironment.PrepareCleanDataDir();
+  }
+
+  public void Dispose() {
+    Environment.SetEnvironmentVariable("GAMEBOT_USE_ADB", _prevUseAdb);
+    Environment.SetEnvironmentVariable("GAMEBOT_DYNAMIC_PORT", _prevDynamicPort);
+    Environment.SetEnvironmentVariable("GAMEBOT_AUTH_TOKEN", _prevAuthToken);
+    Environment.SetEnvironmentVariable("GAMEBOT_DATA_DIR", _prevDataDir);
+    GC.SuppressFinalize(this);
+  }
+
+  // A go-to-home-screen primitive step always dispatches in stub mode (GAMEBOT_USE_ADB=false),
+  // giving a deterministic "success" outcome with no image/session dependency.
+  private static object DispatchingStep(string stepId, object? condition = null) => new {
+    stepId,
+    stepType = "Action",
+    condition,
+    primitiveAction = new { type = "go-to-home-screen", schemaVersion = "v1", payload = new { } }
+  };
+
+  private static object CommandOutcomeCondition(string stepRef, string expectedState) => new {
+    type = "commandOutcome",
+    stepRef,
+    expectedState
+  };
+
+  private static async Task<string> CreateSessionAsync(HttpClient client, string gameName) {
+    var gameResp = await client.PostAsJsonAsync(new Uri("/api/games", UriKind.Relative), new { name = gameName, description = "desc" }).ConfigureAwait(false);
+    gameResp.EnsureSuccessStatusCode();
+    var game = await gameResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(false);
+    var gameId = game!["id"]!.ToString();
+
+    var sessionResp = await client.PostAsJsonAsync(new Uri("/api/sessions", UriKind.Relative), new { gameId }).ConfigureAwait(false);
+    sessionResp.EnsureSuccessStatusCode();
+    var session = await sessionResp.Content.ReadFromJsonAsync<Dictionary<string, object>>().ConfigureAwait(false);
+    return session!["id"]!.ToString()!;
+  }
+
+  private static async Task<(HttpStatusCode CreateStatus, JsonElement? CreateBody, JsonElement? Execution)> CreateAndExecuteAsync(
+      HttpClient client, string name, object[] steps) {
+    var sessionId = await CreateSessionAsync(client, name + "-game").ConfigureAwait(false);
+
+    var createResponse = await client.PostAsJsonAsync("/api/sequences", new { name, version = 1, steps }).ConfigureAwait(false);
+    var createBody = await createResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    if (createResponse.StatusCode != HttpStatusCode.Created) {
+      return (createResponse.StatusCode, createBody, null);
+    }
+
+    var sequenceId = createBody.GetProperty("id").GetString();
+    var executeResponse = await client.PostAsJsonAsync($"/api/sequences/{sequenceId}/execute", new { sessionId }).ConfigureAwait(false);
+    executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    var execution = await executeResponse.Content.ReadFromJsonAsync<JsonElement>().ConfigureAwait(false);
+    return (createResponse.StatusCode, createBody, execution);
+  }
+
+  private static object[] BreakInLoopThenTopLevelGateSteps(string breakExpectedState) => new object[] {
+    DispatchingStep("probe"),
+    new {
+      stepId = "loop-1",
+      stepType = "Loop",
+      loop = new { loopType = "count", count = 1, maxIterations = 1 },
+      body = new object[] {
+        new {
+          stepId = "cluster-not-found-break",
+          stepType = "Break",
+          breakCondition = CommandOutcomeCondition("probe", breakExpectedState)
+        }
+      }
+    },
+    DispatchingStep("gate", CommandOutcomeCondition("cluster-not-found-break", "break"))
+  };
+
+  [Fact] // T014 (US2)
+  public async Task CreatingSequenceWithCrossScopeBreakReferenceIsAcceptedNotRejected() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    // probe's outcome is "success"; expectedState "success" makes the break fire — but the
+    // acceptance being tested here is creation, not the break firing.
+    var (createStatus, createBody, _) = await CreateAndExecuteAsync(
+        client, "cross-scope-break-ref-accepted", BreakInLoopThenTopLevelGateSteps("success")).ConfigureAwait(false);
+
+    createStatus.Should().Be(HttpStatusCode.Created);
+    createBody!.Value.TryGetProperty("errors", out _).Should().BeFalse();
+  }
+
+  [Fact] // T014 (US2)
+  public async Task CrossScopeBreakReferenceResolvesToBreakWhenTheBreakFires() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    // Break's own condition: commandOutcome{stepRef:"probe", expectedState:"success"} — probe
+    // dispatches successfully ("success"), so this matches and the break fires.
+    var (_, _, execution) = await CreateAndExecuteAsync(
+        client, "cross-scope-break-fires", BreakInLoopThenTopLevelGateSteps("success")).ConfigureAwait(false);
+
+    var steps = execution!.Value.GetProperty("steps");
+    var gate = FindStep(steps, "gate");
+    gate.GetProperty("status").GetString().Should().Be("Succeeded");
+    gate.GetProperty("actionOutcome").GetString().Should().NotBe("skipped");
+  }
+
+  [Fact] // T014 (US2)
+  public async Task CrossScopeBreakReferenceResolvesToNoBreakWhenTheBreakDoesNotFire() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    // Break's own condition: commandOutcome{stepRef:"probe", expectedState:"failed"} — probe's
+    // actual outcome is "success" (≠ "failed"), so the break does not fire.
+    var (_, _, execution) = await CreateAndExecuteAsync(
+        client, "cross-scope-break-no-fire", BreakInLoopThenTopLevelGateSteps("failed")).ConfigureAwait(false);
+
+    var steps = execution!.Value.GetProperty("steps");
+    var gate = FindStep(steps, "gate");
+    gate.GetProperty("status").GetString().Should().Be("Skipped");
+    gate.GetProperty("actionOutcome").GetString().Should().Be("skipped");
+  }
+
+  [Fact] // T015 (US2) — a commandOutcome condition referencing a Break step within its OWN loop
+         // body (already validation-legal before this feature) now actually resolves at runtime,
+         // instead of always failing with "reference unavailable" (the Break outcome was never
+         // recorded for lookup before this feature).
+  public async Task CommandOutcomeReferencingBreakWithinItsOwnLoopBodyResolvesAtRuntime() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var steps = new object[] {
+      DispatchingStep("probe"),
+      new {
+        stepId = "loop-1",
+        stepType = "Loop",
+        loop = new { loopType = "count", count = 2, maxIterations = 2 },
+        body = new object[] {
+          new {
+            stepId = "brk",
+            stepType = "Break",
+            // probe's outcome is "success"; expecting "failed" never matches, so the break never
+            // fires and every iteration records "no_break".
+            breakCondition = CommandOutcomeCondition("probe", "failed")
+          },
+          DispatchingStep("same-body-gate", CommandOutcomeCondition("brk", "no_break"))
+        }
+      }
+    };
+
+    var (createStatus, _, execution) = await CreateAndExecuteAsync(
+        client, "same-body-break-ref", steps).ConfigureAwait(false);
+
+    createStatus.Should().Be(HttpStatusCode.Created);
+    execution!.Value.GetProperty("status").GetString().Should().Be("Succeeded");
+
+    var allSteps = execution.Value.GetProperty("steps");
+    var sameBodyGates = new List<JsonElement>();
+    foreach (var s in allSteps.EnumerateArray()) {
+      if (s.TryGetProperty("commandId", out var id) && id.GetString() == "same-body-gate") {
+        sameBodyGates.Add(s);
+      }
+    }
+    sameBodyGates.Should().HaveCount(2);
+    sameBodyGates.Should().OnlyContain(s => s.GetProperty("status").GetString() == "Succeeded");
+  }
+
+  [Fact] // T016 (US2) — FR-011 regression: a stepRef that is validation-legal (reachable + prior)
+         // but names a step that did NOT execute this run (an If branch not taken) still fails the
+         // referencing step and the sequence with the existing "unavailable" error — widening
+         // reference scope must not introduce a new silent-success/silent-skip path.
+  public async Task ReferencingAStepFromTheNotTakenIfBranchStillFailsHard() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var steps = new object[] {
+      DispatchingStep("probe"),
+      new {
+        stepId = "if-1",
+        stepType = "If",
+        // probe's outcome is "success"; expecting "failed" is false, so the else (empty) branch
+        // runs and "sometimes-step" (in the then branch) never executes this run.
+        @if = new { condition = CommandOutcomeCondition("probe", "failed") },
+        body = new object[] { DispatchingStep("sometimes-step") },
+        elseBody = Array.Empty<object>()
+      },
+      DispatchingStep("gate", CommandOutcomeCondition("sometimes-step", "success"))
+    };
+
+    var (createStatus, _, execution) = await CreateAndExecuteAsync(
+        client, "not-taken-branch-ref", steps).ConfigureAwait(false);
+
+    // Structurally reachable and prior, so creation succeeds (this is what feature 081 changes) —
+    // but the reference is unresolvable at runtime because "sometimes-step" never ran this time.
+    createStatus.Should().Be(HttpStatusCode.Created);
+    execution!.Value.GetProperty("status").GetString().Should().Be("Failed");
+    var gate = FindStep(execution.Value.GetProperty("steps"), "gate");
+    gate.GetProperty("message").GetString().Should().Contain("unavailable");
+  }
+
+  [Fact] // T022 (US3) — the whole-tree resolution mechanism built for US2 generalizes to an
+         // ordinary (non-Break) step nested inside a different Loop's body, using the existing
+         // success/failed/skipped vocabulary exactly as a top-level reference does today.
+  public async Task CrossScopeReferenceToNonBreakStepNestedInADifferentLoopResolvesAtRuntime() {
+    using var app = new WebApplicationFactory<Program>();
+    var client = app.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+    var steps = new object[] {
+      new {
+        stepId = "loop-1",
+        stepType = "Loop",
+        loop = new { loopType = "count", count = 1, maxIterations = 1 },
+        body = new object[] { DispatchingStep("inner-command") }
+      },
+      DispatchingStep("gate", CommandOutcomeCondition("inner-command", "success"))
+    };
+
+    var (createStatus, _, execution) = await CreateAndExecuteAsync(
+        client, "non-break-nested-ref", steps).ConfigureAwait(false);
+
+    createStatus.Should().Be(HttpStatusCode.Created);
+    execution!.Value.GetProperty("status").GetString().Should().Be("Succeeded");
+    var gate = FindStep(execution.Value.GetProperty("steps"), "gate");
+    gate.GetProperty("status").GetString().Should().Be("Succeeded");
+    gate.GetProperty("actionOutcome").GetString().Should().NotBe("skipped");
+  }
+
+  private static JsonElement FindStep(JsonElement steps, string stepId) {
+    foreach (var step in steps.EnumerateArray()) {
+      if (step.TryGetProperty("commandId", out var id) && id.GetString() == stepId) {
+        return step;
+      }
+    }
+    throw new InvalidOperationException($"No step with commandId '{stepId}' found in execution result.");
+  }
+}

--- a/tests/unit/Sequences/LoopValidationTests.cs
+++ b/tests/unit/Sequences/LoopValidationTests.cs
@@ -242,4 +242,91 @@ public sealed class LoopValidationTests {
     var errors = Svc.Validate(new[] { loop });
     errors.Should().BeEmpty();
   }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 9. Feature 081 (FR-006/FR-007/FR-008/FR-009): nested, cross-scope stepRef resolution
+  // ──────────────────────────────────────────────────────────────────────────
+
+  private static SequenceStep BreakStep(string stepId, int order = 0, SequenceStepCondition? condition = null)
+      => new() {
+        Order = order,
+        StepId = stepId,
+        StepType = SequenceStepType.Break,
+        BreakCondition = condition ?? new ImageVisibleStepCondition { ImageId = "img" }
+      };
+
+  private static SequenceStep ActionStepWithCondition(string stepId, int order, SequenceStepCondition condition)
+      => new() {
+        Order = order,
+        StepId = stepId,
+        StepType = SequenceStepType.Action,
+        Action = new SequenceActionPayload { Type = "tap" },
+        Condition = condition
+      };
+
+  [Fact] // T011 (US2)
+  public void CommandOutcomeReferencingBreakNestedInAnEarlierDifferentLoopIsAccepted() {
+    var brk = BreakStep("cluster-not-found-break");
+    var loop1 = LoopStep("loop-1", new CountLoopConfig { Count = 3 }, new[] { brk });
+    var gate = ActionStepWithCondition("gate", 1,
+        new CommandOutcomeStepCondition { StepRef = "cluster-not-found-break", ExpectedState = "break" });
+
+    var errors = Svc.Validate(new[] { loop1, gate });
+
+    errors.Should().BeEmpty();
+  }
+
+  [Fact] // T012 (US2)
+  public void CommandOutcomeExpectedStateBreakAndNoBreakAreAccepted() {
+    var brk = BreakStep("brk");
+    var loop1 = LoopStep("loop-1", new CountLoopConfig { Count = 3 }, new[] { brk });
+    var gateBreak = ActionStepWithCondition("gate-break", 1,
+        new CommandOutcomeStepCondition { StepRef = "brk", ExpectedState = "break" });
+    var gateNoBreak = ActionStepWithCondition("gate-no-break", 2,
+        new CommandOutcomeStepCondition { StepRef = "brk", ExpectedState = "no_break" });
+
+    var errors = Svc.Validate(new[] { loop1, gateBreak, gateNoBreak });
+
+    errors.Should().BeEmpty();
+  }
+
+  [Fact] // T013 (US2) — FR-007: widening reachability does not widen past "prior" — a stepRef
+         // naming a step that is reachable but appears LATER in the sequence's authored structure
+         // (here, nested inside a later Loop's body) is still rejected.
+  public void CommandOutcomeReferencingReachableButLaterNestedStepIsRejected() {
+    var gate = ActionStepWithCondition("gate", 0,
+        new CommandOutcomeStepCondition { StepRef = "later-nested", ExpectedState = "success" });
+    var laterNested = ActionStep("later-nested");
+    var laterLoop = LoopStep("later-loop", new CountLoopConfig { Count = 2 }, new[] { laterNested });
+
+    var errors = Svc.Validate(new[] { gate, laterLoop });
+
+    errors.Should().ContainSingle(e => e.Contains("must reference a prior step"));
+  }
+
+  [Fact] // T021 (US3) — the whole-tree resolution built for US2 is not Break-specific: an
+         // ordinary (non-Break) step nested inside a different Loop's body resolves the same way.
+  public void CommandOutcomeReferencingNonBreakStepNestedInAnEarlierDifferentLoopIsAccepted() {
+    var inner = ActionStep("inner-command", 0);
+    var loop1 = LoopStep("loop-1", new CountLoopConfig { Count = 3 }, new[] { inner });
+    var gate = ActionStepWithCondition("gate", 1,
+        new CommandOutcomeStepCondition { StepRef = "inner-command", ExpectedState = "success" });
+
+    var errors = Svc.Validate(new[] { loop1, gate });
+
+    errors.Should().BeEmpty();
+  }
+
+  [Fact] // T012 (US2) — regression: an unrecognized expectedState is still rejected, now
+         // mentioning the widened vocabulary.
+  public void CommandOutcomeUnknownExpectedStateIsStillRejected() {
+    var brk = BreakStep("brk");
+    var loop1 = LoopStep("loop-1", new CountLoopConfig { Count = 3 }, new[] { brk });
+    var gate = ActionStepWithCondition("gate", 1,
+        new CommandOutcomeStepCondition { StepRef = "brk", ExpectedState = "bogus" });
+
+    var errors = Svc.Validate(new[] { loop1, gate });
+
+    errors.Should().ContainSingle(e => e.Contains("must be one of success|failed|skipped|break|no_break"));
+  }
 }

--- a/tests/unit/Sequences/SequenceRunnerIfTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerIfTests.cs
@@ -271,6 +271,33 @@ public sealed class SequenceRunnerIfTests {
     executed.Should().Equal("cmd-work");
   }
 
+  [Fact] // T004 (feature 081, FR-003): the Loop's exitReason.brokeVia names the Break step's own
+         // id, not the enclosing If step's id.
+  public async Task BreakInsideIfThenBranchLoopExitReasonReportsBreaksOwnIdNotTheIfsId() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new CountLoopConfig { Count = 5 },
+      Body = new List<SequenceStep> {
+        ActionStep(0, "work", "cmd-work"),
+        IfStep("if1", new List<SequenceStep> {
+          new() { Order = 0, StepId = "brk", StepType = SequenceStepType.Break }
+        }, order: 1)
+      }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().Be("brk");
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeFalse();
+  }
+
   // ──────────────────────────────────────────────────────────────────────────
   // US2: else branch
   // ──────────────────────────────────────────────────────────────────────────

--- a/tests/unit/Sequences/SequenceRunnerLoopTests.cs
+++ b/tests/unit/Sequences/SequenceRunnerLoopTests.cs
@@ -667,4 +667,266 @@ public sealed class SequenceRunnerLoopTests {
     breaks.Should().OnlyContain(s => s.ActionOutcome == "no_break");
     result.Steps.Where(s => s.LoopIterations is not null).Should().OnlyContain(s => s.Status != "Failed");
   }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Feature 081 (FR-001/US1): Loop exitReason
+  // ──────────────────────────────────────────────────────────────────────────
+
+  [Fact] // T001 (US1)
+  public async Task CountLoopConditionalBreakFiresExitReasonReportsBrokeViaAndNotExhausted() {
+    var loopStep = CountLoopWithBreak(new ImageVisibleStepCondition { ImageId = "img" }, count: 5);
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().Be("break");
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeFalse();
+  }
+
+  [Fact] // T001/T005 (US1) — a count loop has no "exhausted" concept (Count is fixed, not a
+         // give-up ceiling): running to completion with no break is the "neither" state.
+  public async Task CountLoopCompletesWithNoBreakExitReasonReportsNeitherBrokeNorExhausted() {
+    var loopStep = CountLoopWithBreak(new ImageVisibleStepCondition { ImageId = "img" }, count: 3);
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(false));
+
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().BeNull();
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeFalse();
+  }
+
+  [Fact] // T002 (US1)
+  public async Task WhileLoopBreakFiresExitReasonReportsBrokeViaAndNotExhausted() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new WhileLoopConfig { Condition = new ImageVisibleStepCondition { ImageId = "loop" } },
+      Body = new List<SequenceStep> {
+        ActionBodyStep(0, "inner"),
+        BreakBodyStep(1, new ImageVisibleStepCondition { ImageId = "brk" })
+      }
+    };
+
+    var brkChecks = 0;
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (cond, _) => {
+          if (cond.TargetId == "brk") return Task.FromResult(++brkChecks >= 2);
+          return Task.FromResult(true);
+        });
+
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().Be("break");
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeFalse();
+  }
+
+  [Fact] // T002 (US1)
+  public async Task WhileLoopConditionFalseOnEntryExitReasonReportsNeitherBrokeNorExhausted() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new WhileLoopConfig { Condition = new ImageVisibleStepCondition { ImageId = "img" } },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(false));
+
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().BeNull();
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeFalse();
+  }
+
+  [Fact] // T001/T002 (US1) — FR-004: ExhaustedMaxIterations is independent of ExitOnMaxIterations.
+  public async Task WhileLoopExitOnMaxIterationsTrueExitReasonReportsExhausted() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "recover",
+      StepType = SequenceStepType.Loop,
+      Loop = new WhileLoopConfig {
+        Condition = new ImageVisibleStepCondition { ImageId = "img" },
+        MaxIterations = 3,
+        ExitOnMaxIterations = true
+      },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    result.Status.Should().Be("Succeeded");
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().BeNull();
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeTrue();
+  }
+
+  [Fact] // T001/T002 (US1) — FR-004: still reports exhausted even though ExitOnMaxIterations:false
+         // fails the loop for an unrelated ("Failed") reason today.
+  public async Task WhileLoopExitOnMaxIterationsFalseStillReportsExhaustedEvenThoughLoopFails() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new WhileLoopConfig {
+        Condition = new ImageVisibleStepCondition { ImageId = "img" },
+        MaxIterations = 3
+      },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    result.Status.Should().Be("Failed");
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().BeNull();
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeTrue();
+  }
+
+  [Fact] // T003 (US1)
+  public async Task RepeatUntilLoopBreakFiresExitReasonReportsBrokeViaAndNotExhausted() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new RepeatUntilLoopConfig { Condition = new ImageVisibleStepCondition { ImageId = "until" } },
+      Body = new List<SequenceStep> {
+        ActionBodyStep(0, "inner"),
+        BreakBodyStep(1, new ImageVisibleStepCondition { ImageId = "brk" })
+      }
+    };
+
+    var brkChecks = 0;
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (cond, _) => {
+          if (cond.TargetId == "brk") return Task.FromResult(++brkChecks >= 2);
+          return Task.FromResult(false); // exit condition itself never true
+        });
+
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().Be("break");
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeFalse();
+  }
+
+  [Fact] // T003 (US1)
+  public async Task RepeatUntilLoopExitConditionTrueExitReasonReportsNeitherBrokeNorExhausted() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new RepeatUntilLoopConfig { Condition = new ImageVisibleStepCondition { ImageId = "img" } },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().BeNull();
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeFalse();
+  }
+
+  [Fact] // T003 (US1) — FR-004: exhausted regardless of ExitOnMaxIterations.
+  public async Task RepeatUntilLoopExitOnMaxIterationsTrueExitReasonReportsExhausted() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "cleanup",
+      StepType = SequenceStepType.Loop,
+      Loop = new RepeatUntilLoopConfig {
+        Condition = new ImageVisibleStepCondition { ImageId = "img" },
+        MaxIterations = 3,
+        ExitOnMaxIterations = true
+      },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(false));
+
+    result.Status.Should().Be("Succeeded");
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().BeNull();
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeTrue();
+  }
+
+  [Fact] // T003 (US1) — FR-004: still exhausted even though ExitOnMaxIterations:false fails the loop.
+  public async Task RepeatUntilLoopExitOnMaxIterationsFalseStillReportsExhaustedEvenThoughLoopFails() {
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "loop",
+      StepType = SequenceStepType.Loop,
+      Loop = new RepeatUntilLoopConfig {
+        Condition = new ImageVisibleStepCondition { ImageId = "img" },
+        MaxIterations = 3
+      },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(false));
+
+    result.Status.Should().Be("Failed");
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.ExitReason.Should().NotBeNull();
+    loopResult.ExitReason!.BrokeVia.Should().BeNull();
+    loopResult.ExitReason.ExhaustedMaxIterations.Should().BeTrue();
+  }
+
+  [Fact] // T006 (US1) — regression: exitReason is additive, existing assertions are unaffected.
+  public async Task ExitReasonAdditionDoesNotAffectExistingLoopStatusOrMessageAssertions() {
+    // Re-run of WhileLoopExitOnMaxIterationsGivesUpWithoutFailingTheSequence's existing assertions.
+    var loopStep = new SequenceStep {
+      Order = 0,
+      StepId = "recover",
+      StepType = SequenceStepType.Loop,
+      Loop = new WhileLoopConfig {
+        Condition = new ImageVisibleStepCondition { ImageId = "img" },
+        MaxIterations = 3,
+        ExitOnMaxIterations = true
+      },
+      Body = new List<SequenceStep> { ActionBodyStep(0, "inner") }
+    };
+
+    var runner = new SequenceRunner(new StubRepo(Sequence("s", new[] { loopStep })));
+    var result = await runner.ExecuteAsync("s",
+        (_, _) => Task.CompletedTask,
+        conditionEvaluator: (_, _) => Task.FromResult(true));
+
+    result.Status.Should().Be("Succeeded");
+    var loopResult = result.Steps.Single(s => s.LoopIterations is not null);
+    loopResult.Status.Should().Be("exhausted");
+    loopResult.Message.Should().Contain("gave up after 3 iterations");
+  }
 }


### PR DESCRIPTION
## Summary

Implements FR-001 from the PNS project's feature-request tracker (`C:\src\PNS\docs\api-feature-requests.md`), two related, additive changes to sequence authoring/execution:

- **Loop exit reason**: a `Loop` step's execution result now carries a structured `exitReason: { brokeVia, exhaustedMaxIterations }`, populated across all three loop kinds (count/while/repeat-until), correct even when the firing `Break` is nested inside an `If` within the loop body. `exhaustedMaxIterations` is independent of the `exitOnMaxIterations` flag, per FR-004.
- **Nested `commandOutcome` `stepRef` resolution**: a per-step `condition` gate can now reference any step reachable from the sequence root — not only an immediate sibling — using the sequence's authored order to keep enforcing "must reference a prior step." `expectedState` also gains `break`/`no_break`, and `Break` steps now actually record their fired/not-fired outcome into the runtime outcome map (previously never written, so even an already-legal same-body reference to a `Break` step always failed with "reference unavailable").

This closes the exact gap documented in FR-001's evidence trail: the alliance-donation feature in the PNS project had to fall back on a ~2.0–3.3s screenshot-timing heuristic to guess whether an exhaustion `Break` had fired, because there was no structural way to ask "did this loop's Break fire" or reference a nested step's outcome from a sibling scope.

Both changes are purely additive — every currently-valid sequence, condition, and Loop/Break execution result is unchanged.

## Test plan

- [x] `dotnet build` — whole solution, 0 warnings, 0 errors
- [x] `dotnet test tests/unit` — 982 passed, 0 failed
- [x] `dotnet test tests/integration` — 342 passed, 1 pre-existing skip, 0 failed
- [x] `dotnet test tests/contract` — 125 passed, 0 failed
- [x] New unit tests cover `exitReason` across count/while/repeat-until loops, break-nested-in-If, and the "neither" case
- [x] New unit tests cover validation acceptance of cross-scope `stepRef`, `break`/`no_break` `expectedState`, and the still-enforced ordering rule
- [x] New integration tests (`tests/integration/Sequences/NestedStepOutcomeReferenceIntegrationTests.cs`) prove the whole flow end-to-end over real HTTP: creation acceptance, break vs. no_break resolution, same-body Break reference now resolving, the not-taken-If-branch reference still failing hard, and generality for non-`Break` nested references
- [x] `docs/architecture.md` and `specs/STATUS.md` updated per the living-docs constitution rule
- [x] Full spec-driven paper trail under `specs/081-loop-exit-reason-and-nested-steprefs/` (spec, plan, research, data-model, contracts, quickstart, tasks — all 27 tasks complete)

Note: `C:\src\PNS\docs\api-feature-requests.md` is intentionally left unmodified — that file is owned by the PNS project and must be retested there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)